### PR TITLE
[DO NOT MERGE] Update dependencies to get charts from bitnami charts repo

### DIFF
--- a/incubator/mean/requirements.lock
+++ b/incubator/mean/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mongodb
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.4.7
-digest: sha256:baf63f214bb88d0d7100eea86e218159a1d78e602e7e988db9b6ee73d282cb44
-generated: 2017-02-24T17:51:04.928104617+05:30
+  repository: https://charts.bitnami.com/stable
+  version: 0.4.26
+digest: sha256:0ab7dc42c208d58d62ea81ac201de236622438d759429b72820c60a5863e25c4
+generated: 2018-03-05T15:42:47.582505556Z

--- a/incubator/mean/requirements.yaml
+++ b/incubator/mean/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mongodb
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.bitnami.com/stable
   version: 0.4.x

--- a/stable/drupal/requirements.lock
+++ b/stable/drupal/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/stable
-  version: 2.1.5
-digest: sha256:91441017f30f56c6c28f53013d443f39d2085655817f48d1937cfeb0d0ac580f
-generated: 2018-03-05T16:50:46.486744487Z
+  version: 2.1.6
+digest: sha256:3f72fa66ff2ff87ffa1d9071271ac0f3fd2888f35507e82aed60f38f05d1e1a9
+generated: 2018-03-07T12:45:31.198672412Z

--- a/stable/drupal/requirements.lock
+++ b/stable/drupal/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.0.5
-digest: sha256:784a2dfb3f8c0a334cfb6dd31381ea39bd5a3834f12d95f24aa074be558388e1
-generated: 2017-12-05T17:15:55.281989+01:00
+  repository: https://charts.bitnami.com/stable
+  version: 2.1.5
+digest: sha256:91441017f30f56c6c28f53013d443f39d2085655817f48d1937cfeb0d0ac580f
+generated: 2018-03-05T16:50:46.486744487Z

--- a/stable/drupal/requirements.yaml
+++ b/stable/drupal/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
-  version: 2.1.5
+  version: 2.1.x
   repository: https://charts.bitnami.com/stable
   condition: mariadb.enabled

--- a/stable/drupal/requirements.yaml
+++ b/stable/drupal/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
-  version: 1.0.5
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 2.1.5
+  repository: https://charts.bitnami.com/stable
   condition: mariadb.enabled

--- a/stable/ghost/requirements.lock
+++ b/stable/ghost/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/stable
-  version: 2.1.5
-digest: sha256:91441017f30f56c6c28f53013d443f39d2085655817f48d1937cfeb0d0ac580f
-generated: 2018-03-05T16:50:12.006951155Z
+  version: 2.1.6
+digest: sha256:3f72fa66ff2ff87ffa1d9071271ac0f3fd2888f35507e82aed60f38f05d1e1a9
+generated: 2018-03-07T12:45:32.069627896Z

--- a/stable/ghost/requirements.lock
+++ b/stable/ghost/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.7.0
-digest: sha256:f59f68030aa5c50b9e776b813804875fac911f91c2aa384e991f37a795c5ae34
-generated: 2017-11-27T16:40:56.867665764Z
+  repository: https://charts.bitnami.com/stable
+  version: 2.1.5
+digest: sha256:91441017f30f56c6c28f53013d443f39d2085655817f48d1937cfeb0d0ac580f
+generated: 2018-03-05T16:50:12.006951155Z

--- a/stable/ghost/requirements.yaml
+++ b/stable/ghost/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
-  version: 2.1.5
+  version: 2.1.x
   repository: https://charts.bitnami.com/stable
   condition: mariadb.enabled

--- a/stable/ghost/requirements.yaml
+++ b/stable/ghost/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
-  version: 0.7.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 2.1.5
+  repository: https://charts.bitnami.com/stable
   condition: mariadb.enabled

--- a/stable/jasperreports/requirements.lock
+++ b/stable/jasperreports/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/stable
-  version: 2.1.5
-digest: sha256:30f647e9bbe621d0b68db7a9d36766a25d4c82088a11fe95d359eaecb65db20e
-generated: 2018-03-05T16:50:12.944884677Z
+  version: 2.1.6
+digest: sha256:08a66b41d2d99004f95689abc4cc2509b515027b8b2d507ec90c7979d635cb72
+generated: 2018-03-07T12:45:32.887443629Z

