### PR TITLE
Add Issue/PR templates and stale bot

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,57 @@
+<!--
+If you are reporting a new issue, make sure that we do not have any duplicates
+already open. You can ensure this by searching the issue list for this
+repository. If there is a duplicate, please close your issue and add a comment
+to the existing issue instead.
+
+If you suspect your issue is a bug, please edit your issue description to
+include the BUG REPORT INFORMATION shown below. If you fail to provide this
+information within 7 days, we cannot debug your issue and we'll close it. We
+will, however, reopen it if you later provide the information.
+-------------------------------
+    BUG REPORT INFORMATION
+-------------------------------
+Use the commands below to provide key information from your environment:
+You do NOT have to include this information if this is a FEATURE REQUEST
+-->
+
+**Which chart**:
+
+<!-- The name (and version) of the affected chart. -->
+
+**Description**
+
+<!-- Briefly describe the problem you are having in a few paragraphs. -->
+
+**Steps to reproduce the issue:**
+
+1. [First Step]
+2. [Second Step]
+3. [and so on...]
+
+**Describe the results you received:**
+
+<!-- What actually happens -->
+
+**Describe the results you expected:**
+
+<!-- What you expect to happen -->
+
+**Additional information you deem important (e.g. issue happens only occasionally):**
+
+<!-- Any additional information, configuration or data that might be necessary to reproduce the issue. -->
+
+
+**Version of Helm and Kubernetes**:
+
+- Output of `helm version`:
+
+```
+(paste your output here)
+```
+
+- Output of `kubectl version`:
+
+```
+(paste your output here)
+```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!--
+ Before you open the request please review the following guidelines and tips to help it be more easily integrated:
+
+ - Describe the scope of your change - i.e. what the change does.
+ - Describe any known limitations with your change.
+ - Please run any tests or examples that can exercise your modified code.
+
+ Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).
+
+ Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
+ -->
+
+**Description of the change**
+
+<!-- Describe the scope of your change - i.e. what the change does. -->
+
+**Benefits**
+
+<!-- What benefits will be realized by the code change? -->
+
+**Possible drawbacks**
+
+<!-- Describe any known limitations with your change -->
+
+**Applicable issues**
+
+<!-- Enter any applicable Issues here (You can reference an issue using #) -->
+
+**Additional information**
+
+<!-- If there's anything else that's important and relevant to your pull
+request, mention that information here.-->

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,35 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 15
+
+# Number of days of inactivity before a stale Issue or Pull Request is closed.
+daysUntilClose: 5
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - on-hold
+
+# Label to use when marking as stale
+staleLabel: stale
+
+issues:
+  # Comment to post when marking as stale. Set to `false` to disable
+  markComment: >
+    This Issue has been automatically marked as "stale" because it has not had recent activity (for 15 days). It will be closed if no further activity occurs. Thanks for the feedback.
+
+  # Comment to post when closing a stale Issue or Pull Request.
+  closeComment: >
+    Due to the lack of activity in the last 5 days since it was marked as "stale", we proceed to close this Issue. Do not hesitate to reopen it later if necessary.
+
+pulls:
+  # Comment to post when marking as stale. Set to `false` to disable
+  markComment: >
+    This Pull Request has been automatically marked as "stale" because it has not had recent activity (for 15 days). It will be closed if no further activity occurs. Thank you for your contribution.
+
+  # Comment to post when closing a stale Issue or Pull Request.
+  closeComment: >
+    Due to the lack of activity in the last 5 days since it was marked as "stale", we proceed to close this Pull Request. Do not hesitate to reopen it later if necessary.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30


### PR DESCRIPTION
- Add Issues/PRs templates 
- Add stale bot 
  - 15 days without activity: Send a message and add "stale" label.
  - 5 days without activity since the previous step: Close the Issue/PRs with a new message.
  - If we want to prevent this process from being applied to a specific issue/PR, for example, because it is blocked on our side, we should add the on-hold label to the issue/PR.