### PR TITLE
README, NOTES.txt, values.yaml updates and fixes

### DIFF
--- a/drupal/README.md
+++ b/drupal/README.md
@@ -14,6 +14,11 @@ This chart bootstraps a [Drupal](https://github.com/bitnami/bitnami-docker-drupa
 
 It also packages the Bitnami MariaDB chart which is required for bootstrapping a MariaDB deployment for the database requirements of the Drupal application.
 
+## Prerequisites
+
+- Kubernetes 1.3+ with Alpha APIs enabled
+- PV provisioner support in the underlying infrastructure
+
 ## Get this chart
 
 Download the latest release of the chart from the [releases](../../../releases) page.

--- a/drupal/README.md
+++ b/drupal/README.md
@@ -54,9 +54,8 @@ The following tables lists the configurable parameters of the Drupal chart and t
 
 | Parameter                       | Description                  | Default                                                   |
 | ------------------------------- | ---------------------------- | --------------------------------------------------------- |
-| `image.repo`                    | Drupal image repo            | `bitnami/drupal`                                          |
-| `image.tag`                     | Drupal image tag             | Bitnami Drupal image version                              |
-| `image.pullPolicy`              | Image pull policy            | `Always` if `image.tag` is `latest`, else `IfNotPresent`  |
+| `image`                         | Drupal image                 | `bitnami/drupal:{VERSION}`                                |
+| `imagePullPolicy`               | Image pull policy            | `Always` if `image` tag is `latest`, else `IfNotPresent`  |
 | `drupalUsername`                | User of the application      | `user`                                                    |
 | `drupalPassword`                | Application password         | `bitnami`                                                 |
 | `drupalEmail`                   | Admin email                  | `user@example.com`                                        |

--- a/drupal/README.md
+++ b/drupal/README.md
@@ -52,19 +52,22 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the Drupal chart and their default values.
 
-| Parameter                       | Description                  | Default                                                   |
-| ------------------------------- | ---------------------------- | --------------------------------------------------------- |
-| `image`                         | Drupal image                 | `bitnami/drupal:{VERSION}`                                |
-| `imagePullPolicy`               | Image pull policy            | `Always` if `image` tag is `latest`, else `IfNotPresent`  |
-| `drupalUsername`                | User of the application      | `user`                                                    |
-| `drupalPassword`                | Application password         | `bitnami`                                                 |
-| `drupalEmail`                   | Admin email                  | `user@example.com`                                        |
-| `mariadb.mariadbRootPassword`   | MariaDB admin password       | `nil`                                                     |
-| `serviceType`                   | Kubernetes Service type      | `LoadBalancer`                                            |
-| `persistence.enabled`           | Enable persistence using PVC | `true`                                                    |
-| `persistence.storageClass`      | PVC Storage Class            | `generic`                                                 |
-| `persistence.accessMode`        | PVC Access Mode              | `ReadWriteOnce`                                           |
-| `persistence.size`              | PVC Storage Request          | `8Gi`                                                     |
+| Parameter                         | Description                           | Default                                                   |
+| -------------------------------   | ----------------------------          | --------------------------------------------------------- |
+| `image`                           | Drupal image                          | `bitnami/drupal:{VERSION}`                                |
+| `imagePullPolicy`                 | Image pull policy                     | `Always` if `image` tag is `latest`, else `IfNotPresent`  |
+| `drupalUsername`                  | User of the application               | `user`                                                    |
+| `drupalPassword`                  | Application password                  | `bitnami`                                                 |
+| `drupalEmail`                     | Admin email                           | `user@example.com`                                        |
+| `mariadb.mariadbRootPassword`     | MariaDB admin password                | `nil`                                                     |
+| `serviceType`                     | Kubernetes Service type               | `LoadBalancer`                                            |
+| `persistence.enabled`             | Enable persistence using PVC          | `true`                                                    |
+| `persistence.apache.storageClass` | PVC Storage Class for Apache volume   | `generic`                                                 |
+| `persistence.apache.accessMode`   | PVC Access Mode for Apache volume     | `ReadWriteOnce`                                           |
+| `persistence.apache.size`         | PVC Storage Request for Apache volume | `1Gi`                                                     |
+| `persistence.drupal.storageClass` | PVC Storage Class for Drupal volume   | `generic`                                                 |
+| `persistence.drupal.accessMode`   | PVC Access Mode for Drupal volume     | `ReadWriteOnce`                                           |
+| `persistence.drupal.size`         | PVC Storage Request for Drupal volume | `8Gi`                                                     |
 
 The above parameters map to the env variables defined in [bitnami/drupal](http://github.com/bitnami/bitnami-docker-drupal). For more information please refer to the [bitnami/drupal](http://github.com/bitnami/bitnami-docker-drupal) image documentation.
 

--- a/drupal/templates/NOTES.txt
+++ b/drupal/templates/NOTES.txt
@@ -1,22 +1,26 @@
-1. Get the Drupal login URL running these commands in the same shell:
+1. Get the Drupal URL by running:
 
 {{- if contains "NodePort" .Values.serviceType }}
 
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
+  echo http://$NODE_IP:$NODE_PORT/
 
 {{- else if contains "LoadBalancer" .Values.serviceType }}
 
-**** NOTE: It may take a few minutes for the LoadBalancer IP to be available.                      ****
-****       You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}' ****
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc -w {{ template "fullname" . }}'
 
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP
+  echo http://$SERVICE_IP/
 {{- else if contains "ClusterIP"  .Values.serviceType }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "component={{ template "fullname" . }}-master" -o jsonpath="{.items[0].metadata.name}")
-  echo http://127.0.0.1
-  kubectl port-forward $POD_NAME 80:80
+
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+  echo http://127.0.0.1:8080/
+  kubectl port-forward $POD_NAME 8080:80
 {{- end }}
 
-2. Login with the Username "{{ .Values.drupalUser }}" and password "{{ .Values.drupalPassword }}"
+2. Login with the following credentials
+
+  Username: {{ .Values.drupalUsername }}
+  Password: {{ .Values.drupalPassword }}

--- a/drupal/templates/deployment.yaml
+++ b/drupal/templates/deployment.yaml
@@ -19,8 +19,8 @@ spec:
     spec:
       containers:
       - name: {{ template "fullname" . }}
-        image: "bitnami/drupal:{{ .Values.imageTag }}"
-        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+        image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ default "" .Values.image.pullPolicy | quote }}
         env:
         - name: MARIADB_HOST
           value: {{ template "mariadb.fullname" . }}
