### PR TITLE
Add global registry option

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,5 +1,5 @@
 name: kafka
-version: 1.0.2
+version: 1.1.0
 appVersion: 2.0.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -47,6 +47,7 @@ The following tables lists the configurable parameters of the Kafka chart and th
 
 |          Parameter               |                                                  Description                                               |                                     Default                        |
 |----------------------------------|------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------- |
+| `global.registry`                | Global chart image registry                                                                                | `nil`                                                              |
 | `image.registry`                 | Kafka image registry                                                                                       | `docker.io`                                                        |
 | `image.repository`               | Kafka Image name                                                                                           | `bitnami/kafka`                                                    |
 | `image.tag`                      | Kafka Image tag                                                                                            | `{VERSION}`                                                        |
@@ -57,8 +58,8 @@ The following tables lists the configurable parameters of the Kafka chart and th
 | `replicaCount`                   | Number of Kafka nodes                                                                                      | `1`                                                                |
 | `config`                         | Configuration file for Kafka                                                                               | `nil`                                                              |
 | `allowPlaintextListener`         | Allow to use the PLAINTEXT listener                                                                        | `true`                                                             |
-| `listeners`                       | The address the socket server listens on.                                                                  | `nil`                                                              |
-| `advertisedListeners`             | Hostname and port the broker will advertise to producers and consumers.                                    | `nil`                                                              |
+| `listeners`                      | The address the socket server listens on.                                                                  | `nil`                                                              |
+| `advertisedListeners`            | Hostname and port the broker will advertise to producers and consumers.                                    | `nil`                                                              |
 | `brokerId`                       | ID of the Kafka node                                                                                       | `-1`                                                               |
 | `deleteTopicEnable`              | Switch to enable topic deletion or not.                                                                    | `false`                                                            |
 | `heapOpts`                       | Kafka's Java Heap size.                                                                                    | `-Xmx1024m -Xms1024m`                                              |
@@ -69,7 +70,7 @@ The following tables lists the configurable parameters of the Kafka chart and th
 | `logRetentionHours`              | The minimum age of a log file to be eligible for deletion due to age.                                      | `168`                                                              |
 | `logSegmentBytes`                | The maximum size of a log segment file. When this size is reached a new log segment will be created.       | `_1073741824`                                                      |
 | `logsDirs`                       | A comma separated list of directories under which to store log files.                                      | `/opt/bitnami/kafka/data`                                          |
-| `maxMessageBytes`                       | The largest record batch size allowed by Kafka.                                      | `1000012`                                          |
+| `maxMessageBytes`                | The largest record batch size allowed by Kafka.                                                            | `1000012`                                                          |
 | `numIoThreads`                   | The number of threads doing disk I/O.                                                                      | `8`                                                                |
 | `numNetworkThreads`              | The number of threads handling network requests.                                                           | `3`                                                                |
 | `numPartitions`                  | The default number of log partitions per topic.                                                            | `1`                                                                |

--- a/bitnami/kafka/templates/_helpers.tpl
+++ b/bitnami/kafka/templates/_helpers.tpl
@@ -26,9 +26,14 @@ Create chart name and version as used by the chart label.
 Return the proper Kafka image name
 */}}
 {{- define "kafka.image" -}}
-{{- $registryName := .Values.image.registry -}}
+{{- if .Values.global.registry -}}
+    {{- $registryName := .Values.global.registry -}}
+{{- else -}}
+    {{- $registryName := .Values.image.registry -}}
+{{- end -}}
+{{- $repositoryName := .Values.image.repository -}}
 {{- $tag := .Values.image.tag | toString -}}
-{{- printf "%s/%s:%s" $registryName .Values.image.repository $tag -}}
+{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/kafka/values-production.yaml
+++ b/bitnami/kafka/values-production.yaml
@@ -1,4 +1,5 @@
 ## Global chart image registry
+## Please, note that this registry would be used for all the containers in the chart and dependencies
 ##
 # global:
 #   registry:

--- a/bitnami/kafka/values-production.yaml
+++ b/bitnami/kafka/values-production.yaml
@@ -1,3 +1,8 @@
+## Global chart image registry
+##
+# global:
+#   registry:
+
 ## Bitnami Kafka image version
 ## ref: https://hub.docker.com/r/bitnami/kafka/tags/
 ##
@@ -319,6 +324,10 @@ metrics:
     - kafka.network:*
     - kafka.log:*
 
+##
+## Zookeeper chart configuration
+##
+## https://github.com/bitnami/charts/blob/master/bitnami/zookeeper/values.yaml
 zookeeper:
   enabled: true
 

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -1,4 +1,5 @@
 ## Global chart image registry
+## Please, note that this registry would be used for all the containers in the chart and dependencies
 ##
 # global:
 #   registry:

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -1,3 +1,8 @@
+## Global chart image registry
+##
+# global:
+#   registry:
+
 ## Bitnami Kafka image version
 ## ref: https://hub.docker.com/r/bitnami/kafka/tags/
 ##
@@ -319,6 +324,10 @@ metrics:
     - kafka.network:*
     - kafka.log:*
 
+##
+## Zookeeper chart configuration
+##
+## https://github.com/bitnami/charts/blob/master/bitnami/zookeeper/values.yaml
 zookeeper:
   enabled: true
 

--- a/bitnami/zookeeper/templates/_helpers.tpl
+++ b/bitnami/zookeeper/templates/_helpers.tpl
@@ -26,6 +26,12 @@ Create chart name and version as used by the chart label.
 Return the proper Zookeeper image name
 */}}
 {{- define "zookeeper.image" -}}
+{{- if .Values.global.registry -}}
+    {{- $registryName := .Values.global.registry -}}
+{{- else -}}
+    {{- $registryName := .Values.image.registry -}}
+{{- end -}}
+{{- $repositoryName := .Values.image.repository -}}
 {{- $tag := .Values.image.tag | toString -}}
-{{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository $tag -}}
+{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}


### PR DESCRIPTION
- Add `global.registry` at the top of `values.yaml` (commented out at the beginning).
- Add the required logic to use the global value if it is defined.
- Add a link to the `values.yaml` of Zookeeper in the Kafka `values.yaml` chart (in the section of the Zookeeper options).