### PR TITLE
Improve notes to access deployed services

### DIFF
--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -2,7 +2,7 @@ name: consul
 home: https://www.consul.io/
 sources:
 - https://github.com/bitnami/consul
-version: 1.0.0
+version: 1.0.1
 appVersion: 1.0.6
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/bitnami/consul/templates/NOTES.txt
+++ b/bitnami/consul/templates/NOTES.txt
@@ -16,8 +16,7 @@ In order to access to the Consul Web UI:
 
     export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
     export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "consul.fullname" . }}-ui)
-
-    echo http://$NODE_IP:$NODE_PORT/
+    echo "Consul URL: http://$NODE_IP:$NODE_PORT/"
 
 {{- else if contains "LoadBalancer" .Values.ui.service.type }}
 
@@ -25,15 +24,12 @@ In order to access to the Consul Web UI:
         Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "consul.fullname" . }}-ui'
 
     export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "consul.fullname" . }}-ui -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-
-    echo http://$SERVICE_IP:{{ .Values.httpPort }}/
-
+    echo "Consul URL: http://$SERVICE_IP:{{ .Values.httpPort }}/"
 
 {{- else if contains "ClusterIP"  .Values.ui.service.type }}
 
-    kubectl port-forward {{ template "consul.fullname" . }}-0 --namespace {{ .Release.Namespace }} {{ .Values.httpPort }}:{{ .Values.httpPort }}
-
-    URL : http://127.0.0.1:{{ .Values.httpPort }}
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "consul.fullname" . }}-ui {{ .Values.httpPort }}:{{ .Values.httpPort }}
+    echo "Consul URL: http://127.0.0.1:{{ .Values.httpPort }}"
 
 {{- end }}
 

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: elasticsearch
-version: 2.0.1
+version: 2.0.2
 appVersion: 6.3.2
 description: A highly scalable open-source full-text search and analytics engine
 keywords:

--- a/bitnami/elasticsearch/templates/NOTES.txt
+++ b/bitnami/elasticsearch/templates/NOTES.txt
@@ -32,7 +32,6 @@
     curl http://$SERVICE_IP:{{ .Values.coordinating.service.port }}/
 {{- else if contains "ClusterIP"  .Values.coordinating.service.type }}
 
-    export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "elasticsearch.name" . }},release={{ .Release.Name }},role=coordinating-only" -o jsonpath="{.items[0].metadata.name}")
-    kubectl port-forward $POD_NAME {{ .Values.coordinating.service.port }}:9200 &
-    curl http://127.0.0.1:{{ .Values.coordinating.service.port }}/
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "coordinating.fullname" . }} {{ .Values.coordinating.service.port }}:9200 &
+    curl http://127.0.0.1:9200/
 {{- end }}

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -1,5 +1,5 @@
 name: etcd
-version: 0.0.1
+version: 0.0.2
 appVersion: 3.3.8
 description: etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines
 keywords:

--- a/bitnami/etcd/templates/NOTES.txt
+++ b/bitnami/etcd/templates/NOTES.txt
@@ -37,6 +37,7 @@ To connect to your etcd server from outside the cluster execute the following co
 
     export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
     export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "etcd.fullname" . }})
+    echo "etcd URL: http://$NODE_IP:$NODE_PORT/"
 
 {{- else if contains "LoadBalancer" .Values.service.type }}
 
@@ -44,11 +45,12 @@ To connect to your etcd server from outside the cluster execute the following co
         Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "etcd.fullname" . }}'
 
     export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "etcd.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    echo "etcd URL: http://$SERVICE_IP:2379/"
 
 {{- else if contains "ClusterIP" .Values.service.type }}
 
-    export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "etcd.name" . }}" -o jsonpath="{.items[0].metadata.name}")
-    kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 2379:2379 &
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "etcd.fullname" . }} 2379:2379 &
+    echo "etcd URL: http://127.0.0.1:2379"
 
 {{- end }}
 

--- a/bitnami/jenkins/Chart.yaml
+++ b/bitnami/jenkins/Chart.yaml
@@ -1,5 +1,5 @@
 name: jenkins
-version: 0.4.73
+version: 0.4.74
 appVersion: 2.121.2
 description: The leading open source automation server
 keywords:

