### PR TITLE
Fix single node etcd cluster with auth

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -1,5 +1,5 @@
 name: etcd
-version: 1.4.1
+version: 1.4.2
 appVersion: 3.3.10
 description: etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines
 keywords:

--- a/bitnami/etcd/templates/statefulset.yaml
+++ b/bitnami/etcd/templates/statefulset.yaml
@@ -103,7 +103,11 @@ spec:
               store_member_id &
               if [ -n "${ETCD_ROOT_PASSWORD}" ] && [ "${HOSTNAME}" == "{{ $etcdFullname }}-0" ]; then
                 echo "==> Configuring RBAC authentication!"
+                {{- if gt $replicaCount 1 }}
                 etcd --initial-cluster "default={{ $etcdPeerProtocol }}://{{ $etcdFullname }}-0.{{ $etcdHeadlessServiceName }}.{{ $releaseNamespace }}.svc.cluster.local:{{ $peerPort }}" > /dev/null 2>&1 &
+                {{- else }}
+                etcd > /dev/null 2>&1 &
+                {{- end }}
                 ETCD_PID=$!
                 sleep 5
                 echo "${ETCD_ROOT_PASSWORD}" | etcdctl user add root


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Fix an issue deploying single node etcd cluster with authentication enabled.

**Benefits**

Fixes an issue.

**Applicable issues**

https://github.com/bitnami/charts/issues/902
