### PR TITLE
Update serveral apps to support using existing databases

### DIFF
--- a/stable/jasperreports/Chart.yaml
+++ b/stable/jasperreports/Chart.yaml
@@ -1,5 +1,5 @@
 name: jasperreports
-version: 0.2.6
+version: 0.3.0
 appVersion: 6.4.2
 description: The JasperReports server can be used as a stand-alone or embedded reporting
   and BI server that offers web-based reporting, analytic tools and visualization,

--- a/stable/jasperreports/README.md
+++ b/stable/jasperreports/README.md
@@ -59,10 +59,20 @@ The following tables lists the configurable parameters of the JasperReports char
 | `smtpUser`                    | SMTP user                                    | `nil`                                                    |
 | `smtpPassword`                | SMTP password                                | `nil`                                                    |
 | `smtpProtocol`                | SMTP protocol [`ssl`, `none`]                | `nil`                                                    |
+| `allowEmptyPassword`          | Allow DB blank passwords                     | `yes`                                                    |
+| `externalDatabase.host`       | Host of the external database                | `nil`                                                    |
+| `externalDatabase.port`       | Port of the external database                | `3306`                                                   |
+| `externalDatabase.user`       | Existing username in the external db         | `bn_jasperreports`                                       |
+| `externalDatabase.password`   | Password for the above username              | `nil`                                                    |
+| `externalDatabase.database`   | Name of the existing databse                 | `bitnami_jasperreports`                                  |
+| `mariadb.enabled`             | Wheter to use or not the mariadb chart       | `true`                                                   |
+| `mariadb.mariadbDatabase`     | Database name to create                      | `bitnami_jasperreports`                                  |
+| `mariadb.mariadbUser`         | Database user to create                      | `bn_jasperreports`                                       |
+| `mariadb.mariadbPassword`     | Password for the database                    | `nil`                                                    |
 | `mariadb.mariadbRootPassword` | MariaDB admin password                       | `nil`                                                    |
 | `serviceType`                 | Kubernetes Service type                      | `LoadBalancer`                                           |
 | `persistence.enabled`         | Enable persistence using PVC                 | `true`                                                   |
-| `persistence.storageClass`    | PVC Storage Class for JasperReports volume   | `nil` (uses alpha storage annotation)                     |
+| `persistence.storageClass`    | PVC Storage Class for JasperReports volume   | `nil` (uses alpha storage annotation)                    |
 | `persistence.accessMode`      | PVC Access Mode for JasperReports volume     | `ReadWriteOnce`                                          |
 | `persistence.size`            | PVC Storage Request for JasperReports volume | `8Gi`                                                    |
 | `resources`                   | CPU/Memory resource requests/limits          | Memory: `512Mi`, CPU: `300m`                             |

--- a/stable/jasperreports/requirements.lock
+++ b/stable/jasperreports/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.7.0
-digest: sha256:e1af13ac4ac21f67582006f12d2b4eb78a1a2a59b34338fac850f2bec0b08b41
-generated: 2017-08-09T22:52:49.897385868-04:00
+digest: sha256:f59f68030aa5c50b9e776b813804875fac911f91c2aa384e991f37a795c5ae34
+generated: 2018-03-16T15:44:56.555248+01:00

--- a/stable/jasperreports/requirements.yaml
+++ b/stable/jasperreports/requirements.yaml
@@ -2,3 +2,4 @@ dependencies:
 - name: mariadb
   version: 0.7.0
   repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: mariadb.enabled

--- a/stable/jasperreports/templates/NOTES.txt
+++ b/stable/jasperreports/templates/NOTES.txt
@@ -1,4 +1,4 @@
-
+{{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
 ** Please be patient while the chart is being deployed **
 
 1. Get the JasperReports URL by running:
@@ -27,3 +27,19 @@
 
   echo Username: {{ .Values.jasperreportsUsername }}
   echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "jasperreports.fullname" . }} -o jsonpath="{.data.jasperreports-password}" | base64 --decode)
+
+{{- else -}}
+
+########################################################################################
+### ERROR: You did not provide an external database host in your 'helm install' call ###
+########################################################################################
+
+This deployment will be incomplete until you configure JasperReports with a resolvable database
+host. To configure JasperReports to use and external database host:
+
+
+1. Complete your JasperReports deployment by running:
+
+  helm upgrade {{ .Release.Name }} --set serviceType={{ .Values.serviceType }},mariadb.enabled=false,externalDatabase.host=YOUR_EXTERNAL_DATABASE_HOST stable/jasperreports
+
+{{- end }}

--- a/stable/jasperreports/templates/deployment.yaml
+++ b/stable/jasperreports/templates/deployment.yaml
@@ -16,41 +16,63 @@ spec:
       containers:
       - name: {{ template "jasperreports.fullname" . }}
         image: "{{ .Values.image }}"
-        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+        imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
         env:
+        - name: ALLOW_EMPTY_PASSWORD
+          value: {{ .Values.allowEmptyPassword | quote }}
+        {{- if .Values.mariadb.enabled }}
         - name: MARIADB_HOST
           value: {{ template "jasperreports.mariadb.fullname" . }}
         - name: MARIADB_PORT_NUMBER
           value: "3306"
-        - name: MARIADB_PASSWORD
+        - name: JASPERREPORTS_DATABASE_NAME
+          value: {{ .Values.mariadb.mariadbDatabase | quote }}
+        - name: JASPERREPORTS_DATABASE_USER
+          value: {{ .Values.mariadb.mariadbUser | quote }}
+        - name: JASPERREPORTS_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "jasperreports.mariadb.fullname" . }}
-              key: mariadb-root-password
+              key: mariadb-password
+        {{- else }}
+        - name: MARIADB_HOST
+          value: {{ .Values.externalDatabase.host | quote }}
+        - name: MARIADB_PORT_NUMBER
+          value: {{ .Values.externalDatabase.port | quote }}
+        - name: JASPERREPORTS_DATABASE_NAME
+          value: {{ .Values.externalDatabase.database | quote }}
+        - name: JASPERREPORTS_DATABASE_USER
+          value: {{ .Values.externalDatabase.user | quote }}
+        - name: JASPERREPORTS_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ printf "%s-%s" .Release.Name "externaldb" }}
+              key: db-password
+        {{- end }}
         - name: JASPERREPORTS_USERNAME
-          value: {{ default "" .Values.jasperreportsUsername | quote }}
+          value: {{ .Values.jasperreportsUsername | quote }}
         - name: JASPERREPORTS_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "jasperreports.fullname" . }}
               key: jasperreports-password
         - name: JASPERREPORTS_EMAIL
-          value: {{ default "" .Values.jasperreportsEmail | quote }}
+          value: {{ .Values.jasperreportsEmail | quote }}
         - name: SMTP_HOST
-          value: {{ default "" .Values.smtpHost | quote }}
+          value: {{ .Values.smtpHost | quote }}
         - name: SMTP_PORT
-          value: {{ default "" .Values.smtpPort | quote }}
+          value: {{ .Values.smtpPort | quote }}
         - name: SMTP_EMAIL
-          value: {{ default "" .Values.smtpEmail| quote }}
+          value: {{ .Values.smtpEmail| quote }}
         - name: SMTP_USER
-          value: {{ default "" .Values.smtpUser | quote }}
+          value: {{ .Values.smtpUser | quote }}
         - name: SMTP_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "jasperreports.fullname" . }}
               key: smtp-password
         - name: SMTP_PROTOCOL
-          value: {{ default "" .Values.smtpProtocol | quote }}
+          value: {{ .Values.smtpProtocol | quote }}
         ports:
         - name: http
           containerPort: 8080

--- a/stable/jasperreports/templates/externaldb-secrets.yaml
+++ b/stable/jasperreports/templates/externaldb-secrets.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.mariadb.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+  labels:
+    app: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
+{{- end }}

--- a/stable/jasperreports/values.yaml
+++ b/stable/jasperreports/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami JasperReports image version
 ## ref: https://hub.docker.com/r/bitnami/jasperreports/tags/
 ##
-image: bitnami/jasperreports:6.4.2-r3
+image: bitnami/jasperreports:6.4.2-r4
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -24,6 +24,30 @@ jasperreportsUsername: user
 ##
 jasperreportsEmail: user@example.com
 
+## Set to `yes` to allow the container to be started with blank passwords
+## ref: https://github.com/bitnami/bitnami-docker-jasperreports#environment-variables
+allowEmptyPassword: "yes"
+
+##
+## External database configuration
+##
+externalDatabase:
+  ## Database host
+  host:
+
+  ## Database host
+  port: 3306
+
+  ## Database user
+  user: bn_jasperreports
+
+  ## Database password
+  password:
+
+  ## Database name
+  database: bitnami_jasperreports
+
+
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/bitnami-docker-jasperreports#smtp-configuration
 ##
@@ -38,6 +62,24 @@ jasperreportsEmail: user@example.com
 ## MariaDB chart configuration
 ##
 mariadb:
+  ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+  enabled: true
+
+  ## Create a database
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+  ##
+  mariadbDatabase: bitnami_jasperreports
+
+  ## Create a database user
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  mariadbUser: bn_jasperreports
+
+  ## Password for mariadbUser
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  # mariadbPassword:
+
   ## MariaDB admin password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
   ##

--- a/stable/joomla/Chart.yaml
+++ b/stable/joomla/Chart.yaml
@@ -1,6 +1,6 @@
 name: joomla
-version: 0.5.8
-appVersion: 3.8.5
+version: 0.6.0
+appVersion: 3.8.6
 description: PHP content management system (CMS) for publishing web content
 keywords:
 - joomla

--- a/stable/joomla/README.md
+++ b/stable/joomla/README.md
@@ -58,13 +58,23 @@ The following tables lists the configurable parameters of the Joomla! chart and 
 | `smtpPassword`                    | SMTP password                          | `nil`                                                     |
 | `smtpUsername`                    | User name for SMTP emails              | `nil`                                                     |
 | `smtpProtocol`                    | SMTP protocol [`tls`, `ssl`]           | `nil`                                                     |
+| `allowEmptyPassword`              | Allow DB blank passwords               | `yes`                                                     |
+| `externalDatabase.host`           | Host of the external database          | `nil`                                                     |
+| `externalDatabase.port`           | Port of the external database          | `3306`                                                    |
+| `externalDatabase.user`           | Existing username in the external db   | `bn_joomla`                                               |
+| `externalDatabase.password`       | Password for the above username        | `nil`                                                     |
+| `externalDatabase.database`       | Name of the existing databse           | `bitnami_joomla`                                          |
+| `mariadb.enabled`                 | Wheter to use or not the mariadb chart | `true`                                                    |
+| `mariadb.mariadbDatabase`         | Database name to create                | `bitnami_joomla`                                          |
+| `mariadb.mariadbUser`             | Database user to create                | `bn_joomla`                                               |
+| `mariadb.mariadbPassword`         | Password for the database              | `nil`                                                     |
 | `mariadb.mariadbRootPassword`     | MariaDB admin password                 | `nil`                                                     |
 | `serviceType`                     | Kubernetes Service type                | `LoadBalancer`                                            |
 | `persistence.enabled`             | Enable persistence using PVC           | `true`                                                    |
-| `persistence.apache.storageClass` | PVC Storage Class for Apache volume    | `nil` (uses alpha storage annotation)                                                |
+| `persistence.apache.storageClass` | PVC Storage Class for Apache volume    | `nil` (uses alpha storage annotation)                     |
 | `persistence.apache.accessMode`   | PVC Access Mode for Apache volume      | `ReadWriteOnce`                                           |
 | `persistence.apache.size`         | PVC Storage Request for Apache volume  | `1Gi`                                                     |
-| `persistence.joomla.storageClass` | PVC Storage Class for Joomla! volume   | `nil` (uses alpha storage annotation)                                                |
+| `persistence.joomla.storageClass` | PVC Storage Class for Joomla! volume   | `nil` (uses alpha storage annotation)                     |
 | `persistence.joomla.accessMode`   | PVC Access Mode for Joomla! volume     | `ReadWriteOnce`                                           |
 | `persistence.joomla.size`         | PVC Storage Request for Joomla! volume | `8Gi`                                                     |
 | `resources`                       | CPU/Memory resource requests/limits    | Memory: `512Mi`, CPU: `300m`                              |

--- a/stable/joomla/requirements.lock
+++ b/stable/joomla/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.7.0
-digest: sha256:e1af13ac4ac21f67582006f12d2b4eb78a1a2a59b34338fac850f2bec0b08b41
-generated: 2017-08-09T22:52:50.62658821-04:00
+digest: sha256:f59f68030aa5c50b9e776b813804875fac911f91c2aa384e991f37a795c5ae34
+generated: 2018-03-14T18:31:19.031367+01:00

