### PR TITLE
[bitnami/mysql] Use Existing PVCs to store MySQL data

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 4.0.2
+version: 4.0.3
 appVersion: 5.7.23
 description: Chart to create a Highly available MySQL cluster
 keywords:

--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -43,72 +43,74 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the MySQL chart and their default values.
 
-|             Parameter                     |                     Description                     |                              Default                              |
-|-------------------------------------------|-----------------------------------------------------|-------------------------------------------------------------------|
-| `image.registry`                          | MySQL image registry                              | `docker.io`                                                       |
-| `image.repository`                        | MySQL Image name                                  | `bitnami/mysql`                                                 |
-| `image.tag`                               | MySQL Image tag                                   | `{VERSION}`                                                       |
-| `image.pullPolicy`                        | MySQL image pull policy                           | `Always` if `imageTag` is `latest`, else `IfNotPresent`           |
-| `image.pullSecrets`                       | Specify image pull secrets                          | `nil` (does not add image pull secrets to deployed pods)          |
-| `service.type`                            | Kubernetes service type                             | `ClusterIP`                                                       |
-| `service.port`                            | MySQL service port                                  | `3306`                                                            |
-| `root.password`                           | Password for the `root` user                        | _random 10 character alphanumeric string_                         |
-| `db.user`                                 | Username of new user to create                      | `nil`                                                             |
-| `db.password`                             | Password for the new user                           | _random 10 character alphanumeric string if `db.user` is defined_ |
-| `db.name`                                 | Name for new database to create                     | `my_database`                                                     |
-| `securityContext.enabled`            | Enable security context                                                                      | `true`                            |
-| `securityContext.fsGroup`            | Group ID for the container                                                                   | `1001`                            |
-| `securityContext.runAsUser`          | User ID for the container                                                                    | `1001`              | `replication.enabled`                     | MySQL replication enabled                         | `true`                                                            |
-| `replication.user`                        | MySQL replication user                            | `replicator`                                                      |
-| `replication.password`                    | MySQL replication user password                   | _random 10 character alphanumeric string_                         |
-| `master.antiAffinity`                     | Master pod anti-affinity policy                     | `soft`                                                            |
-| `master.persistence.enabled`              | Enable persistence using a `PersistentVolumeClaim`  | `true`                                                            |
-| `master.persistence.existingClaim`        | Provide an existing `PersistentVolumeClaim`         | `nil`                                                             |
-| `master.persistence.mountPath`            | Configure existing `PersistentVolumeClaim` mount path  | `""`                                                           |
-| `master.persistence.annotations`          | Persistent Volume Claim annotations                 | `{}`                                                              |
-| `master.persistence.storageClass`         | Persistent Volume Storage Class                     | ``                                                                |
-| `master.persistence.accessModes`          | Persistent Volume Access Modes                      | `[ReadWriteOnce]`                                                 |
-| `master.persistence.size`                 | Persistent Volume Size                              | `8Gi`                                                             |
-| `master.config`                           | Config file for the MySQL Master server           | `_default values in the values.yaml file_`                        |
-| `master.resources`                        | CPU/Memory resource requests/limits for master node | `{}`                                                              |
-| `master.livenessProbe.enabled`            | Turn on and off liveness probe (master)             | `true`                                                            |
-| `master.livenessProbe.initialDelaySeconds`| Delay before liveness probe is initiated (master)   | `120`                                                             |
-| `master.livenessProbe.periodSeconds`      | How often to perform the probe (master)             | `10`                                                              |
-| `master.livenessProbe.timeoutSeconds`     | When the probe times out (master)                   | `1`                                                               |
-| `master.livenessProbe.successThreshold`   | Minimum consecutive successes for the probe (master)| `1`                                                               |
-| `master.livenessProbe.failureThreshold`   | Minimum consecutive failures for the probe (master) | `3`                                                               |
-| `master.readinessProbe.enabled`           | Turn on and off readiness probe (master)            | `true`                                                            |
-| `master.readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated (master) | `30`                                                              |
-| `master.readinessProbe.periodSeconds`     | How often to perform the probe (master)             | `10`                                                              |
-| `master.readinessProbe.timeoutSeconds`    | When the probe times out (master)                   | `1`                                                               |
-| `master.readinessProbe.successThreshold`  | Minimum consecutive successes for the probe (master)| `1`                                                               |
-| `master.readinessProbe.failureThreshold`  | Minimum consecutive failures for the probe (master) | `3`                                                               |
-| `slave.replicas`                          | Desired number of slave replicas                    | `1`                                                               |
-| `slave.antiAffinity`                      | Slave pod anti-affinity policy                      | `soft`                                                            |
-| `slave.persistence.enabled`               | Enable persistence using a `PersistentVolumeClaim`  | `true`                                                            |
-| `slave.persistence.annotations`           | Persistent Volume Claim annotations                 | `{}`                                                              |
-| `slave.persistence.storageClass`          | Persistent Volume Storage Class                     | ``                                                                |
-| `slave.persistence.accessModes`           | Persistent Volume Access Modes                      | `[ReadWriteOnce]`                                                 |
-| `slave.persistence.size`                  | Persistent Volume Size                              | `8Gi`                                                             |
-| `slave.config`                            | Config file for the MySQL Slave replicas          | `_default values in the values.yaml file_`                        |
-| `slave.resources`                         | CPU/Memory resource requests/limits for slave node  | `{}`                                                              |
-| `slave.livenessProbe.enabled`             | Turn on and off liveness probe (slave)              | `true`                                                            |
-| `slave.livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated (slave)    | `120`                                                             |
-| `slave.livenessProbe.periodSeconds`       | How often to perform the probe (slave)              | `10`                                                              |
-| `slave.livenessProbe.timeoutSeconds`      | When the probe times out (slave)                    | `1`                                                               |
-| `slave.livenessProbe.successThreshold`    | Minimum consecutive successes for the probe (slave) | `1`                                                               |
-| `slave.livenessProbe.failureThreshold`    | Minimum consecutive failures for the probe (slave)  | `3`                                                               |
-| `slave.readinessProbe.enabled`            | Turn on and off readiness probe (slave)             | `true`                                                            |
-| `slave.readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated (slave)   | `30`                                                              |
-| `slave.readinessProbe.periodSeconds`      | How often to perform the probe (slave)              | `10`                                                              |
-| `slave.readinessProbe.timeoutSeconds`     | When the probe times out (slave)                    | `1`                                                               |
-| `slave.readinessProbe.successThreshold`   | Minimum consecutive successes for the probe (slave) | `1`                                                               |
-| `slave.readinessProbe.failureThreshold`   | Minimum consecutive failures for the probe (slave)  | `3`                                                               |
-| `metrics.enabled`                         | Start a side-car prometheus exporter                | `false`                                                           |
-| `metrics.image`                           | Exporter image name                                 | `prom/mysqld-exporter`                                            |
-| `metrics.imageTag`                        | Exporter image tag                                  | `v0.10.0`                                                         |
-| `metrics.imagePullPolicy`                 | Exporter image pull policy                          | `IfNotPresent`                                                    |
-| `metrics.resources`                       | Exporter resource requests/limit                    | `nil`                                                             |
+|             Parameter                     |                     Description                       |                              Default                              |
+|-------------------------------------------|-------------------------------------------------------|-------------------------------------------------------------------|
+| `image.registry`                          | MySQL image registry                                  | `docker.io`                                                       |
+| `image.repository`                        | MySQL Image name                                      | `bitnami/mysql`                                                   |
+| `image.tag`                               | MySQL Image tag                                       | `{VERSION}`                                                       |
+| `image.pullPolicy`                        | MySQL image pull policy                               | `Always` if `imageTag` is `latest`, else `IfNotPresent`           |
+| `image.pullSecrets`                       | Specify image pull secrets                            | `nil` (does not add image pull secrets to deployed pods)          |
+| `service.type`                            | Kubernetes service type                               | `ClusterIP`                                                       |
+| `service.port`                            | MySQL service port                                    | `3306`                                                            |
+| `root.password`                           | Password for the `root` user                          | _random 10 character alphanumeric string_                         |
+| `db.user`                                 | Username of new user to create                        | `nil`                                                             |
+| `db.password`                             | Password for the new user                             | _random 10 character alphanumeric string if `db.user` is defined_ |
+| `db.name`                                 | Name for new database to create                       | `my_database`                                                     |
+| `securityContext.enabled`                 | Enable security context                               | `true`                                                            |
+| `securityContext.fsGroup`                 | Group ID for the container                            | `1001`                                                            |
+| `securityContext.runAsUser`               | User ID for the container                             | `1001`                                                            |
+| `replication.enabled`                     | MySQL replication enabled                             | `true`                                                            |
+| `replication.user`                        | MySQL replication user                                | `replicator`                                                      |
+| `replication.password`                    | MySQL replication user password                       | _random 10 character alphanumeric string_                         |
+| `master.antiAffinity`                     | Master pod anti-affinity policy                       | `soft`                                                            |
+| `master.persistence.enabled`              | Enable persistence using a `PersistentVolumeClaim`    | `true`                                                            |
+| `master.persistence.existingClaim`        | Provide an existing `PersistentVolumeClaim`           | `nil`                                                             |
+| `master.persistence.mountPath`            | Configure `PersistentVolumeClaim` mount path          | `/bitnami/mysql`                                                  |
+| `master.persistence.annotations`          | Persistent Volume Claim annotations                   | `{}`                                                              |
+| `master.persistence.storageClass`         | Persistent Volume Storage Class                       | ``                                                                |
+| `master.persistence.accessModes`          | Persistent Volume Access Modes                        | `[ReadWriteOnce]`                                                 |
+| `master.persistence.size`                 | Persistent Volume Size                                | `8Gi`                                                             |
+| `master.config`                           | Config file for the MySQL Master server               | `_default values in the values.yaml file_`                        |
+| `master.resources`                        | CPU/Memory resource requests/limits for master node   | `{}`                                                              |
+| `master.livenessProbe.enabled`            | Turn on and off liveness probe (master)               | `true`                                                            |
+| `master.livenessProbe.initialDelaySeconds`| Delay before liveness probe is initiated (master)     | `120`                                                             |
+| `master.livenessProbe.periodSeconds`      | How often to perform the probe (master)               | `10`                                                              |
+| `master.livenessProbe.timeoutSeconds`     | When the probe times out (master)                     | `1`                                                               |
+| `master.livenessProbe.successThreshold`   | Minimum consecutive successes for the probe (master)  | `1`                                                               |
+| `master.livenessProbe.failureThreshold`   | Minimum consecutive failures for the probe (master)   | `3`                                                               |
+| `master.readinessProbe.enabled`           | Turn on and off readiness probe (master)              | `true`                                                            |
+| `master.readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated (master)   | `30`                                                              |
+| `master.readinessProbe.periodSeconds`     | How often to perform the probe (master)               | `10`                                                              |
+| `master.readinessProbe.timeoutSeconds`    | When the probe times out (master)                     | `1`                                                               |
+| `master.readinessProbe.successThreshold`  | Minimum consecutive successes for the probe (master)  | `1`                                                               |
+| `master.readinessProbe.failureThreshold`  | Minimum consecutive failures for the probe (master)   | `3`                                                               |
+| `slave.replicas`                          | Desired number of slave replicas                      | `1`                                                               |
+| `slave.antiAffinity`                      | Slave pod anti-affinity policy                        | `soft`                                                            |
+| `slave.persistence.enabled`               | Enable persistence using a `PersistentVolumeClaim`    | `true`                                                            |
+| `slave.persistence.mountPath`             | Configure `PersistentVolumeClaim` mount path          | `/bitnami/mysql`                                                  |
+| `slave.persistence.annotations`           | Persistent Volume Claim annotations                   | `{}`                                                              |
+| `slave.persistence.storageClass`          | Persistent Volume Storage Class                       | ``                                                                |
+| `slave.persistence.accessModes`           | Persistent Volume Access Modes                        | `[ReadWriteOnce]`                                                 |
+| `slave.persistence.size`                  | Persistent Volume Size                                | `8Gi`                                                             |
+| `slave.config`                            | Config file for the MySQL Slave replicas              | `_default values in the values.yaml file_`                        |
+| `slave.resources`                         | CPU/Memory resource requests/limits for slave node    | `{}`                                                              |
+| `slave.livenessProbe.enabled`             | Turn on and off liveness probe (slave)                | `true`                                                            |
+| `slave.livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated (slave)      | `120`                                                             |
+| `slave.livenessProbe.periodSeconds`       | How often to perform the probe (slave)                | `10`                                                              |
+| `slave.livenessProbe.timeoutSeconds`      | When the probe times out (slave)                      | `1`                                                               |
+| `slave.livenessProbe.successThreshold`    | Minimum consecutive successes for the probe (slave)   | `1`                                                               |
+| `slave.livenessProbe.failureThreshold`    | Minimum consecutive failures for the probe (slave)    | `3`                                                               |
+| `slave.readinessProbe.enabled`            | Turn on and off readiness probe (slave)               | `true`                                                            |
+| `slave.readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated (slave)     | `30`                                                              |
+| `slave.readinessProbe.periodSeconds`      | How often to perform the probe (slave)                | `10`                                                              |
+| `slave.readinessProbe.timeoutSeconds`     | When the probe times out (slave)                      | `1`                                                               |
+| `slave.readinessProbe.successThreshold`   | Minimum consecutive successes for the probe (slave)   | `1`                                                               |
+| `slave.readinessProbe.failureThreshold`   | Minimum consecutive failures for the probe (slave)    | `3`                                                               |
+| `metrics.enabled`                         | Start a side-car prometheus exporter                  | `false`                                                           |
+| `metrics.image`                           | Exporter image name                                   | `prom/mysqld-exporter`                                            |
+| `metrics.imageTag`                        | Exporter image tag                                    | `v0.10.0`                                                         |
+| `metrics.imagePullPolicy`                 | Exporter image pull policy                            | `IfNotPresent`                                                    |
+| `metrics.resources`                       | Exporter resource requests/limit                      | `nil`                                                             |
 
 The above parameters map to the env variables defined in [bitnami/mysql](http://github.com/bitnami/bitnami-docker-mysql). For more information please refer to the [bitnami/mysql](http://github.com/bitnami/bitnami-docker-mysql) image documentation.
 

--- a/bitnami/mysql/templates/master-statefulset.yaml
+++ b/bitnami/mysql/templates/master-statefulset.yaml
@@ -117,18 +117,18 @@ spec:
         resources:
 {{ toYaml .Values.master.resources | indent 10 }}
         volumeMounts:
+{{- if .Values.master.persistence.existingClaim }}
+        - name: {{ .Values.master.persistence.existingClaim }}
+{{- else }}
         - name: data
-          mountPath: /bitnami/mysql
+{{- end }}
+          mountPath: {{ .Values.master.persistence.mountPath }}
         - name: custom-init-scripts
           mountPath: /docker-entrypoint-initdb.d
 {{- if .Values.master.config }}
         - name: config
           mountPath: /opt/bitnami/mysql/conf/my.cnf
           subPath: my.cnf
-{{- if .Values.master.persistence.existingClaim }}
-        - name: {{ .Values.master.persistence.existingClaim }}
-          mountPath: {{ .Values.master.persistence.mountPath }}
-{{- end }}
 {{- end }}
 {{- if .Values.metrics.enabled }}
       - name: metrics
@@ -173,7 +173,7 @@ spec:
         - name: custom-init-scripts
           configMap:
             name: {{ template "mysql.master.fullname" . }}-init-scripts
-{{- if .Values.master.persistence.enabled }}
+{{- if and .Values.master.persistence.enabled ( not .Values.master.persistence.existingClaim ) }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/bitnami/mysql/templates/slave-statefulset.yaml
+++ b/bitnami/mysql/templates/slave-statefulset.yaml
@@ -128,7 +128,7 @@ spec:
 {{ toYaml .Values.slave.resources | indent 10 }}
         volumeMounts:
         - name: data
-          mountPath: /bitnami/mysql
+          mountPath: {{ .Values.slave.persistence.mountPath }}
 {{- if .Values.slave.config }}
         - name: config
           mountPath: /opt/bitnami/mysql/conf/my.cnf

--- a/bitnami/mysql/values-production.yaml
+++ b/bitnami/mysql/values-production.yaml
@@ -85,10 +85,11 @@ master:
     ## If true, use a Persistent Volume Claim, If false, use emptyDir
     ##
     enabled: true
+    mountPath: /bitnami/mysql
     ## Enable persistence using an existing PVC
     ##
     # existingClaim:
-    # mountPath:
+
     ## Persistent Volume Storage Class
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning
@@ -170,6 +171,7 @@ slave:
     ## If true, use a Persistent Volume Claim, If false, use emptyDir
     ##
     enabled: true
+    mountPath: /bitnami/mysql
     # storageClass: "-"
     annotations:
     accessModes:

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -86,10 +86,10 @@ master:
     ## If true, use a Persistent Volume Claim, If false, use emptyDir
     ##
     enabled: true
+    mountPath: /bitnami/mysql
     ## Enable persistence using an existing PVC
     ##
     # existingClaim:
-    # mountPath:
     ## Persistent Volume Storage Class
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning
@@ -172,6 +172,7 @@ slave:
     ## If true, use a Persistent Volume Claim, If false, use emptyDir
     ##
     enabled: true
+    mountPath: /bitnami/mysql
     # storageClass: "-"
     annotations:
     accessModes:


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently we're creating a PVC even if the user indicates its own existing PVC. Furthermore, the one which is dynamically created is being mounted at **/bitnami/data**.

This is a very weird scenario since the user who already has a PVC (with his corresponding PV) can't use it to store the MySQL data.

#### Which issue this PR fixes

fixes https://github.com/bitnami/charts/issues/784