### PR TITLE
[bitnami/zookeeper] - Add ensemble capability

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,5 +1,5 @@
 name: zookeeper
-version: 0.0.1
+version: 0.0.2
 appVersion: 3.4.12
 description: A centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services for distributed applications.
 keywords:

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -52,7 +52,7 @@ The following tables lists the configurable parameters of the Zookeeper chart an
 | `image.pullSecrets`                   | Specify image pull secrets                                          | `nil` (does not add image pull secrets to deployed pods) |
 | `image.debug`                         | Specify if debug values should be set                               | `false`                                                  |
 | `updateStrategy`                      | Update strategies                                                   | `RollingUpdate`                                          |
-| `serverID`                            | ID of the server in the ensemble                                    | `1`                                                      |
+| `replicaCount`                        | Number of ZooKeeper nodes                                           | `1`                                                      |
 | `tickTime`                            | Basic time unit in milliseconds used by ZooKeeper for heartbeats    | `2000`                                                   |
 | `initLimit`                           | Time the ZooKeeper servers in quorum have to connect to a leader    | `10`                                                     |
 | `syncLimit`                           | How far out of date a server can be from a leader                   | `5`                                                      |

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -52,6 +52,7 @@ The following tables lists the configurable parameters of the Zookeeper chart an
 | `image.pullSecrets`                   | Specify image pull secrets                                          | `nil` (does not add image pull secrets to deployed pods) |
 | `image.debug`                         | Specify if debug values should be set                               | `false`                                                  |
 | `updateStrategy`                      | Update strategies                                                   | `RollingUpdate`                                          |
+| `rollingUpdatePartition`              | Partition update strategy                                           | `nil`                                                    |
 | `podManagementpolicy`                 | Pod management policy                                               | `Parallel`                                               |
 | `replicaCount`                        | Number of ZooKeeper nodes                                           | `1`                                                      |
 | `tickTime`                            | Basic time unit in milliseconds used by ZooKeeper for heartbeats    | `2000`                                                   |

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -58,7 +58,6 @@ The following tables lists the configurable parameters of the Zookeeper chart an
 | `initLimit`                           | Time the ZooKeeper servers in quorum have to connect to a leader    | `10`                                                     |
 | `syncLimit`                           | How far out of date a server can be from a leader                   | `5`                                                      |
 | `maxClientCnxns`                      | Number of concurrent connections that a single client may make to a single member | `60`                                       |
-| `servers`                             | List of servers                                                     | `[]`                                                     |
 | `allowAnonymousLogin`                 | Allow to accept connections from unauthenticated users              | `yes`                                                    |
 | `auth.existingSecret`                 | Use existing secret (ignores previous password)                     | `nil`                                                    |
 | `auth.enabled`                        | Enable Zookeeper auth                                               | `false`                                                  |

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -52,6 +52,7 @@ The following tables lists the configurable parameters of the Zookeeper chart an
 | `image.pullSecrets`                   | Specify image pull secrets                                          | `nil` (does not add image pull secrets to deployed pods) |
 | `image.debug`                         | Specify if debug values should be set                               | `false`                                                  |
 | `updateStrategy`                      | Update strategies                                                   | `RollingUpdate`                                          |
+| `podManagementpolicy`                 | Pod management policy                                               | `Parallel`                                               |
 | `replicaCount`                        | Number of ZooKeeper nodes                                           | `1`                                                      |
 | `tickTime`                            | Basic time unit in milliseconds used by ZooKeeper for heartbeats    | `2000`                                                   |
 | `initLimit`                           | Time the ZooKeeper servers in quorum have to connect to a leader    | `10`                                                     |

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: {{ .Release.Service | quote }}
 spec:
   serviceName: {{ template "zookeeper.fullname" . }}-headless
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   updateStrategy:
     type: {{ .Values.updateStrategy | quote }}
   selector:
@@ -50,13 +50,30 @@ spec:
       - name: "{{ template "zookeeper.fullname" . }}"
         image: "{{ template "zookeeper.image" . }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+        command:
