### PR TITLE
Add PVC (alpha) support to WordPress

### DIFF
--- a/wordpress/charts/mariadb/templates/deployment.yaml
+++ b/wordpress/charts/mariadb/templates/deployment.yaml
@@ -57,4 +57,9 @@ spec:
           mountPath: /bitnami/mariadb
       volumes:
       - name: data
+      {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ template "fullname" . }}
+      {{- else }}
         emptyDir: {}
+      {{- end -}}

--- a/wordpress/charts/mariadb/templates/pvc.yaml
+++ b/wordpress/charts/mariadb/templates/pvc.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.persistence.enabled -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}
+  annotations:
+    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end -}}

--- a/wordpress/charts/mariadb/values.yaml
+++ b/wordpress/charts/mariadb/values.yaml
@@ -25,3 +25,12 @@ imageTag: 10.1.14-r3
 ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
 ##
 # mariadbDatabase:
+
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  enabled: true
+  storageClass: generic
+  accessMode: ReadWriteOnce
+  size: 8Gi

--- a/wordpress/templates/apache-pvc.yaml
+++ b/wordpress/templates/apache-pvc.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.persistence.enabled -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}-apache
+  annotations:
+    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.apache.storageClass | quote }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.apache.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.apache.size | quote }}
+{{- end -}}

--- a/wordpress/templates/deployment.yaml
+++ b/wordpress/templates/deployment.yaml
@@ -85,6 +85,16 @@ spec:
           mountPath: /bitnami/apache
       volumes:
       - name: wordpress-data
+      {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ template "fullname" . }}-wordpress
+      {{- else }}
         emptyDir: {}
+      {{- end }}
       - name: apache-data
+      {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ template "fullname" . }}-apache
+      {{- else }}
         emptyDir: {}
+      {{- end }}

--- a/wordpress/templates/wordpress-pvc.yaml
+++ b/wordpress/templates/wordpress-pvc.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.persistence.enabled -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}-wordpress
+  annotations:
+    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.wordpress.storageClass | quote }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.wordpress.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.wordpress.size | quote }}
+{{- end -}}

--- a/wordpress/values.yaml
+++ b/wordpress/values.yaml
@@ -52,13 +52,36 @@ wordpressBlogName: User's Blog!
 ##
 ## MariaDB chart configuration
 ##
-# mariadb:
+mariadb:
   ## MariaDB admin password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
   ##
   # mariadbRootPassword:
 
+  ## Enable persistence using Persistent Volume Claims
+  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  ##
+  persistence:
+    enabled: true
+    storageClass: generic
+    accessMode: ReadWriteOnce
+    size: 8Gi
+
 ## Kubernetes configuration
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer
 ##
 serviceType: LoadBalancer
+
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  enabled: true
+  apache:
+    storageClass: generic
+    accessMode: ReadWriteOnce
+    size: 1Gi
+  wordpress:
+    storageClass: generic
+    accessMode: ReadWriteOnce
+    size: 8Gi


### PR DESCRIPTION
Adds persistence by default support to WordPress and the dependent MariaDB chart.

Persistence by default is achieved using Persistent Volume Claims and the alpha PVC provisioning feature in Kubernetes 1.3+(https://github.com/kubernetes/kubernetes/tree/master/examples/experimental/persistent-volume-provisioning).