### PR TITLE
resources reference name typo fix

### DIFF
--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -73,7 +73,7 @@ spec:
             nami_initialize zookeeper
             exec tini -- /run.sh
         resources:
-{{ toYaml .Values.Resources | indent 10 }}
+{{ toYaml .Values.resources | indent 10 }}
         env:
         - name: ZOO_PORT_NUMBER
           value: {{ .Values.service.port | quote }}


### PR DESCRIPTION
Hello, in statefulset.yaml in Zookeeper helm template there is typo. At this moment zookeeper are not loading default/any resources values. Change
`{{ toYaml .Values.Resources | indent 10 }}`
to
`{{ toYaml .Values.resources | indent 10 }}`
reslove problem.