### PR TITLE
Improve Kubeapps NOTES.txt

### DIFF
--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 0.1.0
+version: 0.1.1
 appVersion: 1.0.0.alpha.5
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/bitnami/kubeapps/templates/NOTES.txt
+++ b/bitnami/kubeapps/templates/NOTES.txt
@@ -1,19 +1,50 @@
-1. Get the application URL by running these commands:
+
+** Please be patient while the chart is being deployed **
+
+Tip:
+
+  Watch the deployment status using the command: kubectl get pods -w --namespace {{ .Release.Namespace }}
+
+Kubeapps can be accessed via port {{ .Values.frontend.service.port }} on the following DNS name from within your cluster:
+
+   {{ template "kubeapps.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+
+To access Kubeapps from outside your K8s cluster, follow the steps below:
+
 {{- if .Values.ingress.enabled }}
+
+1. Get the Kubeapps URL and associate Kubeapps hostname to your cluster external IP:
+
 {{- range .Values.ingress.hosts }}
-  echo http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+   export CLUSTER_IP=$(minikube ip) # On Minikube. Use: `kubectl cluster-info` on others K8s clusters
+   echo "Kubeapps URL: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}"
+   echo "$CLUSTER_IP  {{ . }}" | sudo tee -a /etc/hosts
 {{- end }}
-{{- else if contains "NodePort" .Values.frontend.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "kubeapps.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
+
+{{- else }}
+
+1. Get the Kubeapps URL by running these commands:
+
+{{- if contains "NodePort" .Values.frontend.service.type }}
+
+   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "kubeapps.fullname" . }})
+   echo "Kubeapps URL: http://$NODE_IP:$NODE_PORT"
+
 {{- else if contains "LoadBalancer" .Values.frontend.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status by running 'kubectl get svc -w {{ template "kubeapps.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kubeapps.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ .Values.frontend.service.port }}
+
+ NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+       Watch the status by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "kubeapps.fullname" . }}'
+
+   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kubeapps.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+   echo "Kubeapps URL: http://$SERVICE_IP:{{ .Values.frontend.service.port }}"
+
 {{- else if contains "ClusterIP" .Values.frontend.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "kubeapps.fullname" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:8080
+
+   echo "Kubeapps URL: http://127.0.0.1:{{ .Values.frontend.service.port }}"
+   kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "kubeapps.fullname" . }} {{ .Values.frontend.service.port }}:{{ .Values.frontend.service.port }}
+
 {{- end }}
+{{- end }}
+
+2. Open a browser and access Kubeapps browsing to the obtained URL.


### PR DESCRIPTION
This PR provides several improvements to NOTES.txt on the Kubeapps chart:

 - Standardise NOTES.txt based on other charts.
 - Improves instructions to access when ingress is enabled.
 - Improves port-forwarding access when service type is "ClusterIP" so the tunnel is created addressing the service instead of a single pod.

