### PR TITLE
[node] - Add missing labels to pod spec

### DIFF
--- a/bitnami/node/Chart.yaml
+++ b/bitnami/node/Chart.yaml
@@ -1,5 +1,5 @@
 name: node
-version: 3.0.0
+version: 3.0.1
 appVersion: 9.11.1
 description: Event-driven I/O server-side JavaScript environment based on V8
 keywords:

--- a/bitnami/node/templates/deployment.yaml
+++ b/bitnami/node/templates/deployment.yaml
@@ -13,7 +13,9 @@ spec:
     metadata:
       labels:
         app: {{ template "node.name" . }}
+        chart: {{ template "node.chart" . }}
         release: {{ .Release.Name | quote }}
+        heritage: "{{ .Release.Service }}"
     spec:
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
@@ -53,7 +55,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: {{ template "node.mongodb.fullname" . }}
-              key: mongodb-password 
+              key: mongodb-password
         - name: DATABASE_NAME
           value: {{ .Values.mongodb.mongodbDatabase | quote }}
         - name: DATABASE_CONNECTION_OPTIONS
@@ -64,7 +66,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: {{ template "node.secretName" . }}
-              key: {{ template "externaldb.host" $type }} 
+              key: {{ template "externaldb.host" $type }}
         {{- if not .Values.externaldb.broker.serviceInstanceName }}
         - name: DATABASE_NAME
           valueFrom:
@@ -79,17 +81,17 @@ spec:
           valueFrom:
             secretKeyRef:
               name: {{ template "node.secretName" . }}
-              key: {{ template "externaldb.port" $type }} 
+              key: {{ template "externaldb.port" $type }}
         - name: DATABASE_USER
           valueFrom:
             secretKeyRef:
               name: {{ template "node.secretName" . }}
-              key: {{ template "externaldb.username" $type }} 
+              key: {{ template "externaldb.username" $type }}
         - name: DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "node.secretName" . }}
-              key: {{ template "externaldb.password" $type }} 
+              key: {{ template "externaldb.password" $type }}
         {{- if .Values.externaldb.ssl }}
         - name: DATABASE_CONNECTION_OPTIONS
           value: "ssl=true"


### PR DESCRIPTION
The pod spec in the deployment is missing some of the generic labels.