### PR TITLE
[bitnami/metrics-server] Disable Api service creation by default

### DIFF
--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: metrics-server
-version: 2.1.1
+version: 2.2.0
 appVersion: 0.3.1
 description: Metrics Server is a cluster-wide aggregator of resource usage data. Metrics Server collects metrics from the Summary API, exposed by Kubelet on each node.
 keywords:

--- a/bitnami/metrics-server/README.md
+++ b/bitnami/metrics-server/README.md
@@ -61,7 +61,7 @@ The following tables lists the configurable parameters of the Metrics Server cha
 | `rbac.create`            | Enable RBAC authentication                                                  | `true`                                 |
 | `serviceAccount.create`  | Specifies whether a ServiceAccount should be created                        | `true`                                 |
 | `serviceAccount.name`    | The name of the ServiceAccount to create                                    | Generated using the fullname template  |
-| `apiService.create`      | Specifies whether the v1beta1.metrics.k8s.io API service should be created  | `true`                                 |
+| `apiService.create`      | Specifies whether the v1beta1.metrics.k8s.io API service should be created (This should not be necessary in k8s version >= 1.8)  | `false`                                 |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/metrics-server/templates/NOTES.txt
+++ b/bitnami/metrics-server/templates/NOTES.txt
@@ -1,13 +1,26 @@
 ** Please be patient while the chart is being deployed **
 
 The metric server has been deployed.
-{{ if .Values.apiService.create }}
+{{ if or .Values.apiService.create (.Capabilities.APIVersions.Has "metrics.k8s.io/v1beta1") }}
 In a few minutes you should be able to list metrics using the following
 command:
 
   kubectl get --raw "/apis/metrics.k8s.io/v1beta1/nodes"
 {{ else }}
-NOTE: You have disabled the API service creation for this release. The metrics
-API will not work with this release unless you configure the metrics API
-service outside of this Helm chart.
+########################################################################################
+### ERROR: The metrics.k8s.io/v1beta1 API service is not enabled in the cluster      ###
+########################################################################################
+You have disabled the API service creation for this release. As the Kubernetes version in the cluster 
+does not have metrics.k8s.io/v1beta1, the metrics API will not work with this release unless:
+
+Option A: 
+
+  You complete your metrics-server release by running:
+
+  helm upgrade {{ .Release.Name }} bitnami/metrics-server \
+    --set apiService.create=true
+
+Option B:
+  
+   You configure the metrics API service outside of this Helm chart
 {{- end -}}

--- a/bitnami/metrics-server/templates/_helpers.tpl
+++ b/bitnami/metrics-server/templates/_helpers.tpl
@@ -3,7 +3,8 @@
 Expand the name of the chart.
 */}}
 {{- define "metrics-server.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- $name := default .Chart.Name .Values.nameOverride | replace "-" "" -}}
+{{- default $name | trunc 24 -}}
 {{- end -}}
 
 {{/*
@@ -11,7 +12,7 @@ Create a default fully qualified app name.
 We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "metrics-server.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- $name := default .Chart.Name .Values.nameOverride | replace "-" "" -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
 {{- end -}}
 

--- a/bitnami/metrics-server/values.yaml
+++ b/bitnami/metrics-server/values.yaml
@@ -30,11 +30,11 @@ serviceAccount:
 
 apiService:
   # Specifies if the v1beta1.metrics.k8s.io API service should be created.
-  #
+  # This should not be necessary in k8s version >= 1.8
   # If you disable API service creation you have to
   # manage it outside of this chart for e.g horizontal pod autoscaling to
   # work with this release.
-  create: true
+  create: false
 
 ## Specify the secure port where metrics-server will be running
 ##


### PR DESCRIPTION
Signed-off-by: Javier J. Salmeron Garcia <jsalmeron@bitnami.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
This PR fixes two issues

  - Having the API creation enabled by default caused issues in new K8s clusters
  - The fullname truncation could lead to cases like `releasename-metrics-`, causing issues

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
