### PR TITLE
Add existing volume claim logic to MySQL

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 2.1.1
+version: 2.1.2
 appVersion: 5.7.23
 description: Chart to create a Highly available MySQL cluster
 keywords:

--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -63,6 +63,8 @@ The following tables lists the configurable parameters of the MySQL chart and th
 | `replication.password`                    | MySQL replication user password                   | _random 10 character alphanumeric string_                         |
 | `master.antiAffinity`                     | Master pod anti-affinity policy                     | `soft`                                                            |
 | `master.persistence.enabled`              | Enable persistence using a `PersistentVolumeClaim`  | `true`                                                            |
+| `master.persistence.existingClaim`        | Provide an existing `PersistentVolumeClaim`         | `nil`                                                             |
+| `master.persistence.mountPath`            | Configure existing `PersistentVolumeClaim` mount path  | `""`                                                           |
 | `master.persistence.annotations`          | Persistent Volume Claim annotations                 | `{}`                                                              |
 | `master.persistence.storageClass`         | Persistent Volume Storage Class                     | ``                                                                |
 | `master.persistence.accessModes`          | Persistent Volume Access Modes                      | `[ReadWriteOnce]`                                                 |

--- a/bitnami/mysql/templates/master-statefulset.yaml
+++ b/bitnami/mysql/templates/master-statefulset.yaml
@@ -120,6 +120,10 @@ spec:
         - name: config
           mountPath: /opt/bitnami/mysql/conf/my.cnf
           subPath: my.cnf
+{{- if .Values.master.persistence.existingClaim }}
+        - name: {{ .Values.master.persistence.existingClaim }}
+          mountPath: {{ .Values.master.persistence.mountPath }}
+{{- end }}
 {{- end }}
 {{- if .Values.metrics.enabled }}
       - name: metrics
@@ -151,6 +155,11 @@ spec:
 {{ toYaml .Values.metrics.resources | indent 10 }}
 {{- end }}
       volumes:
+      {{- if and .Values.master.persistence.enabled .Values.master.persistence.existingClaim }}
+        - name: {{ .Values.master.persistence.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.master.persistence.existingClaim }}
+      {{ end }}
       {{- if .Values.master.config }}
         - name: config
           configMap:

--- a/bitnami/mysql/values-production.yaml
+++ b/bitnami/mysql/values-production.yaml
@@ -41,7 +41,7 @@ root:
   ## Option to force users to specify a password. That is required for 'helm upgrade' to work properly.
   ## If it is not force, a random password will be generated.
   forcePassword: true
-  
+
 db:
   ## MySQL username and password
   ## ref: https://github.com/bitnami/bitnami-docker-mysql#creating-a-database-user-on-first-run
@@ -85,6 +85,10 @@ master:
     ## If true, use a Persistent Volume Claim, If false, use emptyDir
     ##
     enabled: true
+    ## Enable persistence using an existing PVC
+    ##
+    # existingClaim:
+    # mountPath:
     ## Persistent Volume Storage Class
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -86,6 +86,10 @@ master:
     ## If true, use a Persistent Volume Claim, If false, use emptyDir
     ##
     enabled: true
+    ## Enable persistence using an existing PVC
+    ##
+    # existingClaim:
+    # mountPath:
     ## Persistent Volume Storage Class
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
As requested on #784 I added existing volume claim logic to MySQL chart as we are doing currently in the upstream MariaDB chart