### PR TITLE
[bitnami/jenkins] move jenkins chart to use jenkins lts docker images version

### DIFF
--- a/bitnami/jenkins/Chart.yaml
+++ b/bitnami/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
-version: 0.4.67
-appVersion: 2.109.0
+version: 0.4.68
+appVersion: 2.107.2
 description: The leading open source automation server
 keywords:
 - jenkins

--- a/bitnami/jenkins/values.yaml
+++ b/bitnami/jenkins/values.yaml
@@ -4,7 +4,7 @@
 image:
   registry: docker.io
   repository: bitnami/jenkins
-  tag: 2.109.0
+  tag: 2.107.2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
At some point we stop releasing the weekly jenkins version to use the LTS one but we didn't update the chart. This PR starts using the jenkins LTS images.