### PR TITLE
[bitnami/elasticsearch] Fix chart not being upgradable

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: elasticsearch
-version: 2.0.5
+version: 3.0.0
 appVersion: 6.4.1
 description: A highly scalable open-source full-text search and analytics engine
 keywords:

--- a/bitnami/elasticsearch/README.md
+++ b/bitnami/elasticsearch/README.md
@@ -172,3 +172,18 @@ $ helm install --name my-release -f values.yaml bitnami/elasticsearch
 The [Bitnami Elasticsearch](https://github.com/bitnami/bitnami-docker-elasticsearch) image stores the Elasticsearch data at the `/bitnami/elasticsearch/data` path of the container.
 
 By default, the chart mounts a [Persistent Volume](http://kubernetes.io/docs/user-guide/persistent-volumes/) at this location. The volume is created using dynamic volume provisioning. See the [Configuration](#configuration) section to configure the PVC.
+
+## Upgrading
+
+### To 3.0.0
+
+Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
+Use the workaround below to upgrade from versions previous to 3.0.0. The following example assumes that the release name is elasticsearch:
+
+```console
+$ kubectl patch deployment elasticsearch-coordinating --type=json -p='[{"op": "remove", "path": "/spec/selector/matchLabels/chart"}]'
+$ kubectl patch deployment elasticsearch-ingest --type=json -p='[{"op": "remove", "path": "/spec/selector/matchLabels/chart"}]'
+$ kubectl patch deployment elasticsearch-master --type=json -p='[{"op": "remove", "path": "/spec/selector/matchLabels/chart"}]'
+$ kubectl patch deployment elasticsearch-metrics --type=json -p='[{"op": "remove", "path": "/spec/selector/matchLabels/chart"}]'
+$ kubectl delete statefulset elasticsearch-data --cascade=false
+```

--- a/bitnami/elasticsearch/templates/coordinating-deploy.yaml
+++ b/bitnami/elasticsearch/templates/coordinating-deploy.yaml
@@ -9,6 +9,11 @@ metadata:
     release: {{ .Release.Name | quote }}
     role: "coordinating-only"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "elasticsearch.name" . }}
+      release: "{{ .Release.Name }}"
+      role: "coordinating-only"      
   replicas: {{ .Values.coordinating.replicas }}
   template:
     metadata:

--- a/bitnami/elasticsearch/templates/data-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/data-statefulset.yaml
@@ -13,7 +13,6 @@ spec:
     matchLabels:
       app: {{ template "elasticsearch.name" . }}
       release: {{ .Release.Name | quote }}
-      chart: {{ template "elasticsearch.chart" . }}
       role: "data"
   serviceName: "{{ template "data.fullname" . }}"
   replicas: {{ .Values.data.replicas }}

--- a/bitnami/elasticsearch/templates/ingest-deploy.yaml
+++ b/bitnami/elasticsearch/templates/ingest-deploy.yaml
@@ -10,6 +10,11 @@ metadata:
     release: {{ .Release.Name | quote }}
     role: "ingest"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "elasticsearch.name" . }}
+      release: "{{ .Release.Name }}"
+      role: "ingest"      
   replicas: {{ .Values.ingest.replicas }}
   template:
     metadata:

--- a/bitnami/elasticsearch/templates/master-deploy.yaml
+++ b/bitnami/elasticsearch/templates/master-deploy.yaml
@@ -9,6 +9,11 @@ metadata:
     release: {{ .Release.Name | quote }}
     role: "master"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "elasticsearch.name" . }}
+      release: "{{ .Release.Name }}"
+      role: "master"      
   replicas: {{ .Values.master.replicas }}
   template:
     metadata:

--- a/bitnami/elasticsearch/templates/metrics-deploy.yaml
+++ b/bitnami/elasticsearch/templates/metrics-deploy.yaml
@@ -10,6 +10,11 @@ metadata:
     release: {{ .Release.Name | quote }}
     role: "metrics"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "elasticsearch.name" . }}
+      release: "{{ .Release.Name }}"
+      role: "metrics"      
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
What this PR does / why we need it:
Add spec.selector.matchLabels without the chart label.

Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes https://github.com/helm/charts/issues/5657
Chart was not being upgradable
