### PR TITLE
[ bitnami/mysql ] - Allow using custom scripts to initialise the database

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 2.0.1
+version: 2.1.0
 appVersion: 5.7.22
 description: Chart to create a Highly available MySQL cluster
 keywords:

--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -128,6 +128,12 @@ $ helm install --name my-release -f values.yaml bitnami/mysql
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
+## Initialize a fresh instance
+
+The [Bitnami MySQL](https://github.com/bitnami/bitnami-docker-mysql) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, they must be located inside the chart folder `files/docker-entrypoint-initdb.d` so they can be consumed as a ConfigMap.
+
+The allowed extensions are `.sh`, `.sql` and `.sql.gz`.
+
 ## Persistence
 
 The [Bitnami MySQL](https://github.com/bitnami/bitnami-docker-mysql) image stores the MySQL data and configurations at the `/bitnami/mysql` path of the container.

--- a/bitnami/mysql/files/docker-entrypoint-initdb.d/README.md
+++ b/bitnami/mysql/files/docker-entrypoint-initdb.d/README.md
@@ -1,0 +1,3 @@
+You can copy here your custom .sh, .sql or .sql.gz file so they are executed during the first boot of the image.
+
+More info in the [bitnami-docker-mysql](https://github.com/bitnami/bitnami-docker-mysql#initializing-a-new-instance) repository.

--- a/bitnami/mysql/templates/initialization-configmap.yaml
+++ b/bitnami/mysql/templates/initialization-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "master.fullname" . }}-init-scripts
+  labels:
+    app: {{ template "name" . }}
+    component: "master"
+    chart: {{ template "mysql.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+data:
+{{ (.Files.Glob "files/docker-entrypoint-initdb.d/*").AsConfig | indent 2 }}

--- a/bitnami/mysql/templates/master-statefulset.yaml
+++ b/bitnami/mysql/templates/master-statefulset.yaml
@@ -114,6 +114,8 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /bitnami/mysql
+        - name: custom-init-scripts
+          mountPath: /docker-entrypoint-initdb.d
 {{- if .Values.master.config }}
         - name: config
           mountPath: /opt/bitnami/mysql/conf/my.cnf
@@ -154,6 +156,9 @@ spec:
           configMap:
             name: {{ template "master.fullname" . }}
       {{- end }}
+        - name: custom-init-scripts
+          configMap:
+            name: {{ template "master.fullname" . }}-init-scripts
 {{- if .Values.master.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -3,8 +3,8 @@
 ##
 image:
   registry: docker.io
-  repository: bitnami/mysql
-  tag: 5.7.22-debian-9
+  repository: tompizmor/mysql
+  tag: 5.7-init
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -42,7 +42,7 @@ root:
   ## Option to force users to specify a password. That is required for 'helm upgrade' to work properly.
   ## If it is not force, a random password will be generated.
   forcePassword: false
-  
+
 db:
   ## MySQL username and password
   ## ref: https://github.com/bitnami/bitnami-docker-mysql#creating-a-database-user-on-first-run

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -3,8 +3,8 @@
 ##
 image:
   registry: docker.io
-  repository: tompizmor/mysql
-  tag: 5.7-init
+  repository: bitnami/mysql
+  tag: 5.7.22-debian-9
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
This PR adds a new feature to the chart. Now it is possible to execute your custom `.sh`, `.sql` and `.sql.gz` the first time the database image is initialized.

More info about the usage is documented in the README.