### PR TITLE
Enable metrics in Consul values-production.yaml

### DIFF
--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -2,7 +2,7 @@ name: consul
 home: https://www.consul.io/
 sources:
 - https://github.com/bitnami/consul
-version: 2.1.1
+version: 2.2.0
 appVersion: 1.3.0
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/bitnami/consul/README.md
+++ b/bitnami/consul/README.md
@@ -96,7 +96,7 @@ The following tables lists the configurable parameters of the Consul chart and t
 | `metrics.imageTag`                   | Exporter image tag                                     | `v0.3.0`                                                   |
 | `metrics.imagePullPolicy`            | Exporter image pull policy                             | `IfNotPresent`                                             |
 | `metrics.resources`                  | Exporter resource requests/limit                       | `{}`                                                       |
-| `metricspodAnnotations`                | Exporter annotations                                   | `{}`                                                       |
+| `metrics.podAnnotations`                | Exporter annotations                                   | `{}`                                                       |
 | `nodeSelector`                       | Node labels for pod assignment                         | `{}`                                                       |
 | `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated               | 30                                                         |
 | `livenessProbe.periodSeconds`        | How often to perform the probe                         | 10                                                         |
@@ -104,7 +104,7 @@ The following tables lists the configurable parameters of the Consul chart and t
 | `livenessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed.     | 1                |
 | `livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.       | 6                |
 | `podAnnotations`                | Pod annotations                                   | `{}`                                                       |
-sProbe.initialDelaySeconds` | Delay before readiness probe is initiated                                                        | 5                |
+| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                                                        | 5                |
 | `readinessProbe.periodSeconds`       | How often to perform the probe                                                                   | 10               |
 | `readinessProbe.timeoutSeconds`      | When the probe times out                                                                         | 5                |
 | `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed.     | 1                |

--- a/bitnami/consul/README.md
+++ b/bitnami/consul/README.md
@@ -96,14 +96,15 @@ The following tables lists the configurable parameters of the Consul chart and t
 | `metrics.imageTag`                   | Exporter image tag                                     | `v0.3.0`                                                   |
 | `metrics.imagePullPolicy`            | Exporter image pull policy                             | `IfNotPresent`                                             |
 | `metrics.resources`                  | Exporter resource requests/limit                       | `{}`                                                       |
-| `metrics.annotations`                | Exporter annotations                                   | `{}`                                                       |
+| `metricspodAnnotations`                | Exporter annotations                                   | `{}`                                                       |
 | `nodeSelector`                       | Node labels for pod assignment                         | `{}`                                                       |
 | `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated               | 30                                                         |
 | `livenessProbe.periodSeconds`        | How often to perform the probe                         | 10                                                         |
 | `livenessProbe.timeoutSeconds`       | When the probe times out                               | 5                                                          |
 | `livenessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed.     | 1                |
 | `livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.       | 6                |
-| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                                                        | 5                |
+| `podAnnotations`                | Pod annotations                                   | `{}`                                                       |
+sProbe.initialDelaySeconds` | Delay before readiness probe is initiated                                                        | 5                |
 | `readinessProbe.periodSeconds`       | How often to perform the probe                                                                   | 10               |
 | `readinessProbe.timeoutSeconds`      | When the probe times out                                                                         | 5                |
 | `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed.     | 1                |

--- a/bitnami/consul/templates/statefulset.yaml
+++ b/bitnami/consul/templates/statefulset.yaml
@@ -24,6 +24,15 @@ spec:
         chart: {{ template "consul.chart" . }}
         release: {{ .Release.Name | quote }}
         heritage: {{ .Release.Service | quote }}
+{{- if or .Values.podAnnotations .Values.metrics.enabled }}
+      annotations:
+  {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+  {{- end }}
+  {{- if .Values.metrics.podAnnotations }}
+{{ toYaml .Values.metrics.podAnnotations | indent 8 }}
+  {{- end }}
+{{- end }}
     spec:
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:

--- a/bitnami/consul/values-production.yaml
+++ b/bitnami/consul/values-production.yaml
@@ -170,14 +170,13 @@ ui:
 #    },
 #    "serf_lan":"0.0.0.0"
 #    }
-
 ## Pod annotations
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 ##
 podAnnotations: {}
 
 metrics:
-  enabled: false
+  enabled: true
   image:
     registry: docker.io
     repository: prom/consul-exporter


### PR DESCRIPTION
Signed-off-by: Javier J. Salmeron Garcia <jsalmeron@bitnami.com>

This PR enables the use of metrics in the Consul chart. The annotations were missing, as well as a values-production.yaml that enables the metrics by default. 