### PR TITLE
Name truncation fix

### DIFF
--- a/bitnami/apache/templates/_helpers.tpl
+++ b/bitnami/apache/templates/_helpers.tpl
@@ -8,7 +8,7 @@ Expand the name of the chart.
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}

--- a/bitnami/apache/templates/_helpers.tpl
+++ b/bitnami/apache/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -12,7 +12,7 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/etcd/templates/_helpers.tpl
+++ b/bitnami/etcd/templates/_helpers.tpl
@@ -8,7 +8,7 @@ Expand the name of the chart.
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "etcd.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}

--- a/bitnami/etcd/templates/_helpers.tpl
+++ b/bitnami/etcd/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "etcd.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -12,7 +12,7 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "etcd.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/external-dns/templates/_helpers.tpl
+++ b/bitnami/external-dns/templates/_helpers.tpl
@@ -8,7 +8,7 @@ Expand the name of the chart.
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "external-dns.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}

--- a/bitnami/external-dns/templates/_helpers.tpl
+++ b/bitnami/external-dns/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "external-dns.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -12,7 +12,7 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "external-dns.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/kafka/templates/_helpers.tpl
+++ b/bitnami/kafka/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "kafka.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -78,5 +78,5 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "kafka.zookeeper.fullname" -}}
 {{- $name := default "zookeeper" .Values.zookeeper.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/bitnami/memcached/templates/_helpers.tpl
+++ b/bitnami/memcached/templates/_helpers.tpl
@@ -8,7 +8,7 @@ Expand the name of the chart.
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}

--- a/bitnami/memcached/templates/_helpers.tpl
+++ b/bitnami/memcached/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -12,7 +12,7 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/metrics-server/templates/_helpers.tpl
+++ b/bitnami/metrics-server/templates/_helpers.tpl
@@ -4,12 +4,12 @@ Expand the name of the chart.
 */}}
 {{- define "metrics-server.name" -}}
 {{- $name := default .Chart.Name .Values.nameOverride | replace "-" "" -}}
-{{- default $name | trunc 24 -}}
+{{- default $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "metrics-server.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride | replace "-" "" -}}

--- a/bitnami/metrics-server/templates/_helpers.tpl
+++ b/bitnami/metrics-server/templates/_helpers.tpl
@@ -13,7 +13,7 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "metrics-server.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride | replace "-" "" -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/nginx/templates/_helpers.tpl
+++ b/bitnami/nginx/templates/_helpers.tpl
@@ -8,7 +8,7 @@ Expand the name of the chart.
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}

--- a/bitnami/nginx/templates/_helpers.tpl
+++ b/bitnami/nginx/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -12,7 +12,7 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/wildfly/templates/_helpers.tpl
+++ b/bitnami/wildfly/templates/_helpers.tpl
@@ -8,7 +8,7 @@ Expand the name of the chart.
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}

--- a/bitnami/wildfly/templates/_helpers.tpl
+++ b/bitnami/wildfly/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -12,7 +12,7 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/zookeeper/templates/_helpers.tpl
+++ b/bitnami/zookeeper/templates/_helpers.tpl
@@ -8,7 +8,7 @@ Expand the name of the chart.
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "zookeeper.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}

--- a/bitnami/zookeeper/templates/_helpers.tpl
+++ b/bitnami/zookeeper/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "zookeeper.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -12,7 +12,7 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "zookeeper.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

Changes the truncation of certain helm charts from 24 to 63. Most charts already support 63 char long naming, standardized them

**Benefits**

<!-- What benefits will be realized by the code change? -->

Can use longer strings for the name of the deployments (63 instead of 24)

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

If the name of the service/pods are used within the containers, they might cause issues

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
