### PR TITLE
[bitnami/zookeeper] Make trunc consistent between charts

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,5 +1,5 @@
 name: kafka
-version: 1.1.2
+version: 1.1.3
 appVersion: 2.0.1
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/templates/_helpers.tpl
+++ b/bitnami/kafka/templates/_helpers.tpl
@@ -69,5 +69,5 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "kafka.zookeeper.fullname" -}}
 {{- $name := default "zookeeper" .Values.zookeeper.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
 {{- end -}}


### PR DESCRIPTION
zookeeper is using trunc 24 (for compatibility reasons). This PR makes the same trunc for kafka.zookeeper (otherwise it may fail with long names)