### PR TITLE
Delete unexistent option for the latest version of metrics-server

### DIFF
--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: metrics-server
-version: 2.0.0
+version: 2.0.1
 appVersion: 0.2.1
 description: Metrics Server is a cluster-wide aggregator of resource usage data. Metrics Server collects metrics from the Summary API, exposed by Kubelet on each node.
 keywords:

--- a/bitnami/metrics-server/templates/deployment.yaml
+++ b/bitnami/metrics-server/templates/deployment.yaml
@@ -34,6 +34,5 @@ spec:
           containerPort: {{ .Values.securePort }}
         command:
         - metrics-server
-        - --source=kubernetes.summary_api:''
         - --secure-port={{ .Values.securePort }}
-        
+


### PR DESCRIPTION
The `--source` argument does not exist for the latest version of metrics-server (0.3.1).