### PR TITLE
[bitnami/external-dns] Fix chart not being upgradable

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -1,5 +1,5 @@
 name: external-dns
-version: 0.0.1
+version: 1.0.0
 appVersion: 0.5.4
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/bitnami/external-dns/README.md
+++ b/bitnami/external-dns/README.md
@@ -123,3 +123,14 @@ $ helm install --name my-release -f values.yaml bitnami/external-dns
 Find information about the requirements for each DNS provider on the link below:
 
  - [ExternalDNS Tutorials](https://github.com/kubernetes-incubator/external-dns/tree/master/docs/tutorials)
+
+## Upgrading
+
+### To 1.0.0
+
+Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
+Use the workaround below to upgrade from versions previous to 1.0.0. The following example assumes that the release name is external-dns:
+
+```console
+$ kubectl patch deployment externaldns --type=json -p='[{"op": "remove", "path": "/spec/selector/matchLabels/chart"}]'
+```

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -8,6 +8,10 @@ metadata:
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "external-dns.name" . }}
+      release: "{{ .Release.Name }}"
   replicas: {{ .Values.replicas }}
   template:
     metadata:


### PR DESCRIPTION
What this PR does / why we need it:
Add spec.selector.matchLabels without the chart label.

Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes https://github.com/helm/charts/issues/5657
Chart was not being upgradable
