### PR TITLE
Simplify ingress configuration for cert-manager

### DIFF
--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -2,7 +2,7 @@ name: consul
 home: https://www.consul.io/
 sources:
 - https://github.com/bitnami/consul
-version: 2.0.4
+version: 2.1.0
 appVersion: 1.2.3
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/bitnami/consul/README.md
+++ b/bitnami/consul/README.md
@@ -78,17 +78,18 @@ The following tables lists the configurable parameters of the Consul chart and t
 | `maxUnavailable`                     | Pod disruption Budget maxUnavailable                   | `1`                                                        |
 | `nodeAffinity`                       | Consul pod node-affinity setting                       | `nil`                                                      |
 | `antiAffinity`                       | Consul pod anti-affinity setting                       | `soft`                                                     |
-| `ui.service.enabled`                  | Use a service to access Consul Ui                      | `true`                                                     |
-| `ui.service.type`                     | Kubernetes Service Type                                | `ClusterIP`                                                |
-| `ui.ingress.enabled`                  | Enable ingress controller resource                     | `false`                                                    |
-| `ui.ingress.hosts[0].name`            | Hostname to your Consul installation                   | `consul-ui.local`                                          |
-| `ui.ingress.hosts[0].path`            | Path within the url structure                          | `/`                                                        |
-| `ui.ingress.hosts[0].tls`             | Utilize TLS backend in ingress                         | `false`                                                    |
-| `ui.ingress.hosts[0].tlsSecret`       | TLS Secret (certificates)                              | `consul-ui.local-tls`                                      |
-| `ui.ingress.hosts[0].annotations`     | Annotations for this host's ingress record             | `[]`                                                       |
-| `ui.ingress.secrets[0].name`          | TLS Secret Name                                        | `nil`                                                      |
-| `ui.ingress.secrets[0].certificate`   | TLS Secret Certificate                                 | `nil`                                                      |
-| `ui.ingress.secrets[0].key`           | TLS Secret Key                                         | `nil`                                                      |
+| `ui.service.enabled`                 | Use a service to access Consul Ui                      | `true`                                                     |
+| `ui.service.type`                    | Kubernetes Service Type                                | `ClusterIP`                                                |
+| `ui.ingress.enabled`                 | Enable ingress controller resource                     | `false`                                                    |
+| `ui.ingress.hosts[0].name`           | Hostname to your Consul installation                   | `consul-ui.local`                                          |
+| `ui.ingress.hosts[0].path`           | Path within the url structure                          | `/`                                                        |
+| `ui.ingress.hosts[0].tls`            | Utilize TLS backend in ingress                         | `false`                                                    |
+| `ui.ingress.hosts[0].certManager`    | Add annotations for cert-manager                       | `false`                                                    |
+| `ui.ingress.hosts[0].tlsSecret`      | TLS Secret (certificates)                              | `consul-ui.local-tls`                                      |
+| `ui.ingress.hosts[0].annotations`    | Annotations for this host's ingress record             | `[]`                                                       |
+| `ui.ingress.secrets[0].name`         | TLS Secret Name                                        | `nil`                                                      |
+| `ui.ingress.secrets[0].certificate`  | TLS Secret Certificate                                 | `nil`                                                      |
+| `ui.ingress.secrets[0].key`          | TLS Secret Key                                         | `nil`                                                      |
 | `configmap`                          | Consul configuration to be injected as ConfigMap       | `nil`                                                      |
 | `metrics.enabled`                    | Start a side-car prometheus exporter                   | `false`                                                    |
 | `metrics.image`                      | Exporter image                                         | `prom/consul-exporter`                                     |
