### PR TITLE
[bitnami/wildfly] Adapt Chart to non-root container

### DIFF
--- a/bitnami/wildfly/Chart.yaml
+++ b/bitnami/wildfly/Chart.yaml
@@ -1,5 +1,5 @@
 name: wildfly
-version: 2.0.0
+version: 2.1.0
 appVersion: 14.0.1
 description: Chart for Wildfly
 keywords:

--- a/bitnami/wildfly/README.md
+++ b/bitnami/wildfly/README.md
@@ -45,28 +45,31 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the WildFly chart and their default values.
 
-|         Parameter          |              Description               |                           Default                          |
-|----------------------------|----------------------------------------|------------------------------------------------------------|
-| `global.imageRegistry`     | Global Docker image registry           | `nil`                                                      |
-| `image.registry`           | WildFly image registry                 | `docker.io`                                                |
-| `image.repository`         | WildFly Image name                     | `bitnami/wildfly`                                          |
-| `image.tag`                | WildFly Image tag                      | `{VERSION}`                                                |
-| `image.pullPolicy`         | WildFly image pull policy              | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
-| `image.pullSecrets`        | Specify image pull secrets             | `nil` (does not add image pull secrets to deployed pods)   |
-| `wildflyUsername`          | WildFly admin user                     | `user`                                                     |
-| `wildflyPassword`          | WildFly admin password                 | _random 10 character alphanumeric string_                  |
-| `service.type`                    | Kubernetes Service type                    | `LoadBalancer`                                          |
-| `service.port`                    | Service HTTP port                  | `80`                                          |
-| `service.mgmtPort`                    | Service Management port                   | `9990`                                          |
-| `service.nodePorts.http`                 | Kubernetes http node port                  | `""`                                                    |
-| `service.nodePorts.mgmt`                | Kubernetes management node port                 | `""`                                                    |
-| `service.externalTrafficPolicy`   | Enable client source IP preservation       | `Cluster`                                               |
-| `service.loadBalancerIP`   | LoadBalancer service IP address       | `""`                                               |
-| `persistence.enabled`      | Enable persistence using PVC           | `true`                                                     |
-| `persistence.storageClass` | PVC Storage Class for WildFly volume   | `nil` (uses alpha storage class annotation)                |
-| `persistence.accessMode`   | PVC Access Mode for WildFly volume     | `ReadWriteOnce`                                            |
-| `persistence.size`         | PVC Storage Request for WildFly volume | `8Gi`                                                      |
-| `resources`                | CPU/Memory resource requests/limits    | Memory: `512Mi`, CPU: `300m`                               |
+|         Parameter               |              Description               |                           Default                          |
+|---------------------------------|----------------------------------------|------------------------------------------------------------|
+| `global.imageRegistry`          | Global Docker image registry           | `nil`                                                      |
+| `image.registry`                | WildFly image registry                 | `docker.io`                                                |
+| `image.repository`              | WildFly Image name                     | `bitnami/wildfly`                                          |
+| `image.tag`                     | WildFly Image tag                      | `{VERSION}`                                                |
+| `image.pullPolicy`              | WildFly image pull policy              | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
+| `image.pullSecrets`             | Specify image pull secrets             | `nil` (does not add image pull secrets to deployed pods)   |
+| `wildflyUsername`               | WildFly admin user                     | `user`                                                     |
+| `wildflyPassword`               | WildFly admin password                 | _random 10 character alphanumeric string_                  |
+| `securityContext.enabled`       | Enable security context                | `true`                                                     |
+| `securityContext.fsGroup`       | Group ID for the container             | `1001`                                                     |
+| `securityContext.runAsUser`     | User ID for the container              | `1001`                                                     |
+| `service.type`                  | Kubernetes Service type                | `LoadBalancer`                                             |
+| `service.port`                  | Service HTTP port                      | `80`                                                       |
+| `service.mgmtPort`              | Service Management port                | `9990`                                                     |
+| `service.nodePorts.http`        | Kubernetes http node port              | `""`                                                       |
+| `service.nodePorts.mgmt`        | Kubernetes management node port        | `""`                                                       |
+| `service.externalTrafficPolicy` | Enable client source IP preservation   | `Cluster`                                                  |
+| `service.loadBalancerIP`        | LoadBalancer service IP address        | `""`                                                       |
+| `persistence.enabled`           | Enable persistence using PVC           | `true`                                                     |
+| `persistence.storageClass`      | PVC Storage Class for WildFly volume   | `nil` (uses alpha storage class annotation)                |
+| `persistence.accessMode`        | PVC Access Mode for WildFly volume     | `ReadWriteOnce`                                            |
+| `persistence.size`              | PVC Storage Request for WildFly volume | `8Gi`                                                      |
+| `resources`                     | CPU/Memory resource requests/limits    | Memory: `512Mi`, CPU: `300m`                               |
 
 The above parameters map to the env variables defined in [bitnami/wildfly](http://github.com/bitnami/bitnami-docker-wildfly). For more information please refer to the [bitnami/wildfly](http://github.com/bitnami/bitnami-docker-wildfly) image documentation.
 

--- a/bitnami/wildfly/README.md
+++ b/bitnami/wildfly/README.md
@@ -100,6 +100,20 @@ See the [Configuration](#configuration) section to configure the PVC or to disab
 
 ## Upgrading
 
+### To 2.1.0
+
+WildFly container was moved to a non-root approach. There shouldn't be any issue when upgrading since the corresponding `securityContext` is enabled by default. Both the container image and the chart can be upgraded by running the command below:
+
+```
+$ helm upgrade my-release stable/wildfly
+```
+
+If you use a previous container image (previous to **14.0.1-r**) disable the `securityContext` by running the command below:
+
+```
+$ helm upgrade my-release stable/wildfly --set securityContext.enabled=fase,image.tag=XXX
+```
+
 ### To 1.0.0
 
 Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.

--- a/bitnami/wildfly/templates/deployment.yaml
+++ b/bitnami/wildfly/templates/deployment.yaml
@@ -19,6 +19,11 @@ spec:
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
     spec:
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+      {{- end}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.pullSecrets }}

--- a/bitnami/wildfly/values.yaml
+++ b/bitnami/wildfly/values.yaml
@@ -28,6 +28,14 @@ image:
 ##
 imagePullPolicy: IfNotPresent
 
+## Pod Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+##
+securityContext:
+  enabled: true
+  fsGroup: 1001
+  runAsUser: 1001
+
 ## Admin user
 ## ref: https://github.com/bitnami/bitnami-docker-wildfly#creating-a-custom-user
 ##


### PR DESCRIPTION
This PRs adapts Wildfly's deployment so the proper securityContext is set since Bitnami Docker image has been moved to non-root approach.

Please **DO NOT MERGE** this PR (even if you agree with the changes) until the new image is released. I'll update this PR as soon as it's released.