+         - bash
+         - -ec
+         - |
+            # Execute entrypoint as usual after obtaining ZOO_SERVER_ID based on POD hostname
+            HOST=`hostname -s`
+            if [[ $HOST =~ (.*)-([0-9]+)$ ]]; then
+              ORD=${BASH_REMATCH[2]}
+              export ZOO_SERVER_ID=$((ORD+1))
+            else
+              echo "Failed to get index from hostname $HOST"
+              exit 1
+            fi
+            . /opt/bitnami/base/functions
+            . /opt/bitnami/base/helpers
+            print_welcome_page
+            . /init.sh
+            nami_initialize zookeeper
+            exec tini -- /run.sh
         resources:
 {{ toYaml .Values.Resources | indent 10 }}
         env:
         - name: ZOO_PORT_NUMBER
           value: {{ .Values.service.port | quote }}
-        - name: ZOO_SERVER_ID
-          value: {{ .Values.serverID | quote }}
         - name: ZOO_TICK_TIME
           value: {{ .Values.tickTime | quote }}
         - name: ZOO_INIT_LIMIT
@@ -66,7 +83,11 @@ spec:
         - name: ZOO_MAX_CLIENT_CNXNS
           value: {{ .Values.maxClientCnxns | quote }}
         - name: ZOO_SERVERS
-          value: {{ .Values.servers | quote }}
+          {{- $replicaCount := int .Values.replicaCount }}
+          {{- $name := default .Chart.Name .Values.nameOverride -}}
+          {{- $zookeeperFullname := printf "%s-%s" .Release.Name $name | trunc 24  }}
+          {{- $zookeeperHeadlessServiceName := printf "%s-%s" $zookeeperFullname "headless" | trunc 24  }}
+          value: {{range $i, $e := until $replicaCount }}{{ $zookeeperHostname }}-{{ $e }}.{{ $zookeeperHeadlessServiceName }}:2888:3888 {{ end }}
         {{- if .Values.auth.enabled }}
         - name: ZOO_ENABLE_AUTH
           value: "yes"

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -10,6 +10,7 @@ metadata:
 spec:
   serviceName: {{ template "zookeeper.fullname" . }}-headless
   replicas: {{ .Values.replicaCount }}
+  podManagementPolicy: {{ .Values.podManagementPolicy | quote }}
   updateStrategy:
     type: {{ .Values.updateStrategy | quote }}
   selector:
@@ -55,8 +56,8 @@ spec:
          - -ec
          - |
             # Execute entrypoint as usual after obtaining ZOO_SERVER_ID based on POD hostname
-            HOST=`hostname -s`
-            if [[ $HOST =~ (.*)-([0-9]+)$ ]]; then
+            HOSTNAME=`hostname -s`
+            if [[ $HOSTNAME =~ (.*)-([0-9]+)$ ]]; then
               ORD=${BASH_REMATCH[2]}
               export ZOO_SERVER_ID=$((ORD+1))
             else
@@ -84,10 +85,11 @@ spec:
           value: {{ .Values.maxClientCnxns | quote }}
         - name: ZOO_SERVERS
           {{- $replicaCount := int .Values.replicaCount }}
-          {{- $name := default .Chart.Name .Values.nameOverride -}}
-          {{- $zookeeperFullname := printf "%s-%s" .Release.Name $name | trunc 24  }}
+          {{- $followerPort := int .Values.service.followerPort }}
+          {{- $electionPort := int .Values.service.electionPort }}
+          {{- $zookeeperFullname := include "zookeeper.fullname" . }}
           {{- $zookeeperHeadlessServiceName := printf "%s-%s" $zookeeperFullname "headless" | trunc 24  }}
-          value: {{range $i, $e := until $replicaCount }}{{ $zookeeperHostname }}-{{ $e }}.{{ $zookeeperHeadlessServiceName }}:2888:3888 {{ end }}
+          value: {{range $i, $e := until $replicaCount }}{{ $zookeeperFullname }}-{{ $e }}.{{ $zookeeperHeadlessServiceName }}.default.svc.cluster.local:{{ $followerPort }}:{{ $electionPort }} {{ end }}
         {{- if .Values.auth.enabled }}
         - name: ZOO_ENABLE_AUTH
           value: "yes"