--- a/stable/jasperreports/requirements.lock
+++ b/stable/jasperreports/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.7.0
-digest: sha256:e1af13ac4ac21f67582006f12d2b4eb78a1a2a59b34338fac850f2bec0b08b41
-generated: 2017-08-09T22:52:49.897385868-04:00
+  repository: https://charts.bitnami.com/stable
+  version: 2.1.5
+digest: sha256:30f647e9bbe621d0b68db7a9d36766a25d4c82088a11fe95d359eaecb65db20e
+generated: 2018-03-05T16:50:12.944884677Z

--- a/stable/jasperreports/requirements.yaml
+++ b/stable/jasperreports/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.7.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 2.1.5
+  repository: https://charts.bitnami.com/stable

--- a/stable/jasperreports/requirements.yaml
+++ b/stable/jasperreports/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 2.1.5
+  version: 2.1.x
   repository: https://charts.bitnami.com/stable

--- a/stable/joomla/requirements.lock
+++ b/stable/joomla/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.7.0
-digest: sha256:e1af13ac4ac21f67582006f12d2b4eb78a1a2a59b34338fac850f2bec0b08b41
-generated: 2017-08-09T22:52:50.62658821-04:00
+  repository: https://charts.bitnami.com/stable
+  version: 2.1.5
+digest: sha256:30f647e9bbe621d0b68db7a9d36766a25d4c82088a11fe95d359eaecb65db20e
+generated: 2018-03-05T16:50:48.36787125Z

--- a/stable/joomla/requirements.lock
+++ b/stable/joomla/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/stable
-  version: 2.1.5
-digest: sha256:30f647e9bbe621d0b68db7a9d36766a25d4c82088a11fe95d359eaecb65db20e
-generated: 2018-03-05T16:50:48.36787125Z
+  version: 2.1.6
+digest: sha256:08a66b41d2d99004f95689abc4cc2509b515027b8b2d507ec90c7979d635cb72
+generated: 2018-03-07T12:45:33.689626744Z

--- a/stable/joomla/requirements.yaml
+++ b/stable/joomla/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.7.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 2.1.5
+  repository: https://charts.bitnami.com/stable

--- a/stable/joomla/requirements.yaml
+++ b/stable/joomla/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 2.1.5
+  version: 2.1.x
   repository: https://charts.bitnami.com/stable

--- a/stable/magento/requirements.lock
+++ b/stable/magento/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/stable
-  version: 2.1.5
-digest: sha256:91441017f30f56c6c28f53013d443f39d2085655817f48d1937cfeb0d0ac580f
-generated: 2018-03-05T16:50:39.947165401Z
+  version: 2.1.6
+digest: sha256:3f72fa66ff2ff87ffa1d9071271ac0f3fd2888f35507e82aed60f38f05d1e1a9
+generated: 2018-03-07T12:45:34.508835756Z

--- a/stable/magento/requirements.lock
+++ b/stable/magento/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 2.1.2
-digest: sha256:c8b7cfbae3b77525918ec3d38f8b0ce132c963707e7e59f3eaf5bc94347e66f1
-generated: 2018-01-15T11:40:57.489245+01:00
+  repository: https://charts.bitnami.com/stable
+  version: 2.1.5
+digest: sha256:91441017f30f56c6c28f53013d443f39d2085655817f48d1937cfeb0d0ac580f
+generated: 2018-03-05T16:50:39.947165401Z

--- a/stable/magento/requirements.yaml
+++ b/stable/magento/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
-  version: 2.1.2
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 2.1.5
+  repository: https://charts.bitnami.com/stable
   condition: mariadb.enabled

--- a/stable/magento/requirements.yaml
+++ b/stable/magento/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
-  version: 2.1.5
+  version: 2.1.x
   repository: https://charts.bitnami.com/stable
   condition: mariadb.enabled

--- a/stable/mediawiki/requirements.lock
+++ b/stable/mediawiki/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/stable
-  version: 2.1.5
-digest: sha256:91441017f30f56c6c28f53013d443f39d2085655817f48d1937cfeb0d0ac580f
-generated: 2018-03-05T16:50:41.812173677Z
+  version: 2.1.6
+digest: sha256:3f72fa66ff2ff87ffa1d9071271ac0f3fd2888f35507e82aed60f38f05d1e1a9
+generated: 2018-03-07T12:45:35.326581708Z

