### PR TITLE
[bitnami/nginx-ingress-controller] Use geoip2 by default

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress-controller
-version: 3.1.2
+version: 3.1.3
 appVersion: 0.21.0
 description: Chart for the nginx Ingress controller
 keywords:

--- a/bitnami/nginx-ingress-controller/README.md
+++ b/bitnami/nginx-ingress-controller/README.md
@@ -54,7 +54,7 @@ Parameter | Description | Default
 `image.repository` | controller container image repository | `bitnami/nginx-ingress-controller`
 `image.tag` | controller container image tag | `{VERSION}`
 `image.pullPolicy` | controller container image pull policy | `IfNotPresent`
-`config` | nginx ConfigMap entries | `nil`
+`config` | nginx ConfigMap entries | `use-geoip: "false", use-geoip2: "true"`
 `hostNetwork` | If the nginx deployment / daemonset should run on the host's network namespace. Do not set this when `controller.service.externalIPs` is set and `kube-proxy` is used as there will be a port-conflict for port `80` | false
 `defaultBackendService` | default 404 backend service; required only if `defaultBackend.enabled = false` | `""`
 `electionID` | election ID to use for the status update | `ingress-controller-leader`

--- a/bitnami/nginx-ingress-controller/values-production.yaml
+++ b/bitnami/nginx-ingress-controller/values-production.yaml
@@ -11,7 +11,10 @@ image:
   ##
   pullPolicy: IfNotPresent
 
-config: {}
+config:
+  use-geoip: "false"
+  use-geoip2: "true"
+
 # Will add custom header to Nginx https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers
 headers: {}
 

--- a/bitnami/nginx-ingress-controller/values.yaml
+++ b/bitnami/nginx-ingress-controller/values.yaml
@@ -17,7 +17,9 @@ image:
   ##
   pullPolicy: IfNotPresent
 
-config: {}
+config:
+  use-geoip: "false"
+  use-geoip2: "true"
 # Will add custom header to Nginx https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers
 headers: {}
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
geoip is deprecated, so we need to use geoip2 by default
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