@@ -100,13 +101,13 @@ The following tables lists the configurable parameters of the Consul chart and t
 | `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated               | 30                                                         |
 | `livenessProbe.periodSeconds`        | How often to perform the probe                         | 10                                                         |
 | `livenessProbe.timeoutSeconds`       | When the probe times out                               | 5                                                          |
-| `livenessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed.     |  1 |
-| `livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.       |  6 |
-| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                                                        |  5 |
-| `readinessProbe.periodSeconds`       | How often to perform the probe                                                                   | 10 |
-| `readinessProbe.timeoutSeconds`      | When the probe times out                                                                         |  5 |
-| `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed.     |  1 |
-| `readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed after having succeeded.       |  6 |
+| `livenessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed.     | 1                |
+| `livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.       | 6                |
+| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                                                        | 5                |
+| `readinessProbe.periodSeconds`       | How often to perform the probe                                                                   | 10               |
+| `readinessProbe.timeoutSeconds`      | When the probe times out                                                                         | 5                |
+| `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed.     | 1                |
+| `readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed after having succeeded.       | 6                |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/consul/templates/ingress.yaml
+++ b/bitnami/consul/templates/ingress.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- if .tls }}
     ingress.kubernetes.io/secure-backends: "true"
     {{- end }}
+    {{- if .certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
     {{- range $key, $value := .annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/bitnami/consul/values.yaml
+++ b/bitnami/consul/values.yaml
@@ -121,7 +121,7 @@ ui:
       ## A side effect of this will be that the backend consul service will be connected at port 443
       tls: false
 
-      ## Set this to true in order to add the corresponding annontations for cert-manager
+      ## Set this to true in order to add the corresponding annotations for cert-manager
       certManager: false
 
       ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS

--- a/bitnami/consul/values.yaml
+++ b/bitnami/consul/values.yaml
@@ -121,27 +121,27 @@ ui:
       ## A side effect of this will be that the backend consul service will be connected at port 443
       tls: false
 
+      ## Set this to true in order to add the corresponding annontations for cert-manager
+      certManager: false
+
       ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
       tlsSecret: consul-ui.local-tls
 
       ## Ingress annotations done as key:value pairs
-      ## If you're using kube-lego, you will want to add:
-      ## kubernetes.io/tls-acme: true
-      ##
       ## For a full list of possible ingress annotations, please see
       ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
       ##
       ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+      ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
       annotations:
       #  kubernetes.io/ingress.class: nginx
-      #  kubernetes.io/tls-acme: true
     secrets:
     ## If you're providing your own certificates, please use this to add the certificates as secrets
     ## key and certificate should start with -----BEGIN CERTIFICATE----- or
     ## -----BEGIN RSA PRIVATE KEY-----
     ##
     ## name should line up with a tlsSecret set further up
-    ## If you're using kube-lego, this is unneeded, as it will create the secret for you if it is not set
+    ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
     ##
     ## It is also possible to create and manage the certificates outside of this helm chart
     ## Please see README.md for more information

--- a/bitnami/mean/Chart.yaml
+++ b/bitnami/mean/Chart.yaml
@@ -1,5 +1,5 @@
 name: mean
-version: 4.0.2
+version: 4.1.0
 appVersion: 3.6.4
 description: MEAN is a free and open-source JavaScript software stack for building dynamic web sites and web applications. The MEAN stack is MongoDB, Express.js, Angular, and Node.js. Because all components of the MEAN stack support programs written in JavaScript, MEAN applications can be written in one language for both server-side and client-side execution environments.
 keywords:

--- a/bitnami/mean/README.md
+++ b/bitnami/mean/README.md
@@ -84,9 +84,16 @@ The following table lists the configurable parameters of the MEAN chart and thei
 | `externaldb.secretName`                 | Secret containing existing database credentials           | `nil`                                                     |
 | `externaldb.type`                       | Type of database that defines the database secret mapping | `osba`                                                    |
 | `externaldb.broker.serviceInstanceName` | The existing ServiceInstance to be used                   | `nil`                                                     |
-| `ingress.enabled`                       | Enable ingress creation                                   | `false`                                                   |
-| `ingress.path`                          | Ingress path                                              | `/`                                                       |
-| `ingress.host`                          | Ingress host                                              | `example.local`                                           |
+| `ingress.enabled`                       | Enable ingress controller resource                        | `false`                                                   |
+| `ingress.hosts[0].name`                 | Hostname to your MEAN installation                        | `mean.local`                                              |
+| `ingress.hosts[0].path`                 | Path within the url structure                             | `/`                                                       |
+| `ingress.hosts[0].tls`                  | Utilize TLS backend in ingress                            | `false`                                                   |
+| `ingress.hosts[0].certManager`          | Add annotations for cert-manager                          | `false`                                                   |
+| `ingress.hosts[0].tlsSecret`            | TLS Secret (certificates)                                 | `mean.local-tls-secret`                                   |
+| `ingress.hosts[0].annotations`          | Annotations for this host's ingress record                | `[]`                                                      |
+| `ingress.secrets[0].name`               | TLS Secret Name                                           | `nil`                                                     |
+| `ingress.secrets[0].certificate`        | TLS Secret Certificate                                    | `nil`                                                     |
+| `ingress.secrets[0].key`                | TLS Secret Key                                            | `nil`                                                     |
 
 The above parameters map to the env variables defined in [bitnami/node](http://github.com/bitnami/bitnami-docker-node). For more information please refer to the [bitnami/node](http://github.com/bitnami/bitnami-docker-node) image documentation.
 

--- a/bitnami/mean/templates/ingress.yaml
+++ b/bitnami/mean/templates/ingress.yaml
@@ -1,28 +1,36 @@
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
+  name: {{ template "mean.fullname" $ }}
   labels:
-    app: {{ template "mean.name" . }}
-    chart: {{ template "mean.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-  name: {{ template "mean.fullname" . }}
+    app: {{ template "mean.name" $ }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
   annotations:
-    {{- range $key, $value := .Values.ingress.annotations }}
-      {{ $key }}: {{ $value | quote }}
+    {{- if .certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- range $key, $value := .annotations }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
   rules:
-    - host: {{ .Values.ingress.host }}
-      http:
-        paths:
-          - path: {{ .Values.ingress.path }}
-            backend:
-              serviceName: {{ include "mean.fullname" . }}
-              servicePort: {{ .Values.service.port }}
-  {{- if .Values.ingress.tls }}
+  - host: {{ .name }}
+    http:
+      paths:
+        - path: {{ default "/" .path }}
+          backend:
+            serviceName: {{ template "mean.fullname" $ }}
+            servicePort: 80
+{{- if .tls }}
   tls:
-{{ toYaml .Values.ingress.tls | indent 4 }}
-  {{- end -}}
-{{- end -}}
+  - hosts:
+    - {{ .name }}
+    secretName: {{ .tlsSecret }}
+{{- end }}
+---
+{{- end }}
+{{- end }}

--- a/bitnami/mean/values.yaml
+++ b/bitnami/mean/values.yaml
@@ -127,19 +127,46 @@ externaldb:
   broker:
     serviceInstanceName:
 
-## Configure ingress resource that allow you to access the application.
+## Configure the ingress resource that allows you to access your
+## MEAN appliation. Set up the URL
 ## ref: http://kubernetes.io/docs/user-guide/ingress/
 ##
 ingress:
+  ## Set to true to enable ingress record generation
   enabled: false
-  path: /
-  # Used to create an Ingress record.
-  host: example.local
-  # annotations:
-  #   kubernetes.io/ingress.class: nginx
-  #   kubernetes.io/tls-acme: "true"
-  # tls:
-  #   Secrets must be manually created in the namespace.
-  #   - secretName: your-tls-cert
-  #     hosts:
-  #       - example.local
+
+  ## The list of hostnames to be covered with this ingress record.
+  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
+  hosts:
+  - name: mean.local
+
+    ## Set this to true in order to enable TLS on the ingress record
+    tls: false
+
+    ## Set this to true in order to add the corresponding annontations for cert-manager
+    certManager: false
+
+    ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
+    tlsSecret: mean.local-tls
+
+    ## Ingress annotations done as key:value pairs
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+    ##
+    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+    annotations:
+    #  kubernetes.io/ingress.class: nginx
+
+  secrets:
+  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+  ## -----BEGIN RSA PRIVATE KEY-----
+  ##
+  ## name should line up with a tlsSecret set further up
+  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+  ##
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  # - name: mean.local-tls
+  #   key:
+  #   certificate:

--- a/bitnami/mean/values.yaml
+++ b/bitnami/mean/values.yaml
@@ -143,7 +143,7 @@ ingress:
     ## Set this to true in order to enable TLS on the ingress record
     tls: false
 
-    ## Set this to true in order to add the corresponding annontations for cert-manager
+    ## Set this to true in order to add the corresponding annotations for cert-manager
     certManager: false
 
     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS

--- a/bitnami/node/Chart.yaml
+++ b/bitnami/node/Chart.yaml
@@ -1,5 +1,5 @@
 name: node
-version: 6.0.2
+version: 6.1.0
 appVersion: 10.7.0
 description: Event-driven I/O server-side JavaScript environment based on V8
 keywords:

--- a/bitnami/node/README.md
+++ b/bitnami/node/README.md
@@ -78,10 +78,16 @@ The following table lists the configurable parameters of the Node chart and thei
 | `externaldb.secretName`                 | Secret containing existing database credentials           | `nil`                                                     |
 | `externaldb.type`                       | Type of database that defines the database secret mapping | `osba`                                                    |
 | `externaldb.broker.serviceInstanceName` | The existing ServiceInstance to be used                   | `nil`                                                     |
-| `ingress.enabled`                       | Enable ingress creation                                   | `false`                                                   |
-| `ingress.path`                          | Ingress path                                              | `/`                                                       |
-| `ingress.host`                          | Ingress host                                              | `example.local`                                           |
-| `ingress.tls`                           | TLS configuration for the ingress                         | `{}`                                                      |
+| `ingress.enabled`                       | Enable ingress controller resource                        | `false`                                                   |
+| `ingress.hosts[0].name`                 | Hostname to your Node installation                        | `node.local`                                              |
+| `ingress.hosts[0].path`                 | Path within the url structure                             | `/`                                                       |
+| `ingress.hosts[0].tls`                  | Utilize TLS backend in ingress                            | `false`                                                   |
+| `ingress.hosts[0].certManager`          | Add annotations for cert-manager                          | `false`                                                   |
+| `ingress.hosts[0].tlsSecret`            | TLS Secret (certificates)                                 | `node.local-tls-secret`                                   |
+| `ingress.hosts[0].annotations`          | Annotations for this host's ingress record                | `[]`                                                      |
+| `ingress.secrets[0].name`               | TLS Secret Name                                           | `nil`                                                     |
+| `ingress.secrets[0].certificate`        | TLS Secret Certificate                                    | `nil`                                                     |
+| `ingress.secrets[0].key`                | TLS Secret Key                                            | `nil`                                                     |
 
 The above parameters map to the env variables defined in [bitnami/node](http://github.com/bitnami/bitnami-docker-node). For more information please refer to the [bitnami/node](http://github.com/bitnami/bitnami-docker-node) image documentation.
 

--- a/bitnami/node/templates/ingress.yaml
+++ b/bitnami/node/templates/ingress.yaml
@@ -1,28 +1,37 @@
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
+  name: {{ template "node.fullname" $ }}
   labels:
-    app: {{ template "node.name" . }}
-    chart: {{ template "node.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-  name: {{ template "node.fullname" . }}
+    app: {{ template "node.name" $ }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
   annotations:
-    {{- range $key, $value := .Values.ingress.annotations }}
-      {{ $key }}: {{ $value | quote }}
+    {{- if .certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- range $key, $value := .annotations }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
   rules:
-    - host: {{ .Values.ingress.host }}
-      http:
-        paths:
-          - path: {{ .Values.ingress.path }}
-            backend:
-              serviceName: {{ include "node.fullname" . }}
-              servicePort: {{ .Values.service.port }}
-  {{- if .Values.ingress.tls }}
+  - host: {{ .name }}
+    http:
+      paths:
+        - path: {{ default "/" .path }}
+          backend:
+            serviceName: {{ template "node.fullname" $ }}
+            servicePort: 80
+{{- if .tls }}
   tls:
-{{ toYaml .Values.ingress.tls | indent 4 }}
-  {{- end -}}
-{{- end -}}
+  - hosts:
+    - {{ .name }}
+    secretName: {{ .tlsSecret }}
+{{- end }}
+---
+{{- end }}
+{{- end }}
+

--- a/bitnami/node/values.yaml
+++ b/bitnami/node/values.yaml
@@ -110,19 +110,42 @@ externaldb:
   broker:
     serviceInstanceName:
 
-## Configure ingress resource that allow you to access the application. 
-## ref: http://kubernetes.io/docs/user-guide/ingress/
-##
 ingress:
+  ## Set to true to enable ingress record generation
   enabled: false
-  path: /
-  # Used to create an Ingress record.
-  host: example.local
-  # annotations:
-  #   kubernetes.io/ingress.class: nginx
-  #   kubernetes.io/tls-acme: "true"
-  # tls:
-  #   Secrets must be manually created in the namespace.
-  #   - secretName: your-tls-cert
-  #     hosts:
-  #       - example.local
+
+  ## The list of hostnames to be covered with this ingress record.
+  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
+  hosts:
+  - name: node.local
+
+    ## Set this to true in order to enable TLS on the ingress record
+    tls: false
+
+    ## Set this to true in order to add the corresponding annontations for cert-manager
+    certManager: false
+
+    ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
+    tlsSecret: node.local-tls
+
+    ## Ingress annotations done as key:value pairs
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+    ##
+    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+    annotations:
+    #  kubernetes.io/ingress.class: nginx
+
+  secrets:
+  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+  ## -----BEGIN RSA PRIVATE KEY-----
+  ##
+  ## name should line up with a tlsSecret set further up
+  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+  ##
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  # - name: node.local-tls
+  #   key:
+  #   certificate:

--- a/bitnami/node/values.yaml
+++ b/bitnami/node/values.yaml
@@ -122,7 +122,7 @@ ingress:
     ## Set this to true in order to enable TLS on the ingress record
     tls: false
 
-    ## Set this to true in order to add the corresponding annontations for cert-manager
+    ## Set this to true in order to add the corresponding annotations for cert-manager
     certManager: false
 
     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR allows the user to configure the proper annotations when using cert-manager to handle TLS certificates in an easy way. The user just needs to setup a boolean to true to do so.