### PR TITLE
Fix WordPress env vars matching

### DIFF
--- a/wordpress/templates/deployment.yaml
+++ b/wordpress/templates/deployment.yaml
@@ -40,11 +40,11 @@ spec:
               key: wordpress-password
         - name: WORDPRESS_EMAIL
           value: {{ default "" .Values.wordpressEmail | quote }}
-        - name: WORDPRESS_FIRSTNAME
+        - name: WORDPRESS_FIRST_NAME
           value: {{ default "" .Values.wordpressFirstName | quote }}
-        - name: WORDPRESS_LASTNAME
+        - name: WORDPRESS_LAST_NAME
           value: {{ default "" .Values.wordpressLastName | quote }}
-        - name: WORDPRESS_BLOGNAME
+        - name: WORDPRESS_BLOG_NAME
           value: {{ default "" .Values.wordpressBlogName | quote }}
         - name: SMTP_HOST
           value: {{ default "" .Values.smtpHost | quote }}

--- a/wordpress/values.yaml
+++ b/wordpress/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Wordpress image version
 ## ref: https://hub.docker.com/r/bitnami/wordpress/tags/
 ##
-imageTag: 4.6-r0
+imageTag: 4.6-r1
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if imageTag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
This PR should be merged AFTER changes in https://github.com/bitnami/bitnami-docker-wordpress/pull/25 are merged (and image build is triggered in Docker Hub)