### PR TITLE
Fix <nil> jvmFlags

### DIFF
--- a/bitnami/zookeeper/values-production.yaml
+++ b/bitnami/zookeeper/values-production.yaml
@@ -87,7 +87,7 @@ heapSize: 1024
 
 ## Default JVMFLAGS for the ZooKeeper process
 ##
-# jvmFlags:
+jvmFlags: ""
 
 ## Configure ZooKeeper with a custom zoo.cfg file
 ##

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -93,7 +93,7 @@ heapSize: 1024
 
 ## Default JVMFLAGS for the ZooKeeper process
 ##
-# jvmFlags:
+jvmFlags: ""
 
 ## Configure ZooKeeper with a custom zoo.cfg file
 ##


### PR DESCRIPTION
**Description of the change**

Fixes a bug in the chart what causes `"<nil>"` to be passed as the default value of the JVMFLAGS env

**Benefits**

Now the chart works without having to override the `jvmFlags` variable.

**Possible drawbacks**

No idea
