### PR TITLE
[bitnami/node] Allow using extra env. variables

### DIFF
--- a/bitnami/node/Chart.yaml
+++ b/bitnami/node/Chart.yaml
@@ -1,5 +1,5 @@
 name: node
-version: 6.2.3
+version: 6.3.0
 appVersion: 8.12.0
 description: Event-driven I/O server-side JavaScript environment based on V8
 keywords:

--- a/bitnami/node/README.md
+++ b/bitnami/node/README.md
@@ -58,13 +58,14 @@ The following table lists the configurable parameters of the Node chart and thei
 | `image.pullPolicy`                      | NodeJS image pull policy                                  | `IfNotPresent`                                            |
 | `image.pullSecrets`                     | Specify image pull secrets                                | `nil` (does not add image pull secrets to deployed pods)  |
 | `git.registry`                          | Git image registry                                        | `docker.io`                                               |
-| `git.repository`                        | Git image name                                            | `bitnami/git`                                              |
+| `git.repository`                        | Git image name                                            | `bitnami/git`                                             |
 | `git.tag`                               | Git image tag                                             | `latest`                                                  |
 | `git.pullPolicy`                        | Git image pull policy                                     | `Always` if `imageTag` is `latest`, else `IfNotPresent`   |
 | `repository`                            | Repo of the application                                   | `https://github.com/bitnami/sample-mean.git`              |
 | `revision`                              | Revision to checkout                                      | `master`                                                  |
 | `replicas`                              | Number of replicas for the application                    | `1`                                                       |
 | `applicationPort`                       | Port where the application will be running                | `3000`                                                    |
+| `extraEnv`                              | Any extra environment variables to be pass to the pods    | `{}`                                                      |
 | `service.type`                          | Kubernetes Service type                                   | `ClusterIP`                                               |
 | `service.port`                          | Kubernetes Service port                                   | `80`                                                      |
 | `service.annotations`                   | Annotations for the Service                               | {}                                                        |

--- a/bitnami/node/templates/deployment.yaml
+++ b/bitnami/node/templates/deployment.yaml
@@ -106,6 +106,9 @@ spec:
         {{- end }}
         - name: DATA_FOLDER
           value: "/app"
+{{- if .Values.extraEnv }}
+{{ toYaml .Values.extraEnv | indent 8 }}
+{{- end }}
         workingDir: /app
         command: ['/bin/bash', '-c', 'useradd bitnami && su bitnami -c "PATH=/opt/bitnami/node/bin:$PATH npm start"']
         ports:

--- a/bitnami/node/values.yaml
+++ b/bitnami/node/values.yaml
@@ -45,6 +45,9 @@ replicas: 1
 ##
 applicationPort: 3000
 
+# Define custom environment variables to pass to the image here
+extraEnv: {}
+
 ## Kubernetes Service Configuration
 service:
   ## For minikube, set this to NodePort, elsewhere use LoadBalancer


### PR DESCRIPTION
### What this PR does / why we need it:

This PR adds the possibility of defining extra env. variables to be passed to the Node.js containers.