### PR TITLE
[prestahsop, suitecrm, sugarcrm] Update deprecated annotation

### DIFF
--- a/stable/prestashop/Chart.yaml
+++ b/stable/prestashop/Chart.yaml
@@ -1,5 +1,5 @@
 name: prestashop
-version: 0.5.6
+version: 0.5.7
 appVersion: 1.7.3
 description: A popular open source ecommerce solution. Professional tools are easily
   accessible to increase online sales including instant guest checkout, abandoned

--- a/stable/prestashop/templates/svc.yaml
+++ b/stable/prestashop/templates/svc.yaml
@@ -7,12 +7,11 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  annotations:
-    service.beta.kubernetes.io/external-traffic: OnlyLocal
 spec:
   type: {{ .Values.serviceType }}
   {{- if eq .Values.serviceType "LoadBalancer" }}
   loadBalancerIP: {{ default "" .Values.prestashopLoadBalancerIP }}
+  externalTrafficPolicy: Local
   {{- end }}
   ports:
   - name: http

--- a/stable/sugarcrm/Chart.yaml
+++ b/stable/sugarcrm/Chart.yaml
@@ -1,5 +1,5 @@
 name: sugarcrm
-version: 0.2.4
+version: 0.2.5
 appVersion: 6.5.26
 description: SugarCRM enables businesses to create extraordinary customer relationships with the most innovative and affordable CRM solution in the market.
 keywords:

--- a/stable/sugarcrm/templates/svc.yaml
+++ b/stable/sugarcrm/templates/svc.yaml
@@ -7,12 +7,11 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  annotations:
-    service.beta.kubernetes.io/external-traffic: OnlyLocal
 spec:
   type: {{ .Values.serviceType }}
   {{- if eq .Values.serviceType "LoadBalancer" }}
   loadBalancerIP: {{ .Values.sugarcrmLoadBalancerIP }}
+  externalTrafficPolicy: Local
   {{- end }}
   ports:
   - name: http

--- a/stable/suitecrm/Chart.yaml
+++ b/stable/suitecrm/Chart.yaml
@@ -1,5 +1,5 @@
 name: suitecrm
-version: 0.3.8
+version: 0.3.9
 appVersion: 7.9.12
 description: SuiteCRM is a completely open source enterprise-grade Customer Relationship Management (CRM) application. SuiteCRM is a software fork of the popular customer relationship management (CRM) system SugarCRM.
 keywords:

--- a/stable/suitecrm/templates/svc.yaml
+++ b/stable/suitecrm/templates/svc.yaml
@@ -13,6 +13,7 @@ spec:
   type: {{ .Values.serviceType }}
   {{- if eq .Values.serviceType "LoadBalancer" }}
   loadBalancerIP: {{ .Values.suitecrmLoadBalancerIP }}
+  externalTrafficPolicy: Local
   {{- end }}
   ports:
   - name: http


### PR DESCRIPTION
As stated here, the annotation service.beta.kubernetes.io/external-traffic has been deprecated in k8s 1.8.
Instead of using the annotation, now it is needed to set the service.spec.externalTrafficPolicy field to Local.

Without this customization, PrestaShop, SugarCRM and SuiteCRm constantly will log out the user because the client IP is changing.