### PR TITLE
[bitnami/mean] move node version to 8.x and update the dependencies

### DIFF
--- a/bitnami/mean/Chart.yaml
+++ b/bitnami/mean/Chart.yaml
@@ -1,6 +1,6 @@
 name: mean
-version: 4.2.0
-appVersion: 3.6.4
+version: 4.2.1
+appVersion: 4.6.2
 description: MEAN is a free and open-source JavaScript software stack for building dynamic web sites and web applications. The MEAN stack is MongoDB, Express.js, Angular, and Node.js. Because all components of the MEAN stack support programs written in JavaScript, MEAN applications can be written in one language for both server-side and client-side execution environments.
 keywords:
 - node

--- a/bitnami/mean/requirements.lock
+++ b/bitnami/mean/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mongodb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 4.5.0
+  version: 4.6.2
 - name: bitnami-common
   repository: https://charts.bitnami.com/bitnami
   version: 0.0.3
 digest: sha256:e08b8d1bb8197aa8fdc27536aaa1de2e7de210515a451ebe94949a3db55264dd
-generated: 2018-10-16T08:37:10.583517+02:00
+generated: 2018-10-25T11:06:24.877576+02:00

--- a/bitnami/mean/values.yaml
+++ b/bitnami/mean/values.yaml
@@ -10,7 +10,7 @@
 image:
   registry: docker.io
   repository: bitnami/node
-  tag: 9.11.1-prod
+  tag: 8.12.0-prod
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Start using stable node version in Mean chart. Also updated the dependency