### PR TITLE
[bitnami/node] Move chart to node 8.x and update dependencies

### DIFF
--- a/bitnami/node/Chart.yaml
+++ b/bitnami/node/Chart.yaml
@@ -1,6 +1,6 @@
 name: node
-version: 6.2.0
-appVersion: 10.7.0
+version: 6.2.1
+appVersion: 8.12.0
 description: Event-driven I/O server-side JavaScript environment based on V8
 keywords:
 - node

--- a/bitnami/node/requirements.lock
+++ b/bitnami/node/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mongodb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 4.5.0
+  version: 4.6.2
 - name: bitnami-common
   repository: https://charts.bitnami.com/bitnami
   version: 0.0.3
 digest: sha256:e08b8d1bb8197aa8fdc27536aaa1de2e7de210515a451ebe94949a3db55264dd
-generated: 2018-10-16T08:36:36.201735+02:00
+generated: 2018-10-25T10:09:00.707768+02:00

--- a/bitnami/node/values.yaml
+++ b/bitnami/node/values.yaml
@@ -10,7 +10,7 @@
 image:
   registry: docker.io
   repository: bitnami/node
-  tag: 10.7.0-prod
+  tag: 8.12.0-prod
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: tompizmor <tompizmor@gmail.com>

The Node Chart should be using the latest stable version of Node.js (which right now is the 8 branch).
I also updated the dependencies.