### PR TITLE
Add comments warning about custom user strings

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mysql
-version: 4.5.0
+version: 4.5.1
 appVersion: 5.7.25
 description: Chart to create a Highly available MySQL cluster
 keywords:

--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -45,78 +45,78 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the MySQL chart and their default values.
 
-|             Parameter                     |                     Description                       |                              Default                              |
-|-------------------------------------------|-------------------------------------------------------|-------------------------------------------------------------------|
-| `global.imageRegistry`                    | Global Docker image registry                          | `nil`                                                             |
-| `global.imagePullSecrets`                 | Global Docker registry secret names as an array       | `[]` (does not add image pull secrets to deployed pods)           |
-| `image.registry`                          | MySQL image registry                                  | `docker.io`                                                       |
-| `image.repository`                        | MySQL Image name                                      | `bitnami/mysql`                                                   |
-| `image.tag`                               | MySQL Image tag                                       | `{VERSION}`                                                       |
-| `image.pullPolicy`                        | MySQL image pull policy                               | `Always` if `imageTag` is `latest`, else `IfNotPresent`           |
-| `image.pullSecrets`                       | Specify docker-registry secret names as an array      | `[]` (does not add image pull secrets to deployed pods)           |
-| `service.type`                            | Kubernetes service type                               | `ClusterIP`                                                       |
-| `service.port`                            | MySQL service port                                    | `3306`                                                            |
-| `root.password`                           | Password for the `root` user                          | _random 10 character alphanumeric string_                         |
-| `db.user`                                 | Username of new user to create                        | `nil`                                                             |
-| `db.password`                             | Password for the new user                             | _random 10 character alphanumeric string if `db.user` is defined_ |
-| `db.name`                                 | Name for new database to create                       | `my_database`                                                     |
-| `securityContext.enabled`                 | Enable security context                               | `true`                                                            |
-| `securityContext.fsGroup`                 | Group ID for the container                            | `1001`                                                            |
-| `securityContext.runAsUser`               | User ID for the container                             | `1001`                                                            |
-| `replication.enabled`                     | MySQL replication enabled                             | `true`                                                            |
-| `replication.user`                        | MySQL replication user                                | `replicator`                                                      |
-| `replication.password`                    | MySQL replication user password                       | _random 10 character alphanumeric string_                         |
-| `master.antiAffinity`                     | Master pod anti-affinity policy                       | `soft`                                                            |
-| `master.updateStrategy.type`              | Master statefulset update strategy policy             | `RollingUpdate`                                                   |
-| `master.persistence.enabled`              | Enable persistence using a `PersistentVolumeClaim`    | `true`                                                            |
-| `master.persistence.existingClaim`        | Provide an existing `PersistentVolumeClaim`           | `nil`                                                             |
-| `master.persistence.mountPath`            | Configure `PersistentVolumeClaim` mount path          | `/bitnami/mysql`                                                  |
-| `master.persistence.annotations`          | Persistent Volume Claim annotations                   | `{}`                                                              |
-| `master.persistence.storageClass`         | Persistent Volume Storage Class                       | ``                                                                |
-| `master.persistence.accessModes`          | Persistent Volume Access Modes                        | `[ReadWriteOnce]`                                                 |
-| `master.persistence.size`                 | Persistent Volume Size                                | `8Gi`                                                             |
-| `master.config`                           | Config file for the MySQL Master server               | `_default values in the values.yaml file_`                        |
-| `master.resources`                        | CPU/Memory resource requests/limits for master node   | `{}`                                                              |
-| `master.livenessProbe.enabled`            | Turn on and off liveness probe (master)               | `true`                                                            |
-| `master.livenessProbe.initialDelaySeconds`| Delay before liveness probe is initiated (master)     | `120`                                                             |
-| `master.livenessProbe.periodSeconds`      | How often to perform the probe (master)               | `10`                                                              |
-| `master.livenessProbe.timeoutSeconds`     | When the probe times out (master)                     | `1`                                                               |
-| `master.livenessProbe.successThreshold`   | Minimum consecutive successes for the probe (master)  | `1`                                                               |
-| `master.livenessProbe.failureThreshold`   | Minimum consecutive failures for the probe (master)   | `3`                                                               |
-| `master.readinessProbe.enabled`           | Turn on and off readiness probe (master)              | `true`                                                            |
-| `master.readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated (master)   | `30`                                                              |
-| `master.readinessProbe.periodSeconds`     | How often to perform the probe (master)               | `10`                                                              |
-| `master.readinessProbe.timeoutSeconds`    | When the probe times out (master)                     | `1`                                                               |
-| `master.readinessProbe.successThreshold`  | Minimum consecutive successes for the probe (master)  | `1`                                                               |
-| `master.readinessProbe.failureThreshold`  | Minimum consecutive failures for the probe (master)   | `3`                                                               |
-| `slave.replicas`                          | Desired number of slave replicas                      | `1`                                                               |
-| `slave.antiAffinity`                      | Slave pod anti-affinity policy                        | `soft`                                                            |
-| `slave.updateStrategy.type`               | Slave statefulset update strategy policy              | `RollingUpdate`                                                   |
-| `slave.persistence.enabled`               | Enable persistence using a `PersistentVolumeClaim`    | `true`                                                            |
-| `slave.persistence.mountPath`             | Configure `PersistentVolumeClaim` mount path          | `/bitnami/mysql`                                                  |
-| `slave.persistence.annotations`           | Persistent Volume Claim annotations                   | `{}`                                                              |
-| `slave.persistence.storageClass`          | Persistent Volume Storage Class                       | ``                                                                |
-| `slave.persistence.accessModes`           | Persistent Volume Access Modes                        | `[ReadWriteOnce]`                                                 |
-| `slave.persistence.size`                  | Persistent Volume Size                                | `8Gi`                                                             |
-| `slave.config`                            | Config file for the MySQL Slave replicas              | `_default values in the values.yaml file_`                        |
-| `slave.resources`                         | CPU/Memory resource requests/limits for slave node    | `{}`                                                              |
-| `slave.livenessProbe.enabled`             | Turn on and off liveness probe (slave)                | `true`                                                            |
-| `slave.livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated (slave)      | `120`                                                             |
-| `slave.livenessProbe.periodSeconds`       | How often to perform the probe (slave)                | `10`                                                              |
-| `slave.livenessProbe.timeoutSeconds`      | When the probe times out (slave)                      | `1`                                                               |
-| `slave.livenessProbe.successThreshold`    | Minimum consecutive successes for the probe (slave)   | `1`                                                               |
-| `slave.livenessProbe.failureThreshold`    | Minimum consecutive failures for the probe (slave)    | `3`                                                               |
-| `slave.readinessProbe.enabled`            | Turn on and off readiness probe (slave)               | `true`                                                            |
-| `slave.readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated (slave)     | `30`                                                              |
-| `slave.readinessProbe.periodSeconds`      | How often to perform the probe (slave)                | `10`                                                              |
-| `slave.readinessProbe.timeoutSeconds`     | When the probe times out (slave)                      | `1`                                                               |
-| `slave.readinessProbe.successThreshold`   | Minimum consecutive successes for the probe (slave)   | `1`                                                               |
-| `slave.readinessProbe.failureThreshold`   | Minimum consecutive failures for the probe (slave)    | `3`                                                               |
-| `metrics.enabled`                         | Start a side-car prometheus exporter                  | `false`                                                           |
-| `metrics.image`                           | Exporter image name                                   | `prom/mysqld-exporter`                                            |
-| `metrics.imageTag`                        | Exporter image tag                                    | `v0.10.0`                                                         |
-| `metrics.imagePullPolicy`                 | Exporter image pull policy                            | `IfNotPresent`                                                    |
-| `metrics.resources`                       | Exporter resource requests/limit                      | `nil`                                                             |
+|             Parameter                     |                                  Description                               |                              Default                              |
+|-------------------------------------------|----------------------------------------------------------------------------|-------------------------------------------------------------------|
+| `global.imageRegistry`                    | Global Docker image registry                                               | `nil`                                                             |
+| `global.imagePullSecrets`                 | Global Docker registry secret names as an array                            | `[]` (does not add image pull secrets to deployed pods)           |
+| `image.registry`                          | MySQL image registry                                                       | `docker.io`                                                       |
+| `image.repository`                        | MySQL Image name                                                           | `bitnami/mysql`                                                   |
+| `image.tag`                               | MySQL Image tag                                                            | `{VERSION}`                                                       |
+| `image.pullPolicy`                        | MySQL image pull policy                                                    | `Always` if `imageTag` is `latest`, else `IfNotPresent`           |
+| `image.pullSecrets`                       | Specify docker-registry secret names as an array                           | `[]` (does not add image pull secrets to deployed pods)           |
+| `service.type`                            | Kubernetes service type                                                    | `ClusterIP`                                                       |
+| `service.port`                            | MySQL service port                                                         | `3306`                                                            |
+| `root.password`                           | Password for the `root` user                                               | _random 10 character alphanumeric string_                         |
+| `db.user`                                 | Username of new user to create (should be different from replication.user) | `nil`                                                             |
+| `db.password`                             | Password for the new user                                                  | _random 10 character alphanumeric string if `db.user` is defined_ |
+| `db.name`                                 | Name for new database to create                                            | `my_database`                                                     |
+| `securityContext.enabled`                 | Enable security context                                                    | `true`                                                            |
+| `securityContext.fsGroup`                 | Group ID for the container                                                 | `1001`                                                            |
+| `securityContext.runAsUser`               | User ID for the container                                                  | `1001`                                                            |
+| `replication.enabled`                     | MySQL replication enabled                                                  | `true`                                                            |
+| `replication.user`                        | MySQL replication user (should be different from db.user)                  | `replicator`                                                      |
+| `replication.password`                    | MySQL replication user password                                            | _random 10 character alphanumeric string_                         |
+| `master.antiAffinity`                     | Master pod anti-affinity policy                                            | `soft`                                                            |
+| `master.updateStrategy.type`              | Master statefulset update strategy policy                                  | `RollingUpdate`                                                   |
+| `master.persistence.enabled`              | Enable persistence using a `PersistentVolumeClaim`                         | `true`                                                            |
+| `master.persistence.existingClaim`        | Provide an existing `PersistentVolumeClaim`                                | `nil`                                                             |
+| `master.persistence.mountPath`            | Configure `PersistentVolumeClaim` mount path                               | `/bitnami/mysql`                                                  |
+| `master.persistence.annotations`          | Persistent Volume Claim annotations                                        | `{}`                                                              |
+| `master.persistence.storageClass`         | Persistent Volume Storage Class                                            | ``                                                                |
+| `master.persistence.accessModes`          | Persistent Volume Access Modes                                             | `[ReadWriteOnce]`                                                 |
+| `master.persistence.size`                 | Persistent Volume Size                                                     | `8Gi`                                                             |
+| `master.config`                           | Config file for the MySQL Master server                                    | `_default values in the values.yaml file_`                        |
+| `master.resources`                        | CPU/Memory resource requests/limits for master node                        | `{}`                                                              |
+| `master.livenessProbe.enabled`            | Turn on and off liveness probe (master)                                    | `true`                                                            |
+| `master.livenessProbe.initialDelaySeconds`| Delay before liveness probe is initiated (master)                          | `120`                                                             |
+| `master.livenessProbe.periodSeconds`      | How often to perform the probe (master)                                    | `10`                                                              |
+| `master.livenessProbe.timeoutSeconds`     | When the probe times out (master)                                          | `1`                                                               |
+| `master.livenessProbe.successThreshold`   | Minimum consecutive successes for the probe (master)                       | `1`                                                               |
+| `master.livenessProbe.failureThreshold`   | Minimum consecutive failures for the probe (master)                        | `3`                                                               |
+| `master.readinessProbe.enabled`           | Turn on and off readiness probe (master)                                   | `true`                                                            |
+| `master.readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated (master)                        | `30`                                                              |
+| `master.readinessProbe.periodSeconds`     | How often to perform the probe (master)                                    | `10`                                                              |
+| `master.readinessProbe.timeoutSeconds`    | When the probe times out (master)                                          | `1`                                                               |
+| `master.readinessProbe.successThreshold`  | Minimum consecutive successes for the probe (master)                       | `1`                                                               |
+| `master.readinessProbe.failureThreshold`  | Minimum consecutive failures for the probe (master)                        | `3`                                                               |
+| `slave.replicas`                          | Desired number of slave replicas                                           | `1`                                                               |
+| `slave.antiAffinity`                      | Slave pod anti-affinity policy                                             | `soft`                                                            |
+| `slave.updateStrategy.type`               | Slave statefulset update strategy policy                                   | `RollingUpdate`                                                   |
+| `slave.persistence.enabled`               | Enable persistence using a `PersistentVolumeClaim`                         | `true`                                                            |
+| `slave.persistence.mountPath`             | Configure `PersistentVolumeClaim` mount path                               | `/bitnami/mysql`                                                  |
+| `slave.persistence.annotations`           | Persistent Volume Claim annotations                                        | `{}`                                                              |
+| `slave.persistence.storageClass`          | Persistent Volume Storage Class                                            | ``                                                                |
+| `slave.persistence.accessModes`           | Persistent Volume Access Modes                                             | `[ReadWriteOnce]`                                                 |
+| `slave.persistence.size`                  | Persistent Volume Size                                                     | `8Gi`                                                             |
+| `slave.config`                            | Config file for the MySQL Slave replicas                                   | `_default values in the values.yaml file_`                        |
+| `slave.resources`                         | CPU/Memory resource requests/limits for slave node                         | `{}`                                                              |
+| `slave.livenessProbe.enabled`             | Turn on and off liveness probe (slave)                                     | `true`                                                            |
+| `slave.livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated (slave)                           | `120`                                                             |
+| `slave.livenessProbe.periodSeconds`       | How often to perform the probe (slave)                                     | `10`                                                              |
+| `slave.livenessProbe.timeoutSeconds`      | When the probe times out (slave)                                           | `1`                                                               |
+| `slave.livenessProbe.successThreshold`    | Minimum consecutive successes for the probe (slave)                        | `1`                                                               |
+| `slave.livenessProbe.failureThreshold`    | Minimum consecutive failures for the probe (slave)                         | `3`                                                               |
+| `slave.readinessProbe.enabled`            | Turn on and off readiness probe (slave)                                    | `true`                                                            |
+| `slave.readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated (slave)                          | `30`                                                              |
+| `slave.readinessProbe.periodSeconds`      | How often to perform the probe (slave)                                     | `10`                                                              |
+| `slave.readinessProbe.timeoutSeconds`     | When the probe times out (slave)                                           | `1`                                                               |
+| `slave.readinessProbe.successThreshold`   | Minimum consecutive successes for the probe (slave)                        | `1`                                                               |
+| `slave.readinessProbe.failureThreshold`   | Minimum consecutive failures for the probe (slave)                         | `3`                                                               |
+| `metrics.enabled`                         | Start a side-car prometheus exporter                                       | `false`                                                           |
+| `metrics.image`                           | Exporter image name                                                        | `prom/mysqld-exporter`                                            |
+| `metrics.imageTag`                        | Exporter image tag                                                         | `v0.10.0`                                                         |
+| `metrics.imagePullPolicy`                 | Exporter image pull policy                                                 | `IfNotPresent`                                                    |
+| `metrics.resources`                       | Exporter resource requests/limit                                           | `nil`                                                             |
 
 The above parameters map to the env variables defined in [bitnami/mysql](http://github.com/bitnami/bitnami-docker-mysql). For more information please refer to the [bitnami/mysql](http://github.com/bitnami/bitnami-docker-mysql) image documentation.
 

--- a/bitnami/mysql/values-production.yaml
+++ b/bitnami/mysql/values-production.yaml
@@ -54,6 +54,7 @@ root:
 db:
   ## MySQL username and password
   ## ref: https://github.com/bitnami/bitnami-docker-mysql#creating-a-database-user-on-first-run
+  ## Note that this user should be different from the MySQL replication user (replication.user)
   ##
   user:
   password:
@@ -73,6 +74,7 @@ replication:
   ##
   ## MySQL replication user
   ## ref: https://github.com/bitnami/bitnami-docker-mysql#setting-up-a-replication-cluster
+  ## Note that this user should be different from the MySQL user (db.user)
   ##
   user: replicator
   ## MySQL replication user password

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -55,6 +55,7 @@ root:
 db:
   ## MySQL username and password
   ## ref: https://github.com/bitnami/bitnami-docker-mysql#creating-a-database-user-on-first-run
+  ## Note that this user should be different from the MySQL replication user (replication.user)
   ##
   user:
   password:
@@ -74,6 +75,7 @@ replication:
   ##
   ## MySQL replication user
   ## ref: https://github.com/bitnami/bitnami-docker-mysql#setting-up-a-replication-cluster
+  ## Note that this user should be different from the MySQL user (db.user)
   ##
   user: replicator
   ## MySQL replication user password


### PR DESCRIPTION
**Description of the change**

Warn users about using the same name for db and replication user.

**Applicable issues**

#1126 