### PR TITLE
[bitnami/mysql] Remove unnecessary env. variable on slave pods

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 4.0.3
+version: 4.0.4
 appVersion: 5.7.23
 description: Chart to create a Highly available MySQL cluster
 keywords:

--- a/bitnami/mysql/templates/slave-statefulset.yaml
+++ b/bitnami/mysql/templates/slave-statefulset.yaml
@@ -65,22 +65,6 @@ spec:
         image: {{ template "mysql.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         env:
-        - name: MYSQL_ROOT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "fullname" . }}
-              key: mysql-root-password
-        {{- if .Values.db.user }}
-        - name: MYSQL_USER
-          value: "{{ .Values.db.user }}"
-        - name: MYSQL_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "fullname" . }}
-              key: mysql-password
-        {{- end }}
-        - name: MYSQL_DATABASE
-          value: "{{ .Values.db.name }}"
         - name: MYSQL_REPLICATION_MODE
           value: "slave"
         - name: MYSQL_MASTER_HOST
@@ -107,7 +91,7 @@ spec:
         {{- if .Values.slave.livenessProbe.enabled }}
         livenessProbe:
           exec:
-            command: ["sh", "-c", "exec mysqladmin status -uroot -p$MYSQL_ROOT_PASSWORD"]
+            command: ["sh", "-c", "exec mysqladmin status -uroot -p$MYSQL_MASTER_ROOT_PASSWORD"]
           initialDelaySeconds: {{ .Values.slave.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.slave.livenessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.slave.livenessProbe.timeoutSeconds }}
@@ -117,7 +101,7 @@ spec:
         {{- if .Values.slave.readinessProbe.enabled }}
         readinessProbe:
           exec:
-            command: ["sh", "-c", "exec mysqladmin status -uroot -p$MYSQL_ROOT_PASSWORD"]
+            command: ["sh", "-c", "exec mysqladmin status -uroot -p$MYSQL_MASTER_ROOT_PASSWORD"]
           initialDelaySeconds: {{ .Values.slave.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.slave.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.slave.readinessProbe.timeoutSeconds }}
@@ -139,12 +123,12 @@ spec:
         image: {{ template "metrics.image" . }}
         imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
         env:
-        - name: MYSQL_ROOT_PASSWORD
+        - name: MYSQL_MASTER_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "fullname" . }}
               key: mysql-root-password
-        command: [ 'sh', '-c', 'DATA_SOURCE_NAME="root:$MYSQL_ROOT_PASSWORD@(localhost:3306)/" /bin/mysqld_exporter' ]
+        command: [ 'sh', '-c', 'DATA_SOURCE_NAME="root:$MYSQL_MASTER_ROOT_PASSWORD@(localhost:3306)/" /bin/mysqld_exporter' ]
         ports:
         - name: metrics
           containerPort: 9104


### PR DESCRIPTION
### What this PR does / why we need it:

This PR removes unnecessary env. variables on Slave pods since they're not used.