### PR TITLE
[bitnami/mysql] Allow including gzip files as initdb scripts

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 4.2.1
+version: 4.2.2
 appVersion: 5.7.24
 description: Chart to create a Highly available MySQL cluster
 keywords:

--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -16,7 +16,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 
 ## Prerequisites
 
-- Kubernetes 1.4+ with Beta APIs enabled
+- Kubernetes 1.10+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/mysql/templates/initialization-configmap.yaml
+++ b/bitnami/mysql/templates/initialization-configmap.yaml
@@ -1,4 +1,4 @@
-{{ if  (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|sql|sql.gz]") }}
+{{- if  (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql,sql.gz}") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,6 +9,11 @@ metadata:
     chart: {{ template "mysql.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+binaryData:
+{{- $root := . }}
+{{- range $path, $bytes := .Files.Glob "files/docker-entrypoint-initdb.d/*.sql.gz" }}
+  {{ base $path }}: {{ $root.Files.Get $path | b64enc | quote }}
+{{- end }}
 data:
-{{ (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|sql|sql.gz]").AsConfig | indent 2 }}
-{{ end }}
+{{ (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql}").AsConfig | indent 2 }}
+{{- end }}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

GZIP files must be treated as **binaryData** on configMaps. This PR ensures that those init scripts compressed on that format are mounted as binaries.