--- a/bitnami/jenkins/templates/NOTES.txt
+++ b/bitnami/jenkins/templates/NOTES.txt
@@ -7,7 +7,7 @@
 
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT/
+  echo "Jenkins URL: http://$NODE_IP:$NODE_PORT/"
 
 {{- else if contains "LoadBalancer" .Values.serviceType }}
 
@@ -15,12 +15,12 @@
 ** Watch the status using: kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "fullname" . }} **
 
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP/
+  echo "Jenkins URL:  http://$SERVICE_IP/"
 {{- else if contains "ClusterIP"  .Values.serviceType }}
 
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
-  echo http://127.0.0.1:8080/
-  kubectl port-forward $POD_NAME 8080:80
+  echo "Jenkins URL: http://127.0.0.1:8080/"
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "fullname" . }} 8080:80
+
 {{- end }}
 
 2. Login with the following credentials

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,5 +1,5 @@
 name: kafka
-version: 0.0.6
+version: 0.0.7
 appVersion: 1.1.1
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/templates/NOTES.txt
+++ b/bitnami/kafka/templates/NOTES.txt
@@ -54,6 +54,7 @@ To connect to your Kafka server from outside the cluster execute the following c
 
     export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
     export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "kafka.fullname" . }})
+    echo "Kafka URL: http://$NODE_IP:$NODE_PORT/"
 
 {{- else if contains "LoadBalancer" .Values.service.type }}
 
@@ -61,11 +62,12 @@ To connect to your Kafka server from outside the cluster execute the following c
         Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "kafka.fullname" . }}'
 
     export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kafka.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    echo "Kafka URL: http://$SERVICE_IP:9092"
 
 {{- else if contains "ClusterIP" .Values.service.type }}
 
-    export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "kafka.name" . }}" -o jsonpath="{.items[0].metadata.name}")
-    kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 9092:9092 &
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "kafka.fullname" . }} 9092:9092 &
+    echo "Kafka URL: http://127.0.0.1:9092"
 
 {{- end }}
 {{ if .Values.auth.enabled }}

--- a/bitnami/mean/Chart.yaml
+++ b/bitnami/mean/Chart.yaml
@@ -1,5 +1,5 @@
 name: mean
-version: 2.0.1
+version: 2.0.2
 appVersion: 3.6.4
 description: MEAN is a free and open-source JavaScript software stack for building dynamic web sites and web applications. The MEAN stack is MongoDB, Express.js, Angular, and Node.js. Because all components of the MEAN stack support programs written in JavaScript, MEAN applications can be written in one language for both server-side and client-side execution environments.
 keywords:

--- a/bitnami/mean/templates/NOTES.txt
+++ b/bitnami/mean/templates/NOTES.txt
@@ -1,11 +1,11 @@
 
-1. Get the URL of your Node app by running:
+1. Get the URL of your MEAN app by running:
 
 {{- if contains "NodePort" .Values.serviceType }}
 
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "mean.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT/
+  echo "MEAN app URL: http://$NODE_IP:$NODE_PORT/"
 
 {{- else if contains "LoadBalancer" .Values.serviceType }}
 
@@ -13,11 +13,11 @@
         Watch the status with: 'kubectl get svc -w {{ template "mean.fullname" . }} --namespace {{ .Release.Namespace }}'
 
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "mean.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP/
+  echo "MEAN app URL: http://$SERVICE_IP/"
+
 {{- else if contains "ClusterIP"  .Values.serviceType }}
 
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "mean.name" . }}" -l "release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  kubectl port-forward $POD_NAME 3000:3000
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "mean.fullname" . }} 3000:3000
+  echo "MEAN app URL: http://127.0.0.1:3000/"
 
-  Access to http://127.0.0.1:3000/
 {{- end }}

--- a/bitnami/node/Chart.yaml
+++ b/bitnami/node/Chart.yaml
@@ -1,5 +1,5 @@
 name: node
-version: 4.0.0
+version: 4.0.1
 appVersion: 10.7.0
 description: Event-driven I/O server-side JavaScript environment based on V8
 keywords:

--- a/bitnami/node/templates/NOTES.txt
+++ b/bitnami/node/templates/NOTES.txt
@@ -5,7 +5,7 @@
 
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "node.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT/
+  echo "Node app URL: http://$NODE_IP:$NODE_PORT/"
 
 {{- else if contains "LoadBalancer" .Values.serviceType }}
 
