### PR TITLE
[bitnami/zookeeper] Fix Statefulset when Namespace is not default

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,5 +1,5 @@
 name: zookeeper
-version: 0.0.5
+version: 0.0.6
 appVersion: 3.4.12
 description: A centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services for distributed applications.
 keywords:

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -93,7 +93,7 @@ spec:
           {{- $electionPort := int .Values.service.electionPort }}
           {{- $zookeeperFullname := include "zookeeper.fullname" . }}
           {{- $zookeeperHeadlessServiceName := printf "%s-%s" $zookeeperFullname "headless" | trunc 24  }}
-          value: {{range $i, $e := until $replicaCount }}{{ $zookeeperFullname }}-{{ $e }}.{{ $zookeeperHeadlessServiceName }}.default.svc.cluster.local:{{ $followerPort }}:{{ $electionPort }} {{ end }}
+          value: {{range $i, $e := until $replicaCount }}{{ $zookeeperFullname }}-{{ $e }}.{{ $zookeeperHeadlessServiceName }}.{{ .Release.Namespace }}.svc.cluster.local:{{ $followerPort }}:{{ $electionPort }} {{ end }}
         {{- if .Values.auth.enabled }}
         - name: ZOO_ENABLE_AUTH
           value: "yes"


### PR DESCRIPTION
**What this PR does / why we need it:** 

Statefulset template is assuming the chart is released on the default namespace. This PR adapt it so it configure Zookeeper properly.

**Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged):**

Fixes https://github.com/bitnami/charts/issues/758