### PR TITLE
Update statefulset.yaml

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,5 +1,5 @@
 name: zookeeper
-version: 1.0.1
+version: 1.0.2
 appVersion: 3.4.12
 description: A centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services for distributed applications.
 keywords:

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -91,7 +91,7 @@ spec:
           {{- $electionPort := int .Values.service.electionPort }}
           {{- $releaseNamespace := .Release.Namespace }}
           {{- $zookeeperFullname := include "zookeeper.fullname" . }}
-          {{- $zookeeperHeadlessServiceName := printf "%s-%s" $zookeeperFullname "headless" | trunc 24  }}
+          {{- $zookeeperHeadlessServiceName := printf "%s-%s" $zookeeperFullname "headless" | trunc 63  }}
           value: {{range $i, $e := until $replicaCount }}{{ $zookeeperFullname }}-{{ $e }}.{{ $zookeeperHeadlessServiceName }}.{{ $releaseNamespace }}.svc.cluster.local:{{ $followerPort }}:{{ $electionPort }} {{ end }}
         {{- if .Values.auth.enabled }}
         - name: ZOO_ENABLE_AUTH


### PR DESCRIPTION
Increase the ZOO_SERVERS name limit from 24 to 63.

Because of the long length my service name was trimmed to
```
zookeeper-zookeeper-0.zookeeper-zookeeper-head.infrastructure.svc.cluster.local:2888:3888
zookeeper-zookeeper-1.zookeeper-zookeeper-head.infrastructure.svc.cluster.local:2888:3888
zookeeper-zookeeper-2.zookeeper-zookeeper-head.infrastructure.svc.cluster.local:2888:3888
```
whereas the name should be
```
zookeeper-zookeeper-0.zookeeper-zookeeper-headless.infrastructure.svc.cluster.local:2888:3888
zookeeper-zookeeper-1.zookeeper-zookeeper-headless.infrastructure.svc.cluster.local:2888:3888
zookeeper-zookeeper-2.zookeeper-zookeeper-headless.infrastructure.svc.cluster.local:2888:3888
```
