### PR TITLE
Add allowRemoteManagement as a parameter for the Tomcat Helm Chart

### DIFF
--- a/incubator/tomcat/README.md
+++ b/incubator/tomcat/README.md
@@ -55,6 +55,8 @@ The following tables lists the configurable parameters of the Tomcat chart and t
 | `persistence.accessMode`   | PVC Access Mode for Tomcat volume     | `ReadWriteOnce`                             |
 | `persistence.size`         | PVC Storage Request for Tomcat volume | `8Gi`                                       |
 | `resources`                | CPU/Memory resource requests/limits   | Memory: `512Mi`, CPU: `300m`                |
+| `allowRemoteManagement`    | Enable remote management of Tomcat    | `false`                                     |
+
 
 The above parameters map to the env variables defined in [bitnami/tomcat](http://github.com/bitnami/bitnami-docker-tomcat). For more information please refer to the [bitnami/tomcat](http://github.com/bitnami/bitnami-docker-tomcat) image documentation.
 

--- a/incubator/tomcat/README.md
+++ b/incubator/tomcat/README.md
@@ -55,7 +55,7 @@ The following tables lists the configurable parameters of the Tomcat chart and t
 | `persistence.accessMode`   | PVC Access Mode for Tomcat volume     | `ReadWriteOnce`                             |
 | `persistence.size`         | PVC Storage Request for Tomcat volume | `8Gi`                                       |
 | `resources`                | CPU/Memory resource requests/limits   | Memory: `512Mi`, CPU: `300m`                |
-| `allowRemoteManagement`    | Enable remote management of Tomcat    | `false`                                     |
+| `allowRemoteManagement`    | Enable remote management of Tomcat    | `0`, `1` to enable it                  |
 
 
 The above parameters map to the env variables defined in [bitnami/tomcat](http://github.com/bitnami/bitnami-docker-tomcat). For more information please refer to the [bitnami/tomcat](http://github.com/bitnami/bitnami-docker-tomcat) image documentation.

--- a/incubator/tomcat/templates/deployment.yaml
+++ b/incubator/tomcat/templates/deployment.yaml
@@ -25,6 +25,8 @@ spec:
             secretKeyRef:
               name: {{ template "fullname" . }}
               key: tomcat-password
+        - name: TOMCAT_ALLOW_REMOTE_MANAGEMENT
+          value: {{ default "" .Values.allowRemoteManagement | quote }}
         ports:
         - name: http
           containerPort: 8080

--- a/incubator/tomcat/values.yaml
+++ b/incubator/tomcat/values.yaml
@@ -18,6 +18,11 @@ tomcatUsername: user
 ##
 # tomcatPassword:
 
+## Expose management services
+## ref: https://github.com/bitnami/charts/tree/master/incubator/tomcat#configuration
+##
+allowRemoteManagement: false
+
 ## Kubernetes configuration
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer
 ##

--- a/incubator/tomcat/values.yaml
+++ b/incubator/tomcat/values.yaml
@@ -21,7 +21,7 @@ tomcatUsername: user
 ## Expose management services
 ## ref: https://github.com/bitnami/charts/tree/master/incubator/tomcat#configuration
 ##
-allowRemoteManagement: false
+allowRemoteManagement: 1
 
 ## Kubernetes configuration
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer

--- a/incubator/tomcat/values.yaml
+++ b/incubator/tomcat/values.yaml
@@ -21,7 +21,7 @@ tomcatUsername: user
 ## Expose management services
 ## ref: https://github.com/bitnami/charts/tree/master/incubator/tomcat#configuration
 ##
-allowRemoteManagement: 1
+allowRemoteManagement: 0
 
 ## Kubernetes configuration
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer


### PR DESCRIPTION
This PR is intended to add the parameter to remotely get access to the Tomcat management services and make us able to test all the services in our CI/CD systems.