### PR TITLE
fix(bitnami/etcd): wrong paths in statefulset.yaml template and bad init logic

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -1,5 +1,5 @@
 name: etcd
-version: 1.5.1
+version: 1.5.2
 appVersion: 3.3.11
 description: etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines
 keywords:

--- a/bitnami/etcd/templates/statefulset.yaml
+++ b/bitnami/etcd/templates/statefulset.yaml
@@ -70,7 +70,7 @@ spec:
       {{- $etcdFullname := include "etcd.fullname" . }}
       {{- $releaseNamespace := .Release.Namespace }}
       {{- $etcdHeadlessServiceName := printf "%s-%s" $etcdFullname "headless" }}
-      {{- $dnsBase := .Values.dnsBase }}
+      {{- $dnsBase := .Values.service.dnsBase }}
       {{- $etcdPeerProtocol := include "etcd.peerProtocol" . }}
       {{- $etcdClientProtocol := include "etcd.clientProtocol" . }}
       - name: "{{ template "etcd.fullname" . }}"

--- a/bitnami/etcd/templates/statefulset.yaml
+++ b/bitnami/etcd/templates/statefulset.yaml
@@ -100,7 +100,7 @@ spec:
               mkdir -p "${DATA_DIR}"
               ## Setting up new cluster
               echo "==> There is no data at all. Creating new cluster"
-              export ETCDCTL_ENDPOINTS="{{ $etcdClientProtocol }}://{{ $etcdFullname }}-0.{{ $etcdHeadlessServiceName }}.{{ .Release.Namespace }}.svc.cluster.local:{{ $clientPort }}"
+              export ETCDCTL_ENDPOINTS="{{ $etcdClientProtocol }}://{{ $etcdFullname }}-0.{{ $etcdHeadlessServiceName }}.{{ .Release.Namespace }}.{{ $dnsBase }}:{{ $clientPort }}"
               store_member_id &
               if [ -n "${ETCD_ROOT_PASSWORD}" ] && [ "${HOSTNAME}" == "{{ $etcdFullname }}-0" ]; then
                 echo "==> Configuring RBAC authentication!"

--- a/bitnami/etcd/templates/statefulset.yaml
+++ b/bitnami/etcd/templates/statefulset.yaml
@@ -104,11 +104,7 @@ spec:
               store_member_id &
               if [ -n "${ETCD_ROOT_PASSWORD}" ] && [ "${HOSTNAME}" == "{{ $etcdFullname }}-0" ]; then
                 echo "==> Configuring RBAC authentication!"
-                {{- if gt $replicaCount 1 }}
-                etcd --initial-cluster "default={{ $etcdPeerProtocol }}://{{ $etcdFullname }}-0.{{ $etcdHeadlessServiceName }}.{{ $releaseNamespace }}.{{ $dnsBase }}:{{ $peerPort }}" > /dev/null 2>&1 &
-                {{- else }}
                 etcd > /dev/null 2>&1 &
-                {{- end }}
                 ETCD_PID=$!
                 sleep 5
                 echo "${ETCD_ROOT_PASSWORD}" | etcdctl user add root

--- a/bitnami/etcd/templates/statefulset.yaml
+++ b/bitnami/etcd/templates/statefulset.yaml
@@ -200,7 +200,7 @@ spec:
         - name: ETCD_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ if .Values.auth.existingSecret }}{{ .Values.auth.existingSecret }}{{ else }}{{ template "etcd.fullname" . }}{{ end }}
+              name: {{ if .Values.auth.rbac.existingSecret }}{{ .Values.auth.rbac.existingSecret }}{{ else }}{{ template "etcd.fullname" . }}{{ end }}
               key: etcd-root-password
         {{- end }}
 


### PR DESCRIPTION
`$dnsBase` is being initialized as `.Values.dnsBase` but the right value is `.Values.service.dnsBase`.

Failure would look like this on logs:

```
2019-02-02 00:41:14.161479 I | pkg/flags: recognized and used environment variable ETCD_ADVERTISE_CLIENT_URLS=http://queenly-swan-etcd-2.queenly-swan-etcd-headless.default.:2379
```

By adding a `dnsBase` key in the root level with value `svc.cluster.local` this issue can be worked-around.

This PR also fixes #1040 and fixes #1041 with make the initialization of more than one replica possible and it enables the chart to actually use existing secrets for rbac root by fixing the wrong path it used to try to retrieve it.