### PR TITLE
bump version of images including OpenSSL security fixes

### DIFF
--- a/apache/Chart.yaml
+++ b/apache/Chart.yaml
@@ -1,5 +1,5 @@
 name: apache
-version: 0.3.0
+version: 0.3.1
 description: Chart for Apache HTTP Server
 keywords:
 - apache

--- a/apache/values.yaml
+++ b/apache/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Apache image version
 ## ref: https://hub.docker.com/r/bitnami/apache/tags/
 ##
-imageTag: 2.4.23-r5
+imageTag: 2.4.23-r6
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,5 +1,5 @@
 name: drupal
-version: 0.3.0
+version: 0.3.1
 description: One of the most versatile open source content management systems.
 keywords:
 - drupal

--- a/drupal/charts/mariadb/Chart.yaml
+++ b/drupal/charts/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 0.3.0
+version: 0.3.1
 description: Chart for MariaDB
 keywords:
 - mariadb

--- a/drupal/charts/mariadb/values.yaml
+++ b/drupal/charts/mariadb/values.yaml
@@ -2,7 +2,7 @@
 ## ref: https://hub.docker.com/r/bitnami/mariadb/tags/
 ##
 ## Default: none
-imageTag: 10.1.14-r3
+imageTag: 10.1.17-r1
 
 ## Specify a imagePullPolicy
 ## Default to 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Drupal image version
 ## ref: https://hub.docker.com/r/bitnami/drupal/tags/
 ##
-image: bitnami/drupal:8.1.9-r0
+image: bitnami/drupal:8.1.9-r1
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/ghost/Chart.yaml
+++ b/ghost/Chart.yaml
@@ -1,5 +1,5 @@
 name: ghost
-version: 0.3.0
+version: 0.3.1
 description: A simple, powerful publishing platform that allows you to share your stories with the world
 keywords:
 - ghost

--- a/ghost/charts/mariadb/Chart.yaml
+++ b/ghost/charts/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 0.3.0
+version: 0.3.1
 description: Chart for MariaDB
 keywords:
 - mariadb

--- a/ghost/charts/mariadb/values.yaml
+++ b/ghost/charts/mariadb/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami MariaDB image version
 ## ref: https://hub.docker.com/r/bitnami/mariadb/tags/
 ##
-imageTag: 10.1.14-r5
+imageTag: 10.1.17-r1
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/ghost/values.yaml
+++ b/ghost/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Ghost image version
 ## ref: https://hub.docker.com/r/bitnami/ghost/tags/
 ##
-imageTag: 0.11.0-r0
+imageTag: 0.11.0-r1
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/jenkins/Chart.yaml
+++ b/jenkins/Chart.yaml
@@ -1,5 +1,5 @@
 name: jenkins
-version: 0.3.0
+version: 0.3.1
 description: The leading open source automation server
 keywords:
 - jenkins

--- a/jenkins/values.yaml
+++ b/jenkins/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Jenkins image version
 ## ref: https://hub.docker.com/r/bitnami/jenkins/tags/
 ##
-imageTag: 2.23-r0
+imageTag: 2.23-r1
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/joomla/Chart.yaml
+++ b/joomla/Chart.yaml
@@ -1,5 +1,5 @@
 name: joomla
-version: 0.3.0
+version: 0.3.1
 description: PHP content management system (CMS) for publishing web content
 keywords:
 - joomla

--- a/joomla/charts/mariadb/Chart.yaml
+++ b/joomla/charts/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 0.3.0
+version: 0.3.1
 description: Chart for MariaDB
 keywords:
 - mariadb

--- a/joomla/charts/mariadb/values.yaml
+++ b/joomla/charts/mariadb/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami MariaDB image version
 ## ref: https://hub.docker.com/r/bitnami/mariadb/tags/
 ##
-imageTag: 10.1.14-r5
+imageTag: 10.1.17-r1
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/joomla/values.yaml
+++ b/joomla/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Joomla image version
 ## ref: https://hub.docker.com/r/bitnami/joomla/tags/
 ##
-imageTag: 3.6.2-r2
+imageTag: 3.6.2-r3
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/magento/Chart.yaml
+++ b/magento/Chart.yaml
@@ -1,5 +1,5 @@
 name: magento
