### PR TITLE
Rename MARIADB_PORT env var to MARIADB_PORT_NUMBER

### DIFF
--- a/incubator/suitecrm/Chart.yaml
+++ b/incubator/suitecrm/Chart.yaml
@@ -1,5 +1,5 @@
 name: suitecrm
-version: 0.1.1
+version: 0.1.2
 description: SuiteCRM is a completely open source enterprise-grade Customer Relationship Management (CRM) application. SuiteCRM is a software fork of the popular customer relationship management (CRM) system SugarCRM.
 keywords:
 - suitecrm

--- a/incubator/suitecrm/templates/deployment.yaml
+++ b/incubator/suitecrm/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         env:
         - name: MARIADB_HOST
           value: {{ template "mariadb.fullname" . }}
-        - name: MARIADB_PORT
+        - name: MARIADB_PORT_NUMBER
           value: "3306"
         - name: MARIADB_PASSWORD
           valueFrom:

--- a/incubator/suitecrm/values.yaml
+++ b/incubator/suitecrm/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami SuiteCRM image version
 ## ref: https://hub.docker.com/r/bitnami/suitecrm/tags/
 ##
-image: bitnami/suitecrm:7.8.2-r0
+image: bitnami/suitecrm:7.9.0-r1
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
In order to avoid environment variable collision with k8s services, we can add a suffix to the *_PORT environment variables so we can be sure that any service name will work.