### PR TITLE
[bitnami/elasticsearch] Avoid using 'appended' configuration files

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: elasticsearch
-version: 4.5.0
+version: 4.6.0
 appVersion: 6.6.1
 description: A highly scalable open-source full-text search and analytics engine
 keywords:

--- a/bitnami/elasticsearch/templates/cm.yaml
+++ b/bitnami/elasticsearch/templates/cm.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.config }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,13 +9,6 @@ metadata:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
 data:
-  elasticsearch_custom.yml: |-
-
-    discovery:
-      zen:
-        ping.unicast.hosts: {{ template "elasticsearch.discovery.fullname" . }}
-        minimum_master_nodes: 2
-
-{{- if .Values.config }}
+  elasticsearch.yml: |-
 {{ toYaml .Values.config | indent 4 }}
 {{- end }}

--- a/bitnami/elasticsearch/templates/coordinating-deploy.yaml
+++ b/bitnami/elasticsearch/templates/coordinating-deploy.yaml
@@ -73,6 +73,8 @@ spec:
         env:
         - name: ELASTICSEARCH_CLUSTER_NAME
           value: {{ .Values.name | quote }}
+        - name: ELASTICSEARCH_CLUSTER_HOSTS
+          value: {{ template "elasticsearch.discovery.fullname" . }}
         {{- if .Values.plugins }}
         - name: ELASTICSEARCH_PLUGINS
           value: {{ .Values.plugins | quote }}
@@ -113,9 +115,9 @@ spec:
         resources:
 {{ toYaml .Values.coordinating.resources | indent 10 }}
         volumeMounts:
-        - mountPath: /opt/bitnami/elasticsearch/config/elasticsearch_custom.yml
+        - mountPath: /opt/bitnami/elasticsearch/config/elasticsearch.yml
           name: "config"
-          subPath: elasticsearch_custom.yml
+          subPath: elasticsearch.yml
         - name: "data"
           mountPath: "/bitnami/elasticsearch/data/"
       volumes:

--- a/bitnami/elasticsearch/templates/data-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/data-statefulset.yaml
@@ -74,6 +74,8 @@ spec:
         env:
         - name: ELASTICSEARCH_CLUSTER_NAME
           value: {{ .Values.name | quote }}
+        - name: ELASTICSEARCH_CLUSTER_HOSTS
+          value: {{ template "elasticsearch.discovery.fullname" . }}
         {{- if .Values.plugins }}
         - name: ELASTICSEARCH_PLUGINS
           value: {{ .Values.plugins | quote }}
@@ -112,9 +114,9 @@ spec:
         resources:
 {{ toYaml .Values.data.resources | indent 10 }}
         volumeMounts:
-        - mountPath: /opt/bitnami/elasticsearch/config/elasticsearch_custom.yml
+        - mountPath: /opt/bitnami/elasticsearch/config/elasticsearch.yml
           name: "config"
-          subPath: elasticsearch_custom.yml
+          subPath: elasticsearch.yml
         - name: "data"
           mountPath: "/bitnami/elasticsearch/data"
       volumes:

--- a/bitnami/elasticsearch/templates/ingest-deploy.yaml
+++ b/bitnami/elasticsearch/templates/ingest-deploy.yaml
@@ -74,6 +74,8 @@ spec:
         env:
         - name: ELASTICSEARCH_CLUSTER_NAME
           value: {{ .Values.name | quote }}
+        - name: ELASTICSEARCH_CLUSTER_HOSTS
+          value: {{ template "elasticsearch.discovery.fullname" . }}
         {{- if .Values.plugins }}
         - name: ELASTICSEARCH_PLUGINS
           value: {{ .Values.plugins | quote }}
@@ -114,9 +116,9 @@ spec:
         resources:
 {{ toYaml .Values.ingest.resources | indent 10 }}
         volumeMounts:
-        - mountPath: /opt/bitnami/elasticsearch/config/elasticsearch_custom.yml
+        - mountPath: /opt/bitnami/elasticsearch/config/elasticsearch.yml
           name: "config"
-          subPath: elasticsearch_custom.yml
+          subPath: elasticsearch.yml
         - name: "data"
           mountPath: "/bitnami/elasticsearch/data/"
       volumes:

--- a/bitnami/elasticsearch/templates/master-deploy.yaml
+++ b/bitnami/elasticsearch/templates/master-deploy.yaml
@@ -74,6 +74,8 @@ spec:
         env:
         - name: ELASTICSEARCH_CLUSTER_NAME
           value: {{ .Values.name | quote }}
+        - name: ELASTICSEARCH_CLUSTER_HOSTS
+          value: {{ template "elasticsearch.discovery.fullname" . }}
         {{- if .Values.plugins }}
         - name: ELASTICSEARCH_PLUGINS
           value: {{ .Values.plugins | quote }}
@@ -112,9 +114,9 @@ spec:
         resources:
 {{ toYaml .Values.master.resources | indent 10 }}
         volumeMounts:
-        - mountPath: /opt/bitnami/elasticsearch/config/elasticsearch_custom.yml
+        - mountPath: /opt/bitnami/elasticsearch/config/elasticsearch.yml
           name: "config"
-          subPath: elasticsearch_custom.yml
+          subPath: elasticsearch.yml
         - name: "data"
           mountPath: "/bitnami/elasticsearch/data"
       volumes:


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

We're not supporting appending custom configuration to the main ES configuration file as we found conflicts when setting an already set configuration option. Therefore, we need to adapt the chart to this new approach.