### PR TITLE
[bitnami/mysql] Avoid creating a Deployment for a test client to check connectivity with MySQL

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 4.2.0
+version: 4.2.1
 appVersion: 5.7.24
 description: Chart to create a Highly available MySQL cluster
 keywords:

--- a/bitnami/mysql/templates/NOTES.txt
+++ b/bitnami/mysql/templates/NOTES.txt
@@ -21,7 +21,7 @@ To connect to your database:
 
   1. Run a pod that you can use as a client:
 
-      kubectl run {{ template "fullname" . }}-client --rm --tty -i --image  {{ template "mysql.image" . }} --namespace {{ .Release.Namespace }} --command -- bash
+      kubectl run {{ template "fullname" . }}-client --rm --tty -i --restart='Never' --image  {{ template "mysql.image" . }} --namespace {{ .Release.Namespace }} --command -- bash
 
   2. To connect to master service (read/write):
 


### PR DESCRIPTION
**Description of the change**

Adapt NOTES.txt so it doesn't create a deployment for pods used to test connectivity.

More info: From `kubectl run --help | grep Never`:

> --restart='Always': The restart policy for this Pod.  Legal values [Always, OnFailure, Never].  
> If set to 'Always' a deployment is created, if set to 'OnFailure' a job is created, if set to 'Never', a regular pod is created. For the latter two --replicas must be 1.  
> Default 'Always', for CronJobs `Never`.