@@ -32,7 +32,7 @@ spec:
               name: {{ template "mariadb.fullname" . }}
               key: mariadb-root-password
         - name: DRUPAL_USERNAME
-          value: {{ default "" .Values.drupalUser | quote }}
+          value: {{ default "" .Values.drupalUsername | quote }}
         - name: DRUPAL_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/drupal/templates/deployment.yaml
+++ b/drupal/templates/deployment.yaml
@@ -19,8 +19,8 @@ spec:
     spec:
       containers:
       - name: {{ template "fullname" . }}
-        image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
-        imagePullPolicy: {{ default "" .Values.image.pullPolicy | quote }}
+        image: "{{ .Values.image }}"
+        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         env:
         - name: MARIADB_HOST
           value: {{ template "mariadb.fullname" . }}

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -1,7 +1,15 @@
 ## Bitnami Drupal image version
 ## ref: https://hub.docker.com/r/bitnami/drupal/tags/
 ##
-imageTag: 8.1.9-r0
+image:
+  repo: bitnami/drupal
+  tag: 8.1.9-r0
+
+  ## Specify a imagePullPolicy
+  ## Defaults to 'Always' if image.tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  # pullPolicy:
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
@@ -12,7 +20,7 @@ imageTag: 8.1.9-r0
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-drupal#configuration
 ##
-drupalUser: user
+drupalUsername: user
 
 ## Application password
 ## ref: https://github.com/bitnami/bitnami-docker-drupal#configuration

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -1,18 +1,10 @@
 ## Bitnami Drupal image version
 ## ref: https://hub.docker.com/r/bitnami/drupal/tags/
 ##
-image:
-  repo: bitnami/drupal
-  tag: 8.1.9-r0
-
-  ## Specify a imagePullPolicy
-  ## Defaults to 'Always' if image.tag is 'latest', else set to 'IfNotPresent'
-  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-  ##
-  # pullPolicy:
+image: bitnami/drupal:8.1.9-r0
 
 ## Specify a imagePullPolicy
-## Defaults to 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
+## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
 ##
 # imagePullPolicy:

--- a/redmine/README.md
+++ b/redmine/README.md
@@ -54,9 +54,8 @@ The following tables lists the configurable parameters of the Redmine chart and 
 
 | Parameter                       | Description                     | Default                                                   |
 | ------------------------------- | ------------------------------- | --------------------------------------------------------- |
-| `image.repo`                    | Redmine image repo              | `bitnami/redmine`                                         |
-| `image.tag`                     | Redmine image tag               | Bitnami Redmine image version                             |
-| `image.pullPolicy`              | Image pull policy               | `Always` if `image.tag` is `latest`, else `IfNotPresent`  |
+| `image`                         | Redmine image                   | `bitnami/redmine:{VERSION}`                               |
+| `imagePullPolicy`               | Image pull policy               | `Always` if `image` tag is `latest`, else `IfNotPresent`  |
 | `redmineUsername`               | User of the application         | `user`                                                    |
 | `redminePassword`               | Application password            | `bitnami`                                                 |
 | `redmineEmail`                  | Admin email                     | `user@example.com`                                        |