--- a/stable/mediawiki/requirements.lock
+++ b/stable/mediawiki/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.7.0
-digest: sha256:f59f68030aa5c50b9e776b813804875fac911f91c2aa384e991f37a795c5ae34
-generated: 2017-12-05T17:16:36.715765+01:00
+  repository: https://charts.bitnami.com/stable
+  version: 2.1.5
+digest: sha256:91441017f30f56c6c28f53013d443f39d2085655817f48d1937cfeb0d0ac580f
+generated: 2018-03-05T16:50:41.812173677Z

--- a/stable/mediawiki/requirements.yaml
+++ b/stable/mediawiki/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
-  version: 2.1.5
+  version: 2.1.x
   repository: https://charts.bitnami.com/stable
   condition: mariadb.enabled

--- a/stable/mediawiki/requirements.yaml
+++ b/stable/mediawiki/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
-  version: 0.7.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 2.1.5
+  repository: https://charts.bitnami.com/stable
   condition: mariadb.enabled

--- a/stable/moodle/requirements.lock
+++ b/stable/moodle/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/stable
-  version: 2.1.5
-digest: sha256:30f647e9bbe621d0b68db7a9d36766a25d4c82088a11fe95d359eaecb65db20e
-generated: 2018-03-05T15:45:10.119810348Z
+  version: 2.1.6
+digest: sha256:08a66b41d2d99004f95689abc4cc2509b515027b8b2d507ec90c7979d635cb72
+generated: 2018-03-07T12:45:36.125997813Z

--- a/stable/moodle/requirements.lock
+++ b/stable/moodle/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.7.0
-digest: sha256:e1af13ac4ac21f67582006f12d2b4eb78a1a2a59b34338fac850f2bec0b08b41
-generated: 2017-08-09T22:52:52.983181778-04:00
+  repository: https://charts.bitnami.com/stable
+  version: 2.1.5
+digest: sha256:30f647e9bbe621d0b68db7a9d36766a25d4c82088a11fe95d359eaecb65db20e
+generated: 2018-03-05T15:45:10.119810348Z

--- a/stable/moodle/requirements.yaml
+++ b/stable/moodle/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.7.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 2.1.5
+  repository: https://charts.bitnami.com/stable

--- a/stable/moodle/requirements.yaml
+++ b/stable/moodle/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 2.1.5
+  version: 2.1.x
   repository: https://charts.bitnami.com/stable

--- a/stable/opencart/requirements.lock
+++ b/stable/opencart/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.7.0
-digest: sha256:e1af13ac4ac21f67582006f12d2b4eb78a1a2a59b34338fac850f2bec0b08b41
-generated: 2017-08-09T22:52:53.617765447-04:00
+  repository: https://charts.bitnami.com/stable
+  version: 2.1.5
+digest: sha256:30f647e9bbe621d0b68db7a9d36766a25d4c82088a11fe95d359eaecb65db20e
+generated: 2018-03-05T16:50:51.716064406Z

--- a/stable/opencart/requirements.lock
+++ b/stable/opencart/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/stable
-  version: 2.1.5
-digest: sha256:30f647e9bbe621d0b68db7a9d36766a25d4c82088a11fe95d359eaecb65db20e
-generated: 2018-03-05T16:50:51.716064406Z
+  version: 2.1.6
+digest: sha256:08a66b41d2d99004f95689abc4cc2509b515027b8b2d507ec90c7979d635cb72
+generated: 2018-03-07T12:45:36.964640755Z

--- a/stable/opencart/requirements.yaml
+++ b/stable/opencart/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.7.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 2.1.5
+  repository: https://charts.bitnami.com/stable

--- a/stable/opencart/requirements.yaml
+++ b/stable/opencart/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 2.1.5
+  version: 2.1.x
   repository: https://charts.bitnami.com/stable

