### PR TITLE
[bitnami/apache] Add global 'imagePullSecrets' to overwrite any other existing one

### DIFF
--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: apache
-version: 4.0.7
+version: 4.1.0
 appVersion: 2.4.38
 description: Chart for Apache HTTP Server
 keywords:

--- a/bitnami/apache/README.md
+++ b/bitnami/apache/README.md
@@ -44,30 +44,31 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the Apache chart and their default values.
 
-| Parameter                         | Description                           | Default                                                   |
-| --------------------------------- | ------------------------------------- | --------------------------------------------------------- |
-| `global.imageRegistry`            | Global Docker image registry          | `nil`                                                     |
-| `image.registry`                  | Apache image registry                 | `docker.io`                                               |
-| `image.repository`                | Apache Image name                     | `bitnami/apache`                                          |
-| `image.tag`                       | Apache Image tag                      | `{VERSION}`                                               |
-| `image.pullPolicy`                | Apache image pull policy              | `Always`                                                  |
-| `image.pullSecrets`               | Specify docker-registry secret names as an array            | `[]` (does not add image pull secrets to deployed pods)  |
-| `podAnnotations`                | Pod annotations                                   | `{}`                                                       |
-| `metrics.enabled`                          | Start a side-car prometheus exporter                                                                           | `false`                                              |
-| `metrics.image.registry`                   | Apache exporter image registry                                                                                  | `docker.io`                                          |
-| `metrics.image.repository`                 | Apache exporter image name                                                                                      | `lusotycoon/apache-exporter`                           |
-| `metrics.image.tag`                        | Apache exporter image tag                                                                                       | `v0.5.0`                                            |
-| `metrics.image.pullPolicy`                 | Image pull policy                                                                                              | `IfNotPresent`                                       |
-| `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                                                               | `nil`                                                |
-| `metrics.podAnnotations`                   | Additional annotations for Metrics exporter pod                                                                | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}`                                                   |
-| `metrics.resources`                        | Exporter resource requests/limit                                                                               | {}                        |
-| `service.type`                    | Kubernetes Service type                    | `LoadBalancer`                                          |
-| `service.port`                    | Service HTTP port                  | `80`                                          |
-| `service.httpsPort`                    | Service HTTPS port                   | `443`                                          |
-| `service.nodePorts.http`                 | Kubernetes http node port                  | `""`                                                    |
-| `service.nodePorts.https`                | Kubernetes https node port                 | `""`                                                    |
-| `service.externalTrafficPolicy`   | Enable client source IP preservation       | `Cluster`                                               |
-| `service.loadBalancerIP`   | LoadBalancer service IP address       | `""`                                               |
+| Parameter                         | Description                                       | Default                                                      |
+| --------------------------------- | ------------------------------------------------- | ------------------------------------------------------------ |
+| `global.imageRegistry`            | Global Docker image registry                      | `nil`                                                        |
+| `global.imagePullSecrets`         | Global Docker registry secret names as an array   | `[]` (does not add image pull secrets to deployed pods)      |
+| `image.registry`                  | Apache Docker image registry                      | `docker.io`                                                  |
+| `image.repository`                | Apache Docker image name                          | `bitnami/apache`                                             |
+| `image.tag`                       | Apache Docker image tag                           | `{VERSION}`                                                  |
+| `image.pullPolicy`                | Apache Docker image pull policy                   | `Always`                                                     |
+| `image.pullSecrets`               | Specify Docker registry secret names as an array  | `[]` (does not add image pull secrets to deployed pods)      |
+| `podAnnotations`                  | Pod annotations                                   | `{}`                                                         |
+| `metrics.enabled`                 | Start a side-car prometheus exporter              | `false`                                                      |
+| `metrics.image.registry`          | Apache exporter image registry                    | `docker.io`                                                  |
+| `metrics.image.repository`        | Apache exporter image name                        | `lusotycoon/apache-exporter`                                 |
+| `metrics.image.tag`               | Apache exporter image tag                         | `v0.5.0`                                                     |
+| `metrics.image.pullPolicy`        | Apache exporter image pull policy                 | `IfNotPresent`                                               |
+| `metrics.image.pullSecrets`       | Specify Docker registry secret names as an array  | `[]` (does not add image pull secrets to deployed pods)      |
+| `metrics.podAnnotations`          | Additional annotations for Metrics exporter pod   | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
+| `metrics.resources`               | Exporter resource requests/limit                  | {}                                                           |
+| `service.type`                    | Kubernetes Service type                           | `LoadBalancer`                                               |
+| `service.port`                    | Service HTTP port                                 | `80`                                                         |
+| `service.httpsPort`               | Service HTTPS port                                | `443`                                                        |
+| `service.nodePorts.http`          | Kubernetes http node port                         | `""`                                                         |
+| `service.nodePorts.https`         | Kubernetes https node port                        | `""`                                                         |
+| `service.externalTrafficPolicy`   | Enable client source IP preservation              | `Cluster`                                                    |
+| `service.loadBalancerIP`          | LoadBalancer service IP address                   | `""`                                                         |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/apache/templates/_helpers.tpl
+++ b/bitnami/apache/templates/_helpers.tpl
@@ -39,6 +39,41 @@ Also, we can't use a single if because lazy evaluation is not an option
 {{- end -}}
 
 {{/*
+Return the proper Apache Docker Image Registry Secret Names
+*/}}
+{{- define "apache.imagePullSecrets" -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- else if or .Values.image.pullSecrets .Values.metrics.image.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.metrics.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end -}}
+{{- else if or .Values.image.pullSecrets .Values.metrics.image.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.metrics.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the proper image name (for the metrics image)
 */}}
 {{- define "metrics.image" -}}

