### PR TITLE
[ bitnami/postgresql ] - Allow using custom scripts to initialize PostgreSQL

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 2.0.1
+version: 2.1.0
 appVersion: 10.4.0
 description: Chart for PostgreSQL
 keywords:

--- a/bitnami/postgresql/README.md
+++ b/bitnami/postgresql/README.md
@@ -116,6 +116,12 @@ Instead of using specific variables for the PostgreSQL configuration, this helm 
 
 Add your custom file to "files/postgresql.conf" in your working directory. This file will be mounted as configMap to the containers and it will be used for configuring the PostgreSQL server.
 
+## Initialize a fresh instance
+
+The [Bitnami PostgreSQL](https://github.com/bitnami/bitnami-docker-postgresql) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, they must be located inside the chart folder `files/docker-entrypoint-initdb.d` so they can be consumed as a ConfigMap.
+
+The allowed extensions are `.sh`, `.sql` and `.sql.gz`.
+
 ## Production and horizontal scaling
 
 The following repo contains the recommended production settings for PostgreSQL server in an alternative [values file](values-production.yaml). Please read carefully the comments in the values-production.yaml file to set up your environment

--- a/bitnami/postgresql/files/docker-entrypoint-initdb.d/README.md
+++ b/bitnami/postgresql/files/docker-entrypoint-initdb.d/README.md
@@ -1,0 +1,3 @@
+You can copy here your custom `.sh`, `.sql` or `.sql.gz` file so they are executed during the first boot of the image.
+
+More info in the [bitnami-docker-postgresql](https://github.com/bitnami/bitnami-docker-postgresql#initializing-a-new-instance) repository.

--- a/bitnami/postgresql/templates/initialization-configmap.yaml
+++ b/bitnami/postgresql/templates/initialization-configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "postgresql.fullname" . }}-init-scripts
+  labels:
+    app: "{{ template "postgresql.name" . }}"
+    chart: {{ template "postgresql.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+data:
+{{ (.Files.Glob "files/docker-entrypoint-initdb.d/*").AsConfig | indent 2 }}

--- a/bitnami/postgresql/templates/statefulset.yaml
+++ b/bitnami/postgresql/templates/statefulset.yaml
@@ -107,6 +107,8 @@ spec:
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         {{- end }}
         volumeMounts:
+        - name: custom-init-scripts
+          mountPath: /docker-entrypoint-initdb.d
         {{- if .Values.persistence.enabled }}
         - name: data
           mountPath: /bitnami/postgresql
@@ -114,7 +116,7 @@ spec:
         {{ if  (.Files.Glob "files/postgresql.conf") }}
         - name: postgresql-config
           mountPath: /opt/bitnami/postgresql/conf/postgresql.conf
-          subPath: postgresql.conf 
+          subPath: postgresql.conf
         {{ end }}
       volumes:
       {{ if  (.Files.Glob "files/postgresql.conf") }}
@@ -122,6 +124,9 @@ spec:
         configMap:
           name: {{ template "postgresql.fullname" . }}-configuration
       {{ end }}
+      - name: custom-init-scripts
+        configMap:
+          name: {{ template "postgresql.fullname" . }}-init-scripts
 {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
@@ -146,8 +151,8 @@ spec:
       {{- end }}
       {{- end }}
 {{- else }}
-        - name: data
-          emptyDir: {}
+      - name: data
+        emptyDir: {}
 {{- end }}
 
 


### PR DESCRIPTION
This PR adds a new feature to the chart. Now it is possible to execute your custom `.sh`, `.sql` and `.sql.gz` the first time the database image is initialized.

More info about the usage is documented in the README.