### PR TITLE
[elasticseach] - Correct empty plugins case

### DIFF
--- a/bitnami/elasticsearch/templates/master-deploy.yaml
+++ b/bitnami/elasticsearch/templates/master-deploy.yaml
@@ -79,8 +79,8 @@ spec:
           value: {{ .Values.name | quote }}
         {{- if .Values.plugins }}
         - name: ELASTICSEARCH_PLUGINS
-        {{- end }}
           value: {{ .Values.plugins | quote }}
+        {{- end }}
         - name: ELASTICSEARCH_HEAP_SIZE
           value: {{ .Values.master.heapSize | quote }}
         - name: ELASTICSEARCH_IS_DEDICATED_NODE


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Move end of if function so empty `.Values.plugins` does not overwrite the cluster name with `nil` and cause cluster connectivity issues between master deployment & the rest of the elasticsearch components.

**Benefits**

Elasticsearch deployment will work when no plugins are provided

**Possible drawbacks**

None that I'm aware.

**Applicable issues**

Possibly resolving #984 

**Additional information**

Testing an upgrade `--dry-run` it appears the value of `ELASTICSEARCH_CLUSTER_NAME` is no longer `"<nil>"`.