### PR TITLE
Add default rc manifests

### DIFF
--- a/mariadb-cluster/manifests/mariadb-master-rc.yaml
+++ b/mariadb-cluster/manifests/mariadb-master-rc.yaml
@@ -1,0 +1,68 @@
+#helm:generate helm tpl -d tpl/values.toml -o manifests/mariadb-master-rc.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: mariadb-master
+  labels:
+    provider: mariadb
+    mode: master
+    heritage: bitnami
+spec:
+  replicas: 1
+  selector:
+    provider: mariadb
+    mode: master
+    version: 5.5.48-0-r01
+  template:
+    metadata:
+      labels:
+        provider: mariadb
+        mode: master
+        version: 5.5.48-0-r01
+        heritage: bitnami
+    spec:
+      containers:
+      - name: mariadb
+        image: bitnami/mariadb:5.5.48-0-r01
+        args:
+        - --max_connect_errors=1000
+        env:
+        - name: MARIADB_USER
+          value: "my-user"
+        - name: MARIADB_PASSWORD
+          value: "my-password"
+        - name: MARIADB_DATABASE
+          value: "my-database"
+        - name: MARIADB_REPLICATION_MODE
+          value: master
+        - name: MARIADB_REPLICATION_USER
+          value: "replication-user"
+        - name: MARIADB_REPLICATION_PASSWORD
+          value: "replication-password"
+        ports:
+        - name: mysql
+          containerPort: 3306
+        livenessProbe:
+          exec:
+            command:
+            - mysqladmin
+            - ping
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+            - mysqladmin
+            - ping
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        volumeMounts:
+        - name: data
+          mountPath: /bitnami/mariadb/data
+        - name: conf
+          mountPath: /bitnami/mariadb/conf
+      volumes:
+      - name: data
+        emptyDir: {}
+      - name: conf
+        emptyDir: {}

--- a/mariadb-cluster/manifests/mariadb-slave-rc.yaml
+++ b/mariadb-cluster/manifests/mariadb-slave-rc.yaml
@@ -1,0 +1,63 @@
+#helm:generate helm tpl -d tpl/values.toml -o manifests/mariadb-slave-rc.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: mariadb-slave
+  labels:
+    provider: mariadb
+    mode: slave
+    heritage: bitnami
+spec:
+  replicas: 3
+  selector:
+    provider: mariadb
+    mode: slave
+    version: 5.5.48-0-r01
+  template:
+    metadata:
+      labels:
+        provider: mariadb
+        mode: slave
+        version: 5.5.48-0-r01
+    spec:
+      containers:
+      - name: mariadb
+        image: bitnami/mariadb:5.5.48-0-r01
+        args:
+        - --max_connect_errors=1000
+        env:
+        - name: MARIADB_USER
+          value: "my-user"
+        - name: MARIADB_PASSWORD
+          value: "my-password"
+        - name: MARIADB_DATABASE
+          value: "my-database"
+        - name: MARIADB_REPLICATION_MODE
+          value: slave
+        - name: MARIADB_MASTER_HOST
+          value: mariadb-master
+        - name: MARIADB_MASTER_USER
+          value: "my-user"
+        - name: MARIADB_MASTER_PASSWORD
+          value: "my-password"
+        - name: MARIADB_REPLICATION_USER
+          value: "replication-user"
+        - name: MARIADB_REPLICATION_PASSWORD
+          value: "replication-password"
+        ports:
+        - name: mysql
+          containerPort: 3306
+        livenessProbe:
+          exec:
+            command:
+            - mysqladmin
+            - ping
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+            - mysqladmin
+            - ping
+          initialDelaySeconds: 5
+          timeoutSeconds: 1

--- a/mariadb/manifests/mariadb-rc.yaml
+++ b/mariadb/manifests/mariadb-rc.yaml
@@ -1,0 +1,57 @@
+#helm:generate helm tpl -d tpl/values.toml -o manifests/mariadb-rc.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: mariadb
+  labels:
+    provider: mariadb
+    heritage: bitnami
+spec:
+  replicas: 1
+  selector:
+    provider: mariadb
+    version: 5.5.48-0-r01
+  template:
+    metadata:
+      labels:
+        provider: mariadb
+        version: 5.5.48-0-r01
+        heritage: bitnami
+    spec:
+      containers:
+      - name: mariadb
+        image: bitnami/mariadb:5.5.48-0-r01
+        env:
+        - name: MARIADB_USER
+          value: ""
+        - name: MARIADB_PASSWORD
+          value: ""
+        - name: MARIADB_DATABASE
+          value: ""
+        ports:
+        - name: mysql
+          containerPort: 3306
+        livenessProbe:
+          exec:
+            command:
+            - mysqladmin
+            - ping
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+            - mysqladmin
+            - ping
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        volumeMounts:
+        - name: data
+          mountPath: /bitnami/mariadb/data
+        - name: conf
+          mountPath: /bitnami/mariadb/conf
+      volumes:
+      - name: data
+        emptyDir: {}
+      - name: conf
+        emptyDir: {}