-version: 0.3.0
+version: 0.3.1
 description: A feature-rich flexible e-commerce solution. It includes transaction options, multi-store functionality, loyalty programs, product categorization and shopper filtering, promotion rules, and more.
 keywords:
 - magento

--- a/magento/charts/mariadb/Chart.yaml
+++ b/magento/charts/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 0.3.0
+version: 0.3.1
 description: Chart for MariaDB
 keywords:
 - mariadb

--- a/magento/charts/mariadb/values.yaml
+++ b/magento/charts/mariadb/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami MariaDB image version
 ## ref: https://hub.docker.com/r/bitnami/mariadb/tags/
 ##
-imageTag: 10.1.14-r5
+imageTag: 10.1.17-r1
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/magento/values.yaml
+++ b/magento/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Magento image version
 ## ref: https://hub.docker.com/r/bitnami/magento/tags/
 ##
-imageTag: 2.1.1-r0
+imageTag: 2.1.1-r1
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/mariadb-cluster/Chart.yaml
+++ b/mariadb-cluster/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb-cluster
-version: 0.3.0
+version: 0.3.1
 description: Chart to create a Highly available MariaDB cluster
 keywords:
 - mariadb

--- a/mariadb-cluster/values.yaml
+++ b/mariadb-cluster/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami MariaDB image version
 ## ref: https://hub.docker.com/r/bitnami/mariadb/tags/
 ##
-imageTag: 10.1.14-r5
+imageTag: 10.1.17-r1
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/mariadb/Chart.yaml
+++ b/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 0.3.0
+version: 0.3.1
 description: Chart for MariaDB
 keywords:
 - mariadb

--- a/mariadb/values.yaml
+++ b/mariadb/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami MariaDB image version
 ## ref: https://hub.docker.com/r/bitnami/mariadb/tags/
 ##
-imageTag: 10.1.14-r5
+imageTag: 10.1.17-r1
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/mediawiki/Chart.yaml
+++ b/mediawiki/Chart.yaml
@@ -1,5 +1,5 @@
 name: mediawiki
-version: 0.3.0
+version: 0.3.1
 description: Extremely powerful, scalable software and a feature-rich wiki implementation that uses PHP to process and display data stored in a database.
 keywords:
 - mediawiki

--- a/mediawiki/charts/mariadb/Chart.yaml
+++ b/mediawiki/charts/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 0.3.0
+version: 0.3.1
 description: Chart for MariaDB
 keywords:
 - mariadb

--- a/mediawiki/charts/mariadb/values.yaml
+++ b/mediawiki/charts/mariadb/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami MariaDB image version
 ## ref: https://hub.docker.com/r/bitnami/mariadb/tags/
 ##
-imageTag: 10.1.14-r5
+imageTag: 10.1.17-r1
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/mediawiki/values.yaml
+++ b/mediawiki/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami MediaWiki image version
 ## ref: https://hub.docker.com/r/bitnami/mediawiki/tags/
 ##
-imageTag: 1.27.0-r1
+imageTag: 1.27.0-r2
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/memcached/Chart.yaml
+++ b/memcached/Chart.yaml
@@ -1,5 +1,5 @@
 name: memcached
-version: 0.3.1
+version: 0.3.2
 description: Chart for Memcached
 keywords:
 - memcached

--- a/memcached/values.yaml
+++ b/memcached/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Memcached image version
 ## ref: https://hub.docker.com/r/bitnami/mariadb/tags/
 ##
-imageTag: 1.4.25-r4
+imageTag: 1.4.25-r6
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/mongodb/Chart.yaml
+++ b/mongodb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mongodb
-version: 0.3.1
+version: 0.3.2
 description: Chart for MongoDB
 keywords:
 - mongodb

--- a/mongodb/values.yaml
+++ b/mongodb/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami MongoDB image version
 ## ref: https://hub.docker.com/r/bitnami/mongodb/tags/
 ##
