### PR TITLE
[bitnami/mysql] Use proper env. variable on slaves for Master port number & root user

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 3.0.0
+version: 3.0.1
 appVersion: 5.7.23
 description: Chart to create a Highly available MySQL cluster
 keywords:

--- a/bitnami/mysql/templates/slave-statefulset.yaml
+++ b/bitnami/mysql/templates/slave-statefulset.yaml
@@ -85,9 +85,9 @@ spec:
           value: "slave"
         - name: MYSQL_MASTER_HOST
           value: {{ template "fullname" . }}
-        - name: MYSQL_MASTER_PORT
+        - name: MYSQL_MASTER_PORT_NUMBER
           value: "3306"
-        - name: MYSQL_MASTER_USER
+        - name: MYSQL_MASTER_ROOT_USER
           value: "root"
         - name: MYSQL_MASTER_ROOT_PASSWORD
           valueFrom:


### PR DESCRIPTION
### What this PR does / why we need it:

We're not using the right env. variable on slaves to configure the Master port to connect to and the user to use for the connections

Check https://github.com/bitnami/bitnami-docker-mariadb#setting-up-a-replication-cluster