### PR TITLE
[bitnami/kafka] Change the default advertised listeners to the headless service

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,5 +1,5 @@
 name: kafka
-version: 1.2.4
+version: 1.2.5
 appVersion: 2.1.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -90,9 +90,9 @@ spec:
           {{- if .Values.advertisedListeners }}
           value: {{ .Values.advertisedListeners }}
           {{- else if .Values.auth.enabled  }}
-          value: "SASL_SSL://$(MY_POD_IP):$(KAFKA_PORT_NUMBER)"
+          value: 'SASL_SSL://{{ template "kafka.fullname" . }}-headless.{{.Release.Namespace}}:$(KAFKA_PORT_NUMBER)'
           {{- else }}
-          value: "PLAINTEXT://$(MY_POD_IP):$(KAFKA_PORT_NUMBER)"
+          value: 'PLAINTEXT://{{ template "kafka.fullname" . }}-headless.{{.Release.Namespace}}:$(KAFKA_PORT_NUMBER)'
           {{- end }}
         {{- if .Values.auth.enabled }}
         - name: KAFKA_OPTS


### PR DESCRIPTION

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Changes the default setting for advertised listeners to use the DNS name of the headless service instead of the pod IP

**Benefits**
Clients will be able to reconnect successfully in case of brokers changing the IPs
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
None that I can think of.
<!-- Describe any known limitations with your change -->

**Applicable issues**

Fixes #1002 
request, mention that information here.-->
