### PR TITLE
Removing unnecessary configuration section from configuration file

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: elasticsearch
-version: 1.0.3
+version: 1.0.4
 appVersion: 6.2.4
 description: A highly scalable open-source full-text search and analytics engine
 keywords:

--- a/bitnami/elasticsearch/templates/cm.yaml
+++ b/bitnami/elasticsearch/templates/cm.yaml
@@ -10,11 +10,6 @@ metadata:
 data:
   elasticsearch_custom.yml: |-
 
-    cloud:
-      kubernetes:
-        service: {{ template "master.fullname" . }}
-        namespace: {{ .Release.Namespace | quote }}
-
     discovery:
       zen:
         ping.unicast.hosts: {{ template "discovery.fullname" . }}


### PR DESCRIPTION
We deprecated the ES k8s plugin on commit: 25752a0

Therefore, the configuration section deleted it's not necessary anymore.

Fixes: #688