### PR TITLE
[bitnami/elasticsearch] Fix _helpers.tpl removing non-existent image property

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: elasticsearch
-version: 4.6.4
+version: 4.6.5
 appVersion: 6.6.2
 description: A highly scalable open-source full-text search and analytics engine
 keywords:

--- a/bitnami/elasticsearch/templates/_helpers.tpl
+++ b/bitnami/elasticsearch/templates/_helpers.tpl
@@ -126,9 +126,9 @@ Also, we can't use a single if because lazy evaluation is not an option
 Return the proper sysctl image name
 */}}
 {{- define "elasticsearch.sysctl.image" -}}
-{{- $registryName := .Values.sysctlImage.image.registry -}}
-{{- $repositoryName := .Values.sysctlImage.image.repository -}}
-{{- $tag := .Values.sysctlImage.image.tag | toString -}}
+{{- $registryName := .Values.sysctlImage.registry -}}
+{{- $repositoryName := .Values.sysctlImage.repository -}}
+{{- $tag := .Values.sysctlImage.tag | toString -}}
 {{/*
 Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
 but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.


### PR DESCRIPTION
```
render error in "elasticsearch/templates/master-deploy.yaml": template: elasticsearch/templates/_helpers.tpl:129:28: executing "elasticsearch.sysctl.image" at <.Values.sysctlImage....>: can't evaluate field registry in type interface {}
```

Current `values.yaml`:
```yaml
sysctlImage:
  registry: docker.io
  repository: bitnami/minideb
  tag: latest
```
That's the reason of the changes:
```diff
-.Values.sysctlImage.image.XXX
+.Values.sysctlImage.XXX
```