### PR TITLE
Fix load balancer with mix protocols issue

### DIFF
--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -1,8 +1,8 @@
 name: consul
 home: https://www.consul.io/
-sources: 
+sources:
 - https://github.com/bitnami/consul
-version: 0.0.2
+version: 1.0.0
 appVersion: 1.0.6
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/bitnami/consul/README.md
+++ b/bitnami/consul/README.md
@@ -54,7 +54,6 @@ The following tables lists the configurable parameters of the Consul chart and t
 | `image.tag`                          | Consul image tag                                       | `{VERSION}`                                                |
 | `image.pullPolicy`                   | Image pull policy                                      | `Always`                                                   |
 | `image.pullSecrets`                  | Specify image pull secrets                             | `nil`                                                      |
-| `serviceType`                        | Kubernetes Service type                                | `ClusterIP`                                                |
 | `replicas`                           | Number of replicas                                     | `3`                                                        |
 | `httpPort`                           | Consul http listening port                             | `8500`                                                     |
 | `rpcPort`                            | Consul rpc listening port                              | `8400`                                                     |

--- a/bitnami/consul/templates/consul-service.yaml
+++ b/bitnami/consul/templates/consul-service.yaml
@@ -10,7 +10,6 @@ metadata:
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
-  type: "{{ .Values.serviceType }}"
   ports:
   - name: http
     port: {{ .Values.httpPort }}
@@ -29,10 +28,7 @@ spec:
   - name: consuldns-udp
     protocol: "UDP"
     port: {{.Values.consulDnsPort}}
-  {{- if contains "ClusterIP" .Values.serviceType }}
   clusterIP: None
-  {{- end }}  
   selector:
     app: "{{ template "consul.name" . }}"
     release: {{ .Release.Name | quote }}
-

--- a/bitnami/consul/values.yaml
+++ b/bitnami/consul/values.yaml
@@ -17,9 +17,6 @@ image:
   # pullSecrets:
   #   - myRegistrKeySecretName
 
-## Kubernetes service type
-serviceType: ClusterIP
-
 ## Consul replicas
 replicas: 3
 
@@ -113,19 +110,19 @@ ui:
   ingress:
     ## Set to true to enable ingress record generation
     enabled: false
-  
+
     ## The list of hostnames to be covered with this ingress record.
     ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
     hosts:
     - name: consul-ui.local
-  
+
       ## Set this to true in order to enable TLS on the ingress record
       ## A side effect of this will be that the backend consul service will be connected at port 443
       tls: false
-  
+
       ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
       tlsSecret: consul-ui.local-tls
-  
+
       ## Ingress annotations done as key:value pairs
       ## If you're using kube-lego, you will want to add:
       ## kubernetes.io/tls-acme: true
@@ -152,7 +149,7 @@ ui:
     #   certificate:
 
 ## Consul configmap
-#configmap: | 
+#configmap: |
 #    {
 #    "datacenter":"dc2",
 #    "domain":"consul",
@@ -175,8 +172,8 @@ ui:
 
 metrics:
   enabled: false
-  image: 
-    registry: docker.io 
+  image:
+    registry: docker.io
     repository: prom/consul-exporter
     tag: v0.3.0
     pullPolicy: IfNotPresent


### PR DESCRIPTION
The following error appears using `LoadBalancer`:
```
09:33:59 [helm] jenkins ERROR Unable to install chart '/home/agent/workspace/testing/consul/28/helm-test-workspace/charts-repo/bitnami/consul':
09:33:59 [helm] Error: release test failed: Service "test-consul" is invalid: spec.ports: Invalid value:
[]api.ServicePort{api.ServicePort{Name:"http", Protocol:"TCP", Port:8500, TargetPort:intstr.IntOrString{Type:0, IntVal:8500, StrVal:""}, NodePort:0}, api.ServicePort{Name:"rpc", Protocol:"TCP", Port:8400, TargetPort:intstr.IntOrString{Type:0, IntVal:8400, StrVal:""}, NodePort:0}, api.ServicePort{Name:"serflan-tcp", Protocol:"TCP", Port:8301, TargetPort:intstr.IntOrString{Type:0, IntVal:8301, StrVal:""}, NodePort:0}, api.ServicePort{Name:"serflan-udp", Protocol:"UDP", Port:8301, TargetPort:intstr.IntOrString{Type:0, IntVal:8301, StrVal:""}, NodePort:0}, api.ServicePort{Name:"server", Protocol:"TCP", Port:8300, TargetPort:intstr.IntOrString{Type:0, IntVal:8300, StrVal:""}, NodePort:0}, api.ServicePort{Name:"consuldns-tcp", Protocol:"TCP", Port:8600, TargetPort:intstr.IntOrString{Type:0, IntVal:8600, StrVal:""}, NodePort:0}, api.ServicePort{Name:"consuldns-udp", Protocol:"UDP", Port:8600, TargetPort:intstr.IntOrString{Type:0, IntVal:8600, StrVal:""}, NodePort:0}}: 
cannot create an external load balancer with mix protocols
```

LoadBalancer doesn't allow use mix protocols (tcp and udp). This PR fix this issue following the same approach used by the stable chart (https://github.com/kubernetes/charts/tree/master/stable/consul)