### PR TITLE
[bitnami/tensorflow-inception] Fix chart not being upgradable

### DIFF
--- a/bitnami/tensorflow-inception/Chart.yaml
+++ b/bitnami/tensorflow-inception/Chart.yaml
@@ -1,5 +1,5 @@
 name: tensorflow-inception
-version: 0.0.15
+version: 1.0.0
 appVersion: 1.10.1
 description: Open-source software library for serving machine learning models
 keywords:

--- a/bitnami/tensorflow-inception/README.md
+++ b/bitnami/tensorflow-inception/README.md
@@ -90,3 +90,14 @@ $ helm install --name my-release -f values.yaml bitnami/tensorflow-inception
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Upgrading
+
+### To 1.0.0
+
+Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
+Use the workaround below to upgrade from versions previous to 1.0.0. The following example assumes that the release name is tensorflow-inception:
+
+```console
+$ kubectl patch deployment tensorflow-inception --type=json -p='[{"op": "remove", "path": "/spec/selector/matchLabels/chart"}]'
+```

--- a/bitnami/tensorflow-inception/templates/deployment.yaml
+++ b/bitnami/tensorflow-inception/templates/deployment.yaml
@@ -8,6 +8,10 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
+      release: "{{ .Release.Name }}"
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
What this PR does / why we need it:
Add spec.selector.matchLabels without the chart label.

Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes https://github.com/helm/charts/issues/5657
Chart was not being upgradable