--- a/memcached/manifests/memcached-rc.yaml
+++ b/memcached/manifests/memcached-rc.yaml
@@ -1,0 +1,39 @@
+#helm:generate helm tpl -d tpl/values.toml -o manifests/memcached-rc.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: memcached
+  labels:
+    provider: memcached
+    heritage: bitnami
+spec:
+  replicas: 1
+  selector:
+    provider: memcached
+    version: 1.4.25-1
+  template:
+    metadata:
+      labels:
+        provider: memcached
+        version: 1.4.25-1
+        heritage: bitnami
+    spec:
+      containers:
+      - name: memcached
+        image: bitnami/memcached:1.4.25-1
+        env:
+        - name: MEMCACHED_PASSWORD
+          value: ""
+        ports:
+        - name: memcache
+          containerPort: 11211
+        livenessProbe:
+          tcpSocket:
+            port: memcache
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          tcpSocket:
+            port: memcache
+          initialDelaySeconds: 5
+          timeoutSeconds: 1

--- a/mongodb/manifests/mongodb-rc.yaml
+++ b/mongodb/manifests/mongodb-rc.yaml
@@ -1,0 +1,57 @@
+#helm:generate helm tpl -d tpl/values.toml -o manifests/mongodb-rc.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: mongodb
+  labels:
+    provider: mongodb
+    heritage: bitnami
+spec:
+  replicas: 1
+  selector:
+    provider: mongodb
+    version: 3.0.7-1-r02
+  template:
+    metadata:
+      labels:
+        provider: mongodb
+        version: 3.0.7-1-r02
+        heritage: bitnami
+    spec:
+      containers:
+      - name: mongodb
+        image: bitnami/mongodb:3.0.7-1-r02
+        env:
+        - name: MONGODB_USER
+          value: ""
+        - name: MONGODB_PASSWORD
+          value: ""
+        - name: MONGODB_DATABASE
+          value: ""
+        ports:
+        - name: mongodb
+          containerPort: 27017
+        livenessProbe:
+          exec:
+            command:
+            - mongo
+            - ping
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+            - mongo
+            - ping
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        volumeMounts:
+        - name: data
+          mountPath: /bitnami/mongodb/data
+        - name: conf
+          mountPath: /bitnami/mongodb/conf
+      volumes:
+      - name: data
+        emptyDir: {}
+      - name: conf
+        emptyDir: {}

--- a/postgresql/manifests/postgresql-rc.yaml
+++ b/postgresql/manifests/postgresql-rc.yaml
@@ -1,0 +1,59 @@
+#helm:generate helm tpl -d tpl/values.toml -o manifests/postgresql-rc.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: postgresql
+  labels:
+    provider: postgresql
+    heritage: bitnami
+spec:
+  replicas: 1
+  selector:
+    provider: postgresql
+    version: 9.5.1-0
+  template:
+    metadata:
+      labels:
+        provider: postgresql
+        version: 9.5.1-0
+        heritage: bitnami
+    spec:
+      containers:
+      - name: postgresql
+        image: bitnami/postgresql:9.5.1-0
+        env:
+        - name: POSTGRES_USER
+          value: ""
+        - name: POSTGRES_PASSWORD
+          value: ""
+        - name: POSTGRES_DB
+          value: ""
+        ports:
+        - name: postgresql
+          containerPort: 5432
+        livenessProbe:
+          exec:
+            command:
+            - pg_isready
+            - -U
+            - postgres
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+            - pg_isready
+            - -U
+            - postgres
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        volumeMounts:
+        - name: data
+          mountPath: /bitnami/postgresql/data
+        - name: conf
+          mountPath: /bitnami/postgresql/conf
+      volumes:
+      - name: data
+        emptyDir: {}
+      - name: conf
+        emptyDir: {}

--- a/redis/manifests/redis-rc.yaml
+++ b/redis/manifests/redis-rc.yaml
@@ -1,0 +1,53 @@
+#helm:generate helm tpl -d tpl/values.toml -o manifests/redis-rc.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: redis
+  labels:
+    provider: redis
+    heritage: bitnami
+spec:
+  replicas: 1
+  selector:
+    provider: redis
+    version: 3.0.7-1
+  template:
+    metadata:
+      labels:
+        provider: redis
+        version: 3.0.7-1
+        heritage: bitnami
+    spec:
+      containers:
+      - name: redis
+        image: bitnami/redis:3.0.7-1
+        env:
+        - name: REDIS_PASSWORD
+          value: ""
+        ports:
+        - name: redis
+          containerPort: 6379
+        livenessProbe:
+          exec:
+            command:
+            - redis-cli
+            - ping
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+            - redis-cli
+            - ping
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        volumeMounts:
+        - name: data
+          mountPath: /bitnami/redis/data
+        - name: conf
+          mountPath: /bitnami/redis/conf
+      volumes:
+      - name: data
+        emptyDir: {}
+      - name: conf
+        emptyDir: {}

