### PR TITLE
[bitnami/mysql] Increasing 'initialDelaySeconds' to avoid unnecessary resets

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 3.0.1
+version: 3.0.2
 appVersion: 5.7.23
 description: Chart to create a Highly available MySQL cluster
 keywords:

--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -78,7 +78,7 @@ The following tables lists the configurable parameters of the MySQL chart and th
 | `master.livenessProbe.successThreshold`   | Minimum consecutive successes for the probe (master)| `1`                                                               |
 | `master.livenessProbe.failureThreshold`   | Minimum consecutive failures for the probe (master) | `3`                                                               |
 | `master.readinessProbe.enabled`           | Turn on and off readiness probe (master)            | `true`                                                            |
-| `master.readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated (master) | `15`                                                              |
+| `master.readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated (master) | `30`                                                              |
 | `master.readinessProbe.periodSeconds`     | How often to perform the probe (master)             | `10`                                                              |
 | `master.readinessProbe.timeoutSeconds`    | When the probe times out (master)                   | `1`                                                               |
 | `master.readinessProbe.successThreshold`  | Minimum consecutive successes for the probe (master)| `1`                                                               |
@@ -99,7 +99,7 @@ The following tables lists the configurable parameters of the MySQL chart and th
 | `slave.livenessProbe.successThreshold`    | Minimum consecutive successes for the probe (slave) | `1`                                                               |
 | `slave.livenessProbe.failureThreshold`    | Minimum consecutive failures for the probe (slave)  | `3`                                                               |
 | `slave.readinessProbe.enabled`            | Turn on and off readiness probe (slave)             | `true`                                                            |
-| `slave.readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated (slave)   | `15`                                                              |
+| `slave.readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated (slave)   | `30`                                                              |
 | `slave.readinessProbe.periodSeconds`      | How often to perform the probe (slave)              | `10`                                                              |
 | `slave.readinessProbe.timeoutSeconds`     | When the probe times out (slave)                    | `1`                                                               |
 | `slave.readinessProbe.successThreshold`   | Minimum consecutive successes for the probe (slave) | `1`                                                               |

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -156,7 +156,8 @@ master:
     failureThreshold: 3
   readinessProbe:
     enabled: true
-    initialDelaySeconds: 15
+    ## Initializing the database could take some time
+    initialDelaySeconds: 30
     ##
     ## Default Kubernetes values
     periodSeconds: 10
@@ -227,7 +228,8 @@ slave:
     failureThreshold: 3
   readinessProbe:
     enabled: true
-    initialDelaySeconds: 15
+    ## Initializing the database could take some time
+    initialDelaySeconds: 30
     ##
     ## Default Kubernetes values
     periodSeconds: 10


### PR DESCRIPTION
### What this PR does / why we need it:

Our current 'initialDelaySeconds' on ReadinessProbes is too tight. That's making the charts to restart the slaves several times (since they're waiting for the master to be ready). That's not a desired behaviour and we can avoid by increasing the initial delay.

