### PR TITLE
[stable/nginx-ingress-controller] Delete semver comparisons

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress-controller
-version: 1.0.0
+version: 2.0.0
 appVersion: 0.18.0
 description: Chart for the nginx Ingress controller
 keywords:

--- a/bitnami/nginx-ingress-controller/templates/controller-daemonset.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-daemonset.yaml
@@ -42,6 +42,9 @@ spec:
 {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
 {{- end }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
       containers:
         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.name }}
           image: "{{ template "nginx-ingress-controller.image" . }}"
@@ -53,20 +56,12 @@ spec:
           args:
             - /nginx-ingress-controller
             - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ template "nginx-ingress.defaultBackend.fullname" . }}{{ else }}{{ .Values.defaultBackendService }}{{ end }}
-          {{- if and (semverCompare ">=0.9.0-beta.1" .Values.image.tag) .Values.publishService.enabled }}
+          {{- if .Values.publishService.enabled }}
             - --publish-service={{ template "nginx-ingress.publishServicePath" . }}
           {{- end }}
-          {{- if (semverCompare ">=0.9.0-beta.1" .Values.image.tag) }}
             - --election-id={{ .Values.electionID }}
-          {{- end }}
-          {{- if (semverCompare ">=0.9.0-beta.1" .Values.image.tag) }}
             - --ingress-class={{ .Values.ingressClass }}
-          {{- end }}
-          {{- if (semverCompare ">=0.9.0-beta.1" .Values.image.tag) }}
             - --configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}
-          {{- else }}
-            - --nginx-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}
-          {{- end }}
           {{- if .Values.tcp }}
             - --tcp-services-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-tcp
           {{- end }}
@@ -83,16 +78,10 @@ spec:
             - --{{ $key }}
             {{- end }}
           {{- end }}
-          {{- if (semverCompare ">=0.16.0" .Values.image.tag) }}
           securityContext:
             capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-            fsGroup: {{ .Values.securityContext.fsGroup }}
-            runAsUser: {{ .Values.securityContext.runAsUser }}
-          {{- end }}
+              drop: ["ALL"]
+              add: ["NET_BIND_SERVICE"]
           env:
             - name: POD_NAME
               valueFrom:

--- a/bitnami/nginx-ingress-controller/templates/controller-deployment.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-deployment.yaml
@@ -42,6 +42,9 @@ spec:
 {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
 {{- end }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
       containers:
         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.name }}
           image: "{{ template "nginx-ingress-controller.image" . }}"
@@ -53,20 +56,12 @@ spec:
           args:
             - /nginx-ingress-controller
             - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ template "nginx-ingress.defaultBackend.fullname" . }}{{ else }}{{ .Values.defaultBackendService }}{{ end }}
-          {{- if and (semverCompare ">=0.9.0-beta.1" .Values.image.tag) .Values.publishService.enabled }}
+          {{- if .Values.publishService.enabled }}
             - --publish-service={{ template "nginx-ingress.publishServicePath" . }}
           {{- end }}
-          {{- if (semverCompare ">=0.9.0-beta.1" .Values.image.tag) }}
             - --election-id={{ .Values.electionID }}
-          {{- end }}
-          {{- if (semverCompare ">=0.9.0-beta.1" .Values.image.tag) }}
             - --ingress-class={{ .Values.ingressClass }}
-          {{- end }}
-          {{- if (semverCompare ">=0.9.0-beta.1" .Values.image.tag) }}
             - --configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}
-          {{- else }}
-            - --nginx-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}
-          {{- end }}
           {{- if .Values.tcp }}
             - --tcp-services-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-tcp
           {{- end }}
@@ -83,16 +78,10 @@ spec:
             - --{{ $key }}
             {{- end }}
           {{- end }}
-          {{- if (semverCompare ">=0.16.0" .Values.image.tag) }}
           securityContext:
             capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-            fsGroup: {{ .Values.securityContext.fsGroup }}
-            runAsUser: {{ .Values.securityContext.runAsUser }}
-          {{- end }}
+              drop: ["ALL"]
+              add: ["NET_BIND_SERVICE"]
           env:
             - name: POD_NAME
               valueFrom:


### PR DESCRIPTION
Delete all semver comparisons with the image.tag as this can be something different to a version.
For example, it can be 'latest' or a sha checksum.
Also fixed the securityContext settings as `capabilities` seems to only apply to containers and `fsGroup` only applies to pods.