--- a/redmine/manifests/redmine-rc.yaml
+++ b/redmine/manifests/redmine-rc.yaml
@@ -1,0 +1,72 @@
+#helm:generate helm tpl -d tpl/values.toml -o manifests/redmine-rc.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: redmine
+  labels:
+    app: redmine
+    provider: redmine-server
+    heritage: bitnami
+spec:
+  replicas: 1
+  selector:
+    app: redmine
+    provider: redmine-server
+    version: 3.2.1-2
+  template:
+    metadata:
+      labels:
+        app: redmine
+        provider: redmine-server
+        version: 3.2.1-2
+        heritage: bitnami
+    spec:
+      containers:
+      - name: redmine
+        image: bitnami/redmine:3.2.1-2
+        env:
+        - name: MARIADB_HOST
+          value: "mariadb"
+        - name: MARIADB_PORT
+          value: "3306"
+        - name: MARIADB_PASSWORD
+          value: ""
+        - name: REDMINE_USERNAME
+          value: ""
+        - name: REDMINE_PASSWORD
+          value: ""
+        - name: REDMINE_EMAIL
+          value: ""
+        - name: REDMINE_LANG
+          value: ""
+        - name: SMTP_HOST
+          value: ""
+        - name: SMTP_PORT
+          value: ""
+        - name: SMTP_USER
+          value: ""
+        - name: SMTP_PASSWORD
+          value: ""
+        - name: SMTP_TLS
+          value: ""
+        ports:
+        - name: http
+          containerPort: 3000
+        livenessProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 120
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        volumeMounts:
+        - name: data
+          mountPath: /bitnami/redmine
+      volumes:
+      - name: data
+        emptyDir: {}

--- a/run-generators.sh
+++ b/run-generators.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+## Runs the helm generator on all chart templates to create manifests with the
+## default configuration. The command used to generate the manifests is the same
+## as the one specified in the template.
+
+SCRIPT_DIR=$(dirname $0)
+cd $SCRIPT_DIR
+
+BASE_DIR=$PWD
+for file in $(grep -r "^#helm:generate" . --exclude-dir=manifests | cut -d':' -f1)
+do
+  CHART_DIR=$(echo $file | cut -d'/' -f2)
+  TEMPLATE_FILE=$(echo "$file" | cut -d'/' -f3-)
+  COMMAND=$(cat $file | grep ^#helm:generate | cut -d' ' -f2- | sed "s|\$HELM_GENERATE_FILE|$TEMPLATE_FILE|")
+  cd $CHART_DIR
+  echo "Running generator: $COMMAND"
+  $COMMAND
+  cd $BASE_DIR
+done

--- a/tomcat/manifests/tomcat-rc.yaml
+++ b/tomcat/manifests/tomcat-rc.yaml
@@ -1,0 +1,51 @@
+#helm:generate helm tpl -d tpl/values.toml -o manifests/tomcat-rc.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: tomcat
+  labels:
+    provider: tomcat
+    heritage: bitnami
+spec:
+  replicas: 1
+  selector:
+    provider: tomcat
+    version: 7.0.68-0
+  template:
+    metadata:
+      labels:
+        provider: tomcat
+        version: 7.0.68-0
+        heritage: bitnami
+    spec:
+      containers:
+      - name: tomcat
+        image: bitnami/tomcat:7.0.68-0
+        env:
+        - name: TOMCAT_PASSWORD
+          value: ""
+        ports:
+        - name: http
+          containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        volumeMounts:
+        - name: webapps
+          mountPath: /app
+        - name: conf
+          mountPath: /bitnami/tomcat/conf
+      volumes:
+      - name: webapps
+        emptyDir: {}
+      - name: conf
+        emptyDir: {}

--- a/wildfly/manifests/wildfly-rc.yaml
+++ b/wildfly/manifests/wildfly-rc.yaml
@@ -1,0 +1,53 @@
+#helm:generate helm tpl -d tpl/values.toml -o manifests/wildfly-rc.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: wildfly
+  labels:
+    provider: wildfly
+    heritage: bitnami
+spec:
+  replicas: 1
+  selector:
+    provider: wildfly
+    version: 10.0.0-0
+  template:
+    metadata:
+      labels:
+        provider: wildfly
+        version: 10.0.0-0
+        heritage: bitnami
+    spec:
+      containers:
+      - name: wildfly
+        image: bitnami/wildfly:10.0.0-0
+        env:
+        - name: WILDFLY_PASSWORD
+          value: ""
+        ports:
+        - name: http
+          containerPort: 8080
+        - name: mgmt
+          containerPort: 9990
+        livenessProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        volumeMounts:
+        - name: data
+          mountPath: /bitnami/wildfly/data
+        - name: conf
+          mountPath: /bitnami/wildfly/conf
+      volumes:
+      - name: data
+        emptyDir: {}
+      - name: conf
+        emptyDir: {}


### PR DESCRIPTION
This commit adds manifests after running the generators with the default configuration. The `run-generator.sh` script can be used to update the default manifests from the templates.