### PR TITLE
Add persistence to Redmine chart

### DIFF
--- a/redmine/charts/mariadb/templates/deployment.yaml
+++ b/redmine/charts/mariadb/templates/deployment.yaml
@@ -57,4 +57,9 @@ spec:
           mountPath: /bitnami/mariadb
       volumes:
       - name: data
+      {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ template "fullname" . }}
+      {{- else }}
         emptyDir: {}
+      {{- end -}}

--- a/redmine/charts/mariadb/templates/pvc.yaml
+++ b/redmine/charts/mariadb/templates/pvc.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.persistence.enabled -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}
+  annotations:
+    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end -}}

--- a/redmine/charts/mariadb/values.yaml
+++ b/redmine/charts/mariadb/values.yaml
@@ -25,3 +25,12 @@ imageTag: 10.1.14-r3
 ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
 ##
 # mariadbDatabase:
+
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  enabled: true
+  storageClass: generic
+  accessMode: ReadWriteOnce
+  size: 8Gi

--- a/redmine/templates/deployment.yaml
+++ b/redmine/templates/deployment.yaml
@@ -75,4 +75,9 @@ spec:
           mountPath: /bitnami/redmine
       volumes:
       - name: redmine-data
+      {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ template "fullname" . }}
+      {{- else }}
         emptyDir: {}
+      {{- end -}}

--- a/redmine/templates/pvc.yaml
+++ b/redmine/templates/pvc.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.persistence.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}
+  annotations:
+    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end }}

--- a/redmine/values.yaml
+++ b/redmine/values.yaml
@@ -41,13 +41,31 @@ redmineLanguage: en
 ##
 ## MariaDB chart configuration
 ##
-# mariadb:
+mariadb:
   ## MariaDB admin password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
   ##
   # mariadbRootPassword:
 
+  ## Enable persistence using Persistent Volume Claims
+  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  ##
+  persistence:
+    enabled: true
+    storageClass: generic
+    accessMode: ReadWriteOnce
+    size: 8Gi
+
 ## Kubernetes configuration
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer
 ##
 serviceType: LoadBalancer
+
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  enabled: true
+  storageClass: generic
+  accessMode: ReadWriteOnce
+  size: 8Gi


### PR DESCRIPTION
Adds persistence by default support to Redmine and the dependent MariaDB chart.

Persistence by default is achieved using Persistent Volume Claims and the alpha PVC provisioning feature in Kubernetes 1.3+(https://github.com/kubernetes/kubernetes/tree/master/examples/experimental/persistent-volume-provisioning).