--- a/redmine/README.md
+++ b/redmine/README.md
@@ -14,6 +14,11 @@ This chart bootstraps a [Redmine](https://github.com/bitnami/bitnami-docker-redm
 
 It also packages the Bitnami MariaDB chart which is required for bootstrapping a MariaDB deployment for the database requirements of the Redmine application.
 
+## Prerequisites
+
+- Kubernetes 1.3+ with Alpha APIs enabled
+- PV provisioner support in the underlying infrastructure
+
 ## Get this chart
 
 Download the latest release of the chart from the [releases](../../../releases) page.

--- a/redmine/README.md
+++ b/redmine/README.md
@@ -52,21 +52,26 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the Redmine chart and their default values.
 
-|           Parameter           |          Description          |                         Default                         |
-|-------------------------------|-------------------------------|---------------------------------------------------------|
-| `imageTag`                    | `bitnami/redmine` image tag   | Redmine image version                                   |
-| `imagePullPolicy`             | Image pull policy             | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
-| `redmineUser`                 | User of the application       | `user`                                                  |
-| `redminePassword`             | Application password          | `bitnami`                                               |
-| `redmineEmail`                | Admin email                   | `user@example.com`                                      |
-| `redmineLanguage`             | Redmine default data language | `en`                                                    |
-| `smtpHost`                    | SMTP host                     | `nil`                                                   |
-| `smtpPort`                    | SMTP port                     | `nil`                                                   |
-| `smtpUser`                    | SMTP user                     | `nil`                                                   |
-| `smtpPassword`                | SMTP password                 | `nil`                                                   |
-| `smtpTls`                     | Use TLS encryption with SMTP  | `nil`                                                   |
-| `mariadb.mariadbRootPassword` | MariaDB admin password        | `nil`                                                   |
-| `serviceType`                 | Kubernetes Service type       | `LoadBalancer`                                           |
+| Parameter                       | Description                     | Default                                                   |
+| ------------------------------- | ------------------------------- | --------------------------------------------------------- |
+| `image.repo`                    | Redmine image repo              | `bitnami/redmine`                                         |
+| `image.tag`                     | Redmine image tag               | Bitnami Redmine image version                             |
+| `image.pullPolicy`              | Image pull policy               | `Always` if `image.tag` is `latest`, else `IfNotPresent`  |
+| `redmineUsername`               | User of the application         | `user`                                                    |
+| `redminePassword`               | Application password            | `bitnami`                                                 |
+| `redmineEmail`                  | Admin email                     | `user@example.com`                                        |
+| `redmineLanguage`               | Redmine default data language   | `en`                                                      |
+| `smtpHost`                      | SMTP host                       | `nil`                                                     |
+| `smtpPort`                      | SMTP port                       | `nil`                                                     |
+| `smtpUser`                      | SMTP user                       | `nil`                                                     |
+| `smtpPassword`                  | SMTP password                   | `nil`                                                     |
+| `smtpTls`                       | Use TLS encryption with SMTP    | `nil`                                                     |
+| `mariadb.mariadbRootPassword`   | MariaDB admin password          | `nil`                                                     |
+| `serviceType`                   | Kubernetes Service type         | `LoadBalancer`                                            |
+| `persistence.enabled`           | Enable persistence using PVC    | `true`                                                    |
+| `persistence.storageClass`      | PVC Storage Class               | `generic`                                                 |
+| `persistence.accessMode`        | PVC Access Mode                 | `ReadWriteOnce`                                           |
+| `persistence.size`              | PVC Storage Request             | `8Gi`                                                     |
 
 The above parameters map to the env variables defined in [bitnami/redmine](http://github.com/bitnami/bitnami-docker-redmine). For more information please refer to the [bitnami/redmine](http://github.com/bitnami/bitnami-docker-redmine) image documentation.
 
@@ -74,7 +79,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 
 ```bash
 $ helm install --name my-release \
-  --set redmineUser=admin,redminePassword=password,mariadb.mariadbRootPassword=secretpassword \
+  --set redmineUsername=admin,redminePassword=password,mariadb.mariadbRootPassword=secretpassword \
     redmine-x.x.x.tgz
 ```
 
@@ -92,42 +97,5 @@ $ helm install --name my-release -f values.yaml redmine-x.x.x.tgz
 
 The [Bitnami Redmine](https://github.com/bitnami/bitnami-docker-redmine) image stores the Redmine data and configurations at the `/bitnami/redmine` path of the container.
 
-As a placeholder, the chart mounts an [emptyDir](http://kubernetes.io/docs/user-guide/volumes/#emptydir) volume at this location.
-
-> *"An emptyDir volume is first created when a Pod is assigned to a Node, and exists as long as that Pod is running on that node. When a Pod is removed from a node for any reason, the data in the emptyDir is deleted forever."*
-
-For persistence of the data you should replace the `emptyDir` volume with a persistent [storage volume](http://kubernetes.io/docs/user-guide/volumes/), else the data will be lost if the Pod is shutdown.
-
-### Step 1: Create a persistent disk
-
-You first need to create a persistent disk in the cloud platform your cluster is running. For example, on GCE you can use the `gcloud` tool to create a [gcePersistentDisk](http://kubernetes.io/docs/user-guide/volumes/#gcepersistentdisk):
-
-```bash
-$ gcloud compute disks create --size=500GB --zone=us-central1-a redmine-data-disk
-```
-
-### Step 2: Update `templates/deployment.yaml`
-
-Replace:
-
-```yaml
-      volumes:
-      - name: redmine-data
-        emptyDir: {}
-```
-
-with
-
-```yaml
-      volumes:
-      - name: redmine-data
-        gcePersistentDisk:
-          pdName: redmine-data-disk
-          fsType: ext4
-```
-
-> **Note**:
->
-> You should also use a persistent storage volume for the MariaDB deployment.
-
-[Install](#installing-the-chart) the chart after making these changes.
+Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
+See the [Configuration](#configuration) section to configure the PVC or to disable persistence.

--- a/redmine/templates/NOTES.txt
+++ b/redmine/templates/NOTES.txt
@@ -1,22 +1,26 @@
-1. Get the Redmine login URL running these commands in the same shell:
+1. Get the Redmine URL by running:
 
 {{- if contains "NodePort" .Values.serviceType }}
 
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT/admin
+  echo http://$NODE_IP:$NODE_PORT/
 
 {{- else if contains "LoadBalancer" .Values.serviceType }}
 
-**** NOTE: It may take a few minutes for the LoadBalancer IP to be available.                      ****
-****       You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}' ****
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc -w {{ template "fullname" . }}'
 
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP/admin
-{{- else if contains "ClusterIP"  .Values.serviceType }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "component={{ template "fullname" . }}-master" -o jsonpath="{.items[0].metadata.name}")
-  echo http://127.0.0.1/admin
-  kubectl port-forward $POD_NAME 80:80
+  echo http://$SERVICE_IP/
+{{- else if contains "ClusterIP" .Values.serviceType }}
+
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+  echo http://127.0.0.1:3000/
+  kubectl port-forward $POD_NAME 3000:3000
 {{- end }}
 
-2. Login with the Username "{{ .Values.redmineUser }}" and password "{{ .Values.redminePassword }}"
+2. Login with the following credentials
+
+  Username: {{ .Values.redmineUsername }}
+  Password: {{ .Values.redminePassword }}

--- a/redmine/templates/deployment.yaml
+++ b/redmine/templates/deployment.yaml
@@ -19,8 +19,8 @@ spec:
     spec:
       containers:
       - name: {{ template "fullname" . }}
-        image: "bitnami/redmine:{{ .Values.imageTag }}"
-        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+        image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ default "" .Values.image.pullPolicy | quote }}
         env:
         - name: MARIADB_HOST
           value: {{ template "mariadb.fullname" . }}
@@ -32,7 +32,7 @@ spec:
               name: {{ template "mariadb.fullname" . }}
               key: mariadb-root-password
         - name: REDMINE_USERNAME
-          value: {{ default "" .Values.redmineUser | quote }}
+          value: {{ default "" .Values.redmineUsername | quote }}
         - name: REDMINE_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/redmine/templates/deployment.yaml
+++ b/redmine/templates/deployment.yaml
@@ -19,8 +19,8 @@ spec:
     spec:
       containers:
       - name: {{ template "fullname" . }}
-        image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
-        imagePullPolicy: {{ default "" .Values.image.pullPolicy | quote }}
+        image: "{{ .Values.image }}"
+        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         env:
         - name: MARIADB_HOST
           value: {{ template "mariadb.fullname" . }}

--- a/redmine/values.yaml
+++ b/redmine/values.yaml
@@ -1,18 +1,20 @@
 ## Bitnami Redmine image version
 ## ref: https://hub.docker.com/r/bitnami/redmine/tags/
 ##
-imageTag: 3.3.0-r2
+image:
+  repo: bitnami/redmine
+  tag: 3.3.0-r2
 
-## Specify a imagePullPolicy
-## Defaults to 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
-## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-##
-# imagePullPolicy:
+  ## Specify a imagePullPolicy
+  ## Defaults to 'Always' if image.tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  # pullPolicy:
 
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-redmine/#environment-variables
 ##
-redmineUser: user
+redmineUsername: user
 
 ## Application password
 ## ref: https://github.com/bitnami/bitnami-docker-redmine/#environment-variables

--- a/redmine/values.yaml
+++ b/redmine/values.yaml
@@ -1,15 +1,13 @@
 ## Bitnami Redmine image version
 ## ref: https://hub.docker.com/r/bitnami/redmine/tags/
 ##
-image:
-  repo: bitnami/redmine
-  tag: 3.3.0-r2
+image: bitnami/redmine:3.3.0-r2
 
-  ## Specify a imagePullPolicy
-  ## Defaults to 'Always' if image.tag is 'latest', else set to 'IfNotPresent'
-  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-  ##
-  # pullPolicy:
+## Specify a imagePullPolicy
+## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+##
+# imagePullPolicy:
 
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-redmine/#environment-variables

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -1,4 +1,4 @@
-# Wordpress
+# WordPress
 
 [WordPress](https://wordpress.org/) is one of the most versatile open source content management systems on the market. A publishing platform for building blogs and websites.
 
@@ -10,9 +10,9 @@ $ helm install wordpress-x.x.x.tgz
 
 ## Introduction
 
-This chart bootstraps a [Wordpress](https://github.com/bitnami/bitnami-docker-wordpress) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [WordPress](https://github.com/bitnami/bitnami-docker-wordpress) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
-It also packages the Bitnami MariaDB chart which is required for bootstrapping a MariaDB deployment for the database requirements of the Wordpress application.
+It also packages the Bitnami MariaDB chart which is required for bootstrapping a MariaDB deployment for the database requirements of the WordPress application.
 
 ## Get this chart
 
@@ -34,7 +34,7 @@ $ helm install --name my-release wordpress-x.x.x.tgz
 
 *Replace the `x.x.x` placeholder with the chart release version.*
 
-The command deploys Wordpress on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+The command deploys WordPress on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
 
 > **Tip**: List all releases using `helm list`
 
@@ -50,26 +50,31 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following tables lists the configurable parameters of the Wordpress chart and their default values.
+The following tables lists the configurable parameters of the WordPress chart and their default values.
 
-|           Parameter           |          Description          |                         Default                          |
-|-------------------------------|-------------------------------|----------------------------------------------------------|
-| `imageTag`                    | `bitnami/wordpress` image tag | Wordpress image version                                  |
-| `imagePullPolicy`             | Image pull policy             | `Always` if `imageTag` is `latest`, else `IfNotPresent`. |
-| `wordpressUsername`           | User of the application       | `user`                                                   |
-| `wordpressPassword`           | Application password          | `bitnami`                                                |
-| `wordpressEmail`              | Admin email                   | `user@example.com`                                       |
-| `wordpressFirstName`          | First name                    | `FirstName`                                              |
-| `wordpressLastName`           | Last name                     | `LastName`                                               |
-| `wordpressBlogName`           | Blog name                     | `User's Blog!`                                           |
-| `smtpHost`                    | SMTP host                     | `nil`                                                    |
-| `smtpPort`                    | SMTP port                     | `nil`                                                    |
-| `smtpUser`                    | SMTP user                     | `nil`                                                    |
-| `smtpPassword`                | SMTP password                 | `nil`                                                    |
-| `smtpUsername`                | User name for SMTP emails     | `nil`                                                    |
-| `smtpProtocol`                | SMTP protocol [`tls`, `ssl`]  | `nil`                                                    |
-| `mariadb.mariadbRootPassword` | MariaDB admin password        | `nil`                                                    |
-| `serviceType`                 | Kubernetes Service type       | `LoadBalancer`                                           |
+| Parameter                       | Description                     | Default                                                    |
+| ------------------------------- | ------------------------------- | ---------------------------------------------------------- |
+| `image.repo`                    | WordPress image repo            | `bitnami/wordpress`                                        |
+| `image.tag`                     | WordPress image tag             | Bitnami WordPress image version                            |
+| `image.pullPolicy`              | Image pull policy               | `Always` if `image.tag` is `latest`, else `IfNotPresent`   |
+| `wordpressUsername`             | User of the application         | `user`                                                     |
+| `wordpressPassword`             | Application password            | `bitnami`                                                  |
+| `wordpressEmail`                | Admin email                     | `user@example.com`                                         |
+| `wordpressFirstName`            | First name                      | `FirstName`                                                |
+| `wordpressLastName`             | Last name                       | `LastName`                                                 |
+| `wordpressBlogName`             | Blog name                       | `User's Blog!`                                             |
+| `smtpHost`                      | SMTP host                       | `nil`                                                      |
+| `smtpPort`                      | SMTP port                       | `nil`                                                      |
+| `smtpUser`                      | SMTP user                       | `nil`                                                      |
+| `smtpPassword`                  | SMTP password                   | `nil`                                                      |
+| `smtpUsername`                  | User name for SMTP emails       | `nil`                                                      |
+| `smtpProtocol`                  | SMTP protocol [`tls`, `ssl`]    | `nil`                                                      |
+| `mariadb.mariadbRootPassword`   | MariaDB admin password          | `nil`                                                      |
+| `serviceType`                   | Kubernetes Service type         | `LoadBalancer`                                             |
+| `persistence.enabled`           | Enable persistence using PVC    | `true`                                                     |
+| `persistence.storageClass`      | PVC Storage Class               | `generic`                                                  |
+| `persistence.accessMode`        | PVC Access Mode                 | `ReadWriteOnce`                                            |
+| `persistence.size`              | PVC Storage Request             | `8Gi`                                                      |
 
 The above parameters map to the env variables defined in [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress). For more information please refer to the [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress) image documentation.
 
@@ -81,7 +86,7 @@ $ helm install --name my-release \
     wordpress-x.x.x.tgz
 ```
 
-The above command sets the Wordpress application username and password to `admin` and `password` respectively. Additionally it sets the MariaDB `root` user password to `secretpassword`.
+The above command sets the WordPress application username and password to `admin` and `password` respectively. Additionally it sets the MariaDB `root` user password to `secretpassword`.
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
@@ -93,44 +98,7 @@ $ helm install --name my-release -f values.yaml wordpress-x.x.x.tgz
 
 ## Persistence
 
-The [Bitnami Wordpress](https://github.com/bitnami/bitnami-docker-wordpress) image stores the Wordpress data and configurations at the `/bitnami/wordpress` path of the container.
+The [Bitnami WordPress](https://github.com/bitnami/bitnami-docker-wordpress) image stores the WordPress data and configurations at the `/bitnami/wordpress` and `/bitnami/apache` paths of the container.
 
-As a placeholder, the chart mounts an [emptyDir](http://kubernetes.io/docs/user-guide/volumes/#emptydir) volume at this location.
-
-> *"An emptyDir volume is first created when a Pod is assigned to a Node, and exists as long as that Pod is running on that node. When a Pod is removed from a node for any reason, the data in the emptyDir is deleted forever."*
-
-For persistence of the data you should replace the `emptyDir` volume with a persistent [storage volume](http://kubernetes.io/docs/user-guide/volumes/), else the data will be lost if the Pod is shutdown.
-
-### Step 1: Create a persistent disk
-
-You first need to create a persistent disk in the cloud platform your cluster is running. For example, on GCE you can use the `gcloud` tool to create a [gcePersistentDisk](http://kubernetes.io/docs/user-guide/volumes/#gcepersistentdisk):
-
-```bash
-$ gcloud compute disks create --size=500GB --zone=us-central1-a wordpress-data-disk
-```
-
-### Step 2: Update `templates/deployment.yaml`
-
-Replace:
-
-```yaml
-      volumes:
-      - name: wordpress-data
-        emptyDir: {}
-```
-
-with
-
-```yaml
-      volumes:
-      - name: wordpress-data
-        gcePersistentDisk:
-          pdName: wordpress-data-disk
-          fsType: ext4
-```
-
-> **Note**:
->
-> You should also use a persistent storage volume for the MariaDB deployment.
-
-[Install](#installing-the-chart) the chart after making these changes.
+Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
+See the [Configuration](#configuration) section to configure the PVC or to disable persistence.

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -52,28 +52,31 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the WordPress chart and their default values.
 
-| Parameter                       | Description                     | Default                                                    |
-| ------------------------------- | ------------------------------- | ---------------------------------------------------------- |
-| `image`                         | WordPress image                 | `bitnami/wordpress:{VERSION}`                              |
-| `imagePullPolicy`               | Image pull policy               | `Always` if `image` tag is `latest`, else `IfNotPresent`   |
-| `wordpressUsername`             | User of the application         | `user`                                                     |
-| `wordpressPassword`             | Application password            | `bitnami`                                                  |
-| `wordpressEmail`                | Admin email                     | `user@example.com`                                         |
-| `wordpressFirstName`            | First name                      | `FirstName`                                                |
-| `wordpressLastName`             | Last name                       | `LastName`                                                 |
-| `wordpressBlogName`             | Blog name                       | `User's Blog!`                                             |
-| `smtpHost`                      | SMTP host                       | `nil`                                                      |
-| `smtpPort`                      | SMTP port                       | `nil`                                                      |
-| `smtpUser`                      | SMTP user                       | `nil`                                                      |
-| `smtpPassword`                  | SMTP password                   | `nil`                                                      |
-| `smtpUsername`                  | User name for SMTP emails       | `nil`                                                      |
-| `smtpProtocol`                  | SMTP protocol [`tls`, `ssl`]    | `nil`                                                      |
-| `mariadb.mariadbRootPassword`   | MariaDB admin password          | `nil`                                                      |
-| `serviceType`                   | Kubernetes Service type         | `LoadBalancer`                                             |
-| `persistence.enabled`           | Enable persistence using PVC    | `true`                                                     |
-| `persistence.storageClass`      | PVC Storage Class               | `generic`                                                  |
-| `persistence.accessMode`        | PVC Access Mode                 | `ReadWriteOnce`                                            |
-| `persistence.size`              | PVC Storage Request             | `8Gi`                                                      |
+| Parameter                            | Description                              | Default                                                    |
+| -------------------------------      | -------------------------------          | ---------------------------------------------------------- |
+| `image`                              | WordPress image                          | `bitnami/wordpress:{VERSION}`                              |
+| `imagePullPolicy`                    | Image pull policy                        | `Always` if `image` tag is `latest`, else `IfNotPresent`   |
+| `wordpressUsername`                  | User of the application                  | `user`                                                     |
+| `wordpressPassword`                  | Application password                     | `bitnami`                                                  |
+| `wordpressEmail`                     | Admin email                              | `user@example.com`                                         |
+| `wordpressFirstName`                 | First name                               | `FirstName`                                                |
+| `wordpressLastName`                  | Last name                                | `LastName`                                                 |
+| `wordpressBlogName`                  | Blog name                                | `User's Blog!`                                             |
+| `smtpHost`                           | SMTP host                                | `nil`                                                      |
+| `smtpPort`                           | SMTP port                                | `nil`                                                      |
+| `smtpUser`                           | SMTP user                                | `nil`                                                      |
+| `smtpPassword`                       | SMTP password                            | `nil`                                                      |
+| `smtpUsername`                       | User name for SMTP emails                | `nil`                                                      |
+| `smtpProtocol`                       | SMTP protocol [`tls`, `ssl`]             | `nil`                                                      |
+| `mariadb.mariadbRootPassword`        | MariaDB admin password                   | `nil`                                                      |
+| `serviceType`                        | Kubernetes Service type                  | `LoadBalancer`                                             |
+| `persistence.enabled`                | Enable persistence using PVC             | `true`                                                     |
+| `persistence.apache.storageClass`    | PVC Storage Class for Apache volume      | `generic`                                                  |
+| `persistence.apache.accessMode`      | PVC Access Mode for Apache volume        | `ReadWriteOnce`                                            |
+| `persistence.apache.size`            | PVC Storage Request for Apache volume    | `1Gi`                                                      |
+| `persistence.wordpress.storageClass` | PVC Storage Class for WordPress volume   | `generic`                                                  |
+| `persistence.wordpress.accessMode`   | PVC Access Mode for WordPress volume     | `ReadWriteOnce`                                            |
+| `persistence.wordpress.size`         | PVC Storage Request for WordPress volume | `8Gi`                                                      |
 
 The above parameters map to the env variables defined in [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress). For more information please refer to the [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress) image documentation.
 

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -14,6 +14,11 @@ This chart bootstraps a [WordPress](https://github.com/bitnami/bitnami-docker-wo
 
 It also packages the Bitnami MariaDB chart which is required for bootstrapping a MariaDB deployment for the database requirements of the WordPress application.
 
+## Prerequisites
+
+- Kubernetes 1.3+ with Alpha APIs enabled
+- PV provisioner support in the underlying infrastructure
+
 ## Get this chart
 
 Download the latest release of the chart from the [releases](../../../releases) page.

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -54,9 +54,8 @@ The following tables lists the configurable parameters of the WordPress chart an
 
 | Parameter                       | Description                     | Default                                                    |
 | ------------------------------- | ------------------------------- | ---------------------------------------------------------- |
-| `image.repo`                    | WordPress image repo            | `bitnami/wordpress`                                        |
-| `image.tag`                     | WordPress image tag             | Bitnami WordPress image version                            |
-| `image.pullPolicy`              | Image pull policy               | `Always` if `image.tag` is `latest`, else `IfNotPresent`   |
+| `image`                         | WordPress image                 | `bitnami/wordpress:{VERSION}`                              |
+| `imagePullPolicy`               | Image pull policy               | `Always` if `image` tag is `latest`, else `IfNotPresent`   |
 | `wordpressUsername`             | User of the application         | `user`                                                     |
 | `wordpressPassword`             | Application password            | `bitnami`                                                  |
 | `wordpressEmail`                | Admin email                     | `user@example.com`                                         |

--- a/wordpress/templates/NOTES.txt
+++ b/wordpress/templates/NOTES.txt
@@ -1,22 +1,26 @@
-1. Get the Wordpress login URL running these commands in the same shell:
+1. Get the WordPress URL by running:
 
 {{- if contains "NodePort" .Values.serviceType }}
 
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT/wp-admin
+  echo http://$NODE_IP:$NODE_PORT/
 
 {{- else if contains "LoadBalancer" .Values.serviceType }}
 
-**** NOTE: It may take a few minutes for the LoadBalancer IP to be available.                      ****
-****       You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}' ****
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc -w {{ template "fullname" . }}'
 
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP/wp-admin
+  echo http://$SERVICE_IP/
 {{- else if contains "ClusterIP"  .Values.serviceType }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "component={{ template "fullname" . }}-master" -o jsonpath="{.items[0].metadata.name}")
-  echo http://127.0.0.1
-  kubectl port-forward $POD_NAME 80:80
+
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+  echo http://127.0.0.1:8080/
+  kubectl port-forward $POD_NAME 8080:80
 {{- end }}
 
-2. Login with the Username "{{ .Values.wordpressUsername }}" and password "{{ .Values.wordpressPassword }}"
+2. Login with the following credentials
+
+  Username: {{ .Values.wordpressUsername }}
+  Password: {{ .Values.wordpressPassword }}

--- a/wordpress/templates/deployment.yaml
+++ b/wordpress/templates/deployment.yaml
@@ -19,8 +19,8 @@ spec:
     spec:
       containers:
       - name: {{ template "fullname" . }}
-        image: "bitnami/wordpress:{{ .Values.imageTag }}"
-        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+        image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ default "" .Values.image.pullPolicy | quote }}
         env:
         - name: MARIADB_HOST
           value: {{ template "mariadb.fullname" . }}

--- a/wordpress/templates/deployment.yaml
+++ b/wordpress/templates/deployment.yaml
@@ -19,8 +19,8 @@ spec:
     spec:
       containers:
       - name: {{ template "fullname" . }}
-        image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
-        imagePullPolicy: {{ default "" .Values.image.pullPolicy | quote }}
+        image: "{{ .Values.image }}"
+        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         env:
         - name: MARIADB_HOST
           value: {{ template "mariadb.fullname" . }}

--- a/wordpress/values.yaml
+++ b/wordpress/values.yaml
@@ -1,15 +1,13 @@
 ## Bitnami WordPress image version
 ## ref: https://hub.docker.com/r/bitnami/wordpress/tags/
 ##
-image:
-  repo: bitnami/wordpress
-  tag: 4.6.1-r1
+image: bitnami/wordpress:4.6.1-r1
 
-  ## Specify a imagePullPolicy
-  ## Defaults to 'Always' if image.tag is 'latest', else set to 'IfNotPresent'
-  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-  ##
-  # pullPolicy:
+## Specify a imagePullPolicy
+## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+##
+# imagePullPolicy:
 
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables

--- a/wordpress/values.yaml
+++ b/wordpress/values.yaml
@@ -1,13 +1,15 @@
-## Bitnami Wordpress image version
+## Bitnami WordPress image version
 ## ref: https://hub.docker.com/r/bitnami/wordpress/tags/
 ##
-imageTag: 4.6.1-r1
+image:
+  repo: bitnami/wordpress
+  tag: 4.6.1-r1
 
-## Specify a imagePullPolicy
-## Defaults to 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
-## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-##
-# imagePullPolicy:
+  ## Specify a imagePullPolicy
+  ## Defaults to 'Always' if image.tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  # pullPolicy:
 
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables


### PR DESCRIPTION
For Redmine, Drupal and WordPress

General:
- Wordpress -> WordPress

READMEs:
- Add persistence configuration values
- Update persistence sections to describe Persistent Volume Claim usage

NOTES.txt:
- Fixes `kubectl` command for retrieving URL for ClusterIP service type
- Use root (homepage) URLs instead of login URLs
- Fix forwarding commands for ClusterIP service type, and use
  unprivileged port
- Improve LoadBalancer note printout
- Improve credentials printout

values.yaml:
- redmineUser -> redmineUsername
- drupalUser -> drupalUsername

/cc @migmartri @sameersbn 