### PR TITLE
Fix capitalization of clusterIP parameter

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 1.0.1
+version: 1.0.2
 appVersion: 10.4.0
 description: Chart for PostgreSQL
 keywords:

--- a/bitnami/postgresql/templates/svc-headless.yaml
+++ b/bitnami/postgresql/templates/svc-headless.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   type: ClusterIP
-  ClusterIP: None
+  clusterIP: None
   ports:
   - name: postgresql
     port: 5432


### PR DESCRIPTION
In order to fix this issue:

```
Error: error validating "": error validating data: found invalid field ClusterIP for v1.ServiceSpec
```
It seems only some k8s versions complain about this so that's the reason I didn't notice this issue while working on the chart refactor. (https://github.com/kubernetes/kubernetes/issues/19744)