-imageTag: 3.2.9-r0
+imageTag: 3.2.9-r1
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/nginx/Chart.yaml
+++ b/nginx/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx
-version: 0.3.0
+version: 0.3.1
 description: Chart for the nginx server
 keywords:
 - nginx

--- a/nginx/values.yaml
+++ b/nginx/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami NGINX image version
 ## ref: https://hub.docker.com/r/bitnami/nginx/tags/
 ##
-imageTag: 1.10.1-r2
+imageTag: 1.10.1-r3
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/odoo/Chart.yaml
+++ b/odoo/Chart.yaml
@@ -1,5 +1,5 @@
 name: odoo
-version: 0.3.1
+version: 0.3.2
 description: A suite of web based open source business apps.
 keywords:
 - odoo

--- a/odoo/values.yaml
+++ b/odoo/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Odoo image version
 ## ref: https://hub.docker.com/r/bitnami/odoo/tags/
 ##
-imageTag: 9.0.20160620-r2
+imageTag: 9.0.20160620-r3
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/opencart/Chart.yaml
+++ b/opencart/Chart.yaml
@@ -1,5 +1,5 @@
 name: opencart
-version: 0.3.0
+version: 0.3.1
 description: A free and open source e-commerce platform for online merchants. It provides a professional and reliable foundation for a successful online store.
 keywords:
 - opencart

--- a/opencart/charts/mariadb/Chart.yaml
+++ b/opencart/charts/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 0.3.0
+version: 0.3.1
 description: Chart for MariaDB
 keywords:
 - mariadb

--- a/opencart/charts/mariadb/values.yaml
+++ b/opencart/charts/mariadb/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami MariaDB image version
 ## ref: https://hub.docker.com/r/bitnami/mariadb/tags/
 ##
-imageTag: 10.1.14-r5
+imageTag: 10.1.17-r1
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/opencart/values.yaml
+++ b/opencart/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami OpenCart image version
 ## ref: https://hub.docker.com/r/bitnami/opencart/tags/
 ##
-imageTag: 2.3.0.2-r2
+imageTag: 2.3.0.2-r3
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/owncloud/Chart.yaml
+++ b/owncloud/Chart.yaml
@@ -1,5 +1,5 @@
 name: owncloud
-version: 0.3.0
+version: 0.3.1
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
 - owncloud

--- a/owncloud/charts/mariadb/Chart.yaml
+++ b/owncloud/charts/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 0.3.0
+version: 0.3.1
 description: Chart for MariaDB
 keywords:
 - mariadb

--- a/owncloud/charts/mariadb/values.yaml
+++ b/owncloud/charts/mariadb/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami MariaDB image version
 ## ref: https://hub.docker.com/r/bitnami/mariadb/tags/
 ##
-imageTag: 10.1.14-r5
+imageTag: 10.1.17-r1
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/owncloud/values.yaml
+++ b/owncloud/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami ownCloud image version
 ## ref: https://hub.docker.com/r/bitnami/owncloud/tags/
 ##
-imageTag: 9.1.0-r1
+imageTag: 9.1.0-r2
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/phabricator/Chart.yaml
+++ b/phabricator/Chart.yaml
@@ -1,5 +1,5 @@
 name: phabricator
-version: 0.3.0
+version: 0.3.1
 description: Collection of open source web applications that help software companies build better software.
 keywords:
 - phabricator

--- a/phabricator/charts/mariadb/Chart.yaml
+++ b/phabricator/charts/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 0.3.0
+version: 0.3.1
 description: Chart for MariaDB
 keywords:
 - mariadb

--- a/phabricator/charts/mariadb/values.yaml
+++ b/phabricator/charts/mariadb/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami MariaDB image version
 ## ref: https://hub.docker.com/r/bitnami/mariadb/tags/
 ##
-imageTag: 10.1.14-r5
+imageTag: 10.1.17-r1
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/phabricator/values.yaml
+++ b/phabricator/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Phabricator image version
 ## ref: https://hub.docker.com/r/bitnami/phabricator/tags/
 ##
-imageTag: 2016.35-r0
+imageTag: 2016.35-r1
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/phpbb/Chart.yaml
+++ b/phpbb/Chart.yaml
@@ -1,5 +1,5 @@
 name: phpbb