--- a/stable/joomla/requirements.yaml
+++ b/stable/joomla/requirements.yaml
@@ -2,3 +2,4 @@ dependencies:
 - name: mariadb
   version: 0.7.0
   repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: mariadb.enabled

--- a/stable/joomla/templates/NOTES.txt
+++ b/stable/joomla/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
 1. Get the Joomla! URL by running:
 
 {{- if contains "NodePort" .Values.serviceType }}
@@ -24,3 +25,19 @@
 
     echo Username: {{ .Values.joomlaUsername }}
     echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "joomla.fullname" . }} -o jsonpath="{.data.joomla-password}" | base64 --decode)
+
+{{- else -}}
+
+########################################################################################
+### ERROR: You did not provide an external database host in your 'helm install' call ###
+########################################################################################
+
+This deployment will be incomplete until you configure Joomla! with a resolvable database
+host. To configure Joomla! to use and external database host:
+
+
+1. Complete your Joomla! deployment by running:
+
+  helm upgrade {{ .Release.Name }} --set serviceType={{ .Values.serviceType }},mariadb.enabled=false,externalDatabase.host=YOUR_EXTERNAL_DATABASE_HOST stable/joomla
+
+{{- end }}

--- a/stable/joomla/templates/deployment.yaml
+++ b/stable/joomla/templates/deployment.yaml
@@ -19,15 +19,37 @@ spec:
         image: "{{ .Values.image }}"
         imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         env:
+        - name: ALLOW_EMPTY_PASSWORD
+          value: {{ .Values.allowEmptyPassword | quote }}
+        {{- if .Values.mariadb.enabled }}
         - name: MARIADB_HOST
           value: {{ template "joomla.mariadb.fullname" . }}
         - name: MARIADB_PORT_NUMBER
           value: "3306"
-        - name: MARIADB_PASSWORD
+        - name: JOOMLA_DATABASE_NAME
+          value: {{ .Values.mariadb.mariadbDatabase | quote }}
+        - name: JOOMLA_DATABASE_USER
+          value: {{ .Values.mariadb.mariadbUser | quote }}
+        - name: JOOMLA_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "joomla.mariadb.fullname" . }}
-              key: mariadb-root-password
+              key: mariadb-password
+        {{- else }}
+        - name: MARIADB_HOST
+          value: {{ .Values.externalDatabase.host | quote }}
+        - name: MARIADB_PORT_NUMBER
+          value: {{ .Values.externalDatabase.port | quote }}
+        - name: JOOMLA_DATABASE_NAME
+          value: {{ .Values.externalDatabase.database | quote }}
+        - name: JOOMLA_DATABASE_USER
+          value: {{ .Values.externalDatabase.user | quote }}
+        - name: JOOMLA_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ printf "%s-%s" .Release.Name "externaldb" }}
+              key: db-password
+        {{- end }}
         - name: JOOMLA_USERNAME
           value: {{ default "" .Values.joomlaUsername | quote }}
         - name: JOOMLA_PASSWORD

--- a/stable/joomla/templates/externaldb-secrets.yaml
+++ b/stable/joomla/templates/externaldb-secrets.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.mariadb.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+  labels:
+    app: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
+{{- end }}

--- a/stable/joomla/values.yaml
+++ b/stable/joomla/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Joomla! image version
 ## ref: https://hub.docker.com/r/bitnami/joomla/tags/
 ##
-image: bitnami/joomla:3.8.5-r2
+image: bitnami/joomla:3.8.6-r1
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -25,6 +25,29 @@ joomlaUsername: user
 ##
 joomlaEmail: user@example.com
 
+## Set to `yes` to allow the container to be started with blank passwords
+## ref: https://github.com/bitnami/bitnami-docker-joomla#environment-variables
+allowEmptyPassword: "yes"
+
+##
+## External database configuration
+##
+externalDatabase:
+  ## Database host
+  host:
+
+  ## Database host
+  port: 3306
+
+  ## Database user
+  user: bn_jasperreports
+
+  ## Database password
+  password:
+
+  ## Database name
+  database: bitnami_jasperreports
+
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/bitnami-docker-joomla/#smtp-configuration
 ##
@@ -39,6 +62,24 @@ joomlaEmail: user@example.com
 ## MariaDB chart configuration
 ##
 mariadb:
+  ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+  enabled: true
+
+  ## Create a database
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+  ##
+  mariadbDatabase: bitnami_joomla
+
+  ## Create a database user
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  mariadbUser: bn_joomla
+
+  ## Password for mariadbUser
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  # mariadbPassword:
+
   ## MariaDB admin password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
   ##

--- a/stable/moodle/Chart.yaml
+++ b/stable/moodle/Chart.yaml
@@ -1,5 +1,5 @@
 name: moodle
-version: 0.4.7
+version: 0.5.0
 appVersion: 3.4.1
 description: Moodle is a learning platform designed to provide educators, administrators
   and learners with a single robust, secure and integrated system to create personalised

--- a/stable/moodle/README.md
+++ b/stable/moodle/README.md
@@ -69,7 +69,17 @@ The following tables lists the configurable parameters of the Moodle chart and t
 | `persistence.accessMode`            | PVC Access Mode for Moodle volume       | `ReadWriteOnce`                             |
 | `persistence.size`                  | PVC Storage Request for Moodle volume   | `8Gi`                                       |
 | `persistence.existingClaim`         | If PVC exists&bounded for Moodle        | `nil` (when nil, new one is requested)      |
-| `mariadb.mariadbRootPassword`       | MariaDB admin password                  | `nil` (uses alpha storage class annotation) |
+| `allowEmptyPassword`                | Allow DB blank passwords                | `yes`                                       |
+| `externalDatabase.host`             | Host of the external database           | `nil`                                       |
+| `externalDatabase.port`             | Port of the external database           | `3306`                                      |
+| `externalDatabase.user`             | Existing username in the external db    | `bn_moodle`                                 |
+| `externalDatabase.password`         | Password for the above username         | `nil`                                       |
+| `externalDatabase.database`         | Name of the existing databse            | `bitnami_moodle`                            |
+| `mariadb.enabled`                   | Wheter to use or not the mariadb chart  | `true`                                      |
+| `mariadb.mariadbDatabase`           | Database name to create                 | `bitnami_moodle`                            |
+| `mariadb.mariadbUser`               | Database user to create                 | `bn_moodle`                                 |
+| `mariadb.mariadbPassword`           | Password for the database               | `nil`                                       |
+| `mariadb.mariadbRootPassword`       | MariaDB admin password                  | `nil`                                       |
 | `mariadb.persistence.enabled`       | Enable MariaDB persistence using PVC    | `true`                                      |
 | `mariadb.persistence.storageClass`  | PVC Storage Class for MariaDB volume    | `generic`                                   |
 | `mariadb.persistence.accessMode`    | PVC Access Mode for MariaDB volume      | `ReadWriteOnce`                             |

--- a/stable/moodle/requirements.lock
+++ b/stable/moodle/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.7.0
-digest: sha256:e1af13ac4ac21f67582006f12d2b4eb78a1a2a59b34338fac850f2bec0b08b41
-generated: 2017-08-09T22:52:52.983181778-04:00
+digest: sha256:f59f68030aa5c50b9e776b813804875fac911f91c2aa384e991f37a795c5ae34
+generated: 2018-03-15T13:58:06.682767+01:00

--- a/stable/moodle/requirements.yaml
+++ b/stable/moodle/requirements.yaml
@@ -2,3 +2,4 @@ dependencies:
 - name: mariadb
   version: 0.7.0
   repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: mariadb.enabled

--- a/stable/moodle/templates/NOTES.txt
+++ b/stable/moodle/templates/NOTES.txt
@@ -1,4 +1,5 @@
 
+{{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
 ** Please be patient while the chart is being deployed **
 {{- if and .Values.ingress.enabled (ne .Values.serviceType "ClusterIP") }}
 ** Notice : Usually with ingress the serviceType should be set to ClusterIP, which is not the case to this deployment! **
@@ -39,3 +40,19 @@
 
   echo Username: {{ .Values.moodleUsername }}
   echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "moodle.fullname" . }} -o jsonpath="{.data.moodle-password}" | base64 --decode)
+
+{{- else -}}
+
+########################################################################################
+### ERROR: You did not provide an external database host in your 'helm install' call ###
+########################################################################################
+
+This deployment will be incomplete until you configure Moodle with a resolvable database
+host. To configure Moodle to use and external database host:
+
+
+1. Complete your Moodle deployment by running:
+
+  helm upgrade {{ .Release.Name }} --set serviceType={{ .Values.serviceType }},mariadb.enabled=false,externalDatabase.host=YOUR_EXTERNAL_DATABASE_HOST stable/moodle
+
+{{- end }}

--- a/stable/moodle/templates/deployment.yaml
+++ b/stable/moodle/templates/deployment.yaml
@@ -22,15 +22,37 @@ spec:
         image: "{{ .Values.image }}"
         imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         env:
+        - name: ALLOW_EMPTY_PASSWORD
+          value: {{ .Values.allowEmptyPassword | quote }}
+        {{- if .Values.mariadb.enabled }}
         - name: MARIADB_HOST
           value: {{ template "moodle.mariadb.fullname" . }}
         - name: MARIADB_PORT_NUMBER
           value: "3306"
-        - name: MARIADB_PASSWORD
+        - name: MOODLE_DATABASE_NAME
+          value: {{ .Values.mariadb.mariadbDatabase | quote }}
+        - name: MOODLE_DATABASE_USER
+          value: {{ .Values.mariadb.mariadbUser | quote }}
+        - name: MOODLE_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "moodle.mariadb.fullname" . }}
-              key: mariadb-root-password
+              key: mariadb-password
+        {{- else }}
+        - name: MARIADB_HOST
+          value: {{ .Values.externalDatabase.host | quote }}
+        - name: MARIADB_PORT_NUMBER
+          value: {{ .Values.externalDatabase.port | quote }}
+        - name: MOODLE_DATABASE_NAME
+          value: {{ .Values.externalDatabase.database | quote }}
+        - name: MOODLE_DATABASE_USER
+          value: {{ .Values.externalDatabase.user | quote }}
+        - name: MOODLE_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ printf "%s-%s" .Release.Name "externaldb" }}
+              key: db-password
+        {{- end }}
         - name: MOODLE_USERNAME
           value: {{ default "" .Values.moodleUsername | quote }}
         - name: MOODLE_PASSWORD

--- a/stable/moodle/templates/externaldb-secrets.yaml
+++ b/stable/moodle/templates/externaldb-secrets.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.mariadb.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+  labels:
+    app: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
+{{- end }}

