### PR TITLE
[stable/kubeapps] sync from kubeapps/kubeapps

### DIFF
--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 0.1.1
+version: 0.1.2
 appVersion: 1.0.0.alpha.5
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/bitnami/kubeapps/README.md
+++ b/bitnami/kubeapps/README.md
@@ -40,6 +40,8 @@ $ helm repo add bitnami https://charts.bitnami.com/bitnami
 $ helm install --name kubeapps --namespace kubeapps bitnami/kubeapps
 ```
 
+> **IMPORTANT** This assumes an insecure Helm installation, which is not recommended in production. See [the documentation to learn how to secure Helm and Kubeapps in production](securing-kubeapps.md).
+
 The command deploys Kubeapps on the Kubernetes cluster in the `kubeapps` namespace. The [configuration](#configuration) section lists the parameters that can be configured during installation.
 
 > **Tip**: List all releases using `helm list`
@@ -170,3 +172,19 @@ For annotations, please see [this document](https://github.com/kubernetes/ingres
 ##### TLS
 
 TLS can be configured using the `ingress.tls` object in the same format that the Kubernetes Ingress requests. Please see [this example](https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/tls) for more information.
+
+## Troubleshooting
+
+### Forbidden error while installing the Chart
+
+If during installation you run into an error similar to:
+
+```
+Error: release kubeapps failed: clusterroles.rbac.authorization.k8s.io "kubeapps-apprepository-controller" is forbidden: attempt to grant extra privileges: [{[get] [batch] [cronjobs] [] []...
+```
+
+It is possible that your cluster does not have Role Based Access Control (RBAC) fully configured. In which case you should perform the chart installation by setting `rbac.create=false`:
+
+```console
+$ helm install --name kubeapps --namespace kubeapps bitnami/kubeapps --set rbac.create=false
+```

--- a/bitnami/kubeapps/templates/NOTES.txt
+++ b/bitnami/kubeapps/templates/NOTES.txt
@@ -1,4 +1,3 @@
-
 ** Please be patient while the chart is being deployed **
 
 Tip:

--- a/bitnami/kubeapps/templates/apprepository-jobs-bootstrap-rbac.yaml
+++ b/bitnami/kubeapps/templates/apprepository-jobs-bootstrap-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
@@ -42,3 +43,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "kubeapps.apprepository-jobs-bootstrap.fullname" . }}
   namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/bitnami/kubeapps/templates/apprepository-rbac.yaml
+++ b/bitnami/kubeapps/templates/apprepository-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create -}}
 # Need a cluster role because client-go v5.0.1 does not support namespaced
 # informers
 # TODO: remove when we update to client-go v6.0.0
@@ -97,3 +98,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "kubeapps.apprepository.fullname" . }}
   namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/bitnami/kubeapps/templates/user-rbac.yaml
+++ b/bitnami/kubeapps/templates/user-rbac.yaml
@@ -9,6 +9,7 @@
     heritage: {{ .Release.Service }}
 {{- end }}
 
+{{- if .Values.rbac.create -}}
 # kubeapps-applications-read
 # Gives read-only access to all the elements within a Namespace.
 # Usage:
@@ -150,3 +151,4 @@ rules:
   - secrets
   verbs:
   - create
+{{- end -}}

--- a/bitnami/kubeapps/values.yaml
+++ b/bitnami/kubeapps/values.yaml
@@ -23,6 +23,8 @@ apprepository:
     url: https://kubernetes-charts-incubator.storage.googleapis.com
   - name: svc-cat
     url: https://svc-catalog-charts.storage.googleapis.com
+  - name: bitnami
+    url: https://charts.bitnami.com/bitnami
   resources: {}
     # limits:
     #  cpu: 100m
@@ -170,3 +172,8 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# For RBAC support:
+rbac:
+  # Perform creation of RBAC resources
+  create: true


### PR DESCRIPTION
We should wait for https://github.com/bitnami/charts/issues/753 to be fixed before releasing this due to the addition of the Bitnami repo by default (https://github.com/kubeapps/kubeapps/issues/465).