### PR TITLE
Fix indentation in external-dns deployment

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -1,5 +1,5 @@
 name: external-dns
-version: 1.2.1
+version: 1.2.2
 appVersion: 0.5.9
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -87,9 +87,9 @@ spec:
         {{- end }}
         {{- range $key, $value := .Values.extraArgs }}
           {{- if $value }}
-          - --{{ $key }}={{ $value }}
+        - --{{ $key }}={{ $value }}
           {{- else }}
-          - --{{ $key }}
+        - --{{ $key }}
           {{- end }}
         {{- end }}
 


### PR DESCRIPTION

**Description of the change**

This change fixes an indentation issue in one of the templates of the `external-dns` chart. It caused any `extraArgs` to end up joined to the previous command line arg, causing interesting results.

