### PR TITLE
[bitnami/consul] Adapt Chart to non-root container

### DIFF
--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -1,5 +1,5 @@
 name: consul
-version: 3.0.0
+version: 3.1.0
 appVersion: 1.4.0
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/bitnami/consul/README.md
+++ b/bitnami/consul/README.md
@@ -58,18 +58,21 @@ The following tables lists the configurable parameters of the HashiCorp Consul c
 | `image.pullPolicy`                   | Image pull policy                                                | `Always`                                                   |
 | `image.pullSecrets`                  | Specify image pull secrets                                       | `nil`                                                      |
 | `replicas`                           | Number of replicas                                               | `3`                                                        |
-| `port`                           | HashiCorp Consul http listening port                             | `8500`                                                     |
-| `service.rpcPort`                            | HashiCorp Consul rpc listening port                              | `8400`                                                     |
-| `service.serflanPort`                        | Container serf lan listening port                                | `8301`                                                     |
-| `service.serverPort`                         | Container server listening port                                  | `8300`                                                     |
-| `service.consulDnsPort`                      | Container dns listening port                                     | `8600`                                                     |
-| `service.uiPort`                             | HashiCorp Consul UI port                                         | `80`                                                       |
+| `port`                               | HashiCorp Consul http listening port                             | `8500`                                                     |
+| `service.rpcPort`                    | HashiCorp Consul rpc listening port                              | `8400`                                                     |
+| `service.serflanPort`                | Container serf lan listening port                                | `8301`                                                     |
+| `service.serverPort`                 | Container server listening port                                  | `8300`                                                     |
+| `service.consulDnsPort`              | Container dns listening port                                     | `8600`                                                     |
+| `service.uiPort`                     | HashiCorp Consul UI port                                         | `80`                                                       |
 | `datacenterName`                     | HashiCorp Consul datacenter name                                 | `dc1`                                                      |
 | `gossipKey`                          | Gossip key for all members                                       | `nil`                                                      |
 | `domain`                             | HashiCorp Consul domain                                          | `consul`                                                   |
 | `clientAddress`                      | Address in which HashiCorp Consul will bind client interfaces    | `0.0.0.0`                                                  |
 | `serflanAddress`                     | Address used for Serf LAN communications                         | `0.0.0.0`                                                  |
 | `raftMultiplier`                     | Multiplier used to scale key Raft timing parameters              | `10Gi`                                                     |
+| `securityContext.enabled`            | Enable security context                                          | `true`                                                     |
+| `securityContext.fsGroup`            | Group ID for the container                                       | `1001`                                                     |
+| `securityContext.runAsUser`          | User ID for the container                                        | `1001`                                                     |
 | `persistence.enabled`                | Use a PVC to persist data                                        | `true`                                                     |
 | `persistence.storageClass`           | Storage class of backing PVC                                     | `nil` (uses alpha storage class annotation)                |
 | `persistence.accessMode`             | Use volume as ReadOnly or ReadWrite                              | `ReadWriteOnce`                                            |
@@ -99,19 +102,19 @@ The following tables lists the configurable parameters of the HashiCorp Consul c
 | `metrics.imageTag`                   | Exporter image tag                                               | `v0.3.0`                                                   |
 | `metrics.imagePullPolicy`            | Exporter image pull policy                                       | `IfNotPresent`                                             |
 | `metrics.resources`                  | Exporter resource requests/limit                                 | `{}`                                                       |
-| `metrics.podAnnotations`                | Exporter annotations                                          | `{}`                                                       |
+| `metrics.podAnnotations`             | Exporter annotations                                             | `{}`                                                       |
 | `nodeSelector`                       | Node labels for pod assignment                                   | `{}`                                                       |
 | `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                         | 30                                                         |
 | `livenessProbe.periodSeconds`        | How often to perform the probe                                   | 10                                                         |
 | `livenessProbe.timeoutSeconds`       | When the probe times out                                         | 5                                                          |
-| `livenessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed.     | 1                |
-| `livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.       | 6                |
-| `podAnnotations`                | Pod annotations                                   | `{}`                                                       |
-| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                                                        | 5                |
-| `readinessProbe.periodSeconds`       | How often to perform the probe                                                                   | 10               |
-| `readinessProbe.timeoutSeconds`      | When the probe times out                                                                         | 5                |
-| `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed.     | 1                |
-| `readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed after having succeeded.       | 6                |
+| `livenessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed. | 1                              |
+| `livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 6                              |
+| `podAnnotations`                     | Pod annotations                                                  | `{}`                                                       |
+| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                        | 5                                                          |
+| `readinessProbe.periodSeconds`       | How often to perform the probe                                   | 10                                                         |
+| `readinessProbe.timeoutSeconds`      | When the probe times out                                         | 5                                                          |
+| `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed. | 1                              |
+| `readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed after having succeeded. | 6                                |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/consul/README.md
+++ b/bitnami/consul/README.md
@@ -256,7 +256,7 @@ Consul container was moved to a non-root approach. There shouldn't be any issue 
 $ helm upgrade my-release stable/consul
 ```
 
-If you use a previous container image (previous to **1.4.0-r**) disable the `securityContext` by running the command below:
+If you use a previous container image (previous to **1.4.0-r16**) disable the `securityContext` by running the command below:
 
 ```
 $ helm upgrade my-release stable/consul --set securityContext.enabled=fase,image.tag=XXX

--- a/bitnami/consul/README.md
+++ b/bitnami/consul/README.md
@@ -248,6 +248,20 @@ The chart can optionally start a metrics exporter endpoint on port `9107` for [p
 
 ## Upgrading
 
+### To 3.1.0
+
+Consul container was moved to a non-root approach. There shouldn't be any issue when upgrading since the corresponding `securityContext` is enabled by default. Both the container image and the chart can be upgraded by running the command below:
+
+```
+$ helm upgrade my-release stable/consul
+```
+
+If you use a previous container image (previous to **1.4.0-r**) disable the `securityContext` by running the command below:
+
+```
+$ helm upgrade my-release stable/consul --set securityContext.enabled=fase,image.tag=XXX
+```
+
 ### To 2.0.0
 
 Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.

--- a/bitnami/consul/templates/statefulset.yaml
+++ b/bitnami/consul/templates/statefulset.yaml
@@ -34,6 +34,11 @@ spec:
   {{- end }}
 {{- end }}
     spec:
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+      {{- end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.pullSecrets }}

--- a/bitnami/consul/values-production.yaml
+++ b/bitnami/consul/values-production.yaml
@@ -35,6 +35,14 @@ service:
   consulDnsPort: 8600
   uiPort: 80
 
+## Pod Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+##
+securityContext:
+  enabled: true
+  fsGroup: 1001
+  runAsUser: 1001
+
 ## Datacenter name for consul. If not supplied, will use the consul
 ## default 'dc1'
 datacenterName: dc1

--- a/bitnami/consul/values.yaml
+++ b/bitnami/consul/values.yaml
@@ -35,6 +35,14 @@ service:
   consulDnsPort: 8600
   uiPort: 80
 
+## Pod Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+##
+securityContext:
+  enabled: true
+  fsGroup: 1001
+  runAsUser: 1001
+
 ## Datacenter name for consul. If not supplied, will use the consul
 ## default 'dc1'
 datacenterName: dc1


### PR DESCRIPTION
This PRs adapts Consul's Statefulset so the proper securityContext is set since Bitnami Docker image has been moved to non-root approach.

Please **DO NOT MERGE** this PR (even if you agree with the changes) until the new image is released. I'll update this PR as soon as it's released.