### PR TITLE
[bitnami/elasticsearch] Warn users when 'sysctlImage.enabled' is set to false

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: elasticsearch
-version: 4.1.3
+version: 4.1.2
 appVersion: 6.4.2
 description: A highly scalable open-source full-text search and analytics engine
 keywords:

--- a/bitnami/elasticsearch/README.md
+++ b/bitnami/elasticsearch/README.md
@@ -179,9 +179,12 @@ By default, the chart mounts a [Persistent Volume](http://kubernetes.io/docs/use
 
 ## Troubleshooting
 
-Currently, Elasticsearch 5 requires some changes in the kernel of the host machine to work as expected. If those values are not set in the underlying operating system, the ES containers fail to boot with ERROR messages.
+Currently, Elasticsearch requires some changes in the kernel of the host machine to work as expected. If those values are not set in the underlying operating system, the ES containers fail to boot with ERROR messages. More information about these requirements can be found in the links below:
 
-You can use the initContainer created to set those parameters
+- [File Descriptor requirements](https://www.elastic.co/guide/en/elasticsearch/reference/current/file-descriptors.html)
+- [Virtual memory requirements](https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html)
+
+You can use a **privileged** initContainer to changes those settings in the Kernel by enabling the `sysctlImage.enabled`:
 
 ```console
 $ helm install --name my-release \

--- a/bitnami/elasticsearch/templates/NOTES.txt
+++ b/bitnami/elasticsearch/templates/NOTES.txt
@@ -27,8 +27,13 @@
         pods -l app={{ template "elasticsearch.name" . }},role=master -o jsonpath='{.items[0].metadata.name}') \
 	elasticsearch
 
-    By specifying "sysctlImage.enabled=true" you can use a privileged
-    initContainer to changes those settings in the Kernel:
+    You can adapt the Kernel paramters on you cluster as described in the
+    official documentation:
+
+      https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster
+
+    As an alternative, you can specify "sysctlImage.enabled=true" to use a
+    privileged initContainer to change those settings in the Kernel:
 
       helm upgrade {{ .Release.Name }} bitnami/elasticsearch \
         --set sysctlImage.enabled=true

--- a/bitnami/elasticsearch/templates/NOTES.txt
+++ b/bitnami/elasticsearch/templates/NOTES.txt
@@ -27,7 +27,7 @@
         pods -l app={{ template "elasticsearch.name" . }},role=master -o jsonpath='{.items[0].metadata.name}') \
 	elasticsearch
 
-    You can adapt the Kernel paramters on you cluster as described in the
+    You can adapt the Kernel parameters on you cluster as described in the
     official documentation:
 
       https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster

--- a/bitnami/elasticsearch/templates/NOTES.txt
+++ b/bitnami/elasticsearch/templates/NOTES.txt
@@ -11,6 +11,29 @@
     suggest that you switch to "ClusterIP" or "NodePort".
 -------------------------------------------------------------------------------
 {{- end }}
+{{- if not .Values.sysctlImage.enabled }}
+
+-------------------------------------------------------------------------------
+ WARNING
+
+    Elasticsearch requires some changes in the kernel of the host machine to
+    work as expected. If those values are not set in the underlying operating
+    system, the ES containers fail to boot with ERROR messages.
+
+    To check whether the host machine meets the requirements, run the command
+    below:
+
+      kubectl logs --namespace {{ .Release.Namespace }} $(kubectl get --namespace {{ .Release.Namespace }} \
+        pods -l app={{ template "elasticsearch.name" . }},role=master -o jsonpath='{.items[0].metadata.name}') \
+	elasticsearch
+
+    By specifying "sysctlImage.enabled=true" you can use a privileged
+    initContainer to changes those settings in the Kernel:
+
+      helm upgrade {{ .Release.Name }} bitnami/elasticsearch \
+        --set sysctlImage.enabled=true
+
+{{- end }}
 
 ** Please be patient while the chart is being deployed **
 

--- a/bitnami/elasticsearch/templates/coordinating-deploy.yaml
+++ b/bitnami/elasticsearch/templates/coordinating-deploy.yaml
@@ -66,7 +66,7 @@ spec:
           privileged: true
       {{- end }}
       containers:
-      - name: {{ template "elasticsearch.coordinating.fullname" . }}
+      - name: "elasticsearch"
         {{- if .Values.securityContext.enabled }}
         securityContext:
           runAsUser: {{ .Values.securityContext.runAsUser }}

--- a/bitnami/elasticsearch/templates/data-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/data-statefulset.yaml
@@ -62,7 +62,7 @@ spec:
           privileged: true
       {{- end }}
       containers:
-      - name: {{ template "elasticsearch.data.fullname" . }}
+      - name: "elasticsearch"
         image: {{ template "elasticsearch.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         {{- if .Values.securityContext.enabled }}

--- a/bitnami/elasticsearch/templates/ingest-deploy.yaml
+++ b/bitnami/elasticsearch/templates/ingest-deploy.yaml
@@ -67,7 +67,7 @@ spec:
           privileged: true
       {{- end }}
       containers:
-      - name: {{ template "elasticsearch.ingest.fullname" . }}
+      - name: "elasticsearch"
         image: {{ template "elasticsearch.image" . }}
         {{- if .Values.securityContext.enabled }}
         securityContext:

--- a/bitnami/elasticsearch/templates/master-deploy.yaml
+++ b/bitnami/elasticsearch/templates/master-deploy.yaml
@@ -67,7 +67,7 @@ spec:
           privileged: true
       {{- end }}
       containers:
-      - name: {{ template "elasticsearch.master.fullname" . }}
+      - name: "elasticsearch"
         image: {{ template "elasticsearch.image" . }}
         {{- if .Values.securityContext.enabled }}
         securityContext:


### PR DESCRIPTION
### What this PR does / why we need it:

By default, no 'privileged' initContainer is used to adapt the Kernel settings to Elasticsearch requirements.

This PR adds a Warning in the NOTES.txt for users so they can identify easily whether their cluster meets the kernel requirements or not.