### PR TITLE
[bitnami/zookeeper] Manage disruptions when using more than 1 replicas

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zookeeper
-version: 1.6.1
+version: 1.7.0
 appVersion: 3.4.14
 description: A centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services for distributed applications.
 keywords:

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -56,6 +56,7 @@ The following tables lists the configurable parameters of the Zookeeper chart an
 | `image.pullSecrets`                   | Specify docker-registry secret names as an array                    | `[]` (does not add image pull secrets to deployed pods)  |
 | `image.debug`                         | Specify if debug values should be set                               | `false`                                                  |
 | `updateStrategy`                      | Update strategies                                                   | `RollingUpdate`                                          |
+| `podDisruptionBudget.maxUnavailable`  | Max number of pods down simultaneously                              | `1`                                                      |
 | `rollingUpdatePartition`              | Partition update strategy                                           | `nil`                                                    |
 | `podManagementpolicy`                 | Pod management policy                                               | `Parallel`                                               |
 | `replicaCount`                        | Number of ZooKeeper nodes                                           | `1`                                                      |

--- a/bitnami/zookeeper/templates/poddisruptionbudget.yaml
+++ b/bitnami/zookeeper/templates/poddisruptionbudget.yaml
@@ -1,0 +1,20 @@
+{{- if gt .Values.replicaCount 1.0 -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "zookeeper.fullname" . }}
+  labels:
+    app: {{ template "zookeeper.name" . }}
+    chart: {{ template "zookeeper.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/component: {{ template "zookeeper.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "zookeeper.name" . }}
+      release: {{ .Release.Name | quote }}
+      app.kubernetes.io/component: {{ template "zookeeper.name" . }}
+{{ toYaml .Values.podDisruptionBudget | indent 2 }}
+{{- end }}

--- a/bitnami/zookeeper/values-production.yaml
+++ b/bitnami/zookeeper/values-production.yaml
@@ -36,6 +36,14 @@ image:
 ##
 updateStrategy: RollingUpdate
 
+
+## Limits the number of pods of the replicated application that are down simultaneously from voluntary disruptions
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions
+##
+podDisruptionBudget:
+  maxUnavailable: 1  
+
+
 ## Partition update strategy
 ## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions
 ##

--- a/bitnami/zookeeper/values-production.yaml
+++ b/bitnami/zookeeper/values-production.yaml
@@ -38,11 +38,12 @@ updateStrategy: RollingUpdate
 
 
 ## Limits the number of pods of the replicated application that are down simultaneously from voluntary disruptions
+## The PDB will only be created if replicaCount is greater than 1
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions
 ##
 podDisruptionBudget:
   maxUnavailable: 1  
-
+  
 
 ## Partition update strategy
 ## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions

--- a/bitnami/zookeeper/values-production.yaml
+++ b/bitnami/zookeeper/values-production.yaml
@@ -36,14 +36,12 @@ image:
 ##
 updateStrategy: RollingUpdate
 
-
 ## Limits the number of pods of the replicated application that are down simultaneously from voluntary disruptions
 ## The PDB will only be created if replicaCount is greater than 1
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions
 ##
 podDisruptionBudget:
   maxUnavailable: 1  
-  
 
 ## Partition update strategy
 ## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -36,14 +36,12 @@ image:
 ##
 updateStrategy: RollingUpdate
 
-
 ## Limits the number of pods of the replicated application that are down simultaneously from voluntary disruptions
 ## The PDB will only be created if replicaCount is greater than 1
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions
 ##
 podDisruptionBudget:
   maxUnavailable: 1  
-
 
 ## Partition update strategy
 ## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -36,6 +36,15 @@ image:
 ##
 updateStrategy: RollingUpdate
 
+
+## Limits the number of pods of the replicated application that are down simultaneously from voluntary disruptions
+## The PDB will only be created if replicaCount is greater than 1
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions
+##
+podDisruptionBudget:
+  maxUnavailable: 1  
+
+
 ## Partition update strategy
 ## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions
 ##


### PR DESCRIPTION
**Description of the change**

Created a pod distruption budget when replicas is bigger than 1
By default only 1 pod can be unavailable at any point in time
Added additional label to the statefulset so the pdb doesn't select the metrics pod

**Benefits**

A pdb is very useful for replicated application and it will allow us to safely drain a node

**Possible drawbacks**

Can't see any right now

**Additional information**

Tests made: 
- pdb is only applied when replicaCount is 2 or more. 
 - if the additional label wasn't added and the metrics was enabled, then the metrics pod was counted in the pdb (can be easily checked with ```kubectl describe pdb```)
