### PR TITLE
Fix appVersion fields for some Chart.yaml files

### DIFF
--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -1,6 +1,6 @@
 name: apache
-version: 4.0.3
-appVersion: 2.4.39
+version: 4.0.4
+appVersion: 2.4.38
 description: Chart for Apache HTTP Server
 keywords:
 - apache

--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -1,6 +1,6 @@
 name: consul
-version: 4.0.1
-appVersion: 1.4.2
+version: 4.0.2
+appVersion: 1.4.1
 description: Highly available and distributed service discovery and key-value store designed with support for the modern data center to make distributed systems and configuration easy.
 home: https://www.consul.io/
 sources:

--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 name: external-dns
-version: 1.3.1
-appVersion: 0.5.11
+version: 1.3.2
+appVersion: 0.5.10
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:
 - external-dns

--- a/bitnami/jenkins/Chart.yaml
+++ b/bitnami/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
-version: 2.1.3
-appVersion: 2.150.3
+version: 2.1.4
+appVersion: 2.150.2
 description: The leading open source automation server
 keywords:
 - jenkins

--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -1,6 +1,6 @@
 name: mysql
-version: 4.2.3
-appVersion: 5.7.26
+version: 4.2.4
+appVersion: 5.7.25
 description: Chart to create a Highly available MySQL cluster
 keywords:
 - mysql

--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 name: zookeeper
-version: 1.2.2
-appVersion: 3.4.14
+version: 1.2.3
+appVersion: 3.4.13
 description: A centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services for distributed applications.
 keywords:
 - zookeeper


### PR DESCRIPTION
https://github.com/bitnami/charts/pull/1023 modified some `appVersion` fields by mistake. This roll them back and update the `version` field, instead.