-version: 0.3.0
+version: 0.3.1
 description: Community forum that supports the notion of users and groups, file attachments, full-text search, notifications and more.
 keywords:
 - phpbb

--- a/phpbb/charts/mariadb/Chart.yaml
+++ b/phpbb/charts/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 0.3.0
+version: 0.3.1
 description: Chart for MariaDB
 keywords:
 - mariadb

--- a/phpbb/charts/mariadb/values.yaml
+++ b/phpbb/charts/mariadb/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami MariaDB image version
 ## ref: https://hub.docker.com/r/bitnami/mariadb/tags/
 ##
-imageTag: 10.1.14-r5
+imageTag: 10.1.17-r1
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/phpbb/values.yaml
+++ b/phpbb/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami PhpBB image version
 ## ref: https://hub.docker.com/r/bitnami/phpbb/tags/
 ##
-imageTag: 3.1.9-r2
+imageTag: 3.1.9-r3
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/postgresql/Chart.yaml
+++ b/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.3.1
+version: 0.3.2
 description: Chart for PostgreSQL
 keywords:
 - postgresql

--- a/postgresql/values.yaml
+++ b/postgresql/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami PostgreSQL image version
 ## ref: https://hub.docker.com/r/bitnami/postgresql/tags/
 ##
-imageTag: 9.5.3-r5
+imageTag: 9.5.3-r6
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/prestashop/Chart.yaml
+++ b/prestashop/Chart.yaml
@@ -1,5 +1,5 @@
 name: prestashop
-version: 0.3.0
+version: 0.3.1
 description: A popular open source ecommerce solution. Professional tools are easily accessible to increase online sales including instant guest checkout, abandoned cart reminders and automated Email marketing.
 keywords:
 - prestashop

--- a/prestashop/charts/mariadb/Chart.yaml
+++ b/prestashop/charts/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 0.3.0
+version: 0.3.1
 description: Chart for MariaDB
 keywords:
 - mariadb

--- a/prestashop/charts/mariadb/values.yaml
+++ b/prestashop/charts/mariadb/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami MariaDB image version
 ## ref: https://hub.docker.com/r/bitnami/mariadb/tags/
 ##
-imageTag: 10.1.14-r5
+imageTag: 10.1.17-r1
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/prestashop/values.yaml
+++ b/prestashop/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami PrestaShop image version
 ## ref: https://hub.docker.com/r/bitnami/prestashop/tags/
 ##
-imageTag: 1.6.1.6-r2
+imageTag: 1.6.1.6-r4
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/rabbitmq/Chart.yaml
+++ b/rabbitmq/Chart.yaml
@@ -1,5 +1,5 @@
 name: rabbitmq
-version: 0.3.1
+version: 0.3.2
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:
 - rabbitmq

--- a/rabbitmq/values.yaml
+++ b/rabbitmq/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami RabbitMQ image version
 ## ref: https://hub.docker.com/r/bitnami/rabbitmq/tags/
 ##
-imageTag: 3.6.5-r2
+imageTag: 3.6.5-r3
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/redis/Chart.yaml
+++ b/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 0.3.1
+version: 0.3.2
 description: Chart for Redis
 keywords:
 - redis

--- a/redis/Chart.yaml
+++ b/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 0.3.0
+version: 0.3.1
 description: Chart for Redis
 keywords:
 - redis

--- a/redis/values.yaml
+++ b/redis/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Redis image version
 ## ref: https://hub.docker.com/r/bitnami/redis/tags/
 ##
-imageTag: 3.2.0-r3
+imageTag: 3.2.3-r1
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/redmine/Chart.yaml
+++ b/redmine/Chart.yaml
@@ -1,5 +1,5 @@
 name: redmine
-version: 0.3.0
+version: 0.3.1
 description: A flexible project management web application.
 keywords:
 - redmine

--- a/redmine/charts/mariadb/Chart.yaml
+++ b/redmine/charts/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 0.3.0
+version: 0.3.1
 description: Chart for MariaDB
 keywords:
 - mariadb

