### PR TITLE
[upstreamed/mongodb] add limits, affinity, node selector and tolerations for arbiter

### DIFF
--- a/upstreamed/mongodb/templates/statefulset-arbiter-rs.yaml
+++ b/upstreamed/mongodb/templates/statefulset-arbiter-rs.yaml
@@ -38,17 +38,17 @@ spec:
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
       {{- end }}
-      {{- if .Values.affinity }}
+      {{- if .Values.arbiter.affinity }}
       affinity:
-{{ toYaml .Values.affinity | indent 8 }}
+{{ toYaml .Values.arbiter.affinity | indent 8 }}
       {{- end -}}
-      {{- if .Values.nodeSelector }}
+      {{- if .Values.arbiter.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
+{{ toYaml .Values.arbiter.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.tolerations }}
+      {{- if .Values.arbiter.tolerations }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
+{{ toYaml .Values.arbiter.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
@@ -144,7 +144,7 @@ spec:
               subPath: mongodb.conf
           {{- end }}
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.arbiter.resources | indent 12 }}
       volumes:
       {{- if .Values.configmap }}
         - name: config

--- a/upstreamed/mongodb/values-production.yaml
+++ b/upstreamed/mongodb/values-production.yaml
@@ -231,6 +231,34 @@ configmap:
 #    authorization: enabled
 #    keyFile: /opt/bitnami/mongodb/conf/keyfile
 
+
+## Arbiter related settings
+##
+arbiter:
+  ## Node selector
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  nodeSelector: {}
+
+  ## Affinity
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
+
+  ## Tolerations
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations: []
+
+  ## Configure resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+  # limits:
+  #   cpu: 500m
+  #   memory: 512Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 256Mi
+
+
 ## Prometheus Exporter / Metrics
 ##
 metrics:

--- a/upstreamed/mongodb/values.yaml
+++ b/upstreamed/mongodb/values.yaml
@@ -231,6 +231,32 @@ configmap:
 #    authorization: enabled
 #    #keyFile: /opt/bitnami/mongodb/conf/keyfile
 
+## Arbiter related settings
+##
+arbiter:
+  ## Node selector
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  nodeSelector: {}
+
+  ## Affinity
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
+
+  ## Tolerations
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations: []
+
+  ## Configure resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+  # limits:
+  #   cpu: 500m
+  #   memory: 512Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 256Mi
+
 ## Prometheus Exporter / Metrics
 ##
 metrics:


### PR DESCRIPTION
**Description of the change**
Since arbiter is just a mongodb cluster instance to manage vote election procedure, it is not require same amount of resources as other type of mongodb nodes. by default with current chart if we set limits  arbiter pod also get same limits as primary or secondaries, what is westing of resources.
Also pod affinity, node selection and tolerations may vary for arbiter because for example we have pool of big nodes to satisfy primary and secondary nodes and lets say pool which is hold various tools like some controllers and etc. since arbiter not required same resources as real cluster nodes we can deploy it to `utility pool`, while rest cluster will be rolled into specially prepared node pool.

**Benefits**

Save resource when resources limits in use to achieve better pods distribution 

**Possible drawbacks**

People who use arbiters and affected parameters probably should update their value files to keep arbiters deployed to same places where it was before this change (replicate resources limits, nodeselector, affinity, tolerations if was set)

**Applicable issues**

This is about my issue #1057 

**Additional information**

This is correct place to make PR if i want became it available in `stable/mongodb`repository? 