--- a/stable/orangehrm/requirements.lock
+++ b/stable/orangehrm/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/stable
-  version: 2.1.5
-digest: sha256:30f647e9bbe621d0b68db7a9d36766a25d4c82088a11fe95d359eaecb65db20e
-generated: 2018-03-05T16:50:50.254764187Z
+  version: 2.1.6
+digest: sha256:08a66b41d2d99004f95689abc4cc2509b515027b8b2d507ec90c7979d635cb72
+generated: 2018-03-07T12:45:37.769548443Z

--- a/stable/orangehrm/requirements.lock
+++ b/stable/orangehrm/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.7.0
-digest: sha256:e1af13ac4ac21f67582006f12d2b4eb78a1a2a59b34338fac850f2bec0b08b41
-generated: 2017-08-09T22:52:54.510792323-04:00
+  repository: https://charts.bitnami.com/stable
+  version: 2.1.5
+digest: sha256:30f647e9bbe621d0b68db7a9d36766a25d4c82088a11fe95d359eaecb65db20e
+generated: 2018-03-05T16:50:50.254764187Z

--- a/stable/orangehrm/requirements.yaml
+++ b/stable/orangehrm/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.7.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 2.1.5
+  repository: https://charts.bitnami.com/stable

--- a/stable/orangehrm/requirements.yaml
+++ b/stable/orangehrm/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 2.1.5
+  version: 2.1.x
   repository: https://charts.bitnami.com/stable

--- a/stable/osclass/requirements.lock
+++ b/stable/osclass/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/stable
-  version: 2.1.5
-digest: sha256:30f647e9bbe621d0b68db7a9d36766a25d4c82088a11fe95d359eaecb65db20e
-generated: 2018-03-05T16:50:47.427472925Z
+  version: 2.1.6
+digest: sha256:08a66b41d2d99004f95689abc4cc2509b515027b8b2d507ec90c7979d635cb72
+generated: 2018-03-07T12:45:38.577258768Z

--- a/stable/osclass/requirements.lock
+++ b/stable/osclass/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.7.0
-digest: sha256:e1af13ac4ac21f67582006f12d2b4eb78a1a2a59b34338fac850f2bec0b08b41
-generated: 2017-08-09T22:52:55.248933663-04:00
+  repository: https://charts.bitnami.com/stable
+  version: 2.1.5
+digest: sha256:30f647e9bbe621d0b68db7a9d36766a25d4c82088a11fe95d359eaecb65db20e
+generated: 2018-03-05T16:50:47.427472925Z

--- a/stable/osclass/requirements.yaml
+++ b/stable/osclass/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.7.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 2.1.5
+  repository: https://charts.bitnami.com/stable

--- a/stable/osclass/requirements.yaml
+++ b/stable/osclass/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 2.1.5
+  version: 2.1.x
   repository: https://charts.bitnami.com/stable

--- a/stable/owncloud/requirements.lock
+++ b/stable/owncloud/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.7.0
-digest: sha256:e1af13ac4ac21f67582006f12d2b4eb78a1a2a59b34338fac850f2bec0b08b41
-generated: 2017-08-09T22:52:55.91352211-04:00
+  repository: https://charts.bitnami.com/stable
+  version: 2.1.5
+digest: sha256:30f647e9bbe621d0b68db7a9d36766a25d4c82088a11fe95d359eaecb65db20e
+generated: 2018-03-05T16:50:49.322019356Z

--- a/stable/owncloud/requirements.lock
+++ b/stable/owncloud/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/stable
-  version: 2.1.5
-digest: sha256:30f647e9bbe621d0b68db7a9d36766a25d4c82088a11fe95d359eaecb65db20e
-generated: 2018-03-05T16:50:49.322019356Z
+  version: 2.1.6
+digest: sha256:08a66b41d2d99004f95689abc4cc2509b515027b8b2d507ec90c7979d635cb72
+generated: 2018-03-07T12:41:48.916235369Z

--- a/stable/owncloud/requirements.yaml
+++ b/stable/owncloud/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.7.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 2.1.5
+  repository: https://charts.bitnami.com/stable

--- a/stable/owncloud/requirements.yaml
+++ b/stable/owncloud/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 2.1.5
+  version: 2.1.x
   repository: https://charts.bitnami.com/stable

