### PR TITLE
Fix issue configuring etcd auth

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -1,5 +1,5 @@
 name: etcd
-version: 0.0.2
+version: 0.0.3
 appVersion: 3.3.8
 description: etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines
 keywords:

--- a/bitnami/etcd/templates/statefulset.yaml
+++ b/bitnami/etcd/templates/statefulset.yaml
@@ -121,7 +121,7 @@ spec:
                 etcd > /dev/null 2>&1 &
                 ETCD_PID=$!
                 sleep 5
-                echo "$ETCD_ROOT_PASSWORD" | ${AUTH_OPTIONS} etcdctl user add root
+                echo "$ETCD_ROOT_PASSWORD" | etcdctl ${AUTH_OPTIONS} user add root
                 etcdctl ${AUTH_OPTIONS} auth enable
                 etcdctl ${AUTH_OPTIONS} role revoke guest -path '/*' --readwrite
                 kill $ETCD_PID


### PR DESCRIPTION
Currently, the etcd chart fails to start when configuring authentication because there was an argument in the wrong position. This PR fixes it.