### PR TITLE
[bitnami/jenkins] Change JENKINS_HOME var in values.yaml because of the new image

### DIFF
--- a/bitnami/jenkins/Chart.yaml
+++ b/bitnami/jenkins/Chart.yaml
@@ -1,5 +1,5 @@
 name: jenkins
-version: 2.1.1
+version: 2.1.2
 appVersion: 2.150.1
 description: The leading open source automation server
 keywords:

--- a/bitnami/jenkins/values.yaml
+++ b/bitnami/jenkins/values.yaml
@@ -36,7 +36,7 @@ jenkinsUser: user
 
 ## Jenkins home directory
 ##
-homeDir: /opt/bitnami/jenkins/jenkins_home
+jenkinsHome: /opt/bitnami/jenkins/jenkins_home
 
 ## Allows to disable the initial Bitnami configuration for Jenkins
 ##


### PR DESCRIPTION
The assignment in the new image for the env var JENKINS_HOME is jenkinsHome instead of homeDir.