--- a/stable/parse/requirements.lock
+++ b/stable/parse/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mongodb
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.4.15
-digest: sha256:1a4e23d283ae090cf7595d7e255a0804b66a20f94620a4063b1271b2aa8b0879
-generated: 2017-09-03T14:24:36.800583401-04:00
+  repository: https://charts.bitnami.com/stable
+  version: 0.4.26
+digest: sha256:0ab7dc42c208d58d62ea81ac201de236622438d759429b72820c60a5863e25c4
+generated: 2018-03-05T17:08:36.72446191Z

--- a/stable/parse/requirements.yaml
+++ b/stable/parse/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mongodb
-  version: 0.4.15
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 0.4.x
+  repository: https://charts.bitnami.com/stable

--- a/stable/phabricator/requirements.lock
+++ b/stable/phabricator/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.7.0
-digest: sha256:e1af13ac4ac21f67582006f12d2b4eb78a1a2a59b34338fac850f2bec0b08b41
-generated: 2017-08-09T22:52:56.763676666-04:00
+  repository: https://charts.bitnami.com/stable
+  version: 2.1.5
+digest: sha256:30f647e9bbe621d0b68db7a9d36766a25d4c82088a11fe95d359eaecb65db20e
+generated: 2018-03-05T15:43:23.523255145Z

--- a/stable/phabricator/requirements.lock
+++ b/stable/phabricator/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/stable
-  version: 2.1.5
-digest: sha256:30f647e9bbe621d0b68db7a9d36766a25d4c82088a11fe95d359eaecb65db20e
-generated: 2018-03-05T15:43:23.523255145Z
+  version: 2.1.6
+digest: sha256:08a66b41d2d99004f95689abc4cc2509b515027b8b2d507ec90c7979d635cb72
+generated: 2018-03-07T12:45:39.421360712Z

--- a/stable/phabricator/requirements.yaml
+++ b/stable/phabricator/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.7.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 2.1.5
+  repository: https://charts.bitnami.com/stable

--- a/stable/phabricator/requirements.yaml
+++ b/stable/phabricator/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 2.1.5
+  version: 2.1.x
   repository: https://charts.bitnami.com/stable

--- a/stable/phpbb/requirements.lock
+++ b/stable/phpbb/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/stable
-  version: 2.1.5
-digest: sha256:91441017f30f56c6c28f53013d443f39d2085655817f48d1937cfeb0d0ac580f
-generated: 2018-03-05T16:50:43.684563327Z
+  version: 2.1.6
+digest: sha256:3f72fa66ff2ff87ffa1d9071271ac0f3fd2888f35507e82aed60f38f05d1e1a9
+generated: 2018-03-07T12:45:40.228078973Z

--- a/stable/phpbb/requirements.lock
+++ b/stable/phpbb/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.7.0
-digest: sha256:f59f68030aa5c50b9e776b813804875fac911f91c2aa384e991f37a795c5ae34
-generated: 2017-12-05T17:17:21.788784+01:00
+  repository: https://charts.bitnami.com/stable
+  version: 2.1.5
+digest: sha256:91441017f30f56c6c28f53013d443f39d2085655817f48d1937cfeb0d0ac580f
+generated: 2018-03-05T16:50:43.684563327Z

--- a/stable/phpbb/requirements.yaml
+++ b/stable/phpbb/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
-  version: 2.1.5
+  version: 2.1.x
   repository: https://charts.bitnami.com/stable
   condition: mariadb.enabled

--- a/stable/phpbb/requirements.yaml
+++ b/stable/phpbb/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
-  version: 0.7.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 2.1.5
+  repository: https://charts.bitnami.com/stable
   condition: mariadb.enabled

--- a/stable/prestashop/requirements.lock
+++ b/stable/prestashop/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.7.0
-digest: sha256:e1af13ac4ac21f67582006f12d2b4eb78a1a2a59b34338fac850f2bec0b08b41
-generated: 2017-08-09T22:52:58.303930422-04:00
+  repository: https://charts.bitnami.com/stable
+  version: 2.1.5
+digest: sha256:30f647e9bbe621d0b68db7a9d36766a25d4c82088a11fe95d359eaecb65db20e
+generated: 2018-03-05T16:50:44.613923532Z

