### PR TITLE
[bitnami/mysql] Use namespaces on 'slave.fullname' & 'master.fullname' macros to avoid conflicts with other charts

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 3.0.2
+version: 4.0.0
 appVersion: 5.7.23
 description: Chart to create a Highly available MySQL cluster
 keywords:

--- a/bitnami/mysql/templates/NOTES.txt
+++ b/bitnami/mysql/templates/NOTES.txt
@@ -9,7 +9,7 @@ Services:
 
   echo Master: {{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
 {{- if .Values.replication.enabled }}
-  echo Slave:  {{ template "slave.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+  echo Slave:  {{ template "mysql.slave.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
 {{- end }}
 
 Administrator credentials:
@@ -31,5 +31,5 @@ To connect to your database
 
   3. To connect to slave service (read-only):
 
-      mysql -h {{ template "slave.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local -uroot -p {{ .Values.db.name }}
+      mysql -h {{ template "mysql.slave.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local -uroot -p {{ .Values.db.name }}
 {{- end }}

--- a/bitnami/mysql/templates/_helpers.tpl
+++ b/bitnami/mysql/templates/_helpers.tpl
@@ -15,11 +15,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end }}
 
-{{- define "master.fullname" -}}
+{{- define "mysql.master.fullname" -}}
 {{- printf "%s-%s" .Release.Name "mysql-master" | trunc 63 | trimSuffix "-" -}}
 {{- end }}
 
-{{- define "slave.fullname" -}}
+{{- define "mysql.slave.fullname" -}}
 {{- printf "%s-%s" .Release.Name "mysql-slave" | trunc 63 | trimSuffix "-" -}}
 {{- end }}
 

--- a/bitnami/mysql/templates/initialization-configmap.yaml
+++ b/bitnami/mysql/templates/initialization-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "master.fullname" . }}-init-scripts
+  name: {{ template "mysql.master.fullname" . }}-init-scripts
   labels:
     app: {{ template "name" . }}
     component: "master"

--- a/bitnami/mysql/templates/master-configmap.yaml
+++ b/bitnami/mysql/templates/master-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "master.fullname" . }}
+  name: {{ template "mysql.master.fullname" . }}
   labels:
     app: {{ template "name" . }}
     component: "master"

--- a/bitnami/mysql/templates/master-statefulset.yaml
+++ b/bitnami/mysql/templates/master-statefulset.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
-  name: {{ template "master.fullname" . }}
+  name: {{ template "mysql.master.fullname" . }}
   labels:
     app: "{{ template "name" . }}"
     chart: {{ template "mysql.chart" . }}
@@ -14,7 +14,7 @@ spec:
       app: {{ template "name" . }}
       release: "{{ .Release.Name }}"
       component: "master"
-  serviceName: "{{ template "master.fullname" . }}"
+  serviceName: "{{ template "mysql.master.fullname" . }}"
   replicas: 1
   updateStrategy:
     type: RollingUpdate
@@ -168,11 +168,11 @@ spec:
       {{- if .Values.master.config }}
         - name: config
           configMap:
-            name: {{ template "master.fullname" . }}
+            name: {{ template "mysql.master.fullname" . }}
       {{- end }}
         - name: custom-init-scripts
           configMap:
-            name: {{ template "master.fullname" . }}-init-scripts
+            name: {{ template "mysql.master.fullname" . }}-init-scripts
 {{- if .Values.master.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/bitnami/mysql/templates/slave-configmap.yaml
+++ b/bitnami/mysql/templates/slave-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "slave.fullname" . }}
+  name: {{ template "mysql.slave.fullname" . }}
   labels:
     app: {{ template "name" . }}
     component: "slave"

--- a/bitnami/mysql/templates/slave-statefulset.yaml
+++ b/bitnami/mysql/templates/slave-statefulset.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
-  name: {{ template "slave.fullname" . }}
+  name: {{ template "mysql.slave.fullname" . }}
   labels:
     app: "{{ template "name" . }}"
     chart: {{ template "mysql.chart" . }}
@@ -15,7 +15,7 @@ spec:
       app: {{ template "name" . }}
       release: "{{ .Release.Name }}"
       component: "slave"
-  serviceName: "{{ template "slave.fullname" . }}"
+  serviceName: "{{ template "mysql.slave.fullname" . }}"
   replicas: {{ .Values.slave.replicas }}
   updateStrategy:
     type: RollingUpdate
@@ -167,7 +167,7 @@ spec:
       {{- if .Values.slave.config }}
         - name: config
           configMap:
-            name: {{ template "slave.fullname" . }}
+            name: {{ template "mysql.slave.fullname" . }}
       {{- end }}
 {{- if .Values.slave.persistence.enabled }}
   volumeClaimTemplates:

--- a/bitnami/mysql/templates/slave-svc.yaml
+++ b/bitnami/mysql/templates/slave-svc.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "slave.fullname" . }}
+  name: {{ template "mysql.slave.fullname" . }}
   labels:
     app: "{{ template "name" . }}"
     chart: {{ template "mysql.chart" . }}


### PR DESCRIPTION
### What this PR does / why we need it:

We're using macros with names such as 'slave.fullname' or 'master.fullname' on different charts. Therefore, when a chart has as dependencies more than one chart defining them, we face some conflicts.

### Which issue this PR fixes

Fixes #789