### PR TITLE
Add missing values.yaml file for bitnami-common chart

### DIFF
--- a/library/bitnami-common/Chart.yaml
+++ b/library/bitnami-common/Chart.yaml
@@ -1,5 +1,5 @@
 name: bitnami-common
-version: 0.0.2
+version: 0.0.3
 appVersion: 0.0.1
 description: Chart with custom tempaltes used in Bitnami charts.
 keywords:

--- a/library/bitnami-common/values.yaml
+++ b/library/bitnami-common/values.yaml
@@ -1,0 +1,1 @@
+# Empty values.yaml. Required to properly serve the chart.


### PR DESCRIPTION
In order to server the bitnami-common chart it should contain a `values.yaml` file although it is not needed.