--- a/stable/moodle/values.yaml
+++ b/stable/moodle/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Moodle` image version
 ## ref: https://hub.docker.com/r/bitnami/moodle/tags/
 ##
-image: bitnami/moodle:3.4.1-r3
+image: bitnami/moodle:3.4.1-r4
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -24,6 +24,29 @@ moodleUsername: user
 ## ref: https://github.com/bitnami/bitnami-docker-moodle#configuration
 moodleEmail: user@example.com
 
+## Set to `yes` to allow the container to be started with blank passwords
+## ref: https://github.com/bitnami/bitnami-docker-moodle#environment-variables
+allowEmptyPassword: "yes"
+
+##
+## External database configuration
+##
+externalDatabase:
+  ## Database host
+  host:
+
+  ## Database host
+  port: 3306
+
+  ## Database user
+  user: bn_moodle
+
+  ## Database password
+  password:
+
+  ## Database name
+  database: bitnami_moodle
+
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/bitnami-docker-moodle/#smtp-configuration
 # smtpHost:
@@ -36,6 +59,24 @@ moodleEmail: user@example.com
 ## MariaDB chart configuration
 ##
 mariadb:
+  ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+  enabled: true
+
+  ## Create a database
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+  ##
+  mariadbDatabase: bitnami_moodle
+
+  ## Create a database user
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  mariadbUser: bn_moodle
+
+  ## Password for mariadbUser
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  # mariadbPassword:
+
   ## MariaDB admin password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
   ##

--- a/stable/opencart/Chart.yaml
+++ b/stable/opencart/Chart.yaml
@@ -1,5 +1,5 @@
 name: opencart
-version: 0.6.3
+version: 0.7.0
 appVersion: 3.0.2
 description: A free and open source e-commerce platform for online merchants. It provides
   a professional and reliable foundation for a successful online store.

--- a/stable/opencart/README.md
+++ b/stable/opencart/README.md
@@ -59,6 +59,16 @@ The following tables lists the configurable parameters of the OpenCart chart and
 | `smtpUser`                          | SMTP user                                 | `nil`                                                    |
 | `smtpPassword`                      | SMTP password                             | `nil`                                                    |
 | `smtpProtocol`                      | SMTP protocol [`ssl`, `tls`]              | `nil`                                                    |
+| `allowEmptyPassword`                | Allow DB blank passwords                  | `yes`                                                    |
+| `externalDatabase.host`             | Host of the external database             | `nil`                                                    |
+| `externalDatabase.port`             | Port of the external database             | `3306`                                                   |
+| `externalDatabase.user`             | Existing username in the external db      | `bn_opencart`                                            |
+| `externalDatabase.password`         | Password for the above username           | `nil`                                                    |
+| `externalDatabase.database`         | Name of the existing databse              | `bitnami_opencart`                                       |
+| `mariadb.enabled`                   | Wheter to use or not the mariadb chart    | `true`                                                   |
+| `mariadb.mariadbDatabase`           | Database name to create                   | `bitnami_opencart`                                       |
+| `mariadb.mariadbUser`               | Database user to create                   | `bn_opencart`                                            | 
+| `mariadb.mariadbPassword`           | Password for the database                 | `nil`                                                    |
 | `mariadb.mariadbRootPassword`       | MariaDB admin password                    | `nil`                                                    |
 | `serviceType`                       | Kubernetes Service type                   | `LoadBalancer`                                           |
 | `persistence.enabled`               | Enable persistence using PVC              | `true`                                                   |

--- a/stable/opencart/requirements.lock
+++ b/stable/opencart/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.7.0
-digest: sha256:e1af13ac4ac21f67582006f12d2b4eb78a1a2a59b34338fac850f2bec0b08b41
-generated: 2017-08-09T22:52:53.617765447-04:00
+digest: sha256:f59f68030aa5c50b9e776b813804875fac911f91c2aa384e991f37a795c5ae34
+generated: 2018-03-15T15:14:56.908345+01:00

--- a/stable/opencart/requirements.yaml
+++ b/stable/opencart/requirements.yaml
@@ -2,3 +2,4 @@ dependencies:
 - name: mariadb
   version: 0.7.0
   repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: mariadb.enabled

--- a/stable/opencart/templates/NOTES.txt
+++ b/stable/opencart/templates/NOTES.txt
@@ -1,3 +1,5 @@
+{{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
+
 {{- if empty (include "opencart.host" .) -}}
 ###############################################################################
 ### ERROR: You did not provide an external host in your 'helm install' call ###
@@ -27,8 +29,17 @@ host. To configure OpenCart with the URL of your service:
 
 2. Complete your OpenCart deployment by running:
 
-  helm upgrade {{ .Release.Name }} \
-    --set opencartHost=$APP_HOST,opencartPassword=$APP_PASSWORD{{ if .Values.mariadb.mariadbRootPassword }},mariadb.mariadbRootPassword=$APP_DATABASE_PASSWORD{{ end }} stable/opencart
+{{- if .Values.mariadb.enabled }}
+
+  helm upgrade {{ .Release.Name }} stable/opencart \
+    --set opencartHost=$APP_HOST,opencartPassword=$APP_PASSWORD{{ if .Values.mariadb.mariadbPassword }},mariadb.mariadbPassword=$APP_DATABASE_PASSWORD{{ end }}
+{{- else }}
+
+  ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
+
+  helm upgrade {{ .Release.Name }} stable/opencart \
+    --set opencartPassword=$APP_PASSWORD,opencartHost=$APP_HOST,serviceType={{ .Values.serviceType }},mariadb.enabled=false{{- if not (empty .Values.externalDatabase.host) }},externalDatabase.host={{ .Values.externalDatabase.host }}{{- end }}{{- if not (empty .Values.externalDatabase.user) }},externalDatabase.user={{ .Values.externalDatabase.user }}{{- end }}{{- if not (empty .Values.externalDatabase.password) }},externalDatabase.password={{ .Values.externalDatabase.password }}{{- end }}{{- if not (empty .Values.externalDatabase.database) }},externalDatabase.database={{ .Values.externalDatabase.database }}{{- end }}
+{{- end }}
 
 {{- else -}}
 1. Get the OpenCart URL by running:
@@ -47,4 +58,35 @@ host. To configure OpenCart with the URL of your service:
 
   echo Admin Username: {{ .Values.opencartUsername }}
   echo Admin Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "opencart.fullname" . }} -o jsonpath="{.data.opencart-password}" | base64 --decode)
+{{- end }}
+
+{{- else -}}
+
+########################################################################################
+### ERROR: You did not provide an external database host in your 'helm install' call ###
+########################################################################################
+
+This deployment will be incomplete until you configure OpenCart with a resolvable database
+host. To configure OpenCart to use and external database host:
+
+1. Complete your OpenCart deployment by running:
+
+{{- if contains "NodePort" .Values.serviceType }}
+  export APP_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+{{- else if contains "LoadBalancer" .Values.serviceType }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "opencart.fullname" . }}'
+
+  export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "opencart.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+{{- else }}
+
+  export APP_HOST=127.0.0.1
+{{- end }}
+  export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "opencart.fullname" . }} -o jsonpath="{.data.opencart-password}" | base64 --decode)
+
+  ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
+
+  helm upgrade {{ .Release.Name }} stable/opencart \
+    --set opencartPassword=$APP_PASSWORD,opencartHost=$APP_HOST,serviceType={{ .Values.serviceType }},mariadb.enabled=false{{- if not (empty .Values.externalDatabase.user) }},externalDatabase.user={{ .Values.externalDatabase.user }}{{- end }}{{- if not (empty .Values.externalDatabase.password) }},externalDatabase.password={{ .Values.externalDatabase.password }}{{- end }}{{- if not (empty .Values.externalDatabase.database) }},externalDatabase.database={{ .Values.externalDatabase.database }}{{- end }},externalDatabase.host=YOUR_EXTERNAL_DATABASE_HOST
 {{- end }}

--- a/stable/opencart/templates/deployment.yaml
+++ b/stable/opencart/templates/deployment.yaml
@@ -19,15 +19,37 @@ spec:
         image: "{{ .Values.image }}"
         imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         env:
+        - name: ALLOW_EMPTY_PASSWORD
+          value: {{ .Values.allowEmptyPassword | quote }}
+        {{- if .Values.mariadb.enabled }}
         - name: MARIADB_HOST
           value: {{ template "opencart.mariadb.fullname" . }}
         - name: MARIADB_PORT_NUMBER
           value: "3306"
-        - name: MARIADB_PASSWORD
+        - name: OPENCART_DATABASE_NAME
+          value: {{ .Values.mariadb.mariadbDatabase | quote }}
+        - name: OPENCART_DATABASE_USER
+          value: {{ .Values.mariadb.mariadbUser | quote }}
+        - name: OPENCART_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "opencart.mariadb.fullname" . }}
-              key: mariadb-root-password
+              key: mariadb-password
+        {{- else }}
+        - name: MARIADB_HOST
+          value: {{ .Values.externalDatabase.host | quote }}
+        - name: MARIADB_PORT_NUMBER
+          value: {{ .Values.externalDatabase.port | quote }}
+        - name: OPENCART_DATABASE_NAME
+          value: {{ .Values.externalDatabase.database | quote }}
+        - name: OPENCART_DATABASE_USER
+          value: {{ .Values.externalDatabase.user | quote }}
+        - name: OPENCART_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ printf "%s-%s" .Release.Name "externaldb" }}
+              key: db-password
+        {{- end }}
         - name: OPENCART_HOST
           value: {{ include "opencart.host" . | quote }}
         - name: OPENCART_USERNAME

--- a/stable/opencart/templates/externaldb-secrets.yaml
+++ b/stable/opencart/templates/externaldb-secrets.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.mariadb.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+  labels:
+    app: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
+{{- end }}

--- a/stable/opencart/values.yaml
+++ b/stable/opencart/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami OpenCart image version
 ## ref: https://hub.docker.com/r/bitnami/opencart/tags/
 ##
-image: bitnami/opencart:3.0.2-0-r3
+image: bitnami/opencart:3.0.2-0-r4
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -35,6 +35,29 @@ opencartUsername: user
 ##
 opencartEmail: user@example.com
 
+## Set to `yes` to allow the container to be started with blank passwords
+## ref: https://github.com/bitnami/bitnami-docker-opencart#environment-variables
+allowEmptyPassword: "yes"
+
+##
+## External database configuration
+##
+externalDatabase:
+  ## Database host
+  host:
+
+  ## Database host
+  port: 3306
+
+  ## Database user
+  user: bn_opencart
+
+  ## Database password
+  password:
+
+  ## Database name
+  database: bitnami_opencart
+
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/bitnami-docker-opencart/#smtp-configuration
 ##
@@ -48,6 +71,24 @@ opencartEmail: user@example.com
 ## MariaDB chart configuration
 ##
 mariadb:
+  ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+  enabled: true
+
+  ## Create a database
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+  ##
+  mariadbDatabase: bitnami_opencart
+
+  ## Create a database user
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  mariadbUser: bn_opencart
+
+  ## Password for mariadbUser
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  # mariadbPassword:
+
   ## MariaDB admin password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
   ##

--- a/stable/orangehrm/Chart.yaml
+++ b/stable/orangehrm/Chart.yaml
@@ -1,5 +1,5 @@
 name: orangehrm
-version: 0.5.3
+version: 0.6.0
 appVersion: 4.0.0
 description: OrangeHRM is a free HR management system that offers a wealth of modules
   to suit the needs of your business.

--- a/stable/orangehrm/README.md
+++ b/stable/orangehrm/README.md
@@ -65,6 +65,16 @@ The following tables lists the configurable parameters of the OrangeHRM chart an
 | `persistence.orangehrm.storageClass` | PVC Storage Class for OrangeHRM volume   | `nil` (uses alpha storage class annotation)    |
 | `persistence.orangehrm.accessMode`   | PVC Access Mode for OrangeHRM volume     | `ReadWriteOnce`                                |
 | `persistence.orangehrm.size`         | PVC Storage Request for OrangeHRM volume | `8Gi`                                          |
+| `allowEmptyPassword`                 | Allow DB blank passwords                 | `yes`                                          |
+| `externalDatabase.host`              | Host of the external database            | `nil`                                          |
+| `externalDatabase.port`              | Port of the external database            | `3306`                                         |
+| `externalDatabase.user`              | Existing username in the external db     | `bn_orangehrm`                                 |
+| `externalDatabase.password`          | Password for the above username          | `nil`                                          |
+| `externalDatabase.database`          | Name of the existing databse             | `bitnami_orangehrm`                            |
+| `mariadb.enabled`                    | Wheter to use or not the mariadb chart   | `true`                                         |
+| `mariadb.mariadbDatabase`            | Database name to create                  | `bitnami_orangehrm`                            |
+| `mariadb.mariadbUser`                | Database user to create                  | `bn_orangehrm`                                 |
+| `mariadb.mariadbPassword`            | Password for the database                | `nil`                                          |
 | `mariadb.mariadbRootPassword`        | MariaDB admin password                   | `nil`                                          |
 | `mariadb.persistence.enabled`        | Enable MariaDB persistence using PVC     | `true`                                         |
 | `mariadb.persistence.storageClass`   | PVC Storage Class for MariaDB volume     | `nil` (uses alpha storage class annotation)    |

--- a/stable/orangehrm/requirements.lock
+++ b/stable/orangehrm/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.7.0
-digest: sha256:e1af13ac4ac21f67582006f12d2b4eb78a1a2a59b34338fac850f2bec0b08b41
-generated: 2017-08-09T22:52:54.510792323-04:00
+digest: sha256:f59f68030aa5c50b9e776b813804875fac911f91c2aa384e991f37a795c5ae34
+generated: 2018-03-15T15:46:51.001597+01:00

--- a/stable/orangehrm/requirements.yaml
+++ b/stable/orangehrm/requirements.yaml
@@ -2,3 +2,4 @@ dependencies:
 - name: mariadb
   version: 0.7.0
   repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: mariadb.enabled

--- a/stable/orangehrm/templates/NOTES.txt
+++ b/stable/orangehrm/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
 
 ** Please be patient while the chart is being deployed **
 
@@ -27,3 +28,19 @@
 
   echo Username: {{ .Values.orangehrmUsername }}
   echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "orangehrm.fullname" . }} -o jsonpath="{.data.orangehrm-password}" | base64 --decode)
+
+{{- else -}}
+
+########################################################################################
+### ERROR: You did not provide an external database host in your 'helm install' call ###
+########################################################################################
+
+This deployment will be incomplete until you configure OrangeHRM with a resolvable database
+host. To configure OrangeHRM to use and external database host:
+
+
+1. Complete your OrangeHRM deployment by running:
+
+  helm upgrade {{ .Release.Name }} --set serviceType={{ .Values.serviceType }},mariadb.enabled=false,externalDatabase.host=YOUR_EXTERNAL_DATABASE_HOST stable/orangehrm
+
+{{- end }}

--- a/stable/orangehrm/templates/deployment.yaml
+++ b/stable/orangehrm/templates/deployment.yaml
@@ -18,15 +18,37 @@ spec:
         image: "{{ .Values.image }}"
         imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         env:
+        - name: ALLOW_EMPTY_PASSWORD
+          value: {{ .Values.allowEmptyPassword | quote }}
+        {{- if .Values.mariadb.enabled }}
         - name: MARIADB_HOST
           value: {{ template "orangehrm.mariadb.fullname" . }}
         - name: MARIADB_PORT_NUMBER
           value: "3306"
-        - name: MARIADB_PASSWORD
+        - name: ORANGEHRM_DATABASE_NAME
+          value: {{ .Values.mariadb.mariadbDatabase | quote }}
+        - name: ORANGEHRM_DATABASE_USER
+          value: {{ .Values.mariadb.mariadbUser | quote }}
+        - name: ORANGEHRM_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "orangehrm.mariadb.fullname" . }}
-              key: mariadb-root-password
+              key: mariadb-password
+        {{- else }}
+        - name: MARIADB_HOST
+          value: {{ .Values.externalDatabase.host | quote }}
+        - name: MARIADB_PORT_NUMBER
+          value: {{ .Values.externalDatabase.port | quote }}
+        - name: ORANGEHRM_DATABASE_NAME
+          value: {{ .Values.externalDatabase.database | quote }}
+        - name: ORANGEHRM_DATABASE_USER
+          value: {{ .Values.externalDatabase.user | quote }}
+        - name: ORANGEHRM_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ printf "%s-%s" .Release.Name "externaldb" }}
+              key: db-password
+        {{- end }}
         - name: ORANGEHRM_USERNAME
           value: {{ default "" .Values.orangehrmUsername | quote }}
         - name: ORANGEHRM_PASSWORD

--- a/stable/orangehrm/templates/externaldb-secrets.yaml
+++ b/stable/orangehrm/templates/externaldb-secrets.yaml
@@ -1,0 +1,15 @@
+
+{{- if not .Values.mariadb.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+  labels:
+    app: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
+{{- end }}

--- a/stable/orangehrm/values.yaml
+++ b/stable/orangehrm/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami OrangeHRM image version
 ## ref: https://hub.docker.com/r/bitnami/orangehrm/tags/
 ##
-image: bitnami/orangehrm:4.0.0-r2
+image: bitnami/orangehrm:4.0.0-r3
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -19,6 +19,30 @@ orangehrmUsername: admin
 ##
 # orangehrmPassword:
 
+## Set to `yes` to allow the container to be started with blank passwords
+## ref: https://github.com/bitnami/bitnami-docker-orangehrm#environment-variables
+allowEmptyPassword: "yes"
+
+##
+## External database configuration
+##
+externalDatabase:
+  ## Database host
+  host:
+
+  ## Database host
+  port: 3306
+
+  ## Database user
+  user: bn_orangehrm
+
+  ## Database password
+  password:
+
+  ## Database name
+  database: bitnami_orangehrm
+
+
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/bitnami-docker-orangehrm/#smtp-configuration
 # smtpHost:
@@ -31,6 +55,24 @@ orangehrmUsername: admin
 ## MariaDB chart configuration
 ##
 mariadb:
+  ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+  enabled: true
+
+  ## Create a database
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+  ##
+  mariadbDatabase: bitnami_orangehrm
+
+  ## Create a database user
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  mariadbUser: bn_orangehrm
+
+  ## Password for mariadbUser
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  # mariadbPassword:
+
   ## MariaDB admin password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
   ##

--- a/stable/osclass/Chart.yaml
+++ b/stable/osclass/Chart.yaml
@@ -1,5 +1,5 @@
 name: osclass
-version: 0.5.3
+version: 0.6.0
 appVersion: 3.7.4
 description: Osclass is a php script that allows you to quickly create and manage
   your own free classifieds site.

--- a/stable/osclass/README.md
+++ b/stable/osclass/README.md
@@ -71,6 +71,16 @@ The following tables lists the configurable parameters of the Osclass chart and 
 | `persistence.moodle.storageClass`  | PVC Storage Class for OSClass volume     | `nil` (uses alpha storage class annotation) |
 | `persistence.moodle.accessMode`    | PVC Access Mode for OSClass volume       | `ReadWriteOnce`                             |
 | `persistence.moodle.size`          | PVC Storage Request for OSClass volume   | `8Gi`                                       |
+| `allowEmptyPassword`               | Allow DB blank passwords                 | `yes`                                       |
+| `externalDatabase.host`            | Host of the external database            | `nil`                                       |
+| `externalDatabase.port`            | Port of the external database            | `3306`                                      |
+| `externalDatabase.user`            | Existing username in the external db     | `bn_osclass`                                |
+| `externalDatabase.password`        | Password for the above username          | `nil`                                       |
+| `externalDatabase.database`        | Name of the existing databse             | `bitnami_osclass`                           |
+| `mariadb.enabled`                  | Wheter to use or not the mariadb chart   | `true`                                      |
+| `mariadb.mariadbDatabase`          | Database name to create                  | `bitnami_osclass`                           |
+| `mariadb.mariadbUser`              | Database user to create                  | `bn_osclass`                                |
+| `mariadb.mariadbPassword`          | Password for the database                | `nil`                                       |
 | `mariadb.mariadbRootPassword`      | MariaDB admin password                   | `nil`                                       |
 | `mariadb.persistence.enabled`      | Enable MariaDB persistence using PVC     | `true`                                      |
 | `mariadb.persistence.storageClass` | PVC Storage Class for MariaDB volume     | `generic`                                   |

--- a/stable/osclass/requirements.lock
+++ b/stable/osclass/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.7.0
-digest: sha256:e1af13ac4ac21f67582006f12d2b4eb78a1a2a59b34338fac850f2bec0b08b41
-generated: 2017-08-09T22:52:55.248933663-04:00
+digest: sha256:f59f68030aa5c50b9e776b813804875fac911f91c2aa384e991f37a795c5ae34
+generated: 2018-03-15T16:14:55.447738+01:00

--- a/stable/osclass/requirements.yaml
+++ b/stable/osclass/requirements.yaml
@@ -2,3 +2,4 @@ dependencies:
 - name: mariadb
   version: 0.7.0
   repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: mariadb.enabled

--- a/stable/osclass/templates/NOTES.txt
+++ b/stable/osclass/templates/NOTES.txt
@@ -1,3 +1,5 @@
+{{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
+
 {{- if empty (include "osclass.host" .) -}}
 ###############################################################################
 ### ERROR: You did not provide an external host in your 'helm install' call ###
@@ -27,8 +29,17 @@ host. To configure Osclass with the URL of your service:
 
 2. Complete your Osclass deployment by running:
 
-  helm upgrade {{ .Release.Name }} \
-    --set osclassHost=$APP_HOST,osclassPassword=$APP_PASSWORD{{ if .Values.mariadb.mariadbRootPassword }},mariadb.mariadbRootPassword=$APP_DATABASE_PASSWORD{{ end }} stable/osclass
+{{- if .Values.mariadb.enabled }}
+
+  helm upgrade {{ .Release.Name }} stable/osclass \
+    --set osclassHost=$APP_HOST,osclassPassword=$APP_PASSWORD{{ if .Values.mariadb.mariadbRootPassword }},mariadb.mariadbRootPassword=$APP_DATABASE_PASSWORD{{ end }}
+{{- else }}
+
+  ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
+
+  helm upgrade {{ .Release.Name }} stable/osclass \
+    --set osclassPassword=$APP_PASSWORD,osclassHost=$APP_HOST,serviceType={{ .Values.serviceType }},mariadb.enabled=false{{- if not (empty .Values.externalDatabase.host) }},externalDatabase.host={{ .Values.externalDatabase.host }}{{- end }}{{- if not (empty .Values.externalDatabase.user) }},externalDatabase.user={{ .Values.externalDatabase.user }}{{- end }}{{- if not (empty .Values.externalDatabase.password) }},externalDatabase.password={{ .Values.externalDatabase.password }}{{- end }}{{- if not (empty .Values.externalDatabase.database) }},externalDatabase.database={{ .Values.externalDatabase.database }}{{- end }}
+{{- end }}
 
 {{- else -}}
 1. Get the Osclass URL by running:
@@ -49,4 +60,36 @@ host. To configure Osclass with the URL of your service:
 
   echo Username  : {{ .Values.osclassUsername }}
   echo Password  : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "osclass.fullname" . }} -o jsonpath="{.data.osclass-password}" | base64 --decode)
+{{- end }}
+
+{{- else -}}
+
+########################################################################################
+### ERROR: You did not provide an external database host in your 'helm install' call ###
+########################################################################################
+
+This deployment will be incomplete until you configure Osclass with a resolvable database
+host. To configure Osclass to use and external database host:
+
+
+1. Complete your Osclass deployment by running:
+
+{{- if contains "NodePort" .Values.serviceType }}
+  export APP_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+{{- else if contains "LoadBalancer" .Values.serviceType }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "osclass.fullname" . }}'
+
+  export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "osclass.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+{{- else }}
+
+  export APP_HOST=127.0.0.1
+{{- end }}
+  export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "osclass.fullname" . }} -o jsonpath="{.data.osclass-password}" | base64 --decode)
+
+  ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
+
+  helm upgrade {{ .Release.Name }} stable/osclass \
+    --set osclassPassword=$APP_PASSWORD,osclassHost=$APP_HOST,serviceType={{ .Values.serviceType }},mariadb.enabled=false{{- if not (empty .Values.externalDatabase.user) }},externalDatabase.user={{ .Values.externalDatabase.user }}{{- end }}{{- if not (empty .Values.externalDatabase.password) }},externalDatabase.password={{ .Values.externalDatabase.password }}{{- end }}{{- if not (empty .Values.externalDatabase.database) }},externalDatabase.database={{ .Values.externalDatabase.database }}{{- end }},externalDatabase.host=YOUR_EXTERNAL_DATABASE_HOST
 {{- end }}

--- a/stable/osclass/templates/deployment.yaml
+++ b/stable/osclass/templates/deployment.yaml
@@ -19,15 +19,37 @@ spec:
         image: "{{ .Values.image }}"
         imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         env:
+        - name: ALLOW_EMPTY_PASSWORD
+          value: {{ .Values.allowEmptyPassword | quote }}
+        {{- if .Values.mariadb.enabled }}
         - name: MARIADB_HOST
           value: {{ template "osclass.mariadb.fullname" . }}
         - name: MARIADB_PORT_NUMBER
           value: "3306"
-        - name: MARIADB_PASSWORD
+        - name: OSCLASS_DATABASE_NAME
+          value: {{ .Values.mariadb.mariadbDatabase | quote }}
+        - name: OSCLASS_DATABASE_USER
+          value: {{ .Values.mariadb.mariadbUser | quote }}
+        - name: OSCLASS_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "osclass.mariadb.fullname" . }}
-              key: mariadb-root-password
+              key: mariadb-password
+        {{- else }}
+        - name: MARIADB_HOST
+          value: {{ .Values.externalDatabase.host | quote }}
+        - name: MARIADB_PORT_NUMBER
+          value: {{ .Values.externalDatabase.port | quote }}
+        - name: OSCLASS_DATABASE_NAME
+          value: {{ .Values.externalDatabase.database | quote }}
+        - name: OSCLASS_DATABASE_USER
+          value: {{ .Values.externalDatabase.user | quote }}
+        - name: OSCLASS_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ printf "%s-%s" .Release.Name "externaldb" }}
+              key: db-password
+        {{- end }}
         - name: OSCLASS_HOST
           value: {{ include "osclass.host" . | quote }}
         - name: OSCLASS_USERNAME

--- a/stable/osclass/templates/externaldb-secrets.yaml
+++ b/stable/osclass/templates/externaldb-secrets.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.mariadb.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+  labels:
+    app: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
+{{- end }}

--- a/stable/osclass/values.yaml
+++ b/stable/osclass/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Osclass image version
 ## ref: https://hub.docker.com/r/bitnami/osclass/tags/
 ##
-image: bitnami/osclass:3.7.4-r3
+image: bitnami/osclass:3.7.4-r4
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -47,6 +47,30 @@ osclassPingEngines: 1
 ##
 osclassSaveStats: 1
 
+## Set to `yes` to allow the container to be started with blank passwords
+## ref: https://github.com/bitnami/bitnami-docker-osclass#environment-variables
+allowEmptyPassword: "yes"
+
+##
+## External database configuration
+##
+externalDatabase:
+  ## Database host
+  host:
+
+  ## Database host
+  port: 3306
+
+  ## Database user
+  user: bn_osclass
+
+  ## Database password
+  password:
+
+  ## Database name
+  database: bitnami_osclass
+
+
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/bitnami-docker-osclass/#smtp-configuration
 ##
@@ -60,6 +84,24 @@ osclassSaveStats: 1
 ## MariaDB chart configuration
 ##
 mariadb:
+  ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+  enabled: true
+
+  ## Create a database
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+  ##
+  mariadbDatabase: bitnami_osclass
+
+  ## Create a database user
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  mariadbUser: bn_osclass
+
+  ## Password for mariadbUser
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  # mariadbPassword:
+
   ## MariaDB admin password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
   ##

--- a/stable/owncloud/Chart.yaml
+++ b/stable/owncloud/Chart.yaml
@@ -1,5 +1,5 @@
 name: owncloud
-version: 0.5.9
+version: 0.6.0
 appVersion: 10.0.7
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/stable/owncloud/README.md
+++ b/stable/owncloud/README.md
@@ -59,15 +59,26 @@ The following tables lists the configurable parameters of the ownCloud chart and
 | `owncloudUsername`                  | User of the application                   | `user`                                      |
 | `owncloudPassword`                  | Application password                      | Randomly generated                          |
 | `owncloudEmail`                     | Admin email                               | `user@example.com`                          |
+| `externalDatabase.host`             | Host of the external database             | `nil`                                       |
+| `allowEmptyPassword`                | Allow DB blank passwords                  | `yes`                                       |
+| `externalDatabase.host`             | Host of the external database             | `nil`                                       |
+| `externalDatabase.port`             | Port of the external database             | `3306`                                      |
+| `externalDatabase.database`         | Name of the existing databse              | `bitnami_owncloud`                          |
+| `externalDatabase.user`             | Existing username in the external db      | `bn_owncloud`                               |
+| `externalDatabase.password`         | Password for the above username           | `nil`                                       |
+| `mariadb.mariadbDatabase`           | Database name to create                   | `bitnami_owncloud`                          |
+| `mariadb.enabled`                   | Wheter to use or not the mariadb chart    | `true`                                      |
+| `mariadb.mariadbPassword`           | Password for the database                 | `nil`                                       |
+| `mariadb.mariadbUser`               | Database user to create                   | `bn_owncloud`                               |
 | `mariadb.mariadbRootPassword`       | MariaDB admin password                    | `nil`                                       |
 | `serviceType`                       | Kubernetes Service type                   | `LoadBalancer`                              |
 | `persistence.enabled`               | Enable persistence using PVC              | `true`                                      |
 | `persistence.apache.storageClass`   | PVC Storage Class for Apache volume       | `nil` (uses alpha storage class annotation) |
-| `persistence.apache.existingClaim`   | An Existing PVC name for Apache volume   | `nil` (uses alpha storage class annotation) |
+| `persistence.apache.existingClaim`  | An Existing PVC name for Apache volume    | `nil` (uses alpha storage class annotation) |
 | `persistence.apache.accessMode`     | PVC Access Mode for Apache volume         | `ReadWriteOnce`                             |
 | `persistence.apache.size`           | PVC Storage Request for Apache volume     | `1Gi`                                       |
 | `persistence.owncloud.storageClass` | PVC Storage Class for ownCloud volume     | `nil` (uses alpha storage class annotation) |
-| `persistence.owncloud.existingClaim` | An Existing PVC name for ownCloud volume | `nil` (uses alpha storage class annotation) |
+| `persistence.owncloud.existingClaim`| An Existing PVC name for ownCloud volume  | `nil` (uses alpha storage class annotation) |
 | `persistence.owncloud.accessMode`   | PVC Access Mode for ownCloud volume       | `ReadWriteOnce`                             |
 | `persistence.owncloud.size`         | PVC Storage Request for ownCloud volume   | `8Gi`                                       |
 | `resources`                         | CPU/Memory resource requests/limits       | Memory: `512Mi`, CPU: `300m`                |

--- a/stable/owncloud/requirements.lock
+++ b/stable/owncloud/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.7.0
-digest: sha256:e1af13ac4ac21f67582006f12d2b4eb78a1a2a59b34338fac850f2bec0b08b41
-generated: 2017-08-09T22:52:55.91352211-04:00
+digest: sha256:f59f68030aa5c50b9e776b813804875fac911f91c2aa384e991f37a795c5ae34
+generated: 2018-03-15T16:48:04.837968+01:00

--- a/stable/owncloud/requirements.yaml
+++ b/stable/owncloud/requirements.yaml
@@ -2,3 +2,4 @@ dependencies:
 - name: mariadb
   version: 0.7.0
   repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: mariadb.enabled

--- a/stable/owncloud/templates/NOTES.txt
+++ b/stable/owncloud/templates/NOTES.txt
@@ -1,3 +1,5 @@
+{{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
+
 {{- if empty (include "owncloud.host" .) -}}
 ###############################################################################
 ### ERROR: You did not provide an external host in your 'helm install' call ###
@@ -27,8 +29,17 @@ host. To configure ownCloud with the URL of your service:
 
 2. Complete your ownCloud deployment by running:
 
-  helm upgrade {{ .Release.Name }} \
-    --set owncloudHost=$APP_HOST,owncloudPassword=$APP_PASSWORD{{ if .Values.mariadb.mariadbRootPassword }},mariadb.mariadbRootPassword=$APP_DATABASE_PASSWORD{{ end }} stable/owncloud
+{{- if .Values.mariadb.enabled }}
+
+  helm upgrade {{ .Release.Name }} stable/owncloud \
+    --set owncloudHost=$APP_HOST,owncloudPassword=$APP_PASSWORD{{ if .Values.mariadb.mariadbRootPassword }},mariadb.mariadbRootPassword=$APP_DATABASE_PASSWORD{{ end }}
+{{- else }}
+
+  ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
+
+  helm upgrade {{ .Release.Name }} stable/owncloud \
+    --set owncloudPassword=$APP_PASSWORD,owncloudHost=$APP_HOST,serviceType={{ .Values.serviceType }},mariadb.enabled=false{{- if not (empty .Values.externalDatabase.host) }},externalDatabase.host={{ .Values.externalDatabase.host }}{{- end }}{{- if not (empty .Values.externalDatabase.user) }},externalDatabase.user={{ .Values.externalDatabase.user }}{{- end }}{{- if not (empty .Values.externalDatabase.password) }},externalDatabase.password={{ .Values.externalDatabase.password }}{{- end }}{{- if not (empty .Values.externalDatabase.database) }},externalDatabase.database={{ .Values.externalDatabase.database }}{{- end }}
+{{- end }}
 
 {{- else -}}
 1. Get the ownCloud URL by running:
@@ -47,4 +58,36 @@ host. To configure ownCloud with the URL of your service:
 
   echo User:     {{ .Values.owncloudUsername }}
   echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "owncloud.fullname" . }} -o jsonpath="{.data.owncloud-password}" | base64 --decode)
+{{- end }}
+
+{{- else -}}
+
+########################################################################################
+### ERROR: You did not provide an external database host in your 'helm install' call ###
+########################################################################################
+
+This deployment will be incomplete until you configure ownCloud with a resolvable database
+host. To configure ownCloud to use and external database host:
+
+
+1. Complete your ownCloud deployment by running:
+
+{{- if contains "NodePort" .Values.serviceType }}
+  export APP_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+{{- else if contains "LoadBalancer" .Values.serviceType }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "owncloud.fullname" . }}'
+
+  export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "owncloud.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+{{- else }}
+
+  export APP_HOST=127.0.0.1
+{{- end }}
+  export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "owncloud.fullname" . }} -o jsonpath="{.data.owncloud-password}" | base64 --decode)
+
+  ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
+
+  helm upgrade {{ .Release.Name }} stable/owncloud \
+    --set owncloudPassword=$APP_PASSWORD,owncloudHost=$APP_HOST,serviceType={{ .Values.serviceType }},mariadb.enabled=false{{- if not (empty .Values.externalDatabase.user) }},externalDatabase.user={{ .Values.externalDatabase.user }}{{- end }}{{- if not (empty .Values.externalDatabase.password) }},externalDatabase.password={{ .Values.externalDatabase.password }}{{- end }}{{- if not (empty .Values.externalDatabase.database) }},externalDatabase.database={{ .Values.externalDatabase.database }}{{- end }},externalDatabase.host=YOUR_EXTERNAL_DATABASE_HOST
 {{- end }}

--- a/stable/owncloud/templates/deployment.yaml
+++ b/stable/owncloud/templates/deployment.yaml
@@ -20,15 +20,37 @@ spec:
         image: "{{ .Values.image }}"
         imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         env:
+        - name: ALLOW_EMPTY_PASSWORD
+          value: {{ .Values.allowEmptyPassword | quote }}
+        {{- if .Values.mariadb.enabled }}
         - name: MARIADB_HOST
           value: {{ template "owncloud.mariadb.fullname" . }}
         - name: MARIADB_PORT_NUMBER
           value: "3306"
-        - name: MARIADB_PASSWORD
+        - name: OWNCLOUD_DATABASE_NAME
+          value: {{ .Values.mariadb.mariadbDatabase | quote }}
+        - name: OWNCLOUD_DATABASE_USER
+          value: {{ .Values.mariadb.mariadbUser | quote }}
+        - name: OWNCLOUD_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "owncloud.mariadb.fullname" . }}
-              key: mariadb-root-password
+              key: mariadb-password
+        {{- else }}
+        - name: MARIADB_HOST
+          value: {{ .Values.externalDatabase.host | quote }}
+        - name: MARIADB_PORT_NUMBER
+          value: {{ .Values.externalDatabase.port | quote }}
+        - name: OWNCLOUD_DATABASE_NAME
+          value: {{ .Values.externalDatabase.database | quote }}
+        - name: OWNCLOUD_DATABASE_USER
+          value: {{ .Values.externalDatabase.user | quote }}
+        - name: OWNCLOUD_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ printf "%s-%s" .Release.Name "externaldb" }}
+              key: db-password
+        {{- end }}
         - name: OWNCLOUD_HOST
           value: {{ include "owncloud.host" . | quote }}
         - name: OWNCLOUD_USERNAME

--- a/stable/owncloud/templates/externaldb-secrets.yaml
+++ b/stable/owncloud/templates/externaldb-secrets.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.mariadb.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+  labels:
+    app: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
+{{- end }}

--- a/stable/owncloud/values.yaml
+++ b/stable/owncloud/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami ownCloud image version
 ## ref: https://hub.docker.com/r/bitnami/owncloud/tags/
 ##
-image: bitnami/owncloud:10.0.7-r3
+image: bitnami/owncloud:10.0.7-r4
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -52,10 +52,51 @@ owncloudUsername: user
 ##
 owncloudEmail: user@example.com
 
+## Set to `yes` to allow the container to be started with blank passwords
+## ref: https://github.com/bitnami/bitnami-docker-owncloud#environment-variables
+allowEmptyPassword: "yes"
+
+##
+## External database configuration
+##
+externalDatabase:
+  ## Database host
+  host:
+
+  ## Database host
+  port: 3306
+
+  ## Database user
+  user: bn_owncloud
+
+  ## Database password
+  password:
+
+  ## Database name
+  database: bitnami_owncloud
+
 ##
 ## MariaDB chart configuration
 ##
 mariadb:
+  ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+  enabled: true
+
+  ## Create a database
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+  ##
+  mariadbDatabase: bitnami_owncloud
+
+  ## Create a database user
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  mariadbUser: bn_owncloud
+
+  ## Password for mariadbUser
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  # mariadbPassword:
+
   ## MariaDB admin password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
   ##
@@ -65,17 +106,17 @@ mariadb:
   ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
   ##
   persistence:
-  enabled: true
-  ## mariadb data Persistent Volume Storage Class
-  ## If defined, storageClassName: <storageClass>
-  ## If set to "-", storageClassName: "", which disables dynamic provisioning
-  ## If undefined (the default) or set to null, no storageClassName spec is
-  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-  ##   GKE, AWS & OpenStack)
-  ##
-  # storageClass: "-"
-  accessMode: ReadWriteOnce
-  size: 8Gi
+    enabled: true
+    ## mariadb data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    accessMode: ReadWriteOnce
+    size: 8Gi
 
 ## Kubernetes configuration
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer

--- a/stable/prestashop/Chart.yaml
+++ b/stable/prestashop/Chart.yaml
@@ -1,5 +1,5 @@
 name: prestashop
-version: 0.5.7
+version: 0.6.0
 appVersion: 1.7.3
 description: A popular open source ecommerce solution. Professional tools are easily
   accessible to increase online sales including instant guest checkout, abandoned

--- a/stable/prestashop/README.md
+++ b/stable/prestashop/README.md
@@ -61,6 +61,16 @@ The following tables lists the configurable parameters of the PrestaShop chart a
 | `smtpUser`                            | SMTP user                                   | `nil`                                                    |
 | `smtpPassword`                        | SMTP password                               | `nil`                                                    |
 | `smtpProtocol`                        | SMTP protocol [`ssl`, `tls`]                | `nil`                                                    |
+| `allowEmptyPassword`                  | Allow DB blank passwords                    | `yes`                                                    |
+| `externalDatabase.host`               | Host of the external database               | `nil`                                                    |
+| `externalDatabase.port`               | SMTP protocol [`ssl`, `none`]               | `3306`                                                   |
+| `externalDatabase.user`               | Existing username in the external db        | `bn_prestashop`                                          |
+| `externalDatabase.password`           | Password for the above username             | `nil`                                                    |
+| `externalDatabase.database`           | Name of the existing databse                | `bitnami_prestashop`                                     |
+| `mariadb.enabled`                     | Wheter to use or not the mariadb chart      | `true`                                                   |
+| `mariadb.mariadbDatabase`             | Database name to create                     | `bitnami_prestashop`                                     |
+| `mariadb.mariadbUser`                 | Database user to create                     | `bn_prestashop`                                          |
+| `mariadb.mariadbPassword`             | Password for the database                   | `nil`                                                    |
 | `mariadb.mariadbRootPassword`         | MariaDB admin password                      | `nil`                                                    |
 | `serviceType`                         | Kubernetes Service type                     | `LoadBalancer`                                           |
 | `persistence.enabled`                 | Enable persistence using PVC                | `true`                                                   |

--- a/stable/prestashop/requirements.lock
+++ b/stable/prestashop/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.7.0
-digest: sha256:e1af13ac4ac21f67582006f12d2b4eb78a1a2a59b34338fac850f2bec0b08b41
-generated: 2017-08-09T22:52:58.303930422-04:00
+digest: sha256:f59f68030aa5c50b9e776b813804875fac911f91c2aa384e991f37a795c5ae34
+generated: 2018-03-15T17:02:26.357827+01:00

--- a/stable/prestashop/requirements.yaml
+++ b/stable/prestashop/requirements.yaml
@@ -2,3 +2,4 @@ dependencies:
 - name: mariadb
   version: 0.7.0
   repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: mariadb.enabled

--- a/stable/prestashop/templates/NOTES.txt
+++ b/stable/prestashop/templates/NOTES.txt
@@ -1,3 +1,5 @@
+{{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
+
 {{- if empty (include "prestashop.host" .) -}}
 ###############################################################################
 ### ERROR: You did not provide an external host in your 'helm install' call ###
@@ -27,8 +29,17 @@ host. To configure PrestaShop with the URL of your service:
 
 2. Complete your PrestaShop deployment by running:
 
-  helm upgrade {{ .Release.Name }} \
-    --set prestashopHost=$APP_HOST,prestashopPassword=$APP_PASSWORD{{ if .Values.mariadb.mariadbRootPassword }},mariadb.mariadbRootPassword=$APP_DATABASE_PASSWORD{{ end }} stable/prestashop
+{{- if .Values.mariadb.enabled }}
+
+  helm upgrade {{ .Release.Name }} stable/prestashop \
+    --set prestashopHost=$APP_HOST,prestashopPassword=$APP_PASSWORD{{ if .Values.mariadb.mariadbRootPassword }},mariadb.mariadbRootPassword=$APP_DATABASE_PASSWORD{{ end }}
+{{- else }}
+
+  ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
+
+  helm upgrade {{ .Release.Name }} stable/prestashop \
+    --set prestashopPassword=$APP_PASSWORD,prestashopHost=$APP_HOST,serviceType={{ .Values.serviceType }},mariadb.enabled=false{{- if not (empty .Values.externalDatabase.host) }},externalDatabase.host={{ .Values.externalDatabase.host }}{{- end }}{{- if not (empty .Values.externalDatabase.user) }},externalDatabase.user={{ .Values.externalDatabase.user }}{{- end }}{{- if not (empty .Values.externalDatabase.password) }},externalDatabase.password={{ .Values.externalDatabase.password }}{{- end }}{{- if not (empty .Values.externalDatabase.database) }},externalDatabase.database={{ .Values.externalDatabase.database }}{{- end }}
+{{- end }}
 
 {{- else -}}
 1. Get the PrestaShop URL by running:
@@ -49,4 +60,36 @@ host. To configure PrestaShop with the URL of your service:
   echo Admin Email   : {{ .Values.prestashopEmail }}
   echo Admin Username: {{ .Values.prestashopUsername }}
   echo Admin Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "prestashop.fullname" . }} -o jsonpath="{.data.prestashop-password}" | base64 --decode)
+{{- end }}
+
+{{- else -}}
+
+########################################################################################
+### ERROR: You did not provide an external database host in your 'helm install' call ###
+########################################################################################
+
+This deployment will be incomplete until you configure PrestaShop with a resolvable database
+host. To configure PrestaShop to use and external database host:
+
+
+1. Complete your PrestaShop deployment by running:
+
+{{- if contains "NodePort" .Values.serviceType }}
+  export APP_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+{{- else if contains "LoadBalancer" .Values.serviceType }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "prestashop.fullname" . }}'
+
+  export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "prestashop.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+{{- else }}
+
+  export APP_HOST=127.0.0.1
+{{- end }}
+  export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "prestashop.fullname" . }} -o jsonpath="{.data.prestashop-password}" | base64 --decode)
+
+  ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
+
+  helm upgrade {{ .Release.Name }} stable/prestashop \
+    --set prestashopPassword=$APP_PASSWORD,prestashopHost=$APP_HOST,serviceType={{ .Values.serviceType }},mariadb.enabled=false{{- if not (empty .Values.externalDatabase.user) }},externalDatabase.user={{ .Values.externalDatabase.user }}{{- end }}{{- if not (empty .Values.externalDatabase.password) }},externalDatabase.password={{ .Values.externalDatabase.password }}{{- end }}{{- if not (empty .Values.externalDatabase.database) }},externalDatabase.database={{ .Values.externalDatabase.database }}{{- end }},externalDatabase.host=YOUR_EXTERNAL_DATABASE_HOST
 {{- end }}

--- a/stable/prestashop/templates/deployment.yaml
+++ b/stable/prestashop/templates/deployment.yaml
@@ -19,15 +19,37 @@ spec:
         image: "{{ .Values.image }}"
         imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
         env:
+        - name: ALLOW_EMPTY_PASSWORD
+          value: {{ .Values.allowEmptyPassword | quote }}
+        {{- if .Values.mariadb.enabled }}
         - name: MARIADB_HOST
           value: {{ template "prestashop.mariadb.fullname" . }}
         - name: MARIADB_PORT_NUMBER
           value: "3306"
-        - name: MARIADB_PASSWORD
+        - name: PRESTASHOP_DATABASE_NAME
+          value: {{ .Values.mariadb.mariadbDatabase | quote }}
+        - name: PRESTASHOP_DATABASE_USER
+          value: {{ .Values.mariadb.mariadbUser | quote }}
+        - name: PRESTASHOP_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "prestashop.mariadb.fullname" . }}
-              key: mariadb-root-password
+              key: mariadb-password
+        {{- else }}
+        - name: MARIADB_HOST
+          value: {{ .Values.externalDatabase.host | quote }}
+        - name: MARIADB_PORT_NUMBER
+          value: {{ .Values.externalDatabase.port | quote }}
+        - name: PRESTASHOP_DATABASE_NAME
+          value: {{ .Values.externalDatabase.database | quote }}
+        - name: PRESTASHOP_DATABASE_USER
+          value: {{ .Values.externalDatabase.user | quote }}
+        - name: PRESTASHOP_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ printf "%s-%s" .Release.Name "externaldb" }}
+              key: db-password
+        {{- end }}
         - name: PRESTASHOP_HOST
           value: {{ include "prestashop.host" . | quote }}
         - name: PRESTASHOP_USERNAME
@@ -43,8 +65,6 @@ spec:
           value: {{ .Values.prestashopFirstName | quote }}
         - name: PRESTASHOP_LAST_NAME
           value: {{ .Values.prestashopLastName | quote }}
-        - name: PRESTASHOP_COOKIE_CHECK_IP
-          value: "no"
         - name: SMTP_HOST
           value: {{ .Values.smtpHost | quote }}
         - name: SMTP_PORT

--- a/stable/prestashop/templates/externaldb-secrets.yaml
+++ b/stable/prestashop/templates/externaldb-secrets.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.mariadb.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+  labels:
+    app: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
+{{- end }}

--- a/stable/prestashop/values.yaml
+++ b/stable/prestashop/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami PrestaShop image version
 ## ref: https://hub.docker.com/r/bitnami/prestashop/tags/
 ##
-image: bitnami/prestashop:1.7.3-0-r0
+image: bitnami/prestashop:1.7.3-0-r1
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -45,6 +45,30 @@ prestashopFirstName: Bitnami
 ##
 prestashopLastName: User
 
+## Set to `yes` to allow the container to be started with blank passwords
+## ref: https://github.com/bitnami/bitnami-docker-prestashop#environment-variables
+allowEmptyPassword: "yes"
+
+##
+## External database configuration
+##
+externalDatabase:
+  ## Database host
+  host:
+
+  ## Database host
+  port: 3306
+
+  ## Database user
+  user: bn_jasperreports
+
+  ## Database password
+  password:
+
+  ## Database name
+  database: bitnami_prestashop
+
+
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/bitnami-docker-prestashop/#smtp-configuration
 ##
@@ -58,6 +82,24 @@ prestashopLastName: User
 ## MariaDB chart configuration
 ##
 mariadb:
+  ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+  enabled: true
+
+  ## Create a database
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+  ##
+  mariadbDatabase: bitnami_prestashop
+
+  ## Create a database user
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  mariadbUser: bn_prestashop
+
+  ## Password for mariadbUser
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  # mariadbPassword:
+
   ## MariaDB admin password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
   ##

--- a/stable/sugarcrm/Chart.yaml
+++ b/stable/sugarcrm/Chart.yaml
@@ -1,5 +1,5 @@
 name: sugarcrm
-version: 0.2.5
+version: 0.3.1
 appVersion: 6.5.26
 description: SugarCRM enables businesses to create extraordinary customer relationships with the most innovative and affordable CRM solution in the market.
 keywords:

--- a/stable/sugarcrm/README.md
+++ b/stable/sugarcrm/README.md
@@ -60,6 +60,16 @@ The following tables lists the configurable parameters of the SugarCRM chart and
 | `sugarcrmSmtpProtocol`              | SMTP Protocol                           | `nil`                                       |
 | `sugarcrmSmtpUser`                  | SMTP user                               | `nil`                                       |
 | `sugarcrmSmtpPassword`              | SMTP password                           | `nil`                                       |
+| `allowEmptyPassword`                | Allow DB blank passwords                | `yes`                                       |
+| `externalDatabase.host`             | Host of the external database           | `nil`                                       |
+| `externalDatabase.port`             | Port of the external database           | `3306`                                      |
+| `externalDatabase.user`             | Existing username in the external db    | `bn_sugarcrm`                               |
+| `externalDatabase.password`         | Password for the above username         | `nil`                                       |
+| `externalDatabase.database`         | Name of the existing databse            | `bitnami_sugarcrm`                          |
+| `mariadb.enabled`                   | Wheter to use or not the mariadb chart  | `true`                                      |
+| `mariadb.mariadbDatabase`           | Database name to create                 | `bitnami_sugarcrm`                          |
+| `mariadb.mariadbUser`               | Database user to create                 | `bn_sugarcrm`                               |
+| `mariadb.mariadbPassword`           | Password for the database               | `nil`                                       |
 | `mariadb.mariadbRootPassword`       | MariaDB admin password                  | `nil`                                       |
 | `serviceType`                       | Kubernetes Service type                 | `LoadBalancer`                              |
 | `persistence.enabled`               | Enable persistence using PVC            | `true`                                      |

--- a/stable/sugarcrm/requirements.lock
+++ b/stable/sugarcrm/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.7.0
-digest: sha256:e1af13ac4ac21f67582006f12d2b4eb78a1a2a59b34338fac850f2bec0b08b41
-generated: 2017-08-09T22:53:00.253043673-04:00
+digest: sha256:f59f68030aa5c50b9e776b813804875fac911f91c2aa384e991f37a795c5ae34
+generated: 2018-03-15T17:23:59.5931+01:00

--- a/stable/sugarcrm/requirements.yaml
+++ b/stable/sugarcrm/requirements.yaml
@@ -2,3 +2,4 @@ dependencies:
 - name: mariadb
   version: 0.7.0
   repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: mariadb.enabled

--- a/stable/sugarcrm/templates/NOTES.txt
+++ b/stable/sugarcrm/templates/NOTES.txt
@@ -1,3 +1,5 @@
+{{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
+
 {{- if empty (include "host" .) -}}
 ###############################################################################
 ### ERROR: You did not provide an external host in your 'helm install' call ###
@@ -27,8 +29,17 @@ host. To configure SugarCRM with the URL of your service:
 
 2. Complete your SugarCRM deployment by running:
 
-  helm upgrade {{ .Release.Name }} \
-    --set sugarcrmHost=$APP_HOST,sugarcrmPassword=$APP_PASSWORD{{ if .Values.mariadb.mariadbRootPassword }},mariadb.mariadbRootPassword=$APP_DATABASE_PASSWORD{{ end }} stable/sugarcrm
+{{- if .Values.mariadb.enabled }}
+
+  helm upgrade {{ .Release.Name }} stable/sugarcrm \
+    --set sugarcrmHost=$APP_HOST,sugarcrmPassword=$APP_PASSWORD{{ if .Values.mariadb.mariadbRootPassword }},mariadb.mariadbRootPassword=$APP_DATABASE_PASSWORD{{ end }}
+{{- else }}
+
+  ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
+
+  helm upgrade {{ .Release.Name }} stable/sugarcrm \
+    --set sugarcrmPassword=$APP_PASSWORD,sugarcrmHost=$APP_HOST,serviceType={{ .Values.serviceType }},mariadb.enabled=false{{- if not (empty .Values.externalDatabase.host) }},externalDatabase.host={{ .Values.externalDatabase.host }}{{- end }}{{- if not (empty .Values.externalDatabase.user) }},externalDatabase.user={{ .Values.externalDatabase.user }}{{- end }}{{- if not (empty .Values.externalDatabase.password) }},externalDatabase.password={{ .Values.externalDatabase.password }}{{- end }}{{- if not (empty .Values.externalDatabase.database) }},externalDatabase.database={{ .Values.externalDatabase.database }}{{- end }}
+{{- end }}
 
 {{- else -}}
 1. Get the SugarCRM URL by running:
@@ -47,4 +58,36 @@ host. To configure SugarCRM with the URL of your service:
 
   echo Username: {{ .Values.sugarcrmUsername }}
   echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.sugarcrm-password}" | base64 --decode)
+{{- end }}
+
+{{- else -}}
+
+########################################################################################
+### ERROR: You did not provide an external database host in your 'helm install' call ###
+########################################################################################
+
+This deployment will be incomplete until you configure SugarCRM with a resolvable database
+host. To configure SugarCRM to use and external database host:
+
+
+1. Complete your SugarCRM deployment by running:
+
+{{- if contains "NodePort" .Values.serviceType }}
+  export APP_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+{{- else if contains "LoadBalancer" .Values.serviceType }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "sugarcrm.fullname" . }}'
+
+  export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "sugarcrm.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+{{- else }}
+
+  export APP_HOST=127.0.0.1
+{{- end }}
+  export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "sugarcrm.fullname" . }} -o jsonpath="{.data.sugarcrm-password}" | base64 --decode)
+
+  ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
+
+  helm upgrade {{ .Release.Name }} stable/sugarcrm \
+    --set sugarcrmPassword=$APP_PASSWORD,sugarcrmHost=$APP_HOST,serviceType={{ .Values.serviceType }},mariadb.enabled=false{{- if not (empty .Values.externalDatabase.user) }},externalDatabase.user={{ .Values.externalDatabase.user }}{{- end }}{{- if not (empty .Values.externalDatabase.password) }},externalDatabase.password={{ .Values.externalDatabase.password }}{{- end }}{{- if not (empty .Values.externalDatabase.database) }},externalDatabase.database={{ .Values.externalDatabase.database }}{{- end }},externalDatabase.host=YOUR_EXTERNAL_DATABASE_HOST
 {{- end }}

--- a/stable/sugarcrm/templates/_helpers.tpl
+++ b/stable/sugarcrm/templates/_helpers.tpl
@@ -19,7 +19,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "mariadb.fullname" -}}
+{{- define "sugarcrm.mariadb.fullname" -}}
 {{- printf "%s-%s" .Release.Name "mariadb" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 

--- a/stable/sugarcrm/templates/deployment.yaml
+++ b/stable/sugarcrm/templates/deployment.yaml
@@ -20,15 +20,37 @@ spec:
         image: "{{ .Values.image }}"
         imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
         env:
+        - name: ALLOW_EMPTY_PASSWORD
+          value: {{ .Values.allowEmptyPassword | quote }}
+        {{- if .Values.mariadb.enabled }}
         - name: MARIADB_HOST
-          value: {{ template "mariadb.fullname" . }}
+          value: {{ template "sugarcrm.mariadb.fullname" . }}
         - name: MARIADB_PORT_NUMBER
           value: "3306"
-        - name: MARIADB_PASSWORD
+        - name: SUGARCRM_DATABASE_NAME
+          value: {{ .Values.mariadb.mariadbDatabase | quote }}
+        - name: SUGARCRM_DATABASE_USER
+          value: {{ .Values.mariadb.mariadbUser | quote }}
+        - name: SUGARCRM_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "mariadb.fullname" . }}
-              key: mariadb-root-password
+              name: {{ template "sugarcrm.mariadb.fullname" . }}
+              key: mariadb-password
+        {{- else }}
+        - name: MARIADB_HOST
+          value: {{ .Values.externalDatabase.host | quote }}
+        - name: MARIADB_PORT_NUMBER
+          value: {{ .Values.externalDatabase.port | quote }}
+        - name: SUGARCRM_DATABASE_NAME
+          value: {{ .Values.externalDatabase.database | quote }}
+        - name: SUGARCRM_DATABASE_USER
+          value: {{ .Values.externalDatabase.user | quote }}
+        - name: SUGARCRM_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ printf "%s-%s" .Release.Name "externaldb" }}
+              key: db-password
+        {{- end }}
         - name: SUGARCRM_HOST
           value: {{ include "host" . | quote }}
         - name: SUGARCRM_USERNAME

--- a/stable/sugarcrm/templates/externaldb-secrets.yaml
+++ b/stable/sugarcrm/templates/externaldb-secrets.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.mariadb.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+  labels:
+    app: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
+{{- end }}

--- a/stable/sugarcrm/values.yaml
+++ b/stable/sugarcrm/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami SugarCRM image version
 ## ref: https://hub.docker.com/r/bitnami/sugarcrm/tags/
 ##
-image: bitnami/sugarcrm:6.5.26-r2
+image: bitnami/sugarcrm:6.5.26-r3
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -39,6 +39,29 @@ sugarcrmEmail: user@example.com
 ##
 sugarcrmLastName: LastName
 
+## Set to `yes` to allow the container to be started with blank passwords
+## ref: https://github.com/bitnami/bitnami-docker-sugarcrm#environment-variables
+allowEmptyPassword: "yes"
+
+##
+## External database configuration
+##
+externalDatabase:
+  ## Database host
+  host:
+
+  ## Database host
+  port: 3306
+
+  ## Database user
+  user: bn_sugarcrm
+
+  ## Database password
+  password:
+
+  ## Database name
+  database: bitnami_sugarcrm
+
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/bitnami-docker-orangehrm/#smtp-configuration
 # sugarcrmSmtpHost:
@@ -51,6 +74,24 @@ sugarcrmLastName: LastName
 ## MariaDB chart configuration
 ##
 mariadb:
+  ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+  enabled: true
+
+  ## Create a database
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+  ##
+  mariadbDatabase: bitnami_sugarcrm
+
+  ## Create a database user
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  mariadbUser: bn_sugarcrm
+
+  ## Password for mariadbUser
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  # mariadbPassword:
+
   ## MariaDB admin password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
   ##

--- a/stable/suitecrm/Chart.yaml
+++ b/stable/suitecrm/Chart.yaml
@@ -1,6 +1,6 @@
 name: suitecrm
-version: 0.3.9
-appVersion: 7.9.12
+version: 0.4.0
+appVersion: 7.10.2
 description: SuiteCRM is a completely open source enterprise-grade Customer Relationship Management (CRM) application. SuiteCRM is a software fork of the popular customer relationship management (CRM) system SugarCRM.
 keywords:
 - suitecrm

--- a/stable/suitecrm/README.md
+++ b/stable/suitecrm/README.md
@@ -60,6 +60,16 @@ The following tables lists the configurable parameters of the SuiteCRM chart and
 | `suitecrmSmtpUser`                  | SMTP user                                 | `nil`                                       |
 | `suitecrmSmtpPassword`              | SMTP password                             | `nil`                                       |
 | `suitecrmSmtpProtocol`              | SMTP protocol [`ssl`, `tls`]              | `nil`                                       |
+| `allowEmptyPassword`                | Allow DB blank passwords                  | `yes`                                       |
+| `externalDatabase.host`             | Host of the external database             | `nil`                                       |
+| `externalDatabase.port`             | Port of the external database             | `3306`                                      |
+| `externalDatabase.user`             | Existing username in the external db      | `bn_suitecrm`                               |
+| `externalDatabase.password`         | Password for the above username           | `nil`                                       |
+| `externalDatabase.database`         | Name of the existing databse              | `bitnami_suitecrm`                          |
+| `mariadb.enabled`                   | Wheter to use or not the mariadb chart    | `true`                                      |
+| `mariadb.mariadbDatabase`           | Database name to create                   | `bitnami_suitecrm`                          |
+| `mariadb.mariadbUser`               | Database user to create                   | `bn_suitecrm`                               |
+| `mariadb.mariadbPassword`           | Password for the database                 | `nil`                                       |
 | `mariadb.mariadbRootPassword`       | MariaDB admin password                    | `nil`                                       |
 | `serviceType`                       | Kubernetes Service type                   | `LoadBalancer`                              |
 | `persistence.enabled`               | Enable persistence using PVC              | `true`                                      |

--- a/stable/suitecrm/requirements.lock
+++ b/stable/suitecrm/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.7.0
-digest: sha256:e1af13ac4ac21f67582006f12d2b4eb78a1a2a59b34338fac850f2bec0b08b41
-generated: 2017-08-09T22:53:01.117093603-04:00
+digest: sha256:f59f68030aa5c50b9e776b813804875fac911f91c2aa384e991f37a795c5ae34
+generated: 2018-03-15T17:44:12.005678+01:00

--- a/stable/suitecrm/requirements.yaml
+++ b/stable/suitecrm/requirements.yaml
@@ -2,3 +2,4 @@ dependencies:
 - name: mariadb
   version: 0.7.0
   repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: mariadb.enabled

--- a/stable/suitecrm/templates/NOTES.txt
+++ b/stable/suitecrm/templates/NOTES.txt
@@ -1,3 +1,5 @@
+{{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
+
 {{- if empty (include "host" .) -}}
 ###############################################################################
 ### ERROR: You did not provide an external host in your 'helm install' call ###
@@ -27,8 +29,17 @@ host. To configure SuiteCRM with the URL of your service:
 
 2. Complete your SuiteCRM deployment by running:
 
-  helm upgrade {{ .Release.Name }} \
-    --set suitecrmHost=$APP_HOST,suitecrmPassword=$APP_PASSWORD{{ if .Values.mariadb.mariadbRootPassword }},mariadb.mariadbRootPassword=$APP_DATABASE_PASSWORD{{ end }} stable/suitecrm
+{{- if .Values.mariadb.enabled }}
+
+  helm upgrade {{ .Release.Name }} stable/suitecrm \
+    --set suitecrmHost=$APP_HOST,suitecrmPassword=$APP_PASSWORD{{ if .Values.mariadb.mariadbRootPassword }},mariadb.mariadbRootPassword=$APP_DATABASE_PASSWORD{{ end }}
+{{- else }}
+
+  ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
+
+  helm upgrade {{ .Release.Name }} stable/suitecrm \
+    --set suitecrmPassword=$APP_PASSWORD,suitecrmHost=$APP_HOST,serviceType={{ .Values.serviceType }},mariadb.enabled=false{{- if not (empty .Values.externalDatabase.host) }},externalDatabase.host={{ .Values.externalDatabase.host }}{{- end }}{{- if not (empty .Values.externalDatabase.user) }},externalDatabase.user={{ .Values.externalDatabase.user }}{{- end }}{{- if not (empty .Values.externalDatabase.password) }},externalDatabase.password={{ .Values.externalDatabase.password }}{{- end }}{{- if not (empty .Values.externalDatabase.database) }},externalDatabase.database={{ .Values.externalDatabase.database }}{{- end }}
+{{- end }}
 
 {{- else -}}
 1. Get the SuiteCRM URL by running:
@@ -47,4 +58,36 @@ host. To configure SuiteCRM with the URL of your service:
 
   echo Username : {{ .Values.suitecrmUsername }}
   echo Password : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.suitecrm-password}" | base64 --decode)
+{{- end }}
+
+{{- else -}}
+
+########################################################################################
+### ERROR: You did not provide an external database host in your 'helm install' call ###
+########################################################################################
+
+This deployment will be incomplete until you configure SuiteCRM with a resolvable database
+host. To configure SuiteCRM to use and external database host:
+
+
+1. Complete your SuiteCRM deployment by running:
+
+{{- if contains "NodePort" .Values.serviceType }}
+  export APP_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+{{- else if contains "LoadBalancer" .Values.serviceType }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "suitecrm.fullname" . }}'
+
+  export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "suitecrm.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+{{- else }}
+
+  export APP_HOST=127.0.0.1
+{{- end }}
+  export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "suitecrm.fullname" . }} -o jsonpath="{.data.suitecrm-password}" | base64 --decode)
+
+  ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
+
+  helm upgrade {{ .Release.Name }} stable/suitecrm \
+    --set suitecrmPassword=$APP_PASSWORD,suitecrmHost=$APP_HOST,serviceType={{ .Values.serviceType }},mariadb.enabled=false{{- if not (empty .Values.externalDatabase.user) }},externalDatabase.user={{ .Values.externalDatabase.user }}{{- end }}{{- if not (empty .Values.externalDatabase.password) }},externalDatabase.password={{ .Values.externalDatabase.password }}{{- end }}{{- if not (empty .Values.externalDatabase.database) }},externalDatabase.database={{ .Values.externalDatabase.database }}{{- end }},externalDatabase.host=YOUR_EXTERNAL_DATABASE_HOST
 {{- end }}

--- a/stable/suitecrm/templates/_helpers.tpl
+++ b/stable/suitecrm/templates/_helpers.tpl
@@ -19,7 +19,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "mariadb.fullname" -}}
+{{- define "suitecrm.mariadb.fullname" -}}
 {{- printf "%s-%s" .Release.Name "mariadb" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 

--- a/stable/suitecrm/templates/deployment.yaml
+++ b/stable/suitecrm/templates/deployment.yaml
@@ -20,15 +20,37 @@ spec:
         image: "{{ .Values.image }}"
         imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
         env:
+        - name: ALLOW_EMPTY_PASSWORD
+          value: {{ .Values.allowEmptyPassword | quote }}
+        {{- if .Values.mariadb.enabled }}
         - name: MARIADB_HOST
-          value: {{ template "mariadb.fullname" . }}
+          value: {{ template "suitecrm.mariadb.fullname" . }}
         - name: MARIADB_PORT_NUMBER
           value: "3306"
-        - name: MARIADB_PASSWORD
+        - name: SUITECRM_DATABASE_NAME
+          value: {{ .Values.mariadb.mariadbDatabase | quote }}
+        - name: SUITECRM_DATABASE_USER
+          value: {{ .Values.mariadb.mariadbUser | quote }}
+        - name: SUITECRM_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "mariadb.fullname" . }}
-              key: mariadb-root-password
+              name: {{ template "suitecrm.mariadb.fullname" . }}
+              key: mariadb-password
+        {{- else }}
+        - name: MARIADB_HOST
+          value: {{ .Values.externalDatabase.host | quote }}
+        - name: MARIADB_PORT_NUMBER
+          value: {{ .Values.externalDatabase.port | quote }}
+        - name: SUITECRM_DATABASE_NAME
+          value: {{ .Values.externalDatabase.database | quote }}
+        - name: SUITECRM_DATABASE_USER
+          value: {{ .Values.externalDatabase.user | quote }}
+        - name: SUITECRM_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ printf "%s-%s" .Release.Name "externaldb" }}
+              key: db-password
+        {{- end }}
         - name: SUITECRM_HOST
           value: {{ include "host" . | quote }}
         - name: SUITECRM_USERNAME

--- a/stable/suitecrm/templates/externaldb-secrets.yaml
+++ b/stable/suitecrm/templates/externaldb-secrets.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.mariadb.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+  labels:
+    app: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
+{{- end }}

--- a/stable/suitecrm/templates/svc.yaml
+++ b/stable/suitecrm/templates/svc.yaml
@@ -7,8 +7,6 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  annotations:
-    service.beta.kubernetes.io/external-traffic: OnlyLocal
 spec:
   type: {{ .Values.serviceType }}
   {{- if eq .Values.serviceType "LoadBalancer" }}

--- a/stable/suitecrm/values.yaml
+++ b/stable/suitecrm/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami SuiteCRM image version
 ## ref: https://hub.docker.com/r/bitnami/suitecrm/tags/
 ##
-image: bitnami/suitecrm:7.9.12-r2
+image: bitnami/suitecrm:7.10.2-r1
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -39,6 +39,30 @@ suitecrmEmail: user@example.com
 ##
 suitecrmLastName: Name
 
+## Set to `yes` to allow the container to be started with blank passwords
+## ref: https://github.com/bitnami/bitnami-docker-suitecrm#environment-variables
+allowEmptyPassword: "yes"
+
+##
+## External database configuration
+##
+externalDatabase:
+  ## Database host
+  host:
+
+  ## Database host
+  port: 3306
+
+  ## Database user
+  user: bn_suitecrm
+
+  ## Database password
+  password:
+
+  ## Database name
+  database: bitnami_suitecrm
+
+
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/bitnami-docker-suitecrm/#smtp-configuration
 ##
@@ -52,6 +76,24 @@ suitecrmLastName: Name
 ## MariaDB chart configuration
 ##
 mariadb:
+  ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+  enabled: true
+
+  ## Create a database
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+  ##
+  mariadbDatabase: bitnami_suitecrm
+
+  ## Create a database user
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  mariadbUser: bn_suitecrm
+
+  ## Password for mariadbUser
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  # mariadbPassword:
+
   ## MariaDB admin password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
   ##

--- a/stable/testlink/Chart.yaml
+++ b/stable/testlink/Chart.yaml
@@ -1,5 +1,5 @@
 name: testlink
-version: 0.4.19
+version: 0.5.0
 appVersion: 1.9.16
 description: Web-based test management system that facilitates software quality assurance.
 icon: https://bitnami.com/assets/stacks/testlink/img/testlink-stack-220x234.png

--- a/stable/testlink/README.md
+++ b/stable/testlink/README.md
@@ -58,6 +58,16 @@ The following tables lists the configurable parameters of the TestLink chart and
 | `smtpUser`                          | SMTP user                               | `nil`                                                   |
 | `smtpPassword`                      | SMTP password                           | `nil`                                                   |
 | `smtpConnectionMode`                | SMTP connection mode [`ssl`, `tls`]     | `nil`                                                   |
+| `allowEmptyPassword`                | Allow DB blank passwords                | `yes`                                                   |
+| `externalDatabase.host`             | Host of the external database           | `nil`                                                   |
+| `externalDatabase.port`             | Port of the external database           | `3306`                                                  |
+| `externalDatabase.user`             | Existing username in the external db    | `bn_testlink`                                           |
+| `externalDatabase.password`         | Password for the above username         | `nil`                                                   |
+| `externalDatabase.database`         | Name of the existing databse            | `bitnami_testlink`                                      |
+| `mariadb.enabled`                   | Wheter to use or not the mariadb chart  | `true`                                                  |
+| `mariadb.mariadbDatabase`           | Database name to create                 | `bitnami_testlink`                                      |
+| `mariadb.mariadbUser`               | Database user to create                 | `bn_testlink`                                           |
+| `mariadb.mariadbPassword`           | Password for the database               | `nil`                                                   |
 | `mariadb.mariadbRootPassword`       | MariaDB admin password                  | `nil`                                                   |
 | `serviceType`                       | Kubernetes Service type                 | `LoadBalancer`                                          |
 | `persistence.enabled`               | Enable persistence using PVC            | `true`                                                  |

--- a/stable/testlink/requirements.lock
+++ b/stable/testlink/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.7.0
-digest: sha256:e1af13ac4ac21f67582006f12d2b4eb78a1a2a59b34338fac850f2bec0b08b41
-generated: 2017-08-09T22:53:01.772059997-04:00
+digest: sha256:f59f68030aa5c50b9e776b813804875fac911f91c2aa384e991f37a795c5ae34
+generated: 2018-03-15T17:53:44.694131+01:00

--- a/stable/testlink/requirements.yaml
+++ b/stable/testlink/requirements.yaml
@@ -2,3 +2,4 @@ dependencies:
 - name: mariadb
   version: 0.7.0
   repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: mariadb.enabled

--- a/stable/testlink/templates/NOTES.txt
+++ b/stable/testlink/templates/NOTES.txt
@@ -1,4 +1,4 @@
-
+{{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
 1. Get the TestLink URL by running:
 
 {{- if contains "NodePort" .Values.serviceType }}
@@ -25,3 +25,19 @@
 
     echo Username: {{ .Values.testlinkUsername }}
     echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.testlink-password}" | base64 --decode)
+
+{{- else -}}
+
+########################################################################################
+### ERROR: You did not provide an external database host in your 'helm install' call ###
+########################################################################################
+
+This deployment will be incomplete until you configure TestLink with a resolvable database
+host. To configure TestLink to use and external database host:
+
+
+1. Complete your TestLink deployment by running:
+
+  helm upgrade {{ .Release.Name }} --set serviceType={{ .Values.serviceType }},mariadb.enabled=false,externalDatabase.host=YOUR_EXTERNAL_DATABASE_HOST stable/testlink
+
+{{- end }}

--- a/stable/testlink/templates/_helpers.tpl
+++ b/stable/testlink/templates/_helpers.tpl
@@ -19,6 +19,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "mariadb.fullname" -}}
+{{- define "testlink.mariadb.fullname" -}}
 {{- printf "%s-%s" .Release.Name "mariadb" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/stable/testlink/templates/deployment.yaml
+++ b/stable/testlink/templates/deployment.yaml
@@ -19,15 +19,37 @@ spec:
         image: "{{ .Values.image }}"
         imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         env:
+        - name: ALLOW_EMPTY_PASSWORD
+          value: {{ .Values.allowEmptyPassword | quote }}
+        {{- if .Values.mariadb.enabled }}
         - name: MARIADB_HOST
-          value: {{ template "mariadb.fullname" . }}
+          value: {{ template "testlink.mariadb.fullname" . }}
         - name: MARIADB_PORT_NUMBER
           value: "3306"
-        - name: MARIADB_PASSWORD
+        - name: TESTLINK_DATABASE_NAME
+          value: {{ .Values.mariadb.mariadbDatabase | quote }}
+        - name: TESTLINK_DATABASE_USER
+          value: {{ .Values.mariadb.mariadbUser | quote }}
+        - name: TESTLINK_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "mariadb.fullname" . }}
-              key: mariadb-root-password
+              name: {{ template "testlink.mariadb.fullname" . }}
+              key: mariadb-password
+        {{- else }}
+        - name: MARIADB_HOST
+          value: {{ .Values.externalDatabase.host | quote }}
+        - name: MARIADB_PORT_NUMBER
+          value: {{ .Values.externalDatabase.port | quote }}
+        - name: TESTLINK_DATABASE_NAME
+          value: {{ .Values.externalDatabase.database | quote }}
+        - name: TESTLINK_DATABASE_USER
+          value: {{ .Values.externalDatabase.user | quote }}
+        - name: TESTLINK_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ printf "%s-%s" .Release.Name "externaldb" }}
+              key: db-password
+        {{- end }}
         - name: TESTLINK_USERNAME
           value: {{ default "" .Values.testlinkUsername | quote }}
         - name: TESTLINK_PASSWORD

--- a/stable/testlink/templates/externaldb-secrets.yaml
+++ b/stable/testlink/templates/externaldb-secrets.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.mariadb.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+  labels:
+    app: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
+{{- end }}

--- a/stable/testlink/values.yaml
+++ b/stable/testlink/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami TestLink image version
 ## ref: https://hub.docker.com/r/bitnami/testlink/tags/
 ##
-image: bitnami/testlink:1.9.16-r10
+image: bitnami/testlink:1.9.16-r11
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -30,6 +30,29 @@ testlinkEmail: user@example.com
 ##
 testlinkLanguage: en_US
 
+## Set to `yes` to allow the container to be started with blank passwords
+## ref: https://github.com/bitnami/bitnami-docker-testlink#environment-variables
+allowEmptyPassword: "yes"
+
+##
+## External database configuration
+##
+externalDatabase:
+  ## Database host
+  host:
+
+  ## Database host
+  port: 3306
+
+  ## Database user
+  user: bn_testlink
+
+  ## Database password
+  password:
+
+  ## Database name
+  database: bitnami_testlink
+
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/bitnami-docker-testlink#smtp-configuration
 ##
@@ -44,6 +67,24 @@ smtpConnectionMode:
 ## MariaDB chart configuration
 ##
 mariadb:
+  ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+  enabled: true
+
+  ## Create a database
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+  ##
+  mariadbDatabase: bitnami_testlink
+
+  ## Create a database user
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  mariadbUser: bn_testlink
+
+  ## Password for mariadbUser
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  # mariadbPassword:
+
   ## MariaDB admin password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
   ##


### PR DESCRIPTION
Update the following charts to support connecting to an already existing database:

- JasperReports
- Joomla
- Moodle
- OpenCart
- OrangeHRM
- Osclass
- ownCloud
- PrestaShop
- SugarCRM
- SuiteCRM
- Testlink