@@ -117,12 +119,16 @@ spec:
         - name: JVMFLAGS
           value: {{ .Values.jvmFlags | quote }}
         ports:
-        - name: zookeeper
+        - name: client
           containerPort: {{ .Values.service.port }}
+        - name: follower
+          containerPort: {{ .Values.service.followerPort }}
+        - name: election
+          containerPort: {{ .Values.service.electionPort }}
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           tcpSocket:
-            port: zookeeper
+            port: client
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -132,7 +138,7 @@ spec:
         {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           tcpSocket:
-            port: zookeeper
+            port: client
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -13,6 +13,10 @@ spec:
   podManagementPolicy: {{ .Values.podManagementPolicy | quote }}
   updateStrategy:
     type: {{ .Values.updateStrategy | quote }}
+    {{- if .Values.rollingUpdatePartition }}
+    rollingUpdate:
+      partition: {{ .Values.rollingUpdatePartition }}
+    {{- end }}
   selector:
     matchLabels:
       app: {{ template "zookeeper.name" . }}

--- a/bitnami/zookeeper/templates/svc-headless.yaml
+++ b/bitnami/zookeeper/templates/svc-headless.yaml
@@ -11,9 +11,15 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-  - name: zookeeper
+  - name: client
     port: 2181
-    targetPort: zookeeper
+    targetPort: client
+  - name: follower
+    port: 2888
+    targetPort: follower
+  - name: election
+    port: 3888
+    targetPort: election
   selector:
     app: {{ template "zookeeper.name" . }}
     release: {{ .Release.Name | quote }}

--- a/bitnami/zookeeper/templates/svc.yaml
+++ b/bitnami/zookeeper/templates/svc.yaml
@@ -10,9 +10,15 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-  - name: zookeeper
+  - name: client
     port: 2181
-    targetPort: zookeeper
+    targetPort: client
+  - name: follower
+    port: 2888
+    targetPort: follower
+  - name: election
+    port: 3888
+    targetPort: election
   selector:
     app: {{ template "zookeeper.name" . }}
     release: {{ .Release.Name | quote }}

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -27,6 +27,11 @@ image:
 ##
 updateStrategy: RollingUpdate
 
+## Partition update strategy
+## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions
+##
+# rollingUpdatePartition:
+
 ## StatefulSet controller supports relax its ordering guarantees while preserving its uniqueness and identity guarantees. There are two valid pod management policies: OrderedReady and Parallel
 ## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy
 ##

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -27,9 +27,9 @@ image:
 ##
 updateStrategy: RollingUpdate
 
-## ID of the server in the ensemble
+## Number of ZooKeeper nodes
 ##
-serverID: 1
+replicaCount: 1
 
 ## Basic time unit in milliseconds used by ZooKeeper for heartbeats
 ##

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -22,10 +22,15 @@ image:
   ##
   debug: false
 
-## StatefulSet controller supports automated updates, there are two valid update strategies, RollingUpdate and OnDelete
+## StatefulSet controller supports automated updates. There are two valid update strategies: RollingUpdate and OnDelete
 ## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets
 ##
 updateStrategy: RollingUpdate
+
+## StatefulSet controller supports relax its ordering guarantees while preserving its uniqueness and identity guarantees. There are two valid pod management policies: OrderedReady and Parallel
+## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy
+##
+podManagementPolicy: Parallel
 
 ## Number of ZooKeeper nodes
 ##
@@ -93,6 +98,8 @@ heapSize: 1024
 service:
   type: ClusterIP
   port: 2181
+  followerPort: 2888
+  electionPort: 3888
 
 ## Zookeeper Pod Security Context
 securityContext:

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -52,10 +52,6 @@ syncLimit: 5
 ##
 maxClientCnxns: 60
 
-## Comma, space or colon separated list of servers. Example: zoo1:2888:3888,zoo2:2888:3888
-##
-# servers: []
-
 ## Allow to accept connections from unauthenticated users
 ##
 allowAnonymousLogin: true


### PR DESCRIPTION
It is possible now to deploy a ZooKeeper ensemble just by specifying the number of nodes with the `replicaCount` parameter. Example:

```
helm install --name zoo-ensempe --set replicaCount=3 bitnami/zookeeper
```