### PR TITLE
[bitnami/metrics-server] Fix RBAC

### DIFF
--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: metrics-server
-version: 2.0.4
+version: 2.0.5
 appVersion: 0.3.1
 description: Metrics Server is a cluster-wide aggregator of resource usage data. Metrics Server collects metrics from the Summary API, exposed by Kubelet on each node.
 keywords:

--- a/bitnami/metrics-server/templates/cluster-role.yaml
+++ b/bitnami/metrics-server/templates/cluster-role.yaml
@@ -19,4 +19,11 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+    - nodes/stats
+    verbs:
+    - get
+    - create
 {{- end -}}


### PR DESCRIPTION
### What this PR does / why we need it:

The RBAC configuration used on the metrics-server needs to be modified so it can **"get/create"** **nodes/stats** 

### Which issue this PR fixes

#fixes https://github.com/bitnami/charts/issues/854