### PR TITLE
[bitnami/kubeapps] Simplify ingress configuration for cert-manager

### DIFF
--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubeapps
-version: 0.7.0
+version: 0.8.0
 appVersion: v1.0.0-beta.2
 description: Kubeapps is a dashboard for your Kubernetes cluster that makes it easy to deploy and manage applications in your cluster using Helm
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/master/docs/img/logo.png

--- a/bitnami/kubeapps/README.md
+++ b/bitnami/kubeapps/README.md
@@ -171,7 +171,7 @@ To enable ingress integration, please set `ingress.enabled` to `true`
 
 ##### Hosts
 
-Most likely you will only want to have one hostname that maps to this Kubeapps installation, however, it is possible to have more than one host.  To facilitate this, the `ingress.hosts` object is an array.
+Most likely you will only want to have one hostname that maps to this Kubeapps installation, however, it is possible to have more than one host. To facilitate this, the `ingress.hosts` object is an array.
 
 ##### Annotations
 
@@ -179,7 +179,9 @@ For annotations, please see [this document](https://github.com/kubernetes/ingres
 
 ##### TLS
 
-TLS can be configured using the `ingress.tls` object in the same format that the Kubernetes Ingress requests. Please see [this example](https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/tls) for more information.
+TLS can be configured using setting the `ingress.hosts[].tls` boolean of the corresponding hostname to true, then you can choose the TLS secret name setting `ingress.hosts[].tlsSecret`. Please see [this example](https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/tls) for more information.
+
+If your cluster has a [cert-manager](https://github.com/jetstack/cert-manager) add-on to automate the management and issuance of TLS certificates, set `ingress.hosts[].certManager` boolean to true to enable the corresponding annotations for cert-manager. Otherwise, you can provide your own certificates using the `ingress.secrets` object.
 
 ## Troubleshooting
 

--- a/bitnami/kubeapps/templates/ingress.yaml
+++ b/bitnami/kubeapps/templates/ingress.yaml
@@ -1,38 +1,36 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "kubeapps.fullname" . -}}
-{{- $ingressPath := .Values.ingress.path -}}
+{{- range .Values.ingress.hosts }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ template "kubeapps.fullname" $ }}
   labels:
-    app: {{ include "kubeapps.name" . }}
-    chart: {{ include "kubeapps.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-{{- with .Values.ingress.annotations }}
+    app: {{ template "kubeapps.name" $ }}
+    chart: {{ template "kubeapps.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
   annotations:
-{{ toYaml . | indent 4 }}
-{{- end }}
+    {{- if .certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- range $key, $value := .annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
-  {{- end }}
-{{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
-    - host: {{ . | quote }}
-      http:
-        paths:
-          - path: {{ $ingressPath }}
-            backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
-  {{- end }}
+  - host: {{ .name }}
+    http:
+      paths:
+      - path: {{ default "/" .path }}
+        backend:
+          serviceName: {{ template "kubeapps.fullname" $ }}
+          servicePort: http
+{{- if .tls }}
+  tls:
+  - hosts:
+    - {{ .name }}
+    secretName: {{ .tlsSecret }}
+{{- end }}
+---
+{{- end }}
 {{- end }}

--- a/bitnami/kubeapps/values.yaml
+++ b/bitnami/kubeapps/values.yaml
@@ -6,16 +6,46 @@
 # The frontend service is the main reverse proxy used to access the Kubeapps UI
 # To expose Kubeapps externally either configure the ingress object below or
 # set frontend.service.type=LoadBalancer in the frontend configuration.
+# ref: http://kubernetes.io/docs/user-guide/ingress/
+#
 ingress:
+  # Set to true to enable ingress record generation
   enabled: false
-  annotations: {}
-  path: /
+
+  # The list of hostnames to be covered with this ingress record.
+  # Most likely this will be just one host, but in the event more hosts are needed, this is an array
   hosts:
-  - kubeapps.local
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
+  - name: kubeapps.local
+    path: /
+    # Set this to true in order to enable TLS on the ingress record
+    tls: false
+    # Set this to true in order to add the corresponding annotations for cert-manager
+    certManager: false
+
+    ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
+    tlsSecret: kubeapps.local-tls
+
+    # Ingress annotations done as key:value pairs
+    # For a full list of possible ingress annotations, please see
+    # ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+    #
+    # If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+    annotations:
+    #  kubernetes.io/ingress.class: nginx
+
+  secrets:
+  # If you're providing your own certificates, please use this to add the certificates as secrets
+  # key and certificate should start with -----BEGIN CERTIFICATE----- or
+  # -----BEGIN RSA PRIVATE KEY-----
+  #
+  # name should line up with a tlsSecret set further up
+  # If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+  #
+  # It is also possible to create and manage the certificates outside of this helm chart
+  # Please see README.md for more information
+  # - name: kubeapps.local-tls
+  #   key:
+  #   certificate:
 
 frontend:
   replicaCount: 2


### PR DESCRIPTION
### What this PR does / why we need it:

This PR allows the user to configure the proper annotations when using cert-manager to handle TLS certificates in an easy way. The user just needs to setup a boolean to true to do so.

E.g.:

```
helm install --name kubeapps --namespace kubeapps bitnami/kubeapps \
  --set ingress.enabled=true \
  --set ingress.hosts[0].name=kubeapps.custom.domain \
  --set ingress.hosts[0].tls=true \
  --set ingress.hosts[0].tlsSecret=kubeapps-tls \
  --set ingress.hosts[0].certManager=true
```

This will generate the following ingress:

```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: kubeapps
  namespace: kubeapps
  labels:
    app: kubeapps
    chart: kubeapps-0.8.0
    release: kubeapps
    heritage: Tiller
  annotations:
    kubernetes.io/tls-acme: "true"
spec:
  rules:
  - host: kubeapps.custom.domain
    http:
      paths:
      - path: /
        backend:
          serviceName: kubeapps
          servicePort: http
  tls:
  - hosts:
    - kubeapps.juan.bkpr.run
    secretName: kubeapps-tls
```