### PR TITLE
namespace agnostic service discovery

### DIFF
--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -93,7 +93,7 @@ spec:
           {{- $electionPort := int .Values.service.electionPort }}
           {{- $zookeeperFullname := include "zookeeper.fullname" . }}
           {{- $zookeeperHeadlessServiceName := printf "%s-%s" $zookeeperFullname "headless" | trunc 24  }}
-          value: {{range $i, $e := until $replicaCount }}{{ $zookeeperFullname }}-{{ $e }}.{{ $zookeeperHeadlessServiceName }}.default.svc.cluster.local:{{ $followerPort }}:{{ $electionPort }} {{ end }}
+          value: {{range $i, $e := until $replicaCount }}{{ $zookeeperFullname }}-{{ $e }}.{{ $zookeeperHeadlessServiceName }}.{{.Values.service.namespace}}.svc.cluster.local:{{ $followerPort }}:{{ $electionPort }} {{ end }}
         {{- if .Values.auth.enabled }}
         - name: ZOO_ENABLE_AUTH
           value: "yes"


### PR DESCRIPTION
This will fail when used on a different namespace. One can as well use {{.Release.Namespace}}