--- a/redmine/charts/mariadb/values.yaml
+++ b/redmine/charts/mariadb/values.yaml
@@ -2,7 +2,7 @@
 ## ref: https://hub.docker.com/r/bitnami/mariadb/tags/
 ##
 ## Default: none
-imageTag: 10.1.14-r3
+imageTag: 10.1.17-r1
 
 ## Specify a imagePullPolicy
 ## Default to 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/redmine/values.yaml
+++ b/redmine/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Redmine image version
 ## ref: https://hub.docker.com/r/bitnami/redmine/tags/
 ##
-image: bitnami/redmine:3.3.0-r2
+image: bitnami/redmine:3.3.0-r3
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/testlink/Chart.yaml
+++ b/testlink/Chart.yaml
@@ -1,5 +1,5 @@
 name: testlink
-version: 0.3.0
+version: 0.3.1
 description: Web-based test management system that facilitates software quality assurance.
 keywords:
 - testlink

--- a/testlink/charts/mariadb/Chart.yaml
+++ b/testlink/charts/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 0.3.0
+version: 0.3.1
 description: Chart for MariaDB
 keywords:
 - mariadb

--- a/testlink/charts/mariadb/values.yaml
+++ b/testlink/charts/mariadb/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami MariaDB image version
 ## ref: https://hub.docker.com/r/bitnami/mariadb/tags/
 ##
-imageTag: 10.1.14-r5
+imageTag: 10.1.17-r1
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/testlink/values.yaml
+++ b/testlink/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami TestLink image version
 ## ref: https://hub.docker.com/r/bitnami/testlink/tags/
 ##
-imageTag: 1.9.14-r1
+imageTag: 1.9.14-r2
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/tomcat/Chart.yaml
+++ b/tomcat/Chart.yaml
@@ -1,5 +1,5 @@
 name: tomcat
-version: 0.3.1
+version: 0.3.2
 description: Chart for Apache Tomcat
 keywords:
 - tomcat

--- a/tomcat/values.yaml
+++ b/tomcat/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Tomcat image version
 ## ref: https://hub.docker.com/r/bitnami/tomcat/tags/
 ##
-imageTag: 8.0.35-r3
+imageTag: 8.0.35-r4
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/wildfly/Chart.yaml
+++ b/wildfly/Chart.yaml
@@ -1,5 +1,5 @@
 name: wildfly
-version: 0.3.1
+version: 0.3.2
 description: Chart for Wildfly
 keywords:
 - wildfly

--- a/wildfly/values.yaml
+++ b/wildfly/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Wildfly image version
 ## ref: https://hub.docker.com/r/bitnami/wildfly/tags/
 ##
-imageTag: 10.0.0-r3
+imageTag: 10.0.0-r4
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/wordpress/Chart.yaml
+++ b/wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 name: wordpress
-version: 0.3.0
+version: 0.3.1
 description: Web publishing platform for building blogs and websites.
 keywords:
 - wordpress

--- a/wordpress/charts/mariadb/Chart.yaml
+++ b/wordpress/charts/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 0.3.0
+version: 0.3.1
 description: Chart for MariaDB
 keywords:
 - mariadb

--- a/wordpress/charts/mariadb/values.yaml
+++ b/wordpress/charts/mariadb/values.yaml
@@ -2,7 +2,7 @@
 ## ref: https://hub.docker.com/r/bitnami/mariadb/tags/
 ##
 ## Default: none
-imageTag: 10.1.14-r3
+imageTag: 10.1.17-r1
 
 ## Specify a imagePullPolicy
 ## Default to 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/wordpress/values.yaml
+++ b/wordpress/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami WordPress image version
 ## ref: https://hub.docker.com/r/bitnami/wordpress/tags/
 ##
-image: bitnami/wordpress:4.6.1-r1
+image: bitnami/wordpress:4.6.1-r2
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
updated charts:
- apache
- drupal
- ghost
- jenkins
- joomla
- magento
- mariadb
- mariadb-cluster
- mediawiki
- memcached
- mongodb
- nginx
- odoo
- opencart
- owncloud
- phabricator
- phpbb
- postgresql
- prestashop
- rabbitmq
- redmine
- testlink
- tomcat
- wildfly
- wordpress