--- a/bitnami/apache/templates/deployment.yaml
+++ b/bitnami/apache/templates/deployment.yaml
@@ -30,12 +30,7 @@ spec:
   {{- end }}
 {{- end }}
     spec:
-      {{- if .Values.image.pullSecrets }}
-      imagePullSecrets:
-      {{- range .Values.image.pullSecrets }}
-        - name: {{ . }}
-      {{- end}}
-      {{- end }}
+{{- include "apache.imagePullSecrets" . | indent 6 }}
       hostAliases:
       - ip: "127.0.0.1"
         hostnames:

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -1,8 +1,11 @@
-## Global Docker image registry
-## Please, note that this will override the image registry for all the images, including dependencies, configured to use the global value
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+## Current available global Docker image parameters: imageRegistry and imagepullSecrets
 ##
 # global:
 #   imageRegistry:
+#   imagePullSecrets:
+#     - myRegistryKeySecretName
 
 ## Bitnami Apache image version
 ## ref: https://hub.docker.com/r/bitnami/apache/tags/
@@ -20,7 +23,7 @@ image:
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   ##
   # pullSecrets:
-  #   - myRegistrKeySecretName
+  #   - myRegistryKeySecretName
 
 ## Pod annotations
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
@@ -40,8 +43,10 @@ metrics:
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
     ##
     # pullSecrets:
-    #   - myRegistrKeySecretName
-     ## Metrics exporter pod Annotation and Labels
+    #   - myRegistryKeySecretName
+  ## Metrics exporter pod Annotation and Labels
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
   podAnnotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9117"

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -3,7 +3,7 @@
 ## Current available global Docker image parameters: imageRegistry and imagepullSecrets
 ##
 # global:
-#   imageRegistry:
+#   imageRegistry: myRegistryMame
 #   imagePullSecrets:
 #     - myRegistryKeySecretName
 


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

This PR allows using a global parameter to indicate the array of secret names to use as Image Registry Secret.

Use:

```bash
$ kubectl create secret XXXX ...
$ helm install bitnami/apache --name apache --set global.imagePullSecrets=XXXX ...
````