### PR TITLE
[bitnami/cassandra] Avoid creating a Deployment for a test client to check connectivity with Cassandra

### DIFF
--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -1,5 +1,5 @@
 name: cassandra
-version: 1.0.0
+version: 1.0.1
 appVersion: 3.11.3
 description: Apache Cassandra is a free and open-source distributed database management system designed to handle large amounts of data across many commodity servers, providing high availability with no single point of failure. Cassandra offers robust support for clusters spanning multiple datacenters, with asynchronous masterless replication allowing low latency operations for all clients.
 icon: https://d33np9n32j53g7.cloudfront.net/assets/stacks/cassandra/img/cassandra-stack-220x234-071ca9e210d165c3972d41ff9f96bd60.png

--- a/bitnami/cassandra/templates/NOTES.txt
+++ b/bitnami/cassandra/templates/NOTES.txt
@@ -17,7 +17,7 @@ To connect to your Cassandra cluster using CQL:
 
 1. Run a Cassandra pod that you can use as a client:
 
-   kubectl run --namespace {{ .Release.Namespace }} {{ template "cassandra.fullname" . }}-client --rm --tty -i \
+   kubectl run --namespace {{ .Release.Namespace }} {{ template "cassandra.fullname" . }}-client --rm --tty -i --restart='Never' \
    --env CASSANDRA_PASSWORD=$CASSANDRA_PASSWORD \
    {{ if and (.Values.networkPolicy.enabled) (not .Values.networkPolicy.allowExternal) }}--labels="{{ template "cassandra.name" . }}-client=true"{{ end }} \
    --image {{ template "cassandra.image" . }} -- bash


### PR DESCRIPTION
**Description of the change**

Adapt NOTES.txt so it doesn't create a deployment for pods used to test connectivity.

More info: From `kubectl run --help | grep Never`:

> --restart='Always': The restart policy for this Pod.  Legal values [Always, OnFailure, Never].  
> If set to 'Always' a deployment is created, if set to 'OnFailure' a job is created, if set to 'Never', a regular pod is created. For the latter two --replicas must be 1.  
> Default 'Always', for CronJobs `Never`.