### PR TITLE
[bitnami/mean] Fix chart not being upgradable

### DIFF
--- a/bitnami/mean/Chart.yaml
+++ b/bitnami/mean/Chart.yaml
@@ -1,5 +1,5 @@
 name: mean
-version: 3.0.0
+version: 4.0.0
 appVersion: 3.6.4
 description: MEAN is a free and open-source JavaScript software stack for building dynamic web sites and web applications. The MEAN stack is MongoDB, Express.js, Angular, and Node.js. Because all components of the MEAN stack support programs written in JavaScript, MEAN applications can be written in one language for both server-side and client-side execution environments.
 keywords:

--- a/bitnami/mean/README.md
+++ b/bitnami/mean/README.md
@@ -218,3 +218,15 @@ Deploying the helm chart enabling the Azure external database makes the followin
   - Your application uses DATABASE_HOST, DATABASE_PORT, DATABASE_USER, DATABASE_PASSWORD, and DATABASE_NAME environment variables to connect to the database.
 
 You can read more about the kubernetes service catalog at https://github.com/kubernetes-bitnami/service-catalog
+
+## Upgrading
+
+### To 4.0.0
+
+Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
+Use the workaround below to upgrade from versions previous to 4.0.0. The following example assumes that the release name is mean:
+
+```console
+$ kubectl patch deployment mean --type=json -p='[{"op": "remove", "path": "/spec/selector/matchLabels/chart"}]'
+$ kubectl patch deployment mean-mongodb --type=json -p='[{"op": "remove", "path": "/spec/selector/matchLabels/chart"}]'
+```

--- a/bitnami/mean/templates/deployment.yaml
+++ b/bitnami/mean/templates/deployment.yaml
@@ -8,6 +8,10 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "mean.name" . }}
+      release: "{{ .Release.Name }}"
   replicas: {{ .Values.replicas }}
   template:
     metadata:


### PR DESCRIPTION
What this PR does / why we need it:
Add spec.selector.matchLabels without the chart label.

Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes https://github.com/helm/charts/issues/5657
Chart was not being upgradable
