### PR TITLE
[bitnami/kafka] Fix chart not being upgradable

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,5 +1,5 @@
 name: kafka
-version: 0.0.9
+version: 1.0.0
 appVersion: 2.0.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -202,3 +202,15 @@ The [Bitnami Kafka](https://github.com/bitnami/bitnami-docker-kafka) image store
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Configuration](#configuration) section to configure the PVC or to disable persistence.
+
+## Upgrading
+
+### To 1.0.0
+
+Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
+Use the workaround below to upgrade from versions previous to 1.0.0. The following example assumes that the release name is kafka:
+
+```console
+$ kubectl delete statefulset kafka-kafka --cascade=false
+$ kubectl delete statefulset kafka-zookeeper --cascade=false
+```

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -8,6 +8,10 @@ metadata:
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "kafka.name" . }}
+      release: "{{ .Release.Name }}"
   serviceName: {{ template "kafka.fullname" . }}-headless
   podManagementPolicy: "Parallel"
   replicas: {{ .Values.replicaCount }}


### PR DESCRIPTION
What this PR does / why we need it:
Add spec.selector.matchLabels without the chart label.

Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes https://github.com/helm/charts/issues/5657
Chart was not being upgradable
