### PR TITLE
[bitnami/elasticsearch] Use namespaces on '*.fullname' macros to avoid conflicts with other charts

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: elasticsearch
-version: 3.0.0
+version: 4.0.0
 appVersion: 6.4.1
 description: A highly scalable open-source full-text search and analytics engine
 keywords:

--- a/bitnami/elasticsearch/templates/NOTES.txt
+++ b/bitnami/elasticsearch/templates/NOTES.txt
@@ -14,24 +14,24 @@
 
 ** Please be patient while the chart is being deployed **
 
-  Elasticsearch can be accessed within the cluster on port {{ .Values.coordinating.service.port }} at {{ template "coordinating.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  Elasticsearch can be accessed within the cluster on port {{ .Values.coordinating.service.port }} at {{ template "elasticsearch.coordinating.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 
   To access from outside the cluster execute the following commands:
 
 {{- if contains "NodePort" .Values.coordinating.service.type }}
 
-    export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "coordinating.fullname" . }})
+    export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "elasticsearch.coordinating.fullname" . }})
     export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
     curl http://$NODE_IP:$NODE_PORT/
 {{- else if contains "LoadBalancer" .Values.coordinating.service.type }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "coordinating.fullname" . }}'
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "elasticsearch.coordinating.fullname" . }}'
 
-    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "coordinating.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "elasticsearch.coordinating.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     curl http://$SERVICE_IP:{{ .Values.coordinating.service.port }}/
 {{- else if contains "ClusterIP"  .Values.coordinating.service.type }}
 
-    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "coordinating.fullname" . }} {{ .Values.coordinating.service.port }}:9200 &
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "elasticsearch.coordinating.fullname" . }} {{ .Values.coordinating.service.port }}:9200 &
     curl http://127.0.0.1:9200/
 {{- end }}

--- a/bitnami/elasticsearch/templates/_helpers.tpl
+++ b/bitnami/elasticsearch/templates/_helpers.tpl
@@ -35,7 +35,7 @@ Return the proper ES image name
 Create a default fully qualified master name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "master.fullname" -}}
+{{- define "elasticsearch.master.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s-%s" .Release.Name $name .Values.master.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -44,7 +44,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Create a default fully qualified ingest name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "ingest.fullname" -}}
+{{- define "elasticsearch.ingest.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s-%s" .Release.Name $name .Values.ingest.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -53,7 +53,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Create a default fully qualified discovery name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "discovery.fullname" -}}
+{{- define "elasticsearch.discovery.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s-%s" .Release.Name $name .Values.discovery.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -62,7 +62,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Create a default fully qualified coordinating name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "coordinating.fullname" -}}
+{{- define "elasticsearch.coordinating.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s-%s" .Release.Name $name .Values.coordinating.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -71,7 +71,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Create a default fully qualified data name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "data.fullname" -}}
+{{- define "elasticsearch.data.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s-%s" .Release.Name $name .Values.data.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -80,7 +80,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Create a default fully qualified metrics name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "metrics.fullname" -}}
+{{- define "elasticsearch.metrics.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s-%s" .Release.Name $name .Values.metrics.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/bitnami/elasticsearch/templates/cm.yaml
+++ b/bitnami/elasticsearch/templates/cm.yaml
@@ -12,7 +12,7 @@ data:
 
     discovery:
       zen:
-        ping.unicast.hosts: {{ template "discovery.fullname" . }}
+        ping.unicast.hosts: {{ template "elasticsearch.discovery.fullname" . }}
         minimum_master_nodes: 2
 
 {{- if .Values.config }}

--- a/bitnami/elasticsearch/templates/coordinating-deploy.yaml
+++ b/bitnami/elasticsearch/templates/coordinating-deploy.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "coordinating.fullname" . }}
+  name: {{ template "elasticsearch.coordinating.fullname" . }}
   labels:
     app: {{ template "elasticsearch.name" . }}
     chart: {{ template "elasticsearch.chart" . }}
@@ -63,7 +63,7 @@ spec:
         securityContext:
           privileged: true
       containers:
-      - name: {{ template "coordinating.fullname" . }}
+      - name: {{ template "elasticsearch.coordinating.fullname" . }}
         {{- if .Values.securityContext.enabled }}
         securityContext:
           runAsUser: {{ .Values.securityContext.runAsUser }}

--- a/bitnami/elasticsearch/templates/coordinating-svc.yaml
+++ b/bitnami/elasticsearch/templates/coordinating-svc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "coordinating.fullname" . }}
+  name: {{ template "elasticsearch.coordinating.fullname" . }}
   labels:
     app: {{ template "elasticsearch.name" . }}
     chart: {{ template "elasticsearch.chart" . |}}

--- a/bitnami/elasticsearch/templates/data-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/data-statefulset.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1beta2
 kind: StatefulSet
 metadata:
