### PR TITLE
Add bitnami-common chart with custom templates

### DIFF
--- a/incubator/bitnami-common/Chart.yaml
+++ b/incubator/bitnami-common/Chart.yaml
@@ -1,0 +1,15 @@
+name: bitnami-common
+version: 0.0.1
+appVersion: 0.0.1
+description: Chart with custom tempaltes used in Bitnami charts.
+keywords:
+- helper
+- template
+- bitnami
+- broker
+- service
+- catalog
+maintainers:
+- name: Bitnami
+  email: containers@bitnami.com
+engine: gotpl

--- a/incubator/bitnami-common/README.md
+++ b/incubator/bitnami-common/README.md
@@ -1,0 +1,3 @@
+# Bitnami Common
+
+This chart just defines a set of templates so that they can be reused in other charts.

--- a/incubator/bitnami-common/templates/_helpers.tpl
+++ b/incubator/bitnami-common/templates/_helpers.tpl
@@ -1,0 +1,56 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+CUSTOM TEMPLATES FOR SECRET MAPPING
+    - host
+    - port
+    - username
+    - password
+*/}}
+
+{{- define "externaldb.host" -}}
+  {{- if eq .type "osba"}}
+    {{- printf "%s" "host" -}}
+  {{- else if eq .type "gce"}}
+    {{- printf "%s" "host" -}}
+  {{- else if eq .type "aws"}}
+    {{- printf "%s" "host" -}}
+  {{- else }}
+    {{- printf "%s" "host" -}}
+  {{- end }}
+{{- end -}}
+
+{{- define "externaldb.port" -}}
+  {{- if eq .type "osba"}}
+    {{- printf "%s" "port" -}}
+  {{- else if eq .type "gce"}}
+    {{- printf "%s" "port" -}}
+  {{- else if eq .type "aws"}}
+    {{- printf "%s" "port" -}}
+  {{- else }}
+    {{- printf "%s" "port" -}}
+  {{- end }}
+{{- end -}}
+
+{{- define "externaldb.username" -}}
+  {{- if eq .type "osba"}}
+    {{- printf "%s" "username" -}}
+  {{- else if eq .type "gce"}}
+    {{- printf "%s" "username" -}}
+  {{- else if eq .type "aws"}}
+    {{- printf "%s" "username" -}}
+  {{- else }}
+    {{- printf "%s" "username" -}}
+  {{- end }}
+{{- end -}}
+
+{{- define "externaldb.password" -}}
+  {{- if eq .type "osba"}}
+    {{- printf "%s" "password" -}}
+  {{- else if eq .type "gce"}}
+    {{- printf "%s" "password" -}}
+  {{- else if eq .type "aws"}}
+    {{- printf "%s" "password" -}}
+  {{- else }}
+    {{- printf "%s" "password" -}}
+  {{- end }}
+{{- end -}}


### PR DESCRIPTION
This chart will be a place to define common templates like the exterdal db helpers for service catalog mapping.