### PR TITLE
Add new chart: ExternalDNS

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -1,0 +1,16 @@
+name: external-dns
+version: 0.0.1
+appVersion: 0.5.4
+description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
+keywords:
+- external-dns
+- network
+- dns
+home: https://github.com/kubernetes-incubator/external-dns
+sources:
+- https://github.com/bitnami/bitnami-docker-external-dns
+maintainers:
+- name: bitnami
+  email: containers@bitnami.com
+engine: gotpl
+icon: https://bitnami.com/assets/stacks/external-dns/img/external-dns-stack-110x117.png

--- a/bitnami/external-dns/README.md
+++ b/bitnami/external-dns/README.md
@@ -1,0 +1,124 @@
+# external-dns
+
+[ExternalDNS](https://github.com/kubernetes-incubator/external-dns) is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
+
+## TL;DR;
+
+```console
+$ helm install bitnami/external-dns
+```
+
+## Introduction
+
+This chart bootstraps a [ExternalDNS](https://github.com/bitnami/bitnami-docker-external-dns) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.4+ with Beta APIs enabled
+- PV provisioner support in the underlying infrastructure
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install --name my-release bitnami/external-dns
+```
+
+The command deploys ExternalDNS on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the external-dns chart and their default values.
+
+
+| Parameter                             | Description                                                                                              | Default                                                  |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `image.registry`                      | ExternalDNS image registry                                                                               | `docker.io`                                              |
+| `image.repository`                    | ExternalDNS Image name                                                                                   | `bitnami/external-dns`                                   |
+| `image.tag`                           | ExternalDNS Image tag                                                                                    | `{VERSION}`                                              |
+| `image.pullPolicy`                    | ExternalDNS image pull policy                                                                            | `Always`                                                 |
+| `image.pullSecrets`                   | Specify image pull secrets                                                                               | `nil` (does not add image pull secrets to deployed pods) |
+| `image.debug`                         | Specify if debug values should be set                                                                    | `false`                                                  |
+| `sources`                             | List of resource types to be observed for new DNS entries by ExternalDNS                                 | `[service, ingress]`                                     |
+| `provider`                            | DNS provider where the DNS records will be created (mandatory). E.g.: aws, azure, google, ...            | `nil`                                                    |
+| `publishInternalServices`             | Whether to publish DNS records for ClusterIP services or not                                             | `false`                                                  |
+| `policy`                              | Method to synchronise DNS records between sources and providers                                          | `upsert-only`                                            |
+| `registry`                            | Registry type                                                                                            | `txt`                                                    |
+| `txtOwnerId`                          | TXT Registry Identifier                                                                                  | `"default"`                                              |
+| `txtPrefix`                           | Prefix to create a TXT record with a name following the pattern prefix.<CNAME record>                    | `nil`                                                    |
+| `logLevel`                            | Verbosity of the ExternalDNS logs                                                                        | `info`                                                   |
+| `domainFilters`                       | Limit possible target zones by domain suffixes                                                           | `[]`                                                     |
+| `annotationFilter`                    | Filter sources managed by external-dns via annotation using label selector semantics                     | `nil`                                                    |
+| `extraArgs`                           | Extra Arguments to passed to external-dns                                                                | `{}`                                                     |
+| `extraEnv`                            | Extra env. variable to set on external-dns container                                                     | `{}`                                                     |
+| `aws.accessKey`                       | `AWS_ACCESS_KEY_ID` to set (only if provider == 'aws')                                                   | `""`                                                     |
+| `aws.secretKey`                       | `AWS_SECRET_ACCESS_KEY` to set (only if provider == 'aws')                                               | `""`                                                     |
+| `aws.region`                          | `AWS_DEFAULT_REGION` to set (only if provider == 'aws')                                                  | `us-east-1`                                              |
+| `aws.roleArn`                         | Use this `role_arn` if role credentials are used (only if provider == 'aws')                             | `""`                                                     |
+| `aws.zoneType`                        | Filter for zones of this type (only if provider == 'aws')                                                | `""`                                                     |
+| `azure.resoureGroup`                  | Azure Resource Group (only if provider == 'azure')                                                       | `""`                                                     |
+| `cloudflare.apiKey`                   | `CF_API_KEY` to set in the environment (only if provider == 'cloudflare')                                | `""`                                                     |
+| `cloudflare.email`                    | `CF_API_EMAIL` to set in the environment (only if provider == 'cloudflare')                              | `""`                                                     |
+| `google.project`                      | Google project (only if provider == 'google')                                                            | `""`                                                     |
+| `google.serviceAccountSecret`         | Secret which contains credentials.json for Google (only if provider == 'google')                         | `""`                                                     |
+| `service.type`                        | Kubernetes Service type                                                                                  | `ClusterIP`                                              |
+| `service.port`                        | ExternalDNS client port                                                                                  | `7979`                                                   |
+| `service.nodePort`                    | Port to bind to for NodePort service type (client port)                                                  | `nil`                                                    |
+| `service.annotations`                 | Annotations for ExternalDNS service                                                                      | {}                                                       |
+| `service.loadBalancerIP`              | loadBalancerIP if ExternalDNS service type is `LoadBalancer`                                             | `nil`                                                    |
+| `rbac.create`                         | Wether to create & use RBAC resources or not                                                             | `false`                                                  |
+| `rbac.serviceAccountName`             | ServiceAccount (ignored if rbac.create == true)                                                          | `default`                                                |
+| `securityContext.enabled`             | Enable security context                                                                                  | `true`                                                   |
+| `securityContext.fsGroup`             | Group ID for the container                                                                               | `1001`                                                   |
+| `securityContext.runAsUser`           | User ID for the container                                                                                | `1001`                                                   |
+| `nodeSelector`                        | Node labels for pod assignment                                                                           | `{}`                                                     |
+| `tolerations`                         | Toleration labels for pod assignment                                                                     | `[]`                                                     |
+| `podAnnotations`                      | Additional annotations to apply to the pod.                                                              | `{}`                                                     |
+| `replicas`                            | Desired number of ExternalDNS replicas                                                                   | `1`                                                      |
+| `resources`                           | CPU/Memory resource requests/limits                                                                      | Memory: `256Mi`, CPU: `250m`                             |
+| `livenessProbe.enabled`               | Turn on and off liveness probe                                                                           | `true`                                                   |
+| `livenessProbe.initialDelaySeconds`   | Delay before liveness probe is initiated                                                                 | 10                                                       |
+| `livenessProbe.periodSeconds`         | How often to perform the probe                                                                           | 10                                                       |
+| `livenessProbe.timeoutSeconds`        | When the probe times out                                                                                 | 5                                                        |
+| `livenessProbe.failureThreshold`      | Minimum consecutive failures for the probe to be considered failed after having succeeded.               | 2                                                        |
+| `livenessProbe.successThreshold`      | Minimum consecutive successes for the probe to be considered successful after having failed              | 1                                                        |
+| `readinessProbe.enabled`              | Turn on and off readiness probe                                                                          | `true`                                                   |
+| `readinessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                                                                 | 5                                                        |
+| `readinessProbe.periodSeconds`        | How often to perform the probe                                                                           | 10                                                       |
+| `readinessProbe.timeoutSeconds`       | When the probe times out                                                                                 | 5                                                        |
+| `readinessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.               | 6                                                        |
+| `readinessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed              | 1                                                        |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install --name my-release \
+  --set auth.rootPassword=secretpassword bitnami/external-dns
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml bitnami/external-dns
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Tutorials
+
+Find information about the requirements for each DNS provider on the link below:
+
+ - [ExternalDNS Tutorials](https://github.com/kubernetes-incubator/external-dns/tree/master/docs/tutorials)

--- a/bitnami/external-dns/README.md
+++ b/bitnami/external-dns/README.md
@@ -55,11 +55,11 @@ The following table lists the configurable parameters of the external-dns chart 
 | `sources`                             | List of resource types to be observed for new DNS entries by ExternalDNS                                 | `[service, ingress]`                                     |
 | `provider`                            | DNS provider where the DNS records will be created (mandatory). E.g.: aws, azure, google, ...            | `nil`                                                    |
 | `publishInternalServices`             | Whether to publish DNS records for ClusterIP services or not                                             | `false`                                                  |
-| `policy`                              | Method to synchronise DNS records between sources and providers                                          | `upsert-only`                                            |
-| `registry`                            | Registry type                                                                                            | `txt`                                                    |
+| `policy`                              | Method to synchronise DNS records between sources and providers (accepted values: sync, upsert-only)     | `upsert-only`                                            |
+| `registry`                            | Registry type (accepted values: txt, noop)                                                               | `txt`                                                    |
 | `txtOwnerId`                          | TXT Registry Identifier                                                                                  | `"default"`                                              |
 | `txtPrefix`                           | Prefix to create a TXT record with a name following the pattern prefix.<CNAME record>                    | `nil`                                                    |
-| `logLevel`                            | Verbosity of the ExternalDNS logs                                                                        | `info`                                                   |
+| `logLevel`                            | Verbosity of the ExternalDNS logs (accepted values: panic, debug, info, warn, error, fatal)              | `info`                                                   |
 | `domainFilters`                       | Limit possible target zones by domain suffixes                                                           | `[]`                                                     |
 | `annotationFilter`                    | Filter sources managed by external-dns via annotation using label selector semantics                     | `nil`                                                    |
 | `extraArgs`                           | Extra Arguments to passed to external-dns                                                                | `{}`                                                     |
@@ -68,7 +68,7 @@ The following table lists the configurable parameters of the external-dns chart 
 | `aws.secretKey`                       | `AWS_SECRET_ACCESS_KEY` to set (only if provider == 'aws')                                               | `""`                                                     |
 | `aws.region`                          | `AWS_DEFAULT_REGION` to set (only if provider == 'aws')                                                  | `us-east-1`                                              |
 | `aws.roleArn`                         | Use this `role_arn` if role credentials are used (only if provider == 'aws')                             | `""`                                                     |
-| `aws.zoneType`                        | Filter for zones of this type (only if provider == 'aws')                                                | `""`                                                     |
+| `aws.zoneType`                        | Filter for zones of this type (only if provider == 'aws', accepted values: public, private)              | `""`                                                     |
 | `azure.resoureGroup`                  | Azure Resource Group (only if provider == 'azure')                                                       | `""`                                                     |
 | `cloudflare.apiKey`                   | `CF_API_KEY` to set in the environment (only if provider == 'cloudflare')                                | `""`                                                     |
 | `cloudflare.email`                    | `CF_API_EMAIL` to set in the environment (only if provider == 'cloudflare')                              | `""`                                                     |

--- a/bitnami/external-dns/templates/NOTES.txt
+++ b/bitnami/external-dns/templates/NOTES.txt
@@ -1,0 +1,45 @@
+{{- if eq .Values.provider "aws" }}
+{{- if or (empty .Values.aws.accessKey) (empty .Values.aws.secretKey) }}
+  ###############################################################################
+  ### ERROR: You chose 'aws' as your DNS provider and you did not set the     ###
+  ### AWS access&secret keys                                                  ###
+  ###############################################################################
+
+Indicate your AWS access&secret keys by installing this chart as shown below:
+
+    $ helm install --name my-release bitnami/external-dns --set provider='aws',aws.accessKey='YOUR_ACCESS_KEY',aws.secretKey='YOUR_SECRET_KEY'
+{{- end }}
+{{- end }}
+{{- if and (eq .Values.provider "google") (empty .Values.google.project) }}
+  ###############################################################################
+  ### ERROR: You chose 'google' as your DNS provider and you did not set      ###
+  ### the project (--set google.project="YOUR_GOOGLE_PROJECT"                 ###
+  ###############################################################################
+
+Indicate your Google Project by installing this chart as shown below:
+
+    $ helm install --name my-release bitnami/external-dns --set provider='google',google.project='YOUR_GOOGLE_PROJECT'
+{{- end }}
+{{- if and (eq .Values.provider "cloudflare") (empty .Values.cloudflare.apiKey) }}
+  ###############################################################################
+  ### ERROR: You chose 'cloudflare' as your DNS provider and you did not set  ###
+  ### the ApiKey                                                              ###
+  ###############################################################################
+
+Indicate your ApiKey by installing this chart as shown below:
+
+  $ helm install --name my-release bitnami/external-dns --set provider='cloudflare',cloudflare.apiKey='YOUR_API_KEY'
+{{- end }}
+{{- if empty .Values.provider }}
+  ##############################################################################
+  ### ERROR: You did not choose any DNS provider.
+  ###############################################################################
+
+Indicate your DNS provider by installing this chart as shown below:
+
+   $ helm install --name my-release bitnami/external-dns --set provider='YOUR_DNS_PROVIDER'
+
+Replace the placeholder YOUR_DNS_PROVIDER with a valid DNS provider (aws, azure, cloudflare, google, ...)
+{{- end }}
+
+** Please be patient while the chart is being deployed **

--- a/bitnami/external-dns/templates/NOTES.txt
+++ b/bitnami/external-dns/templates/NOTES.txt
@@ -7,7 +7,7 @@
 
 Indicate your AWS access&secret keys by installing this chart as shown below:
 
-    $ helm install --name my-release bitnami/external-dns --set provider='aws',aws.accessKey='YOUR_ACCESS_KEY',aws.secretKey='YOUR_SECRET_KEY'
+    $ helm upgrade my-release bitnami/external-dns --set provider='aws',aws.accessKey='YOUR_ACCESS_KEY',aws.secretKey='YOUR_SECRET_KEY'
 {{- end }}
 {{- end }}
 {{- if and (eq .Values.provider "google") (empty .Values.google.project) }}
@@ -18,7 +18,7 @@ Indicate your AWS access&secret keys by installing this chart as shown below:
 
 Indicate your Google Project by installing this chart as shown below:
 
-    $ helm install --name my-release bitnami/external-dns --set provider='google',google.project='YOUR_GOOGLE_PROJECT'
+    $ helm upgrade my-release bitnami/external-dns --set provider='google',google.project='YOUR_GOOGLE_PROJECT'
 {{- end }}
 {{- if and (eq .Values.provider "cloudflare") (empty .Values.cloudflare.apiKey) }}
   ###############################################################################
@@ -28,7 +28,7 @@ Indicate your Google Project by installing this chart as shown below:
 
 Indicate your ApiKey by installing this chart as shown below:
 
-  $ helm install --name my-release bitnami/external-dns --set provider='cloudflare',cloudflare.apiKey='YOUR_API_KEY'
+  $ helm upgrade my-release bitnami/external-dns --set provider='cloudflare',cloudflare.apiKey='YOUR_API_KEY'
 {{- end }}
 {{- if empty .Values.provider }}
   ##############################################################################
@@ -37,7 +37,7 @@ Indicate your ApiKey by installing this chart as shown below:
 
 Indicate your DNS provider by installing this chart as shown below:
 
-   $ helm install --name my-release bitnami/external-dns --set provider='YOUR_DNS_PROVIDER'
+   $ helm upgrade my-release bitnami/external-dns --set provider='YOUR_DNS_PROVIDER'
 
 Replace the placeholder YOUR_DNS_PROVIDER with a valid DNS provider (aws, azure, cloudflare, google, ...)
 {{- end }}

--- a/bitnami/external-dns/templates/_helpers.tpl
+++ b/bitnami/external-dns/templates/_helpers.tpl
@@ -1,0 +1,53 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "external-dns.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "external-dns.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "external-dns.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the proper external-dns image name
+*/}}
+{{- define "external-dns.image" -}}
+{{- $registryName := .Values.image.registry -}}
+{{- $tag := .Values.image.tag | toString -}}
+{{- printf "%s/%s:%s" $registryName .Values.image.repository $tag -}}
+{{- end -}}
+
+{{/*
+Return the AWS credentials file
+*/}}
+{{- define "external-dns.aws-credentials" }}
+[default]
+aws_access_key_id = {{ .Values.aws.accessKey }}
+aws_secret_access_key = {{ .Values.aws.secretKey }}
+{{ end }}
+
+{{/*
+Return the AWS configuration file
+*/}}
+{{- define "external-dns.aws-config" }}
+[profile default]
+{{- if .Values.aws.roleArn }}
+role_arn = {{ .Values.aws.roleArn }}
+{{- end }}
+region = {{ .Values.aws.region }}
+source_profile = default
+{{ end }}

--- a/bitnami/external-dns/templates/clusterrole.yaml
+++ b/bitnami/external-dns/templates/clusterrole.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.rbac.create }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "external-dns.fullname" . }}
+  labels:
+    app: {{ template "external-dns.name" . }}
+    chart: {{ template "external-dns.chart" .  }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+rules:
+- apiGroups:
+  - ""
+  - extensions
+  resources:
+  - ingresses
+  - services
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+{{- end -}}

--- a/bitnami/external-dns/templates/clusterrolebinding.yaml
+++ b/bitnami/external-dns/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "external-dns.fullname" . }}
+  labels:
+    app: {{ template "external-dns.name" . }}
+    chart: {{ template "external-dns.chart" .  }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "external-dns.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "external-dns.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -1,0 +1,203 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "external-dns.fullname" . }}
+  labels:
+    app: {{ template "external-dns.name" . }}
+    chart: {{ template "external-dns.chart" .  }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+spec:
+  replicas: {{ .Values.replicas }}
+  template:
+    metadata:
+     name: {{ template "external-dns.fullname" . }}
+     labels:
+       app: {{ template "external-dns.name" . }}
+       chart: {{ template "external-dns.chart" .  }}
+       release: {{ .Release.Name | quote }}
+       heritage: {{ .Release.Service | quote }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8}}
+      {{- end }}
+    spec:
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range $sec := .Values.image.pullSecrets }}
+        - name: {{$sec | quote }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.rbac.create }}
+      serviceAccountName: {{ template "external-dns.fullname" . }}
+      {{- else }}
+      serviceAccountName: {{ .Values.rbac.serviceAccountName | quote }}
+      {{- end }}
+      containers:
+      - name: {{ template "external-dns.name" . }}
+        image: "{{ template "external-dns.image" . }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+        args:
+        # Generic arguments
+        - --policy={{ .Values.policy }}
+        - --provider={{ .Values.provider }}
+        - --registry={{ .Values.registry }}
+        {{- if .Values.logLevel }}
+        - --log-level={{ .Values.logLevel }}
+        {{- end }}
+        {{- if .Values.publishInternalServices }}
+        - --publish-internal-services
+        {{- end }}
+        {{- if eq .Values.registry "txt" }}
+        - --txt-owner-id={{ .Values.txtOwnerId }}
+        {{- if .Values.txtPrefix }}
+        - --txt-prefix={{ .Values.txtPrefix }}
+        {{- end }}
+        {{- end }}
+        {{- range .Values.sources }}
+          - --source={{ . }}
+        {{- end }}
+        {{- range .Values.domainFilters }}
+        - --domain-filter={{ . }}
+        {{- end }}
+        {{- if .Values.annotationFilter }}
+        - --annotation-filter={{ .Values.annotationFilter }}
+        {{- end }}
+        {{- range $key, $value := .Values.extraArgs }}
+          {{- if $value }}
+          - --{{ $key }}={{ $value }}
+          {{- else }}
+          - --{{ $key }}
+          {{- end }}
+        {{- end }}
+
+        {{- if eq .Values.provider "aws" }}
+        {{- if .Values.aws.zoneType }}
+        - --aws-zone-type={{ .Values.aws.zoneType }}
+        {{- end }}
+        {{- end }}
+
+        {{- if eq .Values.provider "azure" }}
+        {{- if .Values.azure.resoureGroup }}
+        --azure-resource-group={{ .Values.azure.resoureGroup }}
+        {{- end }}
+        {{- end }}
+
+        {{- if eq .Values.provider "google" }}
+        - --google-project={{ .Values.google.project }}
+        {{- end }}
+
+        env:
+        {{- if .Values.image.debug }}
+        - name: BASH_DEBUG
+          value: "1"
+        - name: NAMI_DEBUG
+          value: "1"
+        - name: NAMI_LOG_LEVEL
+          value: "trace8"
+        {{- end }}
+        {{- $root := . -}}
+        {{- range $key, $value := .Values.extraEnv }}
+        - name: {{ $key }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "external-dns.fullname" $root }}
+              key: {{ $key }}
+        {{- end }}
+
+        {{- if eq .Values.provider "aws" }}
+        - name: AWS_DEFAULT_REGION
+          value: {{ .Values.aws.region }}
+        {{- end }}
+
+        {{- if eq .Values.provider "cloudflare" }}
+        - name: CF_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "external-dns.fullname" . }}
+              key: cloudflare_api_key
+        - name: CF_API_EMAIL
+          value: {{ .Values.cloudflare.email | quote }}
+        {{- end }}
+
+        {{- if eq .Values.provider "google" }}
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/secrets/service-account/credentials.json
+        {{- end }}
+
+        ports:
+        - containerPort: {{ .Values.service.port }}
+        {{- if .Values.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: {{ .Values.service.port }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: {{ .Values.service.port }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+        {{- if eq .Values.provider "aws" }}
+        - name: aws-credentials
+          mountPath: /root/.aws
+          readOnly: true
+        {{- end }}
+
+        {{- if eq .Values.provider "azure" }}
+        - name: azure-config-file
+          mountPath: /etc/kubernetes/azure.json
+          readOnly: true
+        {{- end }}
+
+        {{- if eq .Values.provider "google" }}
+        - name: google-service-account
+          mountPath: /etc/secrets/service-account/
+        {{- end }}
+
+      volumes:
+      {{- if eq .Values.provider "aws" }}
+      - name: aws-credentials
+        secret:
+          secretName: {{ template "external-dns.fullname" . }}
+      {{- end }}
+
+      {{- if eq .Values.provider "azure" }}
+      - name: azure-config-file
+        hostPath:
+          path: /etc/kubernetes/azure.json
+          type: File
+      {{- end }}
+
+      {{- if eq .Values.provider "google" }}
+      - name: google-service-account
+        secret:
+          secretName: {{ .Values.google.serviceAccountSecret | quote }}
+      {{- end}}

--- a/bitnami/external-dns/templates/secret.yaml
+++ b/bitnami/external-dns/templates/secret.yaml
@@ -1,0 +1,23 @@
+{{- if or (and .Values.aws.secretKey .Values.aws.accessKey) .Values.cloudflare.apiKey .Values.extraEnv -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "external-dns.fullname" . }}
+  labels:
+    app: {{ template "external-dns.name" . }}
+    chart: {{ template "external-dns.chart" .  }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+type: Opaque
+data:
+  {{- if eq .Values.provider "aws" }}
+  credentials: {{ include "external-dns.aws-credentials" . | b64enc | quote }}
+  config: {{ include "external-dns.aws-config" . | b64enc | quote }}
+  {{- end}}
+  {{- if eq .Values.provider "cloudflare" }}
+  cloudflare_api_key: {{ .Values.cloudflare.apiKey | b64enc | quote }}
+  {{- end }}
+  {{- range $key, $value := .Values.extraEnv }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/bitnami/external-dns/templates/serviceaccount.yaml
+++ b/bitnami/external-dns/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.rbac.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "external-dns.fullname" . }}
+  labels:
+    app: {{ template "external-dns.name" . }}
+    chart: {{ template "external-dns.chart" .  }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+{{- end }}

--- a/bitnami/external-dns/templates/svc.yaml
+++ b/bitnami/external-dns/templates/svc.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "external-dns.fullname" . }}
+  labels:
+    app: {{ template "external-dns.name" . }}
+    chart: {{ template "external-dns.chart" .  }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+  {{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP -}}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  ports:
+  - port: {{ .Values.service.port }}
+    protocol: TCP
+    targetPort: {{ .Values.service.port }}
+    {{- if and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort)) }}
+    nodePort: {{ .Values.service.nodePort  }}
+    {{- end }}
+  selector:
+    app: {{ template "external-dns.name" . }}
+    release: {{ .Release.Name | quote }}

--- a/bitnami/external-dns/values.yaml
+++ b/bitnami/external-dns/values.yaml
@@ -1,4 +1,4 @@
-## Bitnami etcd image version
+## Bitnami external-dns image version
 ## ref: https://hub.docker.com/r/bitnami/external-dns/tags/
 ##
 image:

--- a/bitnami/external-dns/values.yaml
+++ b/bitnami/external-dns/values.yaml
@@ -1,0 +1,166 @@
+## Bitnami etcd image version
+## ref: https://hub.docker.com/r/bitnami/external-dns/tags/
+##
+image:
+  registry: docker.io
+  repository: bitnami/external-dns
+  tag: 0.5.4
+  ## Specify a imagePullPolicy
+  ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  pullPolicy: Always
+
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistrKeySecretName
+
+  ## Set to true if you would like to see extra information on logs
+  ## It turns BASH and NAMI debugging in minideb
+  ## ref:  https://github.com/bitnami/minideb-extras/#turn-on-bash-debugging
+  debug: false
+
+## K8s resources type to be observed for new DNS entries by ExternalDNS
+sources:
+  - service
+  - ingress
+
+## DNS provider where the DNS records will be created. Available providers are:
+## - aws, azure, cloudflare, google
+# provider: aws
+
+# Whether to publish DNS records for ClusterIP services or not (optional)
+publishInternalServices: false
+
+## Method to syncrhonise DNS records between sources and providers. Available methos are:
+## - sync, upsert-only
+policy: upsert-only
+
+## Registry Type. Available types are: txt, noop
+## ref: https://github.com/kubernetes-incubator/external-dns/blob/master/docs/proposal/registry.md
+registry: "txt"
+
+## TXT Registry Identifier
+txtOwnerId: "default"
+## Prefix to create a TXT record with a name following the pattern prefix.<CNAME record>
+# txtPrefix: ""
+
+## Verbosity of the ExternalDNS logs. Available values are:
+## - panic, debug, info, warn, error, fatal
+logLevel: info
+
+## Limit possible target zones by domain suffixes (optional)
+domainFilters: []
+## Filter sources managed by external-dns via annotation using label selector semantics (optional)
+# annotationFilter: ""
+
+## Extra Arguments to passed to external-dns
+extraArgs: {}
+## Extra env. variable to set on external-dns container
+extraEnv: {}
+
+# AWS credentials to be set via arguments/env. variables
+aws:
+  secretKey: ""
+  accessKey: ""
+  roleArn: ""
+  region: "us-east-1"
+  # Zone Filter. Available values are: public, private
+  zoneType: ""
+
+# Azure credentials to be set via arguments/env. variables
+azure:
+  resoureGroup: ""
+
+# Cloudflare credentials to be set via env. variables
+cloudflare:
+  apiKey: ""
+  email: ""
+
+# GCE credentials to be set via arguments/env. variables
+google:
+  project: ""
+  serviceAccountSecret: ""
+
+
+## Kubernetes svc configutarion
+##
+service:
+  ## Kubernetes svc type
+  ##
+  type: ClusterIP
+  port: 7979
+  ## Specify the nodePort value for the LoadBalancer and NodePort service types for the client port
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+  ##
+  # nodePort:
+  ## Provide any additional annotations which may be required. This can be used to
+  ## set the LoadBalancer service type to internal only.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+  ##
+  annotations: {}
+  ## Use loadBalancerIP to request a specific static IP,
+  ## otherwise leave blank
+  ##
+  # loadBalancerIP:
+
+## RBAC parameteres
+## https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+##
+rbac:
+  create: false
+  ## Service Account for pods
+  ## https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  ##
+  serviceAccountName: default
+
+## Kubernetes Security Context
+## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+##
+securityContext:
+  enabled: true
+  fsGroup: 1001
+  runAsUser: 1001
+
+## Node labels and tolerations for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
+nodeSelector: {}
+tolerations: []
+
+## Annotations for external-dns pods
+podAnnotations: {}
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources: {}
+#  limits:
+#    cpu: 50m
+#    memory: 100Mi
+#  requests:
+#    memory: 50Mi
+#    cpu: 10m
+
+## Replica count
+replicas: 1
+
+## Configure extra options for liveness and readiness probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 2
+  successThreshold: 1
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1


### PR DESCRIPTION
**What this PR does / why we need it:**

ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.. More information at: https://github.com/kubernetes-incubator/external-dns

Adds a new Chart that allows to deploy ExternalDNS on your k8s cluster.