### PR TITLE
[bitnami/kafka] Fix kafka advertised name

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,5 +1,5 @@
 name: kafka
-version: 1.2.5
+version: 1.2.6
 appVersion: 2.1.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -70,6 +70,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: KAFKA_ZOOKEEPER_CONNECT
           {{- if .Values.zookeeper.enabled }}
           value: {{ template "kafka.zookeeper.fullname" . }}
@@ -90,9 +94,9 @@ spec:
           {{- if .Values.advertisedListeners }}
           value: {{ .Values.advertisedListeners }}
           {{- else if .Values.auth.enabled  }}
-          value: 'SASL_SSL://{{ template "kafka.fullname" . }}-headless.{{.Release.Namespace}}:$(KAFKA_PORT_NUMBER)'
+          value: 'SASL_SSL://$(MY_POD_NAME).{{ template "kafka.fullname" . }}-headless.{{.Release.Namespace}}:$(KAFKA_PORT_NUMBER)'
           {{- else }}
-          value: 'PLAINTEXT://{{ template "kafka.fullname" . }}-headless.{{.Release.Namespace}}:$(KAFKA_PORT_NUMBER)'
+          value: 'PLAINTEXT://$(MY_POD_NAME).{{ template "kafka.fullname" . }}-headless.{{.Release.Namespace}}:$(KAFKA_PORT_NUMBER)'
           {{- end }}
         {{- if .Values.auth.enabled }}
         - name: KAFKA_OPTS


### PR DESCRIPTION
Signed-off-by: tompizmor <tompizmor@gmail.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Stop using the Kafka headless service name as the advertised hostname for Kafka as it only works when replicas=1. Instead, we should be using the pod name that is also stable.

**Benefits**

Kafka with replicas > 1 works.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

Fixes https://github.com/bitnami/charts/issues/1024

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
