### PR TITLE
[bitnami/zookeeper] Fix chart not being upgradable

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,5 +1,5 @@
 name: zookeeper
-version: 0.0.7
+version: 1.0.0
 appVersion: 3.4.12
 description: A centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services for distributed applications.
 keywords:

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -121,3 +121,14 @@ The [Bitnami Zookeeper](https://github.com/bitnami/bitnami-docker-zookeeper) ima
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Configuration](#configuration) section to configure the PVC or to disable persistence.
+
+## Upgrading
+
+### To 1.0.0
+
+Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
+Use the workaround below to upgrade from versions previous to 1.0.0. The following example assumes that the release name is zookeeper:
+
+```console
+$ kubectl delete statefulset zookeeper --cascade=false
+```

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -20,9 +20,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "zookeeper.name" . }}
-      chart: {{ template "zookeeper.chart" . }}
       release: {{ .Release.Name | quote }}
-      heritage: {{ .Release.Service | quote }}
   template:
     metadata:
       name: "{{ template "zookeeper.fullname" . }}"


### PR DESCRIPTION
Signed-off-by: Javier J. Salmeron Garcia <jsalmeron@bitnami.com>

What this PR does / why we need it:
Add spec.selector.matchLabels without the chart label.

Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes https://github.com/helm/charts/issues/5657
Chart was not being upgradable
