### PR TITLE
Add appiVersion field to Chart.yaml

### DIFF
--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -1,6 +1,6 @@
-name: apache
 apiVersion: v1
-version: 4.0.6
+name: apache
+version: 4.0.7
 appVersion: 2.4.38
 description: Chart for Apache HTTP Server
 keywords:

--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: cassandra
-version: 2.1.4
+version: 2.1.5
 appVersion: 3.11.4
 description: Apache Cassandra is a free and open-source distributed database management system designed to handle large amounts of data across many commodity servers, providing high availability with no single point of failure. Cassandra offers robust support for clusters spanning multiple datacenters, with asynchronous masterless replication allowing low latency operations for all clients.
 icon: https://bitnami.com/assets/stacks/cassandra/img/cassandra-stack-220x234.png

--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: consul
-version: 4.0.4
+version: 4.0.5
 appVersion: 1.4.2
 description: Highly available and distributed service discovery and key-value store designed with support for the modern data center to make distributed systems and configuration easy.
 home: https://www.consul.io/

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: elasticsearch
-version: 4.2.12
+version: 4.2.13
 appVersion: 6.6.1
 description: A highly scalable open-source full-text search and analytics engine
 keywords:

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: etcd
-version: 1.5.5
+version: 1.5.6
 appVersion: 3.3.12
 description: etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines
 keywords:

--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: external-dns
-version: 1.3.4
+version: 1.3.5
 appVersion: 0.5.11
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/bitnami/jenkins/Chart.yaml
+++ b/bitnami/jenkins/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: jenkins
-version: 2.1.6
+version: 2.1.7
 appVersion: 2.150.3
 description: The leading open source automation server
 keywords:

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: kafka
-version: 1.4.0
+version: 1.4.1
 appVersion: 2.1.1
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/mean/Chart.yaml
+++ b/bitnami/mean/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: mean
-version: 6.0.0
+version: 6.0.1
 appVersion: 4.6.2
 description: MEAN is a free and open-source JavaScript software stack for building dynamic web sites and web applications. The MEAN stack is MongoDB, Express.js, Angular, and Node.js. Because all components of the MEAN stack support programs written in JavaScript, MEAN applications can be written in one language for both server-side and client-side execution environments.
 keywords:

--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: memcached
-version: 1.3.3
+version: 1.3.4
 appVersion: 1.5.12
 description: Chart for Memcached
 keywords:

--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: metrics-server
-version: 2.2.1
+version: 2.2.2
 appVersion: 0.3.1
 description: Metrics Server is a cluster-wide aggregator of resource usage data. Metrics Server collects metrics from the Summary API, exposed by Kubelet on each node.
 keywords:

--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: mysql
-version: 4.2.5
+version: 4.2.6
 appVersion: 5.7.25
 description: Chart to create a Highly available MySQL cluster
 keywords:

--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: nginx-ingress-controller
-version: 3.2.1
+version: 3.2.2
 appVersion: 0.22.0
 description: Chart for the nginx Ingress controller
 keywords:

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: nginx
-version: 2.1.4
+version: 2.1.5
 appVersion: 1.14.2
 description: Chart for the nginx server
 keywords:

--- a/bitnami/node/Chart.yaml
+++ b/bitnami/node/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: node
-version: 8.0.0
+version: 8.0.1
 appVersion: 8.15.0
 description: Event-driven I/O server-side JavaScript environment based on V8
 keywords:

--- a/bitnami/tensorflow-inception/Chart.yaml
+++ b/bitnami/tensorflow-inception/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: tensorflow-inception
-version: 3.2.7
+version: 3.2.8
 appVersion: 1.12.0
 description: Open-source software library for serving machine learning models
 keywords:

--- a/bitnami/tensorflow-resnet/Chart.yaml
+++ b/bitnami/tensorflow-resnet/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: tensorflow-resnet
-version: 0.0.4
+version: 0.0.5
 appVersion: 1.12.0
 description: Open-source software library serving the ResNet machine learning model.
 keywords:

--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: tomcat
-version: 2.1.4
+version: 2.1.5
 appVersion: 8.5.38
 description: Chart for Apache Tomcat
 keywords:

--- a/bitnami/wildfly/Chart.yaml
+++ b/bitnami/wildfly/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: wildfly
-version: 2.1.5
+version: 2.1.6
 appVersion: 15.0.1
 description: Chart for Wildfly
 keywords:

--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: zookeeper
-version: 1.2.4
+version: 1.2.5
 appVersion: 3.4.13
 description: A centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services for distributed applications.
 keywords:


### PR DESCRIPTION
According to https://github.com/helm/helm/blob/master/docs/charts.md#the-chartyaml-file:

> The `Chart.yaml` file is required for a chart. It contains the following fields:
> ```yaml
> apiVersion: The chart API version, always "v1" (required)
> name: The name of the chart (required)
> version: A SemVer 2 version (required)
> ...
> ```

We're not using the `apiVersion` field.