### PR TITLE
[bitnami/elasticsearch] Fix custom config file is not applied

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 version: 2.0.4
-appVersion: 6.4.1
+appVersion: 6.4.2
 description: A highly scalable open-source full-text search and analytics engine
 keywords:
 - elasticsearch

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: elasticsearch
-version: 2.0.3
+version: 2.0.4
 appVersion: 6.4.0
 description: A highly scalable open-source full-text search and analytics engine
 keywords:

--- a/bitnami/elasticsearch/templates/coordinating-deploy.yaml
+++ b/bitnami/elasticsearch/templates/coordinating-deploy.yaml
@@ -106,7 +106,7 @@ spec:
         resources:
 {{ toYaml .Values.coordinating.resources | indent 10 }}
         volumeMounts:
-        - mountPath: /bitnami/elasticsearch/conf/elasticsearch_custom.yml
+        - mountPath: /opt/bitnami/elasticsearch/config/elasticsearch_custom.yml
           name: "config"
           subPath: elasticsearch_custom.yml
         - name: "data"

--- a/bitnami/elasticsearch/templates/data-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/data-statefulset.yaml
@@ -106,7 +106,7 @@ spec:
         resources:
 {{ toYaml .Values.data.resources | indent 10 }}
         volumeMounts:
-        - mountPath: /bitnami/elasticsearch/conf/elasticsearch_custom.yml
+        - mountPath: /opt/bitnami/elasticsearch/config/elasticsearch_custom.yml
           name: "config"
           subPath: elasticsearch_custom.yml
         - name: "data"

--- a/bitnami/elasticsearch/templates/ingest-deploy.yaml
+++ b/bitnami/elasticsearch/templates/ingest-deploy.yaml
@@ -107,7 +107,7 @@ spec:
         resources:
 {{ toYaml .Values.ingest.resources | indent 10 }}
         volumeMounts:
-        - mountPath: /bitnami/elasticsearch/conf/elasticsearch_custom.yml
+        - mountPath: /opt/bitnami/elasticsearch/config/elasticsearch_custom.yml
           name: "config"
           subPath: elasticsearch_custom.yml
         - name: "data"

--- a/bitnami/elasticsearch/templates/master-deploy.yaml
+++ b/bitnami/elasticsearch/templates/master-deploy.yaml
@@ -105,7 +105,7 @@ spec:
         resources:
 {{ toYaml .Values.master.resources | indent 10 }}
         volumeMounts:
-        - mountPath: /bitnami/elasticsearch/conf/elasticsearch_custom.yml
+        - mountPath: /opt/bitnami/elasticsearch/config/elasticsearch_custom.yml
           name: "config"
           subPath: elasticsearch_custom.yml
         - name: "data"


### PR DESCRIPTION
Per [libelasticsearch.sh](https://github.com/bitnami/bitnami-docker-elasticsearch/blob/6.4.0-debian-9-r28/6/debian-9/rootfs/libelasticsearch.sh), the configuration directory is specified as `/opt/bitnami/elasticsearch/config` in docker.

The custom config file should be there too.