-  name: {{ template "data.fullname" . }}
+  name: {{ template "elasticsearch.data.fullname" . }}
   labels:
     app: {{ template "elasticsearch.name" . }}
     chart: {{ template "elasticsearch.chart" . }}
@@ -14,7 +14,7 @@ spec:
       app: {{ template "elasticsearch.name" . }}
       release: {{ .Release.Name | quote }}
       role: "data"
-  serviceName: "{{ template "data.fullname" . }}"
+  serviceName: "{{ template "elasticsearch.data.fullname" . }}"
   replicas: {{ .Values.data.replicas }}
   template:
     metadata:
@@ -59,7 +59,7 @@ spec:
         securityContext:
           privileged: true
       containers:
-      - name: {{ template "data.fullname" . }}
+      - name: {{ template "elasticsearch.data.fullname" . }}
         image: {{ template "elasticsearch.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         {{- if .Values.securityContext.enabled }}

--- a/bitnami/elasticsearch/templates/discovery-svc.yaml
+++ b/bitnami/elasticsearch/templates/discovery-svc.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
-  name: {{ template "discovery.fullname" . }}
+  name: {{ template "elasticsearch.discovery.fullname" . }}
   labels:
     app: {{ template "elasticsearch.name" . }}
     chart: {{ template "elasticsearch.chart" . |}}

--- a/bitnami/elasticsearch/templates/ingest-deploy.yaml
+++ b/bitnami/elasticsearch/templates/ingest-deploy.yaml
@@ -2,7 +2,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "ingest.fullname" . }}
+  name: {{ template "elasticsearch.ingest.fullname" . }}
   labels:
     app: {{ template "elasticsearch.name" . }}
     chart: {{ template "elasticsearch.chart" . }}
@@ -64,7 +64,7 @@ spec:
         securityContext:
           privileged: true
       containers:
-      - name: {{ template "ingest.fullname" . }}
+      - name: {{ template "elasticsearch.ingest.fullname" . }}
         image: {{ template "elasticsearch.image" . }}
         {{- if .Values.securityContext.enabled }}
         securityContext:

--- a/bitnami/elasticsearch/templates/ingest-svc.yaml
+++ b/bitnami/elasticsearch/templates/ingest-svc.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "ingest.fullname" . }}
+  name: {{ template "elasticsearch.ingest.fullname" . }}
   labels:
     app: {{ template "elasticsearch.name" . }}
     chart: {{ template "elasticsearch.chart" . }}

--- a/bitnami/elasticsearch/templates/master-deploy.yaml
+++ b/bitnami/elasticsearch/templates/master-deploy.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "master.fullname" . }}
+  name: {{ template "elasticsearch.master.fullname" . }}
   labels:
     app: {{ template "elasticsearch.name" . }}
     chart: {{ template "elasticsearch.chart" . }}
@@ -64,7 +64,7 @@ spec:
         securityContext:
           privileged: true
       containers:
-      - name: {{ template "master.fullname" . }}
+      - name: {{ template "elasticsearch.master.fullname" . }}
         image: {{ template "elasticsearch.image" . }}
         {{- if .Values.securityContext.enabled }}
         securityContext:

--- a/bitnami/elasticsearch/templates/master-svc.yaml
+++ b/bitnami/elasticsearch/templates/master-svc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "master.fullname" . }}
+  name: {{ template "elasticsearch.master.fullname" . }}
   labels:
     app: {{ template "elasticsearch.name" . }}
     chart: {{ template "elasticsearch.chart" . }}

--- a/bitnami/elasticsearch/templates/metrics-deploy.yaml
+++ b/bitnami/elasticsearch/templates/metrics-deploy.yaml
@@ -2,7 +2,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "metrics.fullname" . }}
+  name: {{ template "elasticsearch.metrics.fullname" . }}
   labels:
     app: {{ template "elasticsearch.name" . }}
     chart: {{ template "elasticsearch.chart" . }}
@@ -31,7 +31,7 @@ spec:
       {{- end}}
       {{- end }}
       containers:
-      - name: {{ template "metrics.fullname" . }}
+      - name: {{ template "elasticsearch.metrics.fullname" . }}
         image:  {{ template "metrics.image" . }}
         imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
         args: [ "-es.uri=http://{{ template "coordinating.fullname" . }}:{{ .Values.coordinating.service.port }}", "-es.all=true" ]

--- a/bitnami/elasticsearch/templates/metrics-svc.yaml
+++ b/bitnami/elasticsearch/templates/metrics-svc.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "metrics.fullname" . }}
+  name: {{ template "elasticsearch.metrics.fullname" . }}
   labels:
     app: {{ template "elasticsearch.name" . }}
     chart: {{ template "elasticsearch.chart" . }}


### PR DESCRIPTION
### What this PR does / why we need it:

We're using macros with names such as 'slave.fullname' or 'master.fullname' on different charts. Therefore, when a chart has as dependencies more than one chart defining them, we face some conflicts.

### Which issue this PR fixes

Fixes #789