### PR TITLE
[bitnami/mysql] Improve instructions to upgrade MySQL chart

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 4.0.0
+version: 4.0.1
 appVersion: 5.7.23
 description: Chart to create a Highly available MySQL cluster
 keywords:

--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -144,6 +144,14 @@ The chart mounts a [Persistent Volume](kubernetes.io/docs/user-guide/persistent-
 
 ## Upgrading
 
+It's necessary to set the `root.password` parameter when upgrading for readiness/liveness probes to work properly. When you install this chart for the first time, some notes will be displayed providing the credentials you must use under the 'Administrator credentials' section. Please note down the password and run the command below to upgrade your chart:
+
+```bash
+$ helm upgrade my-release bitnami/mysql --set root.password=[ROOT_PASSWORD]
+```
+
+| Note: you need to substitue the placeholder _[ROOT_PASSWORD]_ with the value obtained in the installation notes.
+
 ### To 3.0.0
 
 Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.

--- a/bitnami/mysql/templates/NOTES.txt
+++ b/bitnami/mysql/templates/NOTES.txt
@@ -17,7 +17,7 @@ Administrator credentials:
   echo Username: root
   echo Password : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.mysql-root-password}" | base64 --decode)
 
-To connect to your database
+To connect to your database:
 
   1. Run a pod that you can use as a client:
 
@@ -33,3 +33,10 @@ To connect to your database
 
       mysql -h {{ template "mysql.slave.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local -uroot -p {{ .Values.db.name }}
 {{- end }}
+
+To upgrade this helm chart:
+
+  1. Obtain the password as described on the 'Administrator credentials' section and set the 'root.password' parameter as shown below:
+
+      ROOT_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.mysql-root-password}" | base64 --decode)
+      helm upgrade {{ .Release.Name }} bitnami/mysql --set root.password=$ROOT_PASSWORD


### PR DESCRIPTION
### What this PR does / why we need it:

When upgrading this chart, it's necessary to set the `root.password` properly so the readiness/liveness probes work as expected. This PR adds that information to the **NOTES.txt** and **README.md** file.