### PR TITLE
[bitnami/memcached] Fix chart not being upgradable

### DIFF
--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -1,5 +1,5 @@
 name: memcached
-version: 0.4.35
+version: 1.0.0
 appVersion: 1.5.10
 description: Chart for Memcached
 keywords:

--- a/bitnami/memcached/README.md
+++ b/bitnami/memcached/README.md
@@ -72,3 +72,14 @@ $ helm install --name my-release -f values.yaml bitnami/memcached
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Upgrading
+
+### To 1.0.0
+
+Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
+Use the workaround below to upgrade from versions previous to 1.0.0. The following example assumes that the release name is memcached:
+
+```console
+$ kubectl patch deployment memcached --type=json -p='[{"op": "remove", "path": "/spec/selector/matchLabels/chart"}]'
+```

--- a/bitnami/memcached/templates/deployment.yaml
+++ b/bitnami/memcached/templates/deployment.yaml
@@ -8,6 +8,10 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
+      release: "{{ .Release.Name }}"
   template:
     metadata:
       labels:


### PR DESCRIPTION
What this PR does / why we need it:
Add spec.selector.matchLabels without the chart label.

Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes https://github.com/helm/charts/issues/5657
Chart was not being upgradable
