### PR TITLE
[bitnami/consul] Fix Consul UI port on NOTES.txt

### DIFF
--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -2,7 +2,7 @@ name: consul
 home: https://www.consul.io/
 sources:
 - https://github.com/bitnami/consul
-version: 1.0.1
+version: 1.1.0
 appVersion: 1.0.6
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/bitnami/consul/README.md
+++ b/bitnami/consul/README.md
@@ -60,6 +60,7 @@ The following tables lists the configurable parameters of the Consul chart and t
 | `serflanPort`                        | Container serf lan listening port                      | `8301`                                                     |
 | `serverPort`                         | Container server listening port                        | `8300`                                                     |
 | `consulDnsPort`                      | Container dns listening port                           | `8600`                                                     |
+| `uiPort`                             | Consul UI port                                         | `80`                                                       |
 | `datacenterName`                     | Consul datacenter name                                 | `dc1`                                                      |
 | `gossipKey`                          | Gossip key for all members                             | `nil`                                                      |
 | `domain`                             | Consul domain                                          | `consul`                                                   |

--- a/bitnami/consul/templates/NOTES.txt
+++ b/bitnami/consul/templates/NOTES.txt
@@ -24,12 +24,12 @@ In order to access to the Consul Web UI:
         Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "consul.fullname" . }}-ui'
 
     export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "consul.fullname" . }}-ui -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-    echo "Consul URL: http://$SERVICE_IP:{{ .Values.httpPort }}/"
+    echo "Consul URL: http://$SERVICE_IP:{{ .Values.uiPort }}/"
 
 {{- else if contains "ClusterIP"  .Values.ui.service.type }}
 
-    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "consul.fullname" . }}-ui {{ .Values.httpPort }}:{{ .Values.httpPort }}
-    echo "Consul URL: http://127.0.0.1:{{ .Values.httpPort }}"
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "consul.fullname" . }}-ui {{ .Values.uiPort }}:{{ .Values.uiPort }}
+    echo "Consul URL: http://127.0.0.1:{{ .Values.uiPort }}"
 
 {{- end }}
 

--- a/bitnami/consul/templates/ui-service.yaml
+++ b/bitnami/consul/templates/ui-service.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   ports:
   - name: http
-    port: 80
+    port: {{ .Values.uiPort }}
     targetPort: http
   type: "{{ .Values.ui.service.type }}"
   selector:

--- a/bitnami/consul/values.yaml
+++ b/bitnami/consul/values.yaml
@@ -26,6 +26,7 @@ rpcPort: 8400
 serflanPort: 8301
 serverPort: 8300
 consulDnsPort: 8600
+uiPort: 80
 
 ## Datacenter name for consul. If not supplied, will use the consul
 ## default 'dc1'


### PR DESCRIPTION
**What this PR does / why we need it:**

Fixes the NOTES.txt instructions about how to access the Consul UI once the chart is deployed.