### PR TITLE
Use secret volumes for sensitive data such as passwords

### DIFF
--- a/_docs/redmine/README.md
+++ b/_docs/redmine/README.md
@@ -179,11 +179,7 @@ $ helmc edit redmine
 
 *or directly edit `~/.helmc/workspace/charts/redmine/tpl/values.toml` in your favourite text editor*
 
-In the default configuration the database user is set to `root` without a password and the Redmine administrator username and password credentials are `user` and `bitnami` respectively.
-
-> **Important:**
->
-> If the database credentials were changed in the MariaDB Chart, please update the database credentials in the Redmine Chart accordingly or the deployment will fail for obvious reasons.
+In the default configuration the Redmine administrator username and password credentials are `user` and `bitnami` respectively.
 
 To configure Redmine data persistence refer to the [Redmine persistence](#redmine-persistence) section.
 

--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -2,12 +2,12 @@ name: drupal
 home: http://www.drupal.org/
 source:
 - https://github.com/bitnami/bitnami-docker-drupal
-version: 0.2.0
+version: 0.2.1
 description: One of the most versatile open source content management systems.
 maintainers:
 - Bitnami <containers@bitnami.com>
 dependencies:
 - name: mariadb
-  version: 0.2.0
+  version: 0.2.1
 details: |-
   Drupal is one of the most versatile open source content management systems on the market.

--- a/drupal/README.md
+++ b/drupal/README.md
@@ -26,15 +26,11 @@ To edit the default Drupal configuration, run
 $ helmc edit drupal
 ```
 
-Here you can update the MariaDB root password, Drupal admin username, password and email address in `tpl/values.toml`. When not specified, the default values are used.
+Here you can update the Drupal admin username, password and email address in `tpl/values.toml`. When not specified, the default values are used.
 
 Refer to the [Environment variables](https://github.com/bitnami/bitnami-docker-drupal/#environment-variables) section of the [Bitnami Drupal](https://github.com/bitnami/bitnami-docker-drupal) image for the default values.
 
 The values of `drupalUser` and `drupalPassword` are the login credentials when you [access the Drupal instance](#access-your-drupal-application).
-
-> Note:
->
-> If you had updated the MariaDB root password for the MariaDB deployment, then ensure you set the same password for the `mariadbRootPassword` field in the Drupal Chart.
 
 Finally, generate the chart to apply your changes to the configuration.
 

--- a/drupal/manifests/drupal-rc.yaml
+++ b/drupal/manifests/drupal-rc.yaml
@@ -12,18 +12,18 @@ spec:
   selector:
     app: drupal
     provider: drupal-server
-    version: 8.1.1-r0
+    version: 8.1.3-r0
   template:
     metadata:
       labels:
         app: drupal
         provider: drupal-server
-        version: 8.1.1-r0
+        version: 8.1.3-r0
         heritage: bitnami
     spec:
       containers:
       - name: drupal
-        image: bitnami/drupal:8.1.1-r0
+        image: bitnami/drupal:8.1.3-r0
         env:
         - name: MARIADB_HOST
           value: "mariadb"

--- a/drupal/manifests/drupal-rc.yaml
+++ b/drupal/manifests/drupal-rc.yaml
@@ -30,11 +30,17 @@ spec:
         - name: MARIADB_PORT
           value: "3306"
         - name: MARIADB_PASSWORD
-          value: ""
+          valueFrom:
+            secretKeyRef:
+              name: drupal
+              key: mariadb-root-password
         - name: DRUPAL_USERNAME
           value: "user"
         - name: DRUPAL_PASSWORD
-          value: "bitnami"
+          valueFrom:
+            secretKeyRef:
+              name: drupal
+              key: drupal-password
         - name: DRUPAL_EMAIL
           value: "user@example.com"
         ports:

--- a/drupal/manifests/drupal-rc.yaml
+++ b/drupal/manifests/drupal-rc.yaml
@@ -32,7 +32,7 @@ spec:
         - name: MARIADB_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: drupal
+              name: mariadb
               key: mariadb-root-password
         - name: DRUPAL_USERNAME
           value: "user"

--- a/drupal/manifests/drupal-secrets.yaml
+++ b/drupal/manifests/drupal-secrets.yaml
@@ -8,5 +8,4 @@ metadata:
     heritage: bitnami
 type: Opaque
 data:
-  mariadb-root-password: ""
   drupal-password: "Yml0bmFtaQ=="

--- a/drupal/manifests/drupal-secrets.yaml
+++ b/drupal/manifests/drupal-secrets.yaml
@@ -1,0 +1,12 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/drupal-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: drupal
+  labels:
+    provider: drupal
+    heritage: bitnami
+type: Opaque
+data:
+  mariadb-root-password: ""
+  drupal-password: "Yml0bmFtaQ=="

--- a/drupal/tpl/drupal-rc.yaml
+++ b/drupal/tpl/drupal-rc.yaml
@@ -32,7 +32,7 @@ spec:
         - name: MARIADB_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: drupal
+              name: mariadb
               key: mariadb-root-password
         - name: DRUPAL_USERNAME
           value: {{ .drupalUser | quote }}

--- a/drupal/tpl/drupal-rc.yaml
+++ b/drupal/tpl/drupal-rc.yaml
@@ -12,18 +12,18 @@ spec:
   selector:
     app: drupal
     provider: drupal-server
-    version: 8.1.1-r0
+    version: 8.1.3-r0
   template:
     metadata:
       labels:
         app: drupal
         provider: drupal-server
-        version: 8.1.1-r0
+        version: 8.1.3-r0
         heritage: bitnami
     spec:
       containers:
       - name: drupal
-        image: bitnami/drupal:8.1.1-r0
+        image: bitnami/drupal:8.1.3-r0
         env:
         - name: MARIADB_HOST
           value: "mariadb"

--- a/drupal/tpl/drupal-rc.yaml
+++ b/drupal/tpl/drupal-rc.yaml
@@ -30,11 +30,17 @@ spec:
         - name: MARIADB_PORT
           value: "3306"
         - name: MARIADB_PASSWORD
-          value: {{ .mariadbRootPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: drupal
+              key: mariadb-root-password
         - name: DRUPAL_USERNAME
           value: {{ .drupalUser | quote }}
         - name: DRUPAL_PASSWORD
-          value: {{ .drupalPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: drupal
+              key: drupal-password
         - name: DRUPAL_EMAIL
           value: {{ .drupalEmail | quote }}
         ports:

--- a/drupal/tpl/drupal-secrets.yaml
+++ b/drupal/tpl/drupal-secrets.yaml
@@ -8,5 +8,4 @@ metadata:
     heritage: bitnami
 type: Opaque
 data:
-  mariadb-root-password: {{ .mariadbRootPassword | b64enc | quote }}
   drupal-password: {{ .drupalPassword | b64enc | quote }}

--- a/drupal/tpl/drupal-secrets.yaml
+++ b/drupal/tpl/drupal-secrets.yaml
@@ -1,0 +1,12 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/drupal-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: drupal
+  labels:
+    provider: drupal
+    heritage: bitnami
+type: Opaque
+data:
+  mariadb-root-password: {{ .mariadbRootPassword | b64enc | quote }}
+  drupal-password: {{ .drupalPassword | b64enc | quote }}

--- a/drupal/tpl/values.toml
+++ b/drupal/tpl/values.toml
@@ -1,4 +1,3 @@
-mariadbRootPassword = ""
 drupalUser = "user"
 drupalPassword = "bitnami"
 drupalEmail = "user@example.com"

--- a/ghost/Chart.yaml
+++ b/ghost/Chart.yaml
@@ -2,7 +2,7 @@ name: ghost
 home: http://www.ghost.org/
 source:
 - https://github.com/bitnami/bitnami-docker-ghost
-version: 0.2.0
+version: 0.2.1
 description: A simple, powerful publishing platform that allows you to share your stories with the world
 maintainers:
 - Bitnami <containers@bitnami.com>

--- a/ghost/manifests/ghost-rc.yaml
+++ b/ghost/manifests/ghost-rc.yaml
@@ -28,7 +28,10 @@ spec:
         - name: GHOST_USERNAME
           value: "user"
         - name: GHOST_PASSWORD
-          value: "bitnami1"
+          valueFrom:
+            secretKeyRef:
+              name: ghost
+              key: ghost-password
         - name: GHOST_EMAIL
           value: "user@example.com"
         - name: BLOG_TITLE
@@ -40,7 +43,10 @@ spec:
         - name: SMTP_USER
           value: ""
         - name: SMTP_PASSWORD
-          value: ""
+          valueFrom:
+            secretKeyRef:
+              name: ghost
+              key: smtp-password
         - name: SMTP_SERVICE
           value: ""
         ports:

--- a/ghost/manifests/ghost-secrets.yaml
+++ b/ghost/manifests/ghost-secrets.yaml
@@ -1,0 +1,12 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/ghost-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ghost
+  labels:
+    provider: ghost
+    heritage: bitnami
+type: Opaque
+data:
+  ghost-password: "Yml0bmFtaTE="
+  smtp-password: ""

--- a/ghost/tpl/ghost-rc.yaml
+++ b/ghost/tpl/ghost-rc.yaml
@@ -28,7 +28,10 @@ spec:
         - name: GHOST_USERNAME
           value: {{ .ghostUser | quote }}
         - name: GHOST_PASSWORD
-          value: {{ .ghostPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: ghost
+              key: ghost-password
         - name: GHOST_EMAIL
           value: {{ .ghostEmail | quote }}
         - name: BLOG_TITLE
@@ -40,7 +43,10 @@ spec:
         - name: SMTP_USER
           value: {{ .smtpUser | quote }}
         - name: SMTP_PASSWORD
-          value: {{ .smtpPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: ghost
+              key: smtp-password
         - name: SMTP_SERVICE
           value: {{ .smtpService | quote }}
         ports:

--- a/ghost/tpl/ghost-secrets.yaml
+++ b/ghost/tpl/ghost-secrets.yaml
@@ -1,0 +1,12 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/ghost-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ghost
+  labels:
+    provider: ghost
+    heritage: bitnami
+type: Opaque
+data:
+  ghost-password: {{ .ghostPassword | b64enc | quote }}
+  smtp-password: {{ .smtpPassword | b64enc | quote }}

--- a/joomla/Chart.yaml
+++ b/joomla/Chart.yaml
@@ -2,12 +2,12 @@ name: joomla
 home: http://www.joomla.org/
 source:
 - https://github.com/bitnami/bitnami-docker-joomla
-version: 0.2.0
+version: 0.2.1
 description: PHP content management system (CMS) for publishing web content
 maintainers:
 - Bitnami <containers@bitnami.com>
 dependencies:
 - name: mariadb
-  version: 0.2.0
+  version: 0.2.1
 details: |-
   Joomla is a PHP content management system (CMS) for publishing web content.

--- a/joomla/README.md
+++ b/joomla/README.md
@@ -26,15 +26,11 @@ To edit the default Joomla configuration, run
 $ helmc edit joomla
 ```
 
-Here you can update the MariaDB root password, Joomla admin username, password and email address in `tpl/values.toml`. When not specified, the default values are used.
+Here you can update the Joomla admin username, password and email address in `tpl/values.toml`. When not specified, the default values are used.
 
 Refer to the [Environment variables](https://github.com/bitnami/bitnami-docker-joomla/#environment-variables) section of the [Bitnami Joomla](https://github.com/bitnami/bitnami-docker-joomla) image for the default values.
 
 The values of `joomlaUser` and `joomlaPassword` are the login credentials when you [access the Joomla instance](#access-your-joomla-application).
-
-> Note:
->
-> If you had updated the MariaDB root password for the MariaDB deployment, then ensure you set the same password for the `mariadbRootPassword` field in the Joomla Chart.
 
 Finally, generate the chart to apply your changes to the configuration.
 

--- a/joomla/manifests/joomla-rc.yaml
+++ b/joomla/manifests/joomla-rc.yaml
@@ -30,11 +30,17 @@ spec:
         - name: MARIADB_PORT
           value: "3306"
         - name: MARIADB_PASSWORD
-          value: ""
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-root-password
         - name: JOOMLA_USERNAME
           value: "user"
         - name: JOOMLA_PASSWORD
-          value: "bitnami"
+          valueFrom:
+            secretKeyRef:
+              name: joomla
+              key: joomla-password
         - name: JOOMLA_EMAIL
           value: "user@example.com"
         - name: SMTP_HOST
@@ -44,7 +50,10 @@ spec:
         - name: SMTP_USER
           value: ""
         - name: SMTP_PASSWORD
-          value: ""
+          valueFrom:
+            secretKeyRef:
+              name: joomla
+              key: smtp-password
         - name: SMTP_PROTOCOL
           value: ""
         ports:

--- a/joomla/manifests/joomla-secrets.yaml
+++ b/joomla/manifests/joomla-secrets.yaml
@@ -1,0 +1,12 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/joomla-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: joomla
+  labels:
+    provider: joomla
+    heritage: bitnami
+type: Opaque
+data:
+  joomla-password: "Yml0bmFtaQ=="
+  smtp-password: ""

--- a/joomla/tpl/joomla-rc.yaml
+++ b/joomla/tpl/joomla-rc.yaml
@@ -30,11 +30,17 @@ spec:
         - name: MARIADB_PORT
           value: "3306"
         - name: MARIADB_PASSWORD
-          value: {{ .mariadbRootPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-root-password
         - name: JOOMLA_USERNAME
           value: {{ .joomlaUser | quote }}
         - name: JOOMLA_PASSWORD
-          value: {{ .joomlaPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: joomla
+              key: joomla-password
         - name: JOOMLA_EMAIL
           value: {{ .joomlaEmail | quote }}
         - name: SMTP_HOST
@@ -44,7 +50,10 @@ spec:
         - name: SMTP_USER
           value: {{ .smtpUser | quote }}
         - name: SMTP_PASSWORD
-          value: {{ .smtpPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: joomla
+              key: smtp-password
         - name: SMTP_PROTOCOL
           value: {{ .smtpProtocol | quote }}
         ports:

--- a/joomla/tpl/joomla-secrets.yaml
+++ b/joomla/tpl/joomla-secrets.yaml
@@ -1,0 +1,12 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/joomla-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: joomla
+  labels:
+    provider: joomla
+    heritage: bitnami
+type: Opaque
+data:
+  joomla-password: {{ .joomlaPassword | b64enc | quote }}
+  smtp-password: {{ .smtpPassword | b64enc | quote }}

--- a/joomla/tpl/values.toml
+++ b/joomla/tpl/values.toml
@@ -1,4 +1,3 @@
-mariadbRootPassword = ""
 joomlaUser = "user"
 joomlaPassword = "bitnami"
 joomlaEmail = "user@example.com"

--- a/mariadb-cluster/Chart.yaml
+++ b/mariadb-cluster/Chart.yaml
@@ -2,7 +2,7 @@ name: mariadb-cluster
 home: https://mariadb.org
 source:
 - https://github.com/bitnami/bitnami-docker-mariadb
-version: 0.2.0
+version: 0.2.1
 description: Chart to create a Highly available MariaDB cluster
 maintainers:
 - Bitnami <containers@bitnami.com>

--- a/mariadb-cluster/manifests/mariadb-master-rc.yaml
+++ b/mariadb-cluster/manifests/mariadb-master-rc.yaml
@@ -12,18 +12,18 @@ spec:
   selector:
     provider: mariadb
     mode: master
-    version: 10.1.14-r0
+    version: 10.1.14-r1
   template:
     metadata:
       labels:
         provider: mariadb
         mode: master
-        version: 10.1.14-r0
+        version: 10.1.14-r1
         heritage: bitnami
     spec:
       containers:
       - name: mariadb
-        image: bitnami/mariadb:10.1.14-r0
+        image: bitnami/mariadb:10.1.14-r1
         env:
         - name: MARIADB_ROOT_PASSWORD
           value: "my-root-password"

--- a/mariadb-cluster/manifests/mariadb-master-rc.yaml
+++ b/mariadb-cluster/manifests/mariadb-master-rc.yaml
@@ -26,11 +26,17 @@ spec:
         image: bitnami/mariadb:10.1.14-r1
         env:
         - name: MARIADB_ROOT_PASSWORD
-          value: "my-root-password"
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-root-password
         - name: MARIADB_USER
           value: "my-user"
         - name: MARIADB_PASSWORD
-          value: "my-password"
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-password
         - name: MARIADB_DATABASE
           value: "my-database"
         - name: MARIADB_REPLICATION_MODE
@@ -38,7 +44,10 @@ spec:
         - name: MARIADB_REPLICATION_USER
           value: "replication-user"
         - name: MARIADB_REPLICATION_PASSWORD
-          value: "replication-password"
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-replication-password
         ports:
         - name: mysql
           containerPort: 3306

--- a/mariadb-cluster/manifests/mariadb-secrets.yaml
+++ b/mariadb-cluster/manifests/mariadb-secrets.yaml
@@ -1,0 +1,13 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/mariadb-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mariadb
+  labels:
+    provider: mariadb
+    heritage: bitnami
+type: Opaque
+data:
+  mariadb-root-password: "bXktcm9vdC1wYXNzd29yZA=="
+  mariadb-password: "bXktcGFzc3dvcmQ="
+  mariadb-replication-password: "cmVwbGljYXRpb24tcGFzc3dvcmQ="

--- a/mariadb-cluster/manifests/mariadb-slave-rc.yaml
+++ b/mariadb-cluster/manifests/mariadb-slave-rc.yaml
@@ -25,11 +25,17 @@ spec:
         image: bitnami/mariadb:10.1.14-r1
         env:
         - name: MARIADB_ROOT_PASSWORD
-          value: "my-root-password"
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-root-password
         - name: MARIADB_USER
           value: "my-user"
         - name: MARIADB_PASSWORD
-          value: "my-password"
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-password
         - name: MARIADB_DATABASE
           value: "my-database"
         - name: MARIADB_REPLICATION_MODE
@@ -41,11 +47,17 @@ spec:
         - name: MARIADB_MASTER_USER
           value: "my-user"
         - name: MARIADB_MASTER_PASSWORD
-          value: "my-password"
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-password
         - name: MARIADB_REPLICATION_USER
           value: "replication-user"
         - name: MARIADB_REPLICATION_PASSWORD
-          value: "replication-password"
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-replication-password
         ports:
         - name: mysql
           containerPort: 3306

--- a/mariadb-cluster/manifests/mariadb-slave-rc.yaml
+++ b/mariadb-cluster/manifests/mariadb-slave-rc.yaml
@@ -12,17 +12,17 @@ spec:
   selector:
     provider: mariadb
     mode: slave
-    version: 10.1.14-r0
+    version: 10.1.14-r1
   template:
     metadata:
       labels:
         provider: mariadb
         mode: slave
-        version: 10.1.14-r0
+        version: 10.1.14-r1
     spec:
       containers:
       - name: mariadb
-        image: bitnami/mariadb:10.1.14-r0
+        image: bitnami/mariadb:10.1.14-r1
         env:
         - name: MARIADB_ROOT_PASSWORD
           value: "my-root-password"

--- a/mariadb-cluster/tpl/mariadb-master-rc.yaml
+++ b/mariadb-cluster/tpl/mariadb-master-rc.yaml
@@ -26,11 +26,17 @@ spec:
         image: bitnami/mariadb:10.1.14-r1
         env:
         - name: MARIADB_ROOT_PASSWORD
-          value: {{ .mariadbRootPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-root-password
         - name: MARIADB_USER
           value: {{ .mariadbUser | quote }}
         - name: MARIADB_PASSWORD
-          value: {{ .mariadbPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-password
         - name: MARIADB_DATABASE
           value: {{ .mariadbDatabase | quote }}
         - name: MARIADB_REPLICATION_MODE
@@ -38,7 +44,10 @@ spec:
         - name: MARIADB_REPLICATION_USER
           value: {{ .mariadbReplicationUser | quote }}
         - name: MARIADB_REPLICATION_PASSWORD
-          value: {{ .mariadbReplicationPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-replication-password
         ports:
         - name: mysql
           containerPort: 3306

--- a/mariadb-cluster/tpl/mariadb-master-rc.yaml
+++ b/mariadb-cluster/tpl/mariadb-master-rc.yaml
@@ -12,18 +12,18 @@ spec:
   selector:
     provider: mariadb
     mode: master
-    version: 10.1.14-r0
+    version: 10.1.14-r1
   template:
     metadata:
       labels:
         provider: mariadb
         mode: master
-        version: 10.1.14-r0
+        version: 10.1.14-r1
         heritage: bitnami
     spec:
       containers:
       - name: mariadb
-        image: bitnami/mariadb:10.1.14-r0
+        image: bitnami/mariadb:10.1.14-r1
         env:
         - name: MARIADB_ROOT_PASSWORD
           value: {{ .mariadbRootPassword | quote }}

--- a/mariadb-cluster/tpl/mariadb-secrets.yaml
+++ b/mariadb-cluster/tpl/mariadb-secrets.yaml
@@ -1,0 +1,13 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/mariadb-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mariadb
+  labels:
+    provider: mariadb
+    heritage: bitnami
+type: Opaque
+data:
+  mariadb-root-password: {{ .mariadbRootPassword | b64enc | quote }}
+  mariadb-password: {{ .mariadbPassword | b64enc | quote }}
+  mariadb-replication-password: {{ .mariadbReplicationPassword | b64enc | quote }}

--- a/mariadb-cluster/tpl/mariadb-slave-rc.yaml
+++ b/mariadb-cluster/tpl/mariadb-slave-rc.yaml
@@ -25,11 +25,17 @@ spec:
         image: bitnami/mariadb:10.1.14-r1
         env:
         - name: MARIADB_ROOT_PASSWORD
-          value: {{ .mariadbRootPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-root-password
         - name: MARIADB_USER
           value: {{ .mariadbUser | quote }}
         - name: MARIADB_PASSWORD
-          value: {{ .mariadbPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-password
         - name: MARIADB_DATABASE
           value: {{ .mariadbDatabase | quote }}
         - name: MARIADB_REPLICATION_MODE
@@ -41,11 +47,17 @@ spec:
         - name: MARIADB_MASTER_USER
           value: {{ .mariadbUser | quote }}
         - name: MARIADB_MASTER_PASSWORD
-          value: {{ .mariadbPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-password
         - name: MARIADB_REPLICATION_USER
           value: {{ .mariadbReplicationUser | quote }}
         - name: MARIADB_REPLICATION_PASSWORD
-          value: {{ .mariadbReplicationPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-replication-password
         ports:
         - name: mysql
           containerPort: 3306

--- a/mariadb-cluster/tpl/mariadb-slave-rc.yaml
+++ b/mariadb-cluster/tpl/mariadb-slave-rc.yaml
@@ -12,17 +12,17 @@ spec:
   selector:
     provider: mariadb
     mode: slave
-    version: 10.1.14-r0
+    version: 10.1.14-r1
   template:
     metadata:
       labels:
         provider: mariadb
         mode: slave
-        version: 10.1.14-r0
+        version: 10.1.14-r1
     spec:
       containers:
       - name: mariadb
-        image: bitnami/mariadb:10.1.14-r0
+        image: bitnami/mariadb:10.1.14-r1
         env:
         - name: MARIADB_ROOT_PASSWORD
           value: {{ .mariadbRootPassword | quote }}

--- a/mariadb/Chart.yaml
+++ b/mariadb/Chart.yaml
@@ -2,7 +2,7 @@ name: mariadb
 home: https://mariadb.org
 source:
 - https://github.com/bitnami/bitnami-docker-mariadb
-version: 0.2.0
+version: 0.2.1
 description: Chart for MariaDB
 maintainers:
 - Bitnami <containers@bitnami.com>

--- a/mariadb/manifests/mariadb-rc.yaml
+++ b/mariadb/manifests/mariadb-rc.yaml
@@ -10,17 +10,17 @@ spec:
   replicas: 1
   selector:
     provider: mariadb
-    version: 10.1.14-r0
+    version: 10.1.14-r1
   template:
     metadata:
       labels:
         provider: mariadb
-        version: 10.1.14-r0
+        version: 10.1.14-r1
         heritage: bitnami
     spec:
       containers:
       - name: mariadb
-        image: bitnami/mariadb:10.1.14-r0
+        image: bitnami/mariadb:10.1.14-r1
         env:
         - name: MARIADB_ROOT_PASSWORD
           value: ""

--- a/mariadb/manifests/mariadb-rc.yaml
+++ b/mariadb/manifests/mariadb-rc.yaml
@@ -23,11 +23,17 @@ spec:
         image: bitnami/mariadb:10.1.14-r1
         env:
         - name: MARIADB_ROOT_PASSWORD
-          value: ""
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-root-password
         - name: MARIADB_USER
           value: ""
         - name: MARIADB_PASSWORD
-          value: ""
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-password
         - name: MARIADB_DATABASE
           value: ""
         ports:

--- a/mariadb/manifests/mariadb-secrets.yaml
+++ b/mariadb/manifests/mariadb-secrets.yaml
@@ -1,0 +1,12 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/mariadb-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mariadb
+  labels:
+    provider: mariadb
+    heritage: bitnami
+type: Opaque
+data:
+  mariadb-root-password: ""
+  mariadb-password: ""

--- a/mariadb/tpl/mariadb-rc.yaml
+++ b/mariadb/tpl/mariadb-rc.yaml
@@ -10,17 +10,17 @@ spec:
   replicas: 1
   selector:
     provider: mariadb
-    version: 10.1.14-r0
+    version: 10.1.14-r1
   template:
     metadata:
       labels:
         provider: mariadb
-        version: 10.1.14-r0
+        version: 10.1.14-r1
         heritage: bitnami
     spec:
       containers:
       - name: mariadb
-        image: bitnami/mariadb:10.1.14-r0
+        image: bitnami/mariadb:10.1.14-r1
         env:
         - name: MARIADB_ROOT_PASSWORD
           value: {{ .mariadbRootPassword | quote }}

--- a/mariadb/tpl/mariadb-rc.yaml
+++ b/mariadb/tpl/mariadb-rc.yaml
@@ -23,11 +23,17 @@ spec:
         image: bitnami/mariadb:10.1.14-r1
         env:
         - name: MARIADB_ROOT_PASSWORD
-          value: {{ .mariadbRootPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-root-password
         - name: MARIADB_USER
           value: {{ .mariadbUser | quote }}
         - name: MARIADB_PASSWORD
-          value: {{ .mariadbPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-password
         - name: MARIADB_DATABASE
           value: {{ .mariadbDatabase | quote }}
         ports:

--- a/mariadb/tpl/mariadb-secrets.yaml
+++ b/mariadb/tpl/mariadb-secrets.yaml
@@ -1,0 +1,12 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/mariadb-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mariadb
+  labels:
+    provider: mariadb
+    heritage: bitnami
+type: Opaque
+data:
+  mariadb-root-password: {{ .mariadbRootPassword | b64enc | quote }}
+  mariadb-password: {{ .mariadbPassword | b64enc | quote }}

--- a/mediawiki/Chart.yaml
+++ b/mediawiki/Chart.yaml
@@ -2,12 +2,12 @@ name: mediawiki
 home: http://www.mediawiki.org/
 source:
 - https://github.com/bitnami/bitnami-docker-mediawiki
-version: 0.2.0
+version: 0.2.1
 description: Extremely powerful, scalable software and a feature-rich wiki implementation that uses PHP to process and display data stored in a database.
 maintainers:
 - Bitnami <containers@bitnami.com>
 dependencies:
 - name: mariadb
-  version: 0.2.0
+  version: 0.2.1
 details: |-
   MediaWiki is an extremely powerful, scalable software and a feature-rich wiki implementation that uses PHP to process and display data stored in a database, such as MySQL.

--- a/mediawiki/README.md
+++ b/mediawiki/README.md
@@ -26,15 +26,11 @@ To edit the default MediaWiki configuration, run
 $ helmc edit mediawiki
 ```
 
-Here you can update the MariaDB root password, MediaWiki admin username, password and email address in `tpl/values.toml`. When not specified, the default values are used.
+Here you can update the MediaWiki admin username, password and email address in `tpl/values.toml`. When not specified, the default values are used.
 
 Refer to the [Environment variables](https://github.com/bitnami/bitnami-docker-mediawiki/#environment-variables) section of the [Bitnami MediaWiki](https://github.com/bitnami/bitnami-docker-mediawiki) image for the default values.
 
 The values of `mediawikiUser` and `mediawikiPassword` are the login credentials when you [access the MediaWiki instance](#access-your-mediawiki-application).
-
-> Note:
->
-> If you had updated the MariaDB root password for the MariaDB deployment, then ensure you set the same password for the `mariadbRootPassword` field in the MediaWiki Chart.
 
 Finally, generate the chart to apply your changes to the configuration.
 

--- a/mediawiki/manifests/mediawiki-rc.yaml
+++ b/mediawiki/manifests/mediawiki-rc.yaml
@@ -30,11 +30,17 @@ spec:
         - name: MARIADB_PORT
           value: "3306"
         - name: MARIADB_PASSWORD
-          value: ""
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-root-password
         - name: MEDIAWIKI_USERNAME
           value: "user"
         - name: MEDIAWIKI_PASSWORD
-          value: "bitnami1"
+          valueFrom:
+            secretKeyRef:
+              name: mediawiki
+              key: mediawiki-password
         - name: MEDIAWIKI_EMAIL
           value: "user@example.com"
         - name: MEDIAWIKI_WIKI_NAME
@@ -48,7 +54,10 @@ spec:
         - name: SMTP_USER
           value: ""
         - name: SMTP_Password
-          value: ""
+          valueFrom:
+            secretKeyRef:
+              name: mediawiki
+              key: smtp-password
         ports:
         - name: http
           containerPort: 80

--- a/mediawiki/manifests/mediawiki-secrets.yaml
+++ b/mediawiki/manifests/mediawiki-secrets.yaml
@@ -1,0 +1,12 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/mediawiki-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mediawiki
+  labels:
+    provider: mediawiki
+    heritage: bitnami
+type: Opaque
+data:
+  mediawiki-password: "Yml0bmFtaTE="
+  smtp-password: ""

--- a/mediawiki/tpl/mediawiki-rc.yaml
+++ b/mediawiki/tpl/mediawiki-rc.yaml
@@ -30,11 +30,17 @@ spec:
         - name: MARIADB_PORT
           value: "3306"
         - name: MARIADB_PASSWORD
-          value: {{ .mariadbRootPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-root-password
         - name: MEDIAWIKI_USERNAME
           value: {{ .mediawikiUser | quote }}
         - name: MEDIAWIKI_PASSWORD
-          value: {{ .mediawikiPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: mediawiki
+              key: mediawiki-password
         - name: MEDIAWIKI_EMAIL
           value: {{ .mediawikiEmail | quote }}
         - name: MEDIAWIKI_WIKI_NAME
@@ -48,7 +54,10 @@ spec:
         - name: SMTP_USER
           value: {{ .smtpUser | quote }}
         - name: SMTP_Password
-          value: {{ .smtpPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: mediawiki
+              key: smtp-password
         ports:
         - name: http
           containerPort: 80

--- a/mediawiki/tpl/mediawiki-secrets.yaml
+++ b/mediawiki/tpl/mediawiki-secrets.yaml
@@ -1,0 +1,12 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/mediawiki-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mediawiki
+  labels:
+    provider: mediawiki
+    heritage: bitnami
+type: Opaque
+data:
+  mediawiki-password: {{ .mediawikiPassword | b64enc | quote }}
+  smtp-password: {{ .smtpPassword | b64enc | quote }}

--- a/mediawiki/tpl/values.toml
+++ b/mediawiki/tpl/values.toml
@@ -1,4 +1,3 @@
-mariadbRootPassword = ""
 mediawikiUser = "user"
 mediawikiPassword = "bitnami1"
 mediawikiEmail = "user@example.com"

--- a/memcached/Chart.yaml
+++ b/memcached/Chart.yaml
@@ -2,7 +2,7 @@ name: memcached
 home: http://memcached.org/
 source:
 - https://github.com/bitnami/bitnami-docker-memcached
-version: 0.2.0
+version: 0.2.1
 description: Chart for Memcached
 maintainers:
 - Bitnami <containers@bitnami.com>

--- a/memcached/manifests/memcached-rc.yaml
+++ b/memcached/manifests/memcached-rc.yaml
@@ -25,7 +25,10 @@ spec:
         - name: MEMCACHED_USER
           value: ""
         - name: MEMCACHED_PASSWORD
-          value: ""
+          valueFrom:
+            secretKeyRef:
+              name: memcached
+              key: memcached-password
         ports:
         - name: memcache
           containerPort: 11211

--- a/memcached/manifests/memcached-secrets.yaml
+++ b/memcached/manifests/memcached-secrets.yaml
@@ -1,0 +1,11 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/memcached-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: memcached
+  labels:
+    provider: memcached
+    heritage: bitnami
+type: Opaque
+data:
+  memcached-password: ""

--- a/memcached/tpl/memcached-rc.yaml
+++ b/memcached/tpl/memcached-rc.yaml
@@ -25,7 +25,10 @@ spec:
         - name: MEMCACHED_USER
           value: {{ .memcachedUser | quote }}
         - name: MEMCACHED_PASSWORD
-          value: {{ .memcachedPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: memcached
+              key: memcached-password
         ports:
         - name: memcache
           containerPort: 11211

--- a/memcached/tpl/memcached-secrets.yaml
+++ b/memcached/tpl/memcached-secrets.yaml
@@ -1,0 +1,11 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/memcached-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: memcached
+  labels:
+    provider: memcached
+    heritage: bitnami
+type: Opaque
+data:
+  memcached-password: {{ .memcachedPassword | b64enc | quote }}

--- a/mongodb/Chart.yaml
+++ b/mongodb/Chart.yaml
@@ -2,7 +2,7 @@ name: mongodb
 home: https://mongodb.org
 source:
 - https://github.com/bitnami/bitnami-docker-mongodb
-version: 0.2.0
+version: 0.2.1
 description: Chart for MongoDB
 maintainers:
 - Bitnami <containers@bitnami.com>

--- a/mongodb/manifests/mongodb-rc.yaml
+++ b/mongodb/manifests/mongodb-rc.yaml
@@ -10,17 +10,17 @@ spec:
   replicas: 1
   selector:
     provider: mongodb
-    version: 3.2.6-r0
+    version: 3.2.7-r0
   template:
     metadata:
       labels:
         provider: mongodb
-        version: 3.2.6-r0
+        version: 3.2.7-r0
         heritage: bitnami
     spec:
       containers:
       - name: mongodb
-        image: bitnami/mongodb:3.2.6-r0
+        image: bitnami/mongodb:3.2.7-r0
         env:
         - name: MONGODB_ROOT_PASSWORD
           value: ""

--- a/mongodb/manifests/mongodb-rc.yaml
+++ b/mongodb/manifests/mongodb-rc.yaml
@@ -23,11 +23,17 @@ spec:
         image: bitnami/mongodb:3.2.7-r0
         env:
         - name: MONGODB_ROOT_PASSWORD
-          value: ""
+          valueFrom:
+            secretKeyRef:
+              name: mongodb
+              key: mongodb-root-password
         - name: MONGODB_USER
           value: ""
         - name: MONGODB_PASSWORD
-          value: ""
+          valueFrom:
+            secretKeyRef:
+              name: mongodb
+              key: mongodb-password
         - name: MONGODB_DATABASE
           value: ""
         ports:

--- a/mongodb/manifests/mongodb-secrets.yaml
+++ b/mongodb/manifests/mongodb-secrets.yaml
@@ -1,0 +1,12 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/mongodb-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mongodb
+  labels:
+    provider: mongodb
+    heritage: bitnami
+type: Opaque
+data:
+  mongodb-root-password: ""
+  mongodb-password: ""

--- a/mongodb/tpl/mongodb-rc.yaml
+++ b/mongodb/tpl/mongodb-rc.yaml
@@ -23,11 +23,17 @@ spec:
         image: bitnami/mongodb:3.2.7-r0
         env:
         - name: MONGODB_ROOT_PASSWORD
-          value: {{ .mongodbRootPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: mongodb
+              key: mongodb-root-password
         - name: MONGODB_USER
           value: {{ .mongodbUser | quote }}
         - name: MONGODB_PASSWORD
-          value: {{ .mongodbPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: mongodb
+              key: mongodb-password
         - name: MONGODB_DATABASE
           value: {{ .mongodbDatabase | quote }}
         ports:

--- a/mongodb/tpl/mongodb-rc.yaml
+++ b/mongodb/tpl/mongodb-rc.yaml
@@ -10,17 +10,17 @@ spec:
   replicas: 1
   selector:
     provider: mongodb
-    version: 3.2.6-r0
+    version: 3.2.7-r0
   template:
     metadata:
       labels:
         provider: mongodb
-        version: 3.2.6-r0
+        version: 3.2.7-r0
         heritage: bitnami
     spec:
       containers:
       - name: mongodb
-        image: bitnami/mongodb:3.2.6-r0
+        image: bitnami/mongodb:3.2.7-r0
         env:
         - name: MONGODB_ROOT_PASSWORD
           value: {{ .mongodbRootPassword | quote }}

--- a/mongodb/tpl/mongodb-secrets.yaml
+++ b/mongodb/tpl/mongodb-secrets.yaml
@@ -1,0 +1,12 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/mongodb-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mongodb
+  labels:
+    provider: mongodb
+    heritage: bitnami
+type: Opaque
+data:
+  mongodb-root-password: {{ .mongodbRootPassword | b64enc | quote }}
+  mongodb-password: {{ .mongodbPassword | b64enc | quote }}

--- a/phpbb/Chart.yaml
+++ b/phpbb/Chart.yaml
@@ -2,12 +2,12 @@ name: phpbb
 home: https://www.phpbb.com/
 source:
 - https://github.com/bitnami/bitnami-docker-phpbb
-version: 0.2.0
+version: 0.2.1
 description: Community forum that supports the notion of users and groups, file attachments, full-text search, notifications and more.
 maintainers:
 - Bitnami <containers@bitnami.com>
 dependencies:
 - name: mariadb
-  version: 0.2.0
+  version: 0.2.1
 details: |-
   phpBB is a community forum that supports the notion of users and groups, file attachments, full-text search, notifications and more.

--- a/phpbb/README.md
+++ b/phpbb/README.md
@@ -26,15 +26,11 @@ To edit the default phpBB configuration, run
 $ helmc edit phpbb
 ```
 
-Here you can update the MariaDB root password, phpBB admin username, password and email address in `tpl/values.toml`. When not specified, the default values are used.
+Here you can update the phpBB admin username, password and email address in `tpl/values.toml`. When not specified, the default values are used.
 
 Refer to the [Environment variables](https://github.com/bitnami/bitnami-docker-phpbb/#environment-variables) section of the [Bitnami phpBB](https://github.com/bitnami/bitnami-docker-phpbb) image for the default values.
 
 The values of `phpbbUser` and `phpbbPassword` are the login credentials when you [access the phpBB instance](#access-your-phpbb-application).
-
-> Note:
->
-> If you had updated the MariaDB root password for the MariaDB deployment, then ensure you set the same password for the `mariadbRootPassword` field in the phpBB Chart.
 
 Finally, generate the chart to apply your changes to the configuration.
 

--- a/phpbb/manifests/phpbb-rc.yaml
+++ b/phpbb/manifests/phpbb-rc.yaml
@@ -30,11 +30,17 @@ spec:
         - name: MARIADB_PORT
           value: "3306"
         - name: MARIADB_PASSWORD
-          value: ""
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-root-password
         - name: PHPBB_USERNAME
           value: "user"
         - name: PHPBB_PASSWORD
-          value: "bitnami"
+          valueFrom:
+            secretKeyRef:
+              name: phpbb
+              key: phpbb-password
         - name: PHPBB_EMAIL
           value: "user@example.com"
         - name: SMTP_HOST
@@ -44,7 +50,10 @@ spec:
         - name: SMTP_USER
           value: ""
         - name: SMTP_PASSWORD
-          value: ""
+          valueFrom:
+            secretKeyRef:
+              name: phpbb
+              key: smtp-password
         - name: SMTP_PROTOCOL
           value: ""
         ports:

--- a/phpbb/manifests/phpbb-secrets.yaml
+++ b/phpbb/manifests/phpbb-secrets.yaml
@@ -1,0 +1,12 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/phpbb-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: phpbb
+  labels:
+    provider: phpbb
+    heritage: bitnami
+type: Opaque
+data:
+  phpbb-password: "Yml0bmFtaQ=="
+  smtp-password: ""

--- a/phpbb/tpl/phpbb-rc.yaml
+++ b/phpbb/tpl/phpbb-rc.yaml
@@ -30,11 +30,17 @@ spec:
         - name: MARIADB_PORT
           value: "3306"
         - name: MARIADB_PASSWORD
-          value: {{ .mariadbRootPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-root-password
         - name: PHPBB_USERNAME
           value: {{ .phpbbUser | quote }}
         - name: PHPBB_PASSWORD
-          value: {{ .phpbbPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: phpbb
+              key: phpbb-password
         - name: PHPBB_EMAIL
           value: {{ .phpbbEmail | quote }}
         - name: SMTP_HOST
@@ -44,7 +50,10 @@ spec:
         - name: SMTP_USER
           value: {{ .smtpUser | quote }}
         - name: SMTP_PASSWORD
-          value: {{ .smtpPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: phpbb
+              key: smtp-password
         - name: SMTP_PROTOCOL
           value: {{ .smtpProtocol | quote }}
         ports:

--- a/phpbb/tpl/phpbb-secrets.yaml
+++ b/phpbb/tpl/phpbb-secrets.yaml
@@ -1,0 +1,12 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/phpbb-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: phpbb
+  labels:
+    provider: phpbb
+    heritage: bitnami
+type: Opaque
+data:
+  phpbb-password: {{ .phpbbPassword | b64enc | quote }}
+  smtp-password: {{ .smtpPassword | b64enc | quote }}

--- a/phpbb/tpl/values.toml
+++ b/phpbb/tpl/values.toml
@@ -1,4 +1,3 @@
-mariadbRootPassword = ""
 phpbbUser = "user"
 phpbbPassword = "bitnami"
 phpbbEmail = "user@example.com"

--- a/postgresql/Chart.yaml
+++ b/postgresql/Chart.yaml
@@ -2,7 +2,7 @@ name: postgresql
 home: http://www.postgresql.org
 source:
 - https://github.com/bitnami/bitnami-docker-postgresql
-version: 0.2.0
+version: 0.2.1
 description: Chart for PostgreSQL
 maintainers:
 - Bitnami <containers@bitnami.com>

--- a/postgresql/manifests/postgresql-rc.yaml
+++ b/postgresql/manifests/postgresql-rc.yaml
@@ -25,7 +25,10 @@ spec:
         - name: POSTGRES_USER
           value: "postgres"
         - name: POSTGRES_PASSWORD
-          value: ""
+          valueFrom:
+            secretKeyRef:
+              name: postgresql
+              key: postgres-password
         - name: POSTGRES_DB
           value: ""
         ports:

--- a/postgresql/manifests/postgresql-secrets.yaml
+++ b/postgresql/manifests/postgresql-secrets.yaml
@@ -1,0 +1,11 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/postgresql-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql
+  labels:
+    provider: postgresql
+    heritage: bitnami
+type: Opaque
+data:
+  postgres-password: ""

--- a/postgresql/tpl/postgresql-rc.yaml
+++ b/postgresql/tpl/postgresql-rc.yaml
@@ -25,7 +25,10 @@ spec:
         - name: POSTGRES_USER
           value: {{ .postgresUser | quote }}
         - name: POSTGRES_PASSWORD
-          value: {{ .postgresPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: postgresql
+              key: postgres-password
         - name: POSTGRES_DB
           value: {{ .postgresDb | quote }}
         ports:

--- a/postgresql/tpl/postgresql-secrets.yaml
+++ b/postgresql/tpl/postgresql-secrets.yaml
@@ -1,0 +1,11 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/postgresql-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql
+  labels:
+    provider: postgresql
+    heritage: bitnami
+type: Opaque
+data:
+  postgres-password: {{ .postgresPassword | b64enc | quote }}

--- a/rabbitmq/Chart.yaml
+++ b/rabbitmq/Chart.yaml
@@ -2,7 +2,7 @@ name: rabbitmq
 home: https://www.rabbitmq.com
 source:
 - https://github.com/bitnami/bitnami-docker-rabbitmq
-version: 0.2.0
+version: 0.2.1
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 maintainers:
 - Bitnami <containers@bitnami.com>

--- a/rabbitmq/manifests/rabbitmq-rc.yaml
+++ b/rabbitmq/manifests/rabbitmq-rc.yaml
@@ -25,9 +25,15 @@ spec:
         - name: RABBITMQ_USERNAME
           value: "user"
         - name: RABBITMQ_PASSWORD
-          value: "bitnami"
+          valueFrom:
+            secretKeyRef:
+              name: rabbitmq
+              key: rabbitmq-password
         - name: RABBITMQ_ERLANGCOOKIE
-          value: ""
+          valueFrom:
+            secretKeyRef:
+              name: rabbitmq
+              key: rabbitmq-erlangcookie
         - name: RABBITMQ_NODEPORT
           value: "5672"
         - name: RABBITMQ_NODETYPE

--- a/rabbitmq/manifests/rabbitmq-secrets.yaml
+++ b/rabbitmq/manifests/rabbitmq-secrets.yaml
@@ -1,0 +1,12 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/rabbitmq-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rabbitmq
+  labels:
+    provider: rabbitmq
+    heritage: bitnami
+type: Opaque
+data:
+  rabbitmq-password: "Yml0bmFtaQ=="
+  rabbitmq-erlangcookie: ""

--- a/rabbitmq/tpl/rabbitmq-rc.yaml
+++ b/rabbitmq/tpl/rabbitmq-rc.yaml
@@ -25,9 +25,15 @@ spec:
         - name: RABBITMQ_USERNAME
           value: {{ .rabbitmqUsername | quote }}
         - name: RABBITMQ_PASSWORD
-          value: {{ .rabbitmqPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: rabbitmq
+              key: rabbitmq-password
         - name: RABBITMQ_ERLANGCOOKIE
-          value: {{ .rabbitmqErlangcookie | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: rabbitmq
+              key: rabbitmq-erlangcookie
         - name: RABBITMQ_NODEPORT
           value: {{ .rabbitmqNodeport | quote }}
         - name: RABBITMQ_NODETYPE

--- a/rabbitmq/tpl/rabbitmq-secrets.yaml
+++ b/rabbitmq/tpl/rabbitmq-secrets.yaml
@@ -1,0 +1,12 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/rabbitmq-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rabbitmq
+  labels:
+    provider: rabbitmq
+    heritage: bitnami
+type: Opaque
+data:
+  rabbitmq-password: {{ .rabbitmqPassword | b64enc | quote }}
+  rabbitmq-erlangcookie: {{ .rabbitmqErlangcookie | b64enc | quote }}

--- a/redis/Chart.yaml
+++ b/redis/Chart.yaml
@@ -2,7 +2,7 @@ name: redis
 home: http://redis.io/
 source:
 - https://github.com/bitnami/bitnami-docker-redis
-version: 0.2.0
+version: 0.2.1
 description: Chart for Redis
 maintainers:
 - Bitnami <containers@bitnami.com>

--- a/redis/manifests/redis-rc.yaml
+++ b/redis/manifests/redis-rc.yaml
@@ -23,7 +23,10 @@ spec:
         image: bitnami/redis:3.2.0-r0
         env:
         - name: REDIS_PASSWORD
-          value: ""
+          valueFrom:
+            secretKeyRef:
+              name: redis
+              key: redis-password
         ports:
         - name: redis
           containerPort: 6379

--- a/redis/manifests/redis-secrets.yaml
+++ b/redis/manifests/redis-secrets.yaml
@@ -1,0 +1,11 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/redis-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis
+  labels:
+    provider: redis
+    heritage: bitnami
+type: Opaque
+data:
+  redis-password: ""

--- a/redis/tpl/redis-rc.yaml
+++ b/redis/tpl/redis-rc.yaml
@@ -23,7 +23,10 @@ spec:
         image: bitnami/redis:3.2.0-r0
         env:
         - name: REDIS_PASSWORD
-          value: {{ .redisPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: redis
+              key: redis-password
         ports:
         - name: redis
           containerPort: 6379

--- a/redis/tpl/redis-secrets.yaml
+++ b/redis/tpl/redis-secrets.yaml
@@ -1,0 +1,11 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/redis-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis
+  labels:
+    provider: redis
+    heritage: bitnami
+type: Opaque
+data:
+  redis-password: {{ .redisPassword | b64enc | quote }}

--- a/redmine/Chart.yaml
+++ b/redmine/Chart.yaml
@@ -2,12 +2,12 @@ name: redmine
 home: http://www.redmine.org/
 source:
 - https://github.com/bitnami/bitnami-docker-redmine
-version: 0.1.2
+version: 0.2.1
 description: A flexible project management web application.
 maintainers:
 - Bitnami <containers@bitnami.com>
 dependencies:
 - name: mariadb
-  version: 0.2.0
+  version: 0.2.1
 details: |-
   Redmine is a flexible project management web application written using Ruby on Rails framework.

--- a/redmine/README.md
+++ b/redmine/README.md
@@ -26,15 +26,11 @@ To edit the default Redmine configuration, run
 $ helmc edit redmine
 ```
 
-Here you can update the MariaDB root password, Redmine admin username, password, email address, language and SMTP settings in `tpl/values.toml`. When not specified, the default values are used.
+Here you can update the Redmine admin username, password, email address, language and SMTP settings in `tpl/values.toml`. When not specified, the default values are used.
 
 Refer to the [Environment variables](https://github.com/bitnami/bitnami-docker-redmine/#environment-variables) section of the [Bitnami Redmine](https://github.com/bitnami/bitnami-docker-redmine) image for the default values.
 
 The values of `redmineUser` and `redminePassword` are the login credentials when you [access the Redmine instance](#access-your-redmine-application).
-
-> Note:
->
-> If you had updated the MariaDB root password for the MariaDB deployment, then ensure you set the same password for the `mariadbRootPassword` field in the Redmine Chart.
 
 Finally, generate the chart to apply your changes to the configuration.
 

--- a/redmine/manifests/redmine-rc.yaml
+++ b/redmine/manifests/redmine-rc.yaml
@@ -30,11 +30,17 @@ spec:
         - name: MARIADB_PORT
           value: "3306"
         - name: MARIADB_PASSWORD
-          value: ""
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-root-password
         - name: REDMINE_USERNAME
           value: "user"
         - name: REDMINE_PASSWORD
-          value: "bitnami"
+          valueFrom:
+            secretKeyRef:
+              name: redmine
+              key: redmine-password
         - name: REDMINE_EMAIL
           value: "user@example.com"
         - name: REDMINE_LANG
@@ -46,7 +52,10 @@ spec:
         - name: SMTP_USER
           value: ""
         - name: SMTP_PASSWORD
-          value: ""
+          valueFrom:
+            secretKeyRef:
+              name: redmine
+              key: smtp-password
         - name: SMTP_TLS
           value: ""
         ports:

--- a/redmine/manifests/redmine-rc.yaml
+++ b/redmine/manifests/redmine-rc.yaml
@@ -12,18 +12,18 @@ spec:
   selector:
     app: redmine
     provider: redmine-server
-    version: 3.2.2-r0
+    version: 3.2.3-r0
   template:
     metadata:
       labels:
         app: redmine
         provider: redmine-server
-        version: 3.2.2-r0
+        version: 3.2.3-r0
         heritage: bitnami
     spec:
       containers:
       - name: redmine
-        image: bitnami/redmine:3.2.2-r0
+        image: bitnami/redmine:3.2.3-r0
         env:
         - name: MARIADB_HOST
           value: "mariadb"

--- a/redmine/manifests/redmine-secrets.yaml
+++ b/redmine/manifests/redmine-secrets.yaml
@@ -1,0 +1,12 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/redmine-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redmine
+  labels:
+    provider: redmine
+    heritage: bitnami
+type: Opaque
+data:
+  redmine-password: "Yml0bmFtaQ=="
+  smtp-password: ""

--- a/redmine/tpl/redmine-rc.yaml
+++ b/redmine/tpl/redmine-rc.yaml
@@ -12,18 +12,18 @@ spec:
   selector:
     app: redmine
     provider: redmine-server
-    version: 3.2.2-r0
+    version: 3.2.3-r0
   template:
     metadata:
       labels:
         app: redmine
         provider: redmine-server
-        version: 3.2.2-r0
+        version: 3.2.3-r0
         heritage: bitnami
     spec:
       containers:
       - name: redmine
-        image: bitnami/redmine:3.2.2-r0
+        image: bitnami/redmine:3.2.3-r0
         env:
         - name: MARIADB_HOST
           value: "mariadb"

--- a/redmine/tpl/redmine-rc.yaml
+++ b/redmine/tpl/redmine-rc.yaml
@@ -30,11 +30,17 @@ spec:
         - name: MARIADB_PORT
           value: "3306"
         - name: MARIADB_PASSWORD
-          value: {{ .mariadbRootPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-root-password
         - name: REDMINE_USERNAME
           value: {{ .redmineUser | quote }}
         - name: REDMINE_PASSWORD
-          value: {{ .redminePassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: redmine
+              key: redmine-password
         - name: REDMINE_EMAIL
           value: {{ .redmineEmail | quote }}
         - name: REDMINE_LANG
@@ -46,7 +52,10 @@ spec:
         - name: SMTP_USER
           value: {{ .smtpUser | quote }}
         - name: SMTP_PASSWORD
-          value: {{ .smtpPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: redmine
+              key: smtp-password
         - name: SMTP_TLS
           value: {{ .smtpTls | quote }}
         ports:

--- a/redmine/tpl/redmine-secrets.yaml
+++ b/redmine/tpl/redmine-secrets.yaml
@@ -1,0 +1,12 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/redmine-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redmine
+  labels:
+    provider: redmine
+    heritage: bitnami
+type: Opaque
+data:
+  redmine-password: {{ .redminePassword | b64enc | quote }}
+  smtp-password: {{ .smtpPassword | b64enc | quote }}

--- a/redmine/tpl/values.toml
+++ b/redmine/tpl/values.toml
@@ -1,4 +1,3 @@
-mariadbRootPassword = ""
 redmineUser = "user"
 redminePassword = "bitnami"
 redmineEmail = "user@example.com"

--- a/testlink/Chart.yaml
+++ b/testlink/Chart.yaml
@@ -2,12 +2,12 @@ name: testlink
 home: http://www.testlink.org/
 source:
 - https://github.com/bitnami/bitnami-docker-testlink
-version: 0.2.0
+version: 0.2.1
 description: Web-based test management system that facilitates software quality assurance. 
 maintainers:
 - Bitnami <containers@bitnami.com>
 dependencies:
 - name: mariadb
-  version: 0.2.0
+  version: 0.2.1
 details: |-
   TestLink is a web-based test management system that facilitates software quality assurance. 

--- a/testlink/README.md
+++ b/testlink/README.md
@@ -26,15 +26,11 @@ To edit the default Testlink configuration, run
 $ helmc edit testlink
 ```
 
-Here you can update the MariaDB root password, Testlink admin username, password and email address in `tpl/values.toml`. When not specified, the default values are used.
+Here you can update the Testlink admin username, password and email address in `tpl/values.toml`. When not specified, the default values are used.
 
 Refer to the [Environment variables](https://github.com/bitnami/bitnami-docker-testlink/#environment-variables) section of the [Bitnami Testlink](https://github.com/bitnami/bitnami-docker-testlink) image for the default values.
 
 The values of `testlinkUser` and `testlinkPassword` are the login credentials when you [access the Testlink instance](#access-your-testlink-application).
-
-> Note:
->
-> If you had updated the MariaDB root password for the MariaDB deployment, then ensure you set the same password for the `mariadbRootPassword` field in the Testlink Chart.
 
 Finally, generate the chart to apply your changes to the configuration.
 

--- a/testlink/manifests/testlink-rc.yaml
+++ b/testlink/manifests/testlink-rc.yaml
@@ -30,11 +30,17 @@ spec:
         - name: MARIADB_PORT
           value: "3306"
         - name: MARIADB_PASSWORD
-          value: ""
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-root-password
         - name: TESTLINK_USERNAME
           value: "user"
         - name: TESTLINK_PASSWORD
-          value: "bitnami"
+          valueFrom:
+            secretKeyRef:
+              name: testlink
+              key: testlink-password
         - name: TESTLINK_EMAIL
           value: "user@example.com"
         - name: TESTLINK_LANGUAGE
@@ -50,7 +56,10 @@ spec:
         - name: SMTP_USER
           value: ""
         - name: SMTP_PASSWORD
-          value: ""
+          valueFrom:
+            secretKeyRef:
+              name: testlink
+              key: smtp-password
         - name: SMTP_PROTOCOL
           value: ""
         ports:

--- a/testlink/manifests/testlink-secrets.yaml
+++ b/testlink/manifests/testlink-secrets.yaml
@@ -1,0 +1,12 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/testlink-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: testlink
+  labels:
+    provider: testlink
+    heritage: bitnami
+type: Opaque
+data:
+  testlink-password: "Yml0bmFtaQ=="
+  smtp-password: ""

--- a/testlink/tpl/testlink-rc.yaml
+++ b/testlink/tpl/testlink-rc.yaml
@@ -30,11 +30,17 @@ spec:
         - name: MARIADB_PORT
           value: "3306"
         - name: MARIADB_PASSWORD
-          value: {{ .mariadbRootPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: mariadb-root-password
         - name: TESTLINK_USERNAME
           value: {{ .testlinkUsername | quote }}
         - name: TESTLINK_PASSWORD
-          value: {{ .testlinkPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: testlink
+              key: testlink-password
         - name: TESTLINK_EMAIL
           value: {{ .testlinkEmail | quote }}
         - name: TESTLINK_LANGUAGE
@@ -46,11 +52,14 @@ spec:
         - name: SMTP_HOST
           value: {{ .smtpHost | quote }}
         - name: SMTP_PORT
-          value: {{ .smtpUser | quote }}
-        - name: SMTP_USER
-          value: {{ .smtpPassword | quote }}
-        - name: SMTP_PASSWORD
           value: {{ .smtpPort | quote }}
+        - name: SMTP_USER
+          value: {{ .smtpUser | quote }}
+        - name: SMTP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: testlink
+              key: smtp-password
         - name: SMTP_PROTOCOL
           value: {{ .smtpProtocol | quote }}
         ports:

--- a/testlink/tpl/testlink-secrets.yaml
+++ b/testlink/tpl/testlink-secrets.yaml
@@ -1,0 +1,12 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/testlink-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: testlink
+  labels:
+    provider: testlink
+    heritage: bitnami
+type: Opaque
+data:
+  testlink-password: {{ .testlinkPassword | b64enc | quote }}
+  smtp-password: {{ .smtpPassword | b64enc | quote }}

--- a/testlink/tpl/values.toml
+++ b/testlink/tpl/values.toml
@@ -1,4 +1,3 @@
-mariadbRootPassword = ""
 testlinkUsername = "user"
 testlinkPassword = "bitnami"
 testlinkEmail = "user@example.com"

--- a/tomcat/Chart.yaml
+++ b/tomcat/Chart.yaml
@@ -2,7 +2,7 @@ name: tomcat
 home: http://tomcat.apache.org
 source:
 - https://github.com/bitnami/bitnami-docker-tomcat
-version: 0.2.0
+version: 0.2.1
 description: Chart for Apache Tomcat
 maintainers:
 - Bitnami <containers@bitnami.com>

--- a/tomcat/manifests/tomcat-rc.yaml
+++ b/tomcat/manifests/tomcat-rc.yaml
@@ -25,7 +25,10 @@ spec:
         - name: TOMCAT_USER
           value: "user"
         - name: TOMCAT_PASSWORD
-          value: ""
+          valueFrom:
+            secretKeyRef:
+              name: tomcat
+              key: tomcat-password
         ports:
         - name: http
           containerPort: 8080

--- a/tomcat/manifests/tomcat-secrets.yaml
+++ b/tomcat/manifests/tomcat-secrets.yaml
@@ -1,0 +1,11 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/tomcat-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tomcat
+  labels:
+    provider: tomcat
+    heritage: bitnami
+type: Opaque
+data:
+  tomcat-password: ""

--- a/tomcat/tpl/tomcat-rc.yaml
+++ b/tomcat/tpl/tomcat-rc.yaml
@@ -25,7 +25,10 @@ spec:
         - name: TOMCAT_USER
           value: {{ .tomcatUser | quote }}
         - name: TOMCAT_PASSWORD
-          value: {{ .tomcatPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: tomcat
+              key: tomcat-password
         ports:
         - name: http
           containerPort: 8080

--- a/tomcat/tpl/tomcat-secrets.yaml
+++ b/tomcat/tpl/tomcat-secrets.yaml
@@ -1,0 +1,11 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/tomcat-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tomcat
+  labels:
+    provider: tomcat
+    heritage: bitnami
+type: Opaque
+data:
+  tomcat-password: {{ .tomcatPassword | b64enc | quote }}

--- a/wildfly/Chart.yaml
+++ b/wildfly/Chart.yaml
@@ -2,7 +2,7 @@ name: wildfly
 home: http://wildfly.org
 source:
 - https://github.com/bitnami/bitnami-docker-wildfly
-version: 0.2.0
+version: 0.2.1
 description: Chart for Wildfly
 maintainers:
 - Bitnami <containers@bitnami.com>

--- a/wildfly/manifests/wildfly-rc.yaml
+++ b/wildfly/manifests/wildfly-rc.yaml
@@ -25,7 +25,10 @@ spec:
         - name: WILDFLY_USER
           value: "user"
         - name: WILDFLY_PASSWORD
-          value: "password"
+          valueFrom:
+            secretKeyRef:
+              name: wildfly
+              key: wildfly-password
         ports:
         - name: http
           containerPort: 8080

--- a/wildfly/manifests/wildfly-secrets.yaml
+++ b/wildfly/manifests/wildfly-secrets.yaml
@@ -1,0 +1,11 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/wildfly-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wildfly
+  labels:
+    provider: wildfly
+    heritage: bitnami
+type: Opaque
+data:
+  wildfly-password: "cGFzc3dvcmQ="

--- a/wildfly/tpl/wildfly-rc.yaml
+++ b/wildfly/tpl/wildfly-rc.yaml
@@ -25,7 +25,10 @@ spec:
         - name: WILDFLY_USER
           value: {{ .wildflyUser | quote }}
         - name: WILDFLY_PASSWORD
-          value: {{ .wildflyPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: wildfly
+              key: wildfly-password
         ports:
         - name: http
           containerPort: 8080

--- a/wildfly/tpl/wildfly-secrets.yaml
+++ b/wildfly/tpl/wildfly-secrets.yaml
@@ -1,0 +1,11 @@
+#helm:generate helmc tpl -d tpl/values.toml -o manifests/wildfly-secrets.yaml $HELM_GENERATE_FILE
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wildfly
+  labels:
+    provider: wildfly
+    heritage: bitnami
+type: Opaque
+data:
+  wildfly-password: {{ .wildflyPassword | b64enc | quote }}


### PR DESCRIPTION
This PR adds Secret volumes in the charts to store sensitive information such as database passwords, user account passwords, smtp password, etc.

The secrets are consumed as environment variables in the RC manifests without the need of mounting the secret volume in the Pod.

Additionally, since values stored in the secret volumes can be accessed my any Pod in the same namespace, we use it in the application charts to fetch the database credentials and thereby removed the need update the database credentials in the application charts. f.e. in https://github.com/sameersbn/charts/blob/7179f88a5361a192879f94ec34d49352bd5838ac/drupal/manifests/drupal-rc.yaml#L32-L36, the value for `MARIADB_PASSWORD` is fetched from the `mariadb` secret volume in the drupal RC manifest.