### PR TITLE
[bitnami/mean] Improve Mean Chart

### DIFF
--- a/bitnami/mean/Chart.yaml
+++ b/bitnami/mean/Chart.yaml
@@ -1,5 +1,5 @@
 name: mean
-version: 2.0.2
+version: 3.0.0
 appVersion: 3.6.4
 description: MEAN is a free and open-source JavaScript software stack for building dynamic web sites and web applications. The MEAN stack is MongoDB, Express.js, Angular, and Node.js. Because all components of the MEAN stack support programs written in JavaScript, MEAN applications can be written in one language for both server-side and client-side execution environments.
 keywords:

--- a/bitnami/mean/README.md
+++ b/bitnami/mean/README.md
@@ -62,7 +62,11 @@ The following table lists the configurable parameters of the MEAN chart and thei
 | `revision`                              | Revision to checkout                                      | `master`                                                  |
 | `replicas`                              | Number of replicas for the application                    | `1`                                                       |
 | `applicationPort`                       | Port where the application will be running                | `3000`                                                    |
-| `serviceType`                           | Kubernetes Service type                                   | `ClusterIP`                                               |
+| `service.type`                          | Kubernetes Service type                                   | `ClusterIP`                                               |
+| `serviec.port`                          | Kubernetes Service port                                   | `80`                                                      |
+| `service.annotations`                   | Annotations for the Service                               | {}                                                        |
+| `service.loadBalancerIP`                | LoadBalancer IP if Service type is `LoadBalancer`         | `nil`                                                     |
+| `service.nodePort`                      | NodePort if Service type is `LoadBalancer` or `NodePort`  | `nil`                                                     |
 | `persistence.enabled`                   | Enable persistence using PVC                              | `false`                                                   |
 | `persistence.path`                      | Path to persisted directory                               | `/app/data`                                               |
 | `persistence.accessMode`                | PVC Access Mode                                           | `ReadWriteOnce`                                           |
@@ -120,7 +124,7 @@ $ helm install stable/nginx-ingress
 Now deploy the mean helm chart:
 
 ```
-$ helm install --name my-release bitnami/mean --set ingress.enabled=true,ingress.host=example.com,serviceType=ClusterIP
+$ helm install --name my-release bitnami/mean --set ingress.enabled=true,ingress.host=example.com,service.type=ClusterIP
 ```
 
 ### Configure TLS termination for your ingress controller

--- a/bitnami/mean/README.md
+++ b/bitnami/mean/README.md
@@ -63,7 +63,7 @@ The following table lists the configurable parameters of the MEAN chart and thei
 | `replicas`                              | Number of replicas for the application                    | `1`                                                       |
 | `applicationPort`                       | Port where the application will be running                | `3000`                                                    |
 | `service.type`                          | Kubernetes Service type                                   | `ClusterIP`                                               |
-| `serviec.port`                          | Kubernetes Service port                                   | `80`                                                      |
+| `service.port`                          | Kubernetes Service port                                   | `80`                                                      |
 | `service.annotations`                   | Annotations for the Service                               | {}                                                        |
 | `service.loadBalancerIP`                | LoadBalancer IP if Service type is `LoadBalancer`         | `nil`                                                     |
 | `service.nodePort`                      | NodePort if Service type is `LoadBalancer` or `NodePort`  | `nil`                                                     |

--- a/bitnami/mean/requirements.lock
+++ b/bitnami/mean/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mongodb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 3.0.1
+  version: 4.2.3
 - name: bitnami-common
   repository: https://charts.bitnami.com/bitnami
   version: 0.0.3
-digest: sha256:199688b1f4f69e2db3f81397e9d122f3bdc7a97f2503d1f4420af1193bf0b9ec
-generated: 2018-06-15T13:04:06.232576472+02:00
+digest: sha256:e08b8d1bb8197aa8fdc27536aaa1de2e7de210515a451ebe94949a3db55264dd
+generated: 2018-09-05T14:56:00.449083032+02:00

--- a/bitnami/mean/requirements.yaml
+++ b/bitnami/mean/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: mongodb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 3.x.x
+  version: 4.x.x
   condition: mongodb.install
 - name: bitnami-common
   repository: https://charts.bitnami.com/bitnami

--- a/bitnami/mean/templates/NOTES.txt
+++ b/bitnami/mean/templates/NOTES.txt
@@ -1,13 +1,13 @@
 
 1. Get the URL of your MEAN app by running:
 
-{{- if contains "NodePort" .Values.serviceType }}
+{{- if contains "NodePort" .Values.service.type }}
 
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "mean.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo "MEAN app URL: http://$NODE_IP:$NODE_PORT/"
 
-{{- else if contains "LoadBalancer" .Values.serviceType }}
+{{- else if contains "LoadBalancer" .Values.service.type }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
         Watch the status with: 'kubectl get svc -w {{ template "mean.fullname" . }} --namespace {{ .Release.Namespace }}'
@@ -15,9 +15,9 @@
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "mean.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo "MEAN app URL: http://$SERVICE_IP/"
 
-{{- else if contains "ClusterIP"  .Values.serviceType }}
+{{- else if contains "ClusterIP"  .Values.service.type }}
 
-  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "mean.fullname" . }} 3000:3000
-  echo "MEAN app URL: http://127.0.0.1:3000/"
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "mean.fullname" . }} {{ .Values.service.port  }}:{{ .Values.service.port }}
+  echo "MEAN app URL: http://127.0.0.1:{{ .Values.service.port }}/"
 
 {{- end }}

--- a/bitnami/mean/templates/ingress.yaml
+++ b/bitnami/mean/templates/ingress.yaml
@@ -20,7 +20,7 @@ spec:
           - path: {{ .Values.ingress.path }}
             backend:
               serviceName: {{ include "mean.fullname" . }}
-              servicePort: 80
+              servicePort: {{ .Values.service.port }}
   {{- if .Values.ingress.tls }}
   tls:
 {{ toYaml .Values.ingress.tls | indent 4 }}

--- a/bitnami/mean/templates/svc.yaml
+++ b/bitnami/mean/templates/svc.yaml
@@ -7,12 +7,22 @@ metadata:
     chart: {{ template "mean.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+{{- if .Values.service.annotations }}
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
 spec:
-  type: {{ .Values.serviceType }}
+  type: {{ .Values.service.type }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   ports:
   - name: http
-    port: 80
+    port: {{ .Values.service.port }}
     targetPort: http
+    {{- if .Values.service.nodePort }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
   selector:
     app: {{ template "mean.name" . }}
     release: "{{ .Release.Name }}"

--- a/bitnami/mean/values.yaml
+++ b/bitnami/mean/values.yaml
@@ -42,7 +42,20 @@ applicationPort: 3000
 ## Kubernetes configuration
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer
 ##
-serviceType: ClusterIP
+service:
+  type: ClusterIP
+  port: 80
+  ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+  ##
+  # nodePort:
+
+  ## Provide any additional annotations which may be required. This can be used to
+  ## set the LoadBalancer service type to internal only.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+  ##
+  annotations: {}
+  # loadBalancerIP:
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/


### PR DESCRIPTION
**What this PR does / why we need it:**

This PR does several improvements on MEAN chart:
 - Allows the user to customise the MEAN K8s service with new parameters (service.nodePort, service.loadBalancerIP.  service.annotations, service.port)
 - Fix NOTES.txt indications to create a port-forward to the right svc port.
 - Updates MongoDB requirements