--- a/stable/prestashop/requirements.lock
+++ b/stable/prestashop/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/stable
-  version: 2.1.5
-digest: sha256:30f647e9bbe621d0b68db7a9d36766a25d4c82088a11fe95d359eaecb65db20e
-generated: 2018-03-05T16:50:44.613923532Z
+  version: 2.1.6
+digest: sha256:08a66b41d2d99004f95689abc4cc2509b515027b8b2d507ec90c7979d635cb72
+generated: 2018-03-07T12:45:41.036403082Z

--- a/stable/prestashop/requirements.yaml
+++ b/stable/prestashop/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.7.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 2.1.5
+  repository: https://charts.bitnami.com/stable

--- a/stable/prestashop/requirements.yaml
+++ b/stable/prestashop/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 2.1.5
+  version: 2.1.x
   repository: https://charts.bitnami.com/stable

--- a/stable/redmine/requirements.lock
+++ b/stable/redmine/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/stable
-  version: 2.1.5
+  version: 2.1.6
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.8.1
-digest: sha256:da7a59dd1e3bcc1a5886aca80018347633c7afcd4fbc17635be7e6cf7ba0966e
-generated: 2018-03-05T17:10:34.262688177Z
+digest: sha256:dd983bce256a1b418cf6d1ac6db960f2df159b34c88ed5d89330cd82f9d926a6
+generated: 2018-03-07T12:45:42.051975817Z

--- a/stable/redmine/requirements.lock
+++ b/stable/redmine/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.7.0
+  repository: https://charts.bitnami.com/stable
+  version: 2.1.5
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.8.1
-digest: sha256:2832b6bf3b75730b1c86c8bd32c14dd2baeff63273aeec3ebc8a1ef2157ff454
-generated: 2017-09-03T14:17:09.786561151-04:00
+digest: sha256:da7a59dd1e3bcc1a5886aca80018347633c7afcd4fbc17635be7e6cf7ba0966e
+generated: 2018-03-05T17:10:34.262688177Z

--- a/stable/redmine/requirements.yaml
+++ b/stable/redmine/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
-  version: 0.7.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 2.1.5
+  repository: https://charts.bitnami.com/stable
   condition: databaseType.mariadb
 - name: postgresql
   version: 0.8.1

--- a/stable/redmine/requirements.yaml
+++ b/stable/redmine/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  version: 2.1.5
+  version: 2.1.x
   repository: https://charts.bitnami.com/stable
   condition: databaseType.mariadb
 - name: postgresql

--- a/stable/sugarcrm/requirements.lock
+++ b/stable/sugarcrm/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/stable
-  version: 2.1.5
-digest: sha256:30f647e9bbe621d0b68db7a9d36766a25d4c82088a11fe95d359eaecb65db20e
-generated: 2018-03-05T16:50:38.998645064Z
+  version: 2.1.6
+digest: sha256:08a66b41d2d99004f95689abc4cc2509b515027b8b2d507ec90c7979d635cb72
+generated: 2018-03-07T12:45:43.098317687Z

--- a/stable/sugarcrm/requirements.lock
+++ b/stable/sugarcrm/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.7.0
-digest: sha256:e1af13ac4ac21f67582006f12d2b4eb78a1a2a59b34338fac850f2bec0b08b41
-generated: 2017-08-09T22:53:00.253043673-04:00
+  repository: https://charts.bitnami.com/stable
+  version: 2.1.5
+digest: sha256:30f647e9bbe621d0b68db7a9d36766a25d4c82088a11fe95d359eaecb65db20e
+generated: 2018-03-05T16:50:38.998645064Z

--- a/stable/sugarcrm/requirements.yaml
+++ b/stable/sugarcrm/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.7.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 2.1.5
+  repository: https://charts.bitnami.com/stable

--- a/stable/sugarcrm/requirements.yaml
+++ b/stable/sugarcrm/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 2.1.5
+  version: 2.1.x
   repository: https://charts.bitnami.com/stable

--- a/stable/suitecrm/requirements.lock
+++ b/stable/suitecrm/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.7.0
-digest: sha256:e1af13ac4ac21f67582006f12d2b4eb78a1a2a59b34338fac850f2bec0b08b41
-generated: 2017-08-09T22:53:01.117093603-04:00
+  repository: https://charts.bitnami.com/stable
+  version: 2.1.5
+digest: sha256:30f647e9bbe621d0b68db7a9d36766a25d4c82088a11fe95d359eaecb65db20e
+generated: 2018-03-05T16:50:40.877063669Z

