### PR TITLE
[bitnami/metrics-server] Fix chart not being upgradable

### DIFF
--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: metrics-server
-version: 1.0.0
+version: 2.0.0
 appVersion: 0.2.1
 description: Metrics Server is a cluster-wide aggregator of resource usage data. Metrics Server collects metrics from the Summary API, exposed by Kubelet on each node.
 keywords:

--- a/bitnami/metrics-server/README.md
+++ b/bitnami/metrics-server/README.md
@@ -86,3 +86,13 @@ In order to enable Role-based access control for Metrics Servier you can run the
 ```console
 $ helm install --name my-release --set rbac.create bitnami/metrics-server
 ```
+## Upgrading
+
+### To 2.0.0
+
+Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
+Use the workaround below to upgrade from versions previous to 2.0.0. The following example assumes that the release name is metrics-server:
+
+```console
+$ kubectl patch deployment metrics-server --type=json -p='[{"op": "remove", "path": "/spec/selector/matchLabels/chart"}]'
+```

--- a/bitnami/metrics-server/templates/deployment.yaml
+++ b/bitnami/metrics-server/templates/deployment.yaml
@@ -11,6 +11,10 @@ spec:
   selector:
     matchLabels:
       app: {{ template "metrics-server.name" . }}
+      release: "{{ .Release.Name }}"
+  selector:
+    matchLabels:
+      app: {{ template "metrics-server.name" . }}
       release: {{ .Release.Name | quote }}
       chart: {{ template "metrics-server.chart" . }}
   template:


### PR DESCRIPTION
What this PR does / why we need it:
Add spec.selector.matchLabels without the chart label.

Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes https://github.com/helm/charts/issues/5657
Chart was not being upgradable
