### PR TITLE
[bitnami/etcd] fix svc template when passing loadBalancerIP property

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -1,5 +1,5 @@
 name: etcd
-version: 1.1.0
+version: 1.1.1
 appVersion: 3.3.8
 description: etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines
 keywords:

--- a/bitnami/etcd/templates/svc.yaml
+++ b/bitnami/etcd/templates/svc.yaml
@@ -13,7 +13,7 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
-  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP -}}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
   ports:


### PR DESCRIPTION
FIx the following issue when installing the chart passing a `loadBalancerIP`:

```
Error: YAML parse error on etcd/templates/svc.yaml: error converting YAML to JSON: yaml: line 10: mapping values are not allowed in this context
```