### PR TITLE
[bitnami/kafka] Fix issue when zookeeper password is specified but auth is disabled

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 1.8.0
+version: 1.8.1
 appVersion: 2.1.1
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -116,11 +116,6 @@ spec:
             secretKeyRef:
               name: {{ if .Values.auth.existingSecret }}{{ .Values.auth.existingSecret }}{{ else }}{{ template "kafka.fullname" . }}{{ end }}
               key: kafka-inter-broker-password
-        {{- end }}
-        {{- if .Values.auth.certificatesPassword }}
-        - name: KAFKA_CERTIFICATE_PASSWORD
-          value: {{ .Values.auth.certificatesPassword | quote }}
-        {{- end }}
         {{- if .Values.auth.zookeeperUser }}
         - name: KAFKA_ZOOKEEPER_USER
           value: {{ .Values.auth.zookeeperUser | quote }}
@@ -131,6 +126,11 @@ spec:
             secretKeyRef:
               name: {{ if .Values.auth.existingSecret }}{{ .Values.auth.existingSecret }}{{ else }}{{ template "kafka.fullname" . }}{{ end }}
               key: kafka-zookeeper-password
+        {{- end }}
+        {{- end }}
+        {{- if .Values.auth.certificatesPassword }}
+        - name: KAFKA_CERTIFICATE_PASSWORD
+          value: {{ .Values.auth.certificatesPassword | quote }}
         {{- end }}
         - name: ALLOW_PLAINTEXT_LISTENER
           {{- if .Values.auth.enabled }}


### PR DESCRIPTION
Signed-off-by: tompizmor <tompizmor@gmail.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
The zookeeper password env var should only be set if auth is enabled. Otherwise, the secret containing the specified password won't be created and the Kafka pod will fail to start:

```
  Warning  Failed            2s (x7 over 75s)     kubelet, minikube  Error: secret "kafka" not found
```

<!-- Describe the scope of your change - i.e. what the change does. -->


