### PR TITLE
Add persistence to Drupal chart

### DIFF
--- a/drupal/charts/mariadb/templates/deployment.yaml
+++ b/drupal/charts/mariadb/templates/deployment.yaml
@@ -57,4 +57,9 @@ spec:
           mountPath: /bitnami/mariadb
       volumes:
       - name: data
+      {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ template "fullname" . }}
+      {{- else }}
         emptyDir: {}
+      {{- end -}}

--- a/drupal/charts/mariadb/templates/pvc.yaml
+++ b/drupal/charts/mariadb/templates/pvc.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.persistence.enabled -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}
+  annotations:
+    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end -}}

--- a/drupal/charts/mariadb/values.yaml
+++ b/drupal/charts/mariadb/values.yaml
@@ -25,3 +25,12 @@ imageTag: 10.1.14-r3
 ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
 ##
 # mariadbDatabase:
+
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  enabled: true
+  storageClass: generic
+  accessMode: ReadWriteOnce
+  size: 8Gi

--- a/drupal/templates/apache-pvc.yaml
+++ b/drupal/templates/apache-pvc.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.persistence.enabled -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}-apache
+  annotations:
+    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.apache.storageClass | quote }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.apache.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.apache.size | quote }}
+{{- end -}}

--- a/drupal/templates/deployment.yaml
+++ b/drupal/templates/deployment.yaml
@@ -64,6 +64,16 @@ spec:
           mountPath: /bitnami/apache
       volumes:
       - name: drupal-data
+      {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ template "fullname" . }}-drupal
+      {{- else }}
         emptyDir: {}
+      {{- end }}
       - name: apache-data
+      {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ template "fullname" . }}-apache
+      {{- else }}
         emptyDir: {}
+      {{- end }}

--- a/drupal/templates/drupal-pvc.yaml
+++ b/drupal/templates/drupal-pvc.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.persistence.enabled -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}-drupal
+  annotations:
+    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.drupal.storageClass | quote }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.drupal.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.drupal.size | quote }}
+{{- end -}}

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -27,13 +27,36 @@ drupalEmail: user@example.com
 ##
 ## MariaDB chart configuration
 ##
-# mariadb:
+mariadb:
   ## MariaDB admin password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
   ##
   # mariadbRootPassword:
 
+  ## Enable persistence using Persistent Volume Claims
+  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  ##
+  persistence:
+    enabled: true
+    storageClass: generic
+    accessMode: ReadWriteOnce
+    size: 8Gi
+
 ## Kubernetes configuration
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer
 ##
 serviceType: LoadBalancer
+
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  enabled: true
+  apache:
+    storageClass: generic
+    accessMode: ReadWriteOnce
+    size: 1Gi
+  drupal:
+    storageClass: generic
+    accessMode: ReadWriteOnce
+    size: 8Gi


### PR DESCRIPTION
Adds persistence by default support to Drupal and the dependent MariaDB chart.

Persistence by default is achieved using Persistent Volume Claims and the alpha PVC provisioning feature in Kubernetes 1.3+(https://github.com/kubernetes/kubernetes/tree/master/examples/experimental/persistent-volume-provisioning).