### PR TITLE
Reduce labels for pod spec

### DIFF
--- a/incubator/mean/templates/deployment.yaml
+++ b/incubator/mean/templates/deployment.yaml
@@ -13,9 +13,6 @@ spec:
     metadata:
       labels:
         app: {{ template "fullname" . }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-        release: "{{ .Release.Name }}"
-        heritage: "{{ .Release.Service }}"
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
           {


### PR DESCRIPTION
Reduces the labels for the pod spec to ensure the chart version changes don't affect the match selector.