### PR TITLE
[bitnami/external-dns] only set google specific config if they are not empty

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -1,5 +1,5 @@
 name: external-dns
-version: 1.2.3
+version: 1.3.0
 appVersion: 0.5.9
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -106,7 +106,9 @@ spec:
         {{- end }}
 
         {{- if eq .Values.provider "google" }}
+        {{- if .Values.google.project }}
         - --google-project={{ .Values.google.project }}
+        {{- end }}
         {{- end }}
 
         env:
@@ -147,8 +149,10 @@ spec:
         {{- end }}
 
         {{- if eq .Values.provider "google" }}
+        {{- if .Values.google.serviceAccountSecret }}
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/secrets/service-account/credentials.json
+        {{- end }}
         {{- end }}
 
         ports:
@@ -191,8 +195,10 @@ spec:
         {{- end }}
 
         {{- if eq .Values.provider "google" }}
+        {{- if .Values.google.serviceAccountSecret }}
         - name: google-service-account
           mountPath: /etc/secrets/service-account/
+        {{- end }}
         {{- end }}
 
       volumes:
@@ -210,7 +216,9 @@ spec:
       {{- end }}
 
       {{- if eq .Values.provider "google" }}
+      {{- if .Values.google.serviceAccountSecret }}
       - name: google-service-account
         secret:
           secretName: {{ .Values.google.serviceAccountSecret | quote }}
+      {{- end}}
       {{- end}}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This makes all google specific provider configurations optional if they are empty `""`. This is in order to make it work on Google Kubernetes Engine (GKE) which, if configured correctly, does not require a separate service account. 

Source: https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/gke.md

**Benefits**

<!-- What benefits will be realized by the code change? -->

This will make the helm install work out of the box on GKE clusters without having to create a dedicated service account.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
This should be fully backward compatible.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->