### PR TITLE
Updated NOTES.txt

### DIFF
--- a/bitnami/mysql/templates/NOTES.txt
+++ b/bitnami/mysql/templates/NOTES.txt
@@ -15,7 +15,7 @@ Services:
 Administrator credentials:
 
   echo Username: root
-  echo Password : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.mysql-root-password}" | base64 --decode)
+  echo Password : echo $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.mysql-root-password}" | base64 --decode)
 
 To connect to your database
 


### PR DESCRIPTION
Running propose command to obtain decoded password throws the error:
```
user@shell $: $(kubectl get secret --namespace default mysql-mysql -o jsonpath="{.data.mysql-root-password
}" | base64 --decode)
bash: password: command not found
user@shell $:
```

Echoing output of this command results in proper output of the password string which is "password" in this example:
```
user@shell $: echo $(kubectl get secret --namespace default mysql-mysql -o jsonpath="{.data.mysql-root-pas
sword}" | base64 --decode)
password
user@shell $:
```

This issue is present in all charts which follow this logic in their NOTES.txt.