@@ -13,11 +13,11 @@
         Watch the status with: 'kubectl get svc -w {{ template "node.fullname" . }} --namespace {{ .Release.Namespace }}'
 
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "node.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP/
+  echo "Node app URL: http://$SERVICE_IP/"
+
 {{- else if contains "ClusterIP"  .Values.serviceType }}
 
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "node.name" . }}" -l "release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  kubectl port-forward $POD_NAME 3000:3000
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "node.fullname" . }} 3000:3000
+  echo "Node app URL: http://127.0.0.1:3000/"
 
-  Access to http://127.0.0.1:3000/
 {{- end }}

--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 2.1.1
+version: 2.1.2
 appVersion: 10.4.0
 description: Chart for PostgreSQL
 keywords:

--- a/bitnami/postgresql/templates/NOTES.txt
+++ b/bitnami/postgresql/templates/NOTES.txt
@@ -47,8 +47,7 @@ To connect to your database from outside the cluster execute the following comma
 
 {{- else if contains "ClusterIP" .Values.service.type }}
 
-    export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "postgresql.name" . }}" -o jsonpath="{.items[0].metadata.name}")
-    kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 5432:5432 &
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "postgresql.fullname" . }} 5432:5432 &
     {{ if .Values.postgresqlPassword }}PGPASSWORD={{ .Values.postgresqlPassword}} "{{- end }}psql --host 127.0.0.1 -U {{ .Values.postgresqlUsername }} 
 
 {{- end }}

--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -1,5 +1,5 @@
 name: tomcat
-version: 0.4.30
+version: 0.4.31
 appVersion: 8.5.32
 description: Chart for Apache Tomcat
 keywords:

--- a/bitnami/tomcat/templates/NOTES.txt
+++ b/bitnami/tomcat/templates/NOTES.txt
@@ -18,10 +18,9 @@
   echo URL            : http://$SERVICE_IP/
   echo Management URL : http://$SERVICE_IP/manager
 {{- else if contains "ClusterIP"  .Values.serviceType }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
   echo URL            : http://127.0.0.1:8080/
   echo Management URL : http://127.0.0.1:8080/manager
-  kubectl port-forward $POD_NAME 8080:8080
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "fullname" . }} 8080:8080
 {{- end }}
 
 2. Login with the following credentials

--- a/bitnami/wildfly/Chart.yaml
+++ b/bitnami/wildfly/Chart.yaml
@@ -1,5 +1,5 @@
 name: wildfly
-version: 0.4.17
+version: 0.4.18
 appVersion: 13.0.0
 description: Chart for Wildfly
 keywords:

--- a/bitnami/wildfly/templates/NOTES.txt
+++ b/bitnami/wildfly/templates/NOTES.txt
@@ -18,10 +18,9 @@
   echo URL            : http://$SERVICE_IP/
   echo Management Url : http://$SERVICE_IP:9990/
 {{- else if contains "ClusterIP"  .Values.serviceType }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
   echo URL            : http://127.0.0.1:8080/
   echo Management URL : http://127.0.0.1:9990/
-  kubectl port-forward $POD_NAME 8080:8080 9990:9990
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "fullname" . }} 8080:8080 9990:9990
 {{- end }}
 
 2. Login with the following credentials

--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,5 +1,5 @@
 name: zookeeper
-version: 0.0.4
+version: 0.0.5
 appVersion: 3.4.12
 description: A centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services for distributed applications.
 keywords:

--- a/bitnami/zookeeper/templates/NOTES.txt
+++ b/bitnami/zookeeper/templates/NOTES.txt
@@ -44,8 +44,7 @@ To connect to your ZooKeeper server from outside the cluster execute the followi
 
 {{- else if contains "ClusterIP" .Values.service.type }}
 
-    export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "zookeeper.name" . }}" -o jsonpath="{.items[0].metadata.name}")
-    kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 2181:2181 &
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "zookeeper.fullname" . }} 2181:2181 &
     zkCli.sh 127.0.0.1:2181
 
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it:**

As described on kubernetes/kubernetes#59809, now kubectl port-foward resolves service port to target port. Therefore, we can access the services deployed as 'ClusterIP' using a simple port-forward.

This PR improves the NOTES.txt so this new method is the one recommended to access the application when using 'ClusterIP'