### PR TITLE
[bitnami/zookeeper] Only specify JVMFLAGS env var if they are provided

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,5 +1,5 @@
 name: zookeeper
-version: 1.2.0
+version: 1.2.1
 appVersion: 3.4.12
 description: A centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services for distributed applications.
 keywords:

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -119,8 +119,10 @@ spec:
         {{- else }}
           value: "no"
         {{- end }}
+        {{- if .Values.jvmFlags }}
         - name: JVMFLAGS
           value: {{ .Values.jvmFlags | quote }}
+        {{- end }}
         ports:
         - name: client
           containerPort: {{ .Values.service.port }}


### PR DESCRIPTION
Signed-off-by: tompizmor <tompizmor@gmail.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Only specify JVMFLAGS env var if they are provided in the values.yaml file. If they are not, depending on the kubernetes environment it can be rendered as the following making zookeeper unable to start:

```
    - name: JVMFLAGS
      value: <nil>
```

