### PR TITLE
Adapt chart to new image solving non-root issues

### DIFF
--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: metrics-server
-version: 0.0.1
+version: 0.0.2
 appVersion: 0.2.1
 description: Metrics Server is a cluster-wide aggregator of resource usage data. Metrics Server collects metrics from the Summary API, exposed by Kubelet on each node.
 keywords:

--- a/bitnami/metrics-server/templates/metrics-server-deployment.yaml
+++ b/bitnami/metrics-server/templates/metrics-server-deployment.yaml
@@ -23,8 +23,6 @@ spec:
         - name: metrics-server
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          workingDir: /tmp
           command:
             - metrics-server
             - --source=kubernetes.summary_api:''
-            - --secure-port=8443


### PR DESCRIPTION
New metrics-server images were released solving some issues with the non-root user. This PR removed some workarounds used previously.