### PR TITLE
[Kafka] - Fix issue with maxMessageBytes default value

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,5 +1,5 @@
 name: kafka
-version: 0.0.7
+version: 0.0.8
 appVersion: 1.1.1
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -148,7 +148,7 @@ spec:
         - name: KAFKA_LOG_RETENTION_HOURS
           value: {{ .Values.logRetentionHours | quote }}
         - name: KAFKA_MAX_MESSAGE_BYTES
-          value: {{ .Values.maxMessageBytes | quote }}           
+          value: {{ .Values.maxMessageBytes | replace "_" "" | quote }}
         - name: KAFKA_SEGMENT_BYTES
           value: {{ .Values.logSegmentBytes | replace "_" "" | quote }}
         - name: KAFKA_LOGS_DIRS

--- a/bitnami/kafka/values-production.yaml
+++ b/bitnami/kafka/values-production.yaml
@@ -94,7 +94,7 @@ logSegmentBytes: _1073741824
 logsDirs: /opt/bitnami/kafka/data
 
 ## The largest record batch size allowed by Kafka
-maxMessageBytes: 1000012
+maxMessageBytes: _1000012
 
 ## The number of threads doing disk I/O.
 numIoThreads: 8

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -94,7 +94,7 @@ logSegmentBytes: _1073741824
 logsDirs: /opt/bitnami/kafka/data
 
 ## The largest record batch size allowed by Kafka
-maxMessageBytes: 1000012
+maxMessageBytes: _1000012
 
 ## The number of threads doing disk I/O.
 numIoThreads: 8


### PR DESCRIPTION
There is an issue in helm that converts large numbers in values.yaml to scientific notation when passing the value to the docker image. So Kafka is configured with a numeric value that it cannot understand and so fails.

https://github.com/helm/helm/issues/3001
https://github.com/helm/helm/issues/1707