--- a/stable/suitecrm/requirements.lock
+++ b/stable/suitecrm/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/stable
-  version: 2.1.5
-digest: sha256:30f647e9bbe621d0b68db7a9d36766a25d4c82088a11fe95d359eaecb65db20e
-generated: 2018-03-05T16:50:40.877063669Z
+  version: 2.1.6
+digest: sha256:08a66b41d2d99004f95689abc4cc2509b515027b8b2d507ec90c7979d635cb72
+generated: 2018-03-07T12:45:43.897563574Z

--- a/stable/suitecrm/requirements.yaml
+++ b/stable/suitecrm/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.7.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 2.1.5
+  repository: https://charts.bitnami.com/stable

--- a/stable/suitecrm/requirements.yaml
+++ b/stable/suitecrm/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 2.1.5
+  version: 2.1.x
   repository: https://charts.bitnami.com/stable

--- a/stable/testlink/requirements.lock
+++ b/stable/testlink/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.7.0
-digest: sha256:e1af13ac4ac21f67582006f12d2b4eb78a1a2a59b34338fac850f2bec0b08b41
-generated: 2017-08-09T22:53:01.772059997-04:00
+  repository: https://charts.bitnami.com/stable
+  version: 2.1.5
+digest: sha256:30f647e9bbe621d0b68db7a9d36766a25d4c82088a11fe95d359eaecb65db20e
+generated: 2018-03-05T16:50:45.546765472Z

--- a/stable/testlink/requirements.lock
+++ b/stable/testlink/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/stable
-  version: 2.1.5
-digest: sha256:30f647e9bbe621d0b68db7a9d36766a25d4c82088a11fe95d359eaecb65db20e
-generated: 2018-03-05T16:50:45.546765472Z
+  version: 2.1.6
+digest: sha256:08a66b41d2d99004f95689abc4cc2509b515027b8b2d507ec90c7979d635cb72
+generated: 2018-03-07T12:45:44.69351066Z

--- a/stable/testlink/requirements.yaml
+++ b/stable/testlink/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.7.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 2.1.5
+  repository: https://charts.bitnami.com/stable

--- a/stable/testlink/requirements.yaml
+++ b/stable/testlink/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 2.1.5
+  version: 2.1.x
   repository: https://charts.bitnami.com/stable

--- a/stable/wordpress/requirements.lock
+++ b/stable/wordpress/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 2.1.1
-digest: sha256:abb98724b82fbb89b183dbd016f18c207c3bfb4970d5c8770a884af1c5304dbc
-generated: 2017-12-13T12:24:01.108769296Z
+  repository: https://charts.bitnami.com/stable
+  version: 2.1.5
+digest: sha256:e822780a1c27a5d1173308891bbe7c66d25079b75361a2cedf3aa61120fb657d
+generated: 2018-03-05T15:41:41.387360348Z

--- a/stable/wordpress/requirements.lock
+++ b/stable/wordpress/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/stable
-  version: 2.1.5
-digest: sha256:e822780a1c27a5d1173308891bbe7c66d25079b75361a2cedf3aa61120fb657d
-generated: 2018-03-05T15:41:41.387360348Z
+  version: 2.1.6
+digest: sha256:694568c82ba07aee345f80ff14de7cb73ddc7e0f5b60c332f359e598ab973978
+generated: 2018-03-07T12:45:45.498276581Z

--- a/stable/wordpress/requirements.yaml
+++ b/stable/wordpress/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  version: 2.1.5
+  version: 2.1.x
   repository: https://charts.bitnami.com/stable
   condition: mariadb.enabled
   tags:

--- a/stable/wordpress/requirements.yaml
+++ b/stable/wordpress/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
-  version: 2.1.1
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 2.1.5
+  repository: https://charts.bitnami.com/stable
   condition: mariadb.enabled
   tags:
     - wordpress-database


### PR DESCRIPTION
This PR updates the `requirements.lock` and `requirements.yaml` files to get the charts from the bitnami chart repo instead of the kubernetes one.