### PR TITLE
[nginx-ingress-controller] Fix registry issue in default backend

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress-controller
-version: 2.1.3
+version: 2.1.4
 appVersion: 0.20.0
 description: Chart for the nginx Ingress controller
 keywords:

--- a/bitnami/nginx-ingress-controller/values.yaml
+++ b/bitnami/nginx-ingress-controller/values.yaml
@@ -297,6 +297,7 @@ defaultBackend:
 
   name: default-backend
   image:
+    registry: docker.io
     repository: bitnami/nginx
     tag: latest
     pullPolicy: Always


### PR DESCRIPTION
Fix chart. Issue found because of the following verification fails
```
repo = data['repository']
        if repo.is_a?(String) && repo.start_with?(BITNAMI_PREFIX)
          reg = data['registry']
          raise "Expected registry to be docker.io for #{repo}, but got '#{reg}'" if reg != 'docker.io'
          tag = data['tag']
          raise 'Missing version tag' unless tag
          list << "#{repo}:#{tag}"
        end
```