### PR TITLE
Rename MARIADB_PORT env var to MARIADB_PORT_NUMBER

### DIFF
--- a/incubator/sugarcrm/Chart.yaml
+++ b/incubator/sugarcrm/Chart.yaml
@@ -1,5 +1,5 @@
 name: sugarcrm
-version: 0.1.1
+version: 0.1.2
 description: SugarCRM enables businesses to create extraordinary customer relationships with the most innovative and affordable CRM solution in the market.
 keywords:
 - sugarcrm

--- a/incubator/sugarcrm/templates/deployment.yaml
+++ b/incubator/sugarcrm/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         env:
         - name: MARIADB_HOST
           value: {{ template "mariadb.fullname" . }}
-        - name: MARIADB_PORT
+        - name: MARIADB_PORT_NUMBER
           value: "3306"
         - name: MARIADB_PASSWORD
           valueFrom:

--- a/incubator/sugarcrm/values.yaml
+++ b/incubator/sugarcrm/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami SugarCRM image version
 ## ref: https://hub.docker.com/r/bitnami/sugarcrm/tags/
 ##
-image: bitnami/sugarcrm:6.5.25-r0
+image: bitnami/sugarcrm:6.5.25-r5
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
In order to avoid environment variable collision with k8s services, we can add a suffix to the *_PORT environment variables so we can be sure that any service name will work.