### PR TITLE
[bitnami//tensorflow-inception] Adapt Chart to non-root container

### DIFF
--- a/bitnami/tensorflow-inception/Chart.yaml
+++ b/bitnami/tensorflow-inception/Chart.yaml
@@ -1,5 +1,5 @@
 name: tensorflow-inception
-version: 3.1.0
+version: 3.2.0
 appVersion: 1.11.1
 description: Open-source software library for serving machine learning models
 keywords:

--- a/bitnami/tensorflow-inception/README.md
+++ b/bitnami/tensorflow-inception/README.md
@@ -60,31 +60,34 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the TensorFlow Inception chart and their default values.
 
-| Parameter                       | Description                            | Default                                                    |
-| ------------------------------- | -------------------------------------- | ---------------------------------------------------------- |
-| `global.imageRegistry`          | Global Docker image registry           | `nil`                                                      |
-| `replicaCount`                           | desired number of pods               | `1`                               |
-| `server.image.registry`         | TensorFlow Serving image registry      | `docker.io`                                                |
-| `server.image.repository`       | TensorFlow Serving Image name          | `bitnami/tensorflow-serving`                               |
-| `server.image.tag`              | TensorFlow Serving Image tag           | `{VERSION}`                                                |
-| `server.image.pullPolicy`       | TensorFlow Serving image pull policy   | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
-| `server.image.pullSecrets`      | Specify image pull secrets             | `nil` (does not add image pull secrets to deployed pods)   |
-| `server.port`                   | Tensorflow server port                 | `8500`                                                     |
-| `client.image.registry`         | TensorFlow Inception image registry    | `docker.io`                                                |
-| `client.image.repository`       | TensorFlow Inception Image name        | `bitnami/tensorflow-inception`                             |
-| `client.image.tag`              | TensorFlow Inception Image tag         | `{VERSION}`                                                |
-| `client.image.pullPolicy`       | TensorFlow Inception image pull policy | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
-| `client.image.pullSecrets`      | Specify image pull secrets             | `nil` (does not add image pull secrets to deployed pods)   |
-| `imagePullPolicy`               | Image pull policy                      | `Always` if `image` tag is `latest`, else `IfNotPresent`   |
-| `podAnnotations`                | Pod annotations                                   | `{}`                                                       |
-| `metrics.enabled`                          | Start a side-car Tensorflow prometheus exporter                                                                           | `false`                                              |
-| `metrics.image.registry`                   | Tensorflow exporter image registry                                                                                  | `docker.io`                                          |
-| `metrics.image.repository`                 | Tensorflow exporter image name                                                                                      | `ynqa/tensorflow-serving-exporter`                           |
-| `metrics.image.tag`                        | Tensorflow exporter image tag                                                                                       | `latest`                                            |
-| `metrics.image.pullPolicy`                 | Image pull policy                                                                                              | `IfNotPresent`                                       |
-| `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                                                               | `nil`                                                |
-| `metrics.podAnnotations`                   | Additional annotations for Metrics exporter pod                                                                | `{prometheus.io/scrape: "true", prometheus.io/port: "9118"}`                                                   |
-| `metrics.resources`                        | Exporter resource requests/limit                                                                               | Memory: `256Mi`, CPU: `100m`                         |
+| Parameter                       | Description                                      | Default                                                      |
+| ------------------------------- | ------------------------------------------------ | ------------------------------------------------------------ |
+| `global.imageRegistry`          | Global Docker image registry                     | `nil`                                                        |
+| `replicaCount`                  | desired number of pods                           | `1`                                                          |
+| `server.image.registry`         | TensorFlow Serving image registry                | `docker.io`                                                  |
+| `server.image.repository`       | TensorFlow Serving Image name                    | `bitnami/tensorflow-serving`                                 |
+| `server.image.tag`              | TensorFlow Serving Image tag                     | `{VERSION}`                                                  |
+| `server.image.pullPolicy`       | TensorFlow Serving image pull policy             | `Always` if `imageTag` is `latest`, else `IfNotPresent`      |
+| `server.image.pullSecrets`      | Specify image pull secrets                       | `nil` (does not add image pull secrets to deployed pods)     |
+| `server.port`                   | Tensorflow server port                           | `8500`                                                       |
+| `client.image.registry`         | TensorFlow Inception image registry              | `docker.io`                                                  |
+| `client.image.repository`       | TensorFlow Inception Image name                  | `bitnami/tensorflow-inception`                               |
+| `client.image.tag`              | TensorFlow Inception Image tag                   | `{VERSION}`                                                  |
+| `client.image.pullPolicy`       | TensorFlow Inception image pull policy           | `Always` if `imageTag` is `latest`, else `IfNotPresent`      |
+| `client.image.pullSecrets`      | Specify image pull secrets                       | `nil` (does not add image pull secrets to deployed pods)     |
+| `securityContext.enabled`       | Enable security context for TensorFlow Serving   | `true`                                                       |
+| `securityContext.fsGroup`       | Group ID for TensorFlow Serving container        | `1001`                                                       |
+| `securityContext.runAsUser`     | User ID for TensorFlow Serving container         | `1001`                                                       |
+| `imagePullPolicy`               | Image pull policy                                | `Always` if `image` tag is `latest`, else `IfNotPresent`     |
+| `podAnnotations`                | Pod annotations                                  | `{}`                                                         |
+| `metrics.enabled`               | Start a side-car Tensorflow prometheus exporter  | `false`                                                      |
+| `metrics.image.registry`        | Tensorflow exporter image registry               | `docker.io`                                                  |
+| `metrics.image.repository`      | Tensorflow exporter image name                   | `ynqa/tensorflow-serving-exporter`                           |
+| `metrics.image.tag`             | Tensorflow exporter image tag                    | `latest`                                                     |
+| `metrics.image.pullPolicy`      | Image pull policy                                | `IfNotPresent`                                               |
+| `metrics.image.pullSecrets`     | Specify docker-registry secret names as an array | `nil`                                                        |
+| `metrics.podAnnotations`        | Additional annotations for Metrics exporter pod  | `{prometheus.io/scrape: "true", prometheus.io/port: "9118"}` |
+| `metrics.resources`             | Exporter resource requests/limit                 | Memory: `256Mi`, CPU: `100m`                                 |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -101,6 +104,20 @@ $ helm install --name my-release -f values.yaml bitnami/tensorflow-inception
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
 ## Upgrading
+
+### To 3.2.0
+
+Tensorflow Serving container was moved to a non-root approach. There shouldn't be any issue when upgrading since the corresponding `securityContext` is enabled by default. Both container image and chart can be upgraded by running the command below:
+
+```
+$ helm upgrade my-release stable/tensorflow-inception
+```
+
+If you use a previous container image (previous to **1.12.0-r34**), disable the `securityContext` by running the command below:
+
+```
+$ helm upgrade my-release stable/tensorflow-inception --set securityContext.enabled=fase,server.image.tag=XXX
+```
 
 ### To 1.0.0
 

--- a/bitnami/tensorflow-inception/templates/deployment.yaml
+++ b/bitnami/tensorflow-inception/templates/deployment.yaml
@@ -29,6 +29,11 @@ spec:
   {{- end }}
 {{- end }}
     spec:
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+      {{- end }}
       {{- if .Values.server.image.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.server.image.pullSecrets }}

--- a/bitnami/tensorflow-inception/values.yaml
+++ b/bitnami/tensorflow-inception/values.yaml
@@ -53,6 +53,14 @@ client:
 ##
 imagePullPolicy: IfNotPresent
 
+## Tensorflow Serving Pod Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+##
+securityContext:
+  enabled: true
+  fsGroup: 1001
+  runAsUser: 1001
+
 ## Kubernetes configuration
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer
 ##


### PR DESCRIPTION
**Description of the change**

This PR adaptas the TensorFlow Inception container to use TensorFlow Serving non-root image 
