### PR TITLE
[bitnami/node] Improve Node Chart

### DIFF
--- a/bitnami/node/Chart.yaml
+++ b/bitnami/node/Chart.yaml
@@ -1,5 +1,5 @@
 name: node
-version: 4.0.1
+version: 5.0.0
 appVersion: 10.7.0
 description: Event-driven I/O server-side JavaScript environment based on V8
 keywords:

--- a/bitnami/node/README.md
+++ b/bitnami/node/README.md
@@ -63,7 +63,11 @@ The following table lists the configurable parameters of the Node chart and thei
 | `revision`                              | Revision to checkout                                      | `master`                                                  |
 | `replicas`                              | Number of replicas for the application                    | `1`                                                       |
 | `applicationPort`                       | Port where the application will be running                | `3000`                                                    |
-| `serviceType`                           | Kubernetes Service type                                   | `LoadBalancer`                                            |
+| `service.type`                          | Kubernetes Service type                                   | `ClusterIP`                                               |
+| `service.port`                          | Kubernetes Service port                                   | `80`                                                      |
+| `service.annotations`                   | Annotations for the Service                               | {}                                                        |
+| `service.loadBalancerIP`                | LoadBalancer IP if Service type is `LoadBalancer`         | `nil`                                                     |
+| `service.nodePort`                      | NodePort if Service type is `LoadBalancer` or `NodePort`  | `nil`                                                     |
 | `persistence.enabled`                   | Enable persistence using PVC                              | `false`                                                   |
 | `persistence.path`                      | Path to persisted directory                               | `/app/data`                                               |
 | `persistence.accessMode`                | PVC Access Mode                                           | `ReadWriteOnce`                                           |
@@ -115,7 +119,7 @@ $ helm install stable/nginx-ingress
 Now deploy the node helm chart:
 
 ```
-$ helm install --name my-release bitnami/node --set ingress.enabled=true,ingress.host=example.com,serviceType=ClusterIP
+$ helm install --name my-release bitnami/node --set ingress.enabled=true,ingress.host=example.com,service.type=ClusterIP
 ```
 
 ### Configure TLS termination for your ingress controller

--- a/bitnami/node/requirements.lock
+++ b/bitnami/node/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mongodb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 4.0.0
+  version: 4.2.3
 - name: bitnami-common
   repository: https://charts.bitnami.com/bitnami
   version: 0.0.3
 digest: sha256:e08b8d1bb8197aa8fdc27536aaa1de2e7de210515a451ebe94949a3db55264dd
-generated: 2018-07-25T12:45:52.416774891+02:00
+generated: 2018-09-05T15:06:25.041888238+02:00

--- a/bitnami/node/templates/NOTES.txt
+++ b/bitnami/node/templates/NOTES.txt
@@ -1,13 +1,13 @@
 
 1. Get the URL of your Node app  by running:
 
-{{- if contains "NodePort" .Values.serviceType }}
+{{- if contains "NodePort" .Values.service.type }}
 
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "node.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo "Node app URL: http://$NODE_IP:$NODE_PORT/"
 
-{{- else if contains "LoadBalancer" .Values.serviceType }}
+{{- else if contains "LoadBalancer" .Values.service.type }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
         Watch the status with: 'kubectl get svc -w {{ template "node.fullname" . }} --namespace {{ .Release.Namespace }}'
@@ -15,9 +15,9 @@
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "node.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo "Node app URL: http://$SERVICE_IP/"
 
-{{- else if contains "ClusterIP"  .Values.serviceType }}
+{{- else if contains "ClusterIP"  .Values.service.type }}
 
-  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "node.fullname" . }} 3000:3000
-  echo "Node app URL: http://127.0.0.1:3000/"
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "node.fullname" . }} {{ .Values.service.port  }}:{{ .Values.service.port }}
+  echo "Node app URL: http://127.0.0.1:{{ .Values.service.port }}/"
 
 {{- end }}

--- a/bitnami/node/templates/ingress.yaml
+++ b/bitnami/node/templates/ingress.yaml
@@ -20,7 +20,7 @@ spec:
           - path: {{ .Values.ingress.path }}
             backend:
               serviceName: {{ include "node.fullname" . }}
-              servicePort: 80
+              servicePort: {{ .Values.service.port }}
   {{- if .Values.ingress.tls }}
   tls:
 {{ toYaml .Values.ingress.tls | indent 4 }}

--- a/bitnami/node/templates/svc.yaml
+++ b/bitnami/node/templates/svc.yaml
@@ -7,12 +7,22 @@ metadata:
     chart: {{ template "node.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+{{- if .Values.service.annotations }}
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
 spec:
-  type: {{ .Values.serviceType }}
+  type: {{ .Values.service.type }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   ports:
   - name: http
-    port: 80
+    port: {{ .Values.service.port }}
     targetPort: http
+    {{- if .Values.service.nodePort }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
   selector:
     app: {{ template "node.name" . }}
     release: "{{ .Release.Name }}"

--- a/bitnami/node/values.yaml
+++ b/bitnami/node/values.yaml
@@ -39,10 +39,22 @@ replicas: 1
 ##
 applicationPort: 3000
 
-## Kubernetes configuration
-## For minikube, set this to NodePort, elsewhere use LoadBalancer
-##
-serviceType: ClusterIP
+## Kubernetes Service Configuration
+service:
+  ## For minikube, set this to NodePort, elsewhere use LoadBalancer
+  ##
+  type: ClusterIP
+  port: 80
+  ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+  ##
+  # nodePort:
+  ## Provide any additional annotations which may be required. This can be used to
+  ## set the LoadBalancer service type to internal only.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+  ##
+  annotations: {}
+  # loadBalancerIP:
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/


### PR DESCRIPTION
### What this PR does / why we need it:

This PR does several improvements on NODE chart:

- Allows the user to customise the NODE K8s service with new parameters (service.nodePort, service.loadBalancerIP. service.annotations, service.port)
- Fix NOTES.txt indications to create a port-forward to the right svc port.
- Updates MongoDB requirements