### PR TITLE
[bitnami/nginx] Fix chart not being upgradable

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx
-version: 0.6.1
+version: 1.0.0
 appVersion: 1.14.0
 description: Chart for the nginx server
 keywords:

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -88,3 +88,14 @@ Install the chart with this value:
 ```console
 $ helm install --name my-release -f custom-vhost.yaml bitnami/nginx
 ```
+
+## Upgrading
+
+### To 1.0.0
+
+Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
+Use the workaround below to upgrade from versions previous to 1.0.0. The following example assumes that the release name is nginx:
+
+```console
+$ kubectl patch deployment nginx --type=json -p='[{"op": "remove", "path": "/spec/selector/matchLabels/chart"}]'
+```

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -8,6 +8,10 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
+      release: "{{ .Release.Name }}"
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
What this PR does / why we need it:
Add spec.selector.matchLabels without the chart label.

Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes https://github.com/helm/charts/issues/5657
Chart was not being upgradable
