### PR TITLE
[bitnami/elasticsearch] Adapt chart to Elasticserch version 7

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: elasticsearch
-version: 4.7.2
-appVersion: 6.7.1
+version: 5.0.0
+appVersion: 7.0.0
 description: A highly scalable open-source full-text search and analytics engine
 keywords:
 - elasticsearch

--- a/bitnami/elasticsearch/templates/coordinating-deploy.yaml
+++ b/bitnami/elasticsearch/templates/coordinating-deploy.yaml
@@ -51,7 +51,7 @@ spec:
       {{- if .Values.coordinating.nodeAffinity }}
 {{ toYaml .Values.coordinating.nodeAffinity | indent 8 }}
       {{- end }}
-{{- include "elasticsearch.imagePullSecrets" . | indent 6 }}
+      {{- include "elasticsearch.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.sysctlImage.enabled }}
       ## Image that performs the sysctl operation to modify Kernel settings (needed sometimes to avoid boot errors)
       initContainers:

--- a/bitnami/elasticsearch/templates/data-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/data-statefulset.yaml
@@ -32,6 +32,7 @@ spec:
         release: {{ .Release.Name | quote }}
         role: "data"
     spec:
+      {{- include "elasticsearch.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}

--- a/bitnami/elasticsearch/templates/ingest-deploy.yaml
+++ b/bitnami/elasticsearch/templates/ingest-deploy.yaml
@@ -23,6 +23,7 @@ spec:
         release: {{ .Release.Name | quote }}
         role: "ingest"
     spec:
+      {{- include "elasticsearch.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}

--- a/bitnami/elasticsearch/templates/master-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/master-statefulset.yaml
@@ -1,5 +1,5 @@
-apiVersion: extensions/v1beta1
-kind: Deployment
+apiVersion: apps/v1beta2
+kind: StatefulSet
 metadata:
   name: {{ template "elasticsearch.master.fullname" . }}
   labels:
@@ -12,8 +12,9 @@ spec:
   selector:
     matchLabels:
       app: {{ template "elasticsearch.name" . }}
-      release: "{{ .Release.Name }}"
+      release: {{ .Release.Name | quote }}
       role: "master"
+  serviceName: "{{ template "elasticsearch.master.fullname" . }}"
   replicas: {{ .Values.master.replicas }}
   template:
     metadata:
@@ -52,7 +53,6 @@ spec:
       {{- if .Values.master.nodeAffinity }}
 {{ toYaml .Values.master.nodeAffinity | indent 8 }}
       {{- end }}
-{{- include "elasticsearch.imagePullSecrets" . | indent 6 }}
       {{- if .Values.sysctlImage.enabled }}
       ## Image that performs the sysctl operation to modify Kernel settings (needed sometimes to avoid boot errors)
       initContainers:
@@ -66,16 +66,20 @@ spec:
       containers:
       - name: "elasticsearch"
         image: {{ template "elasticsearch.image" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         {{- if .Values.securityContext.enabled }}
         securityContext:
           runAsUser: {{ .Values.securityContext.runAsUser }}
         {{- end }}
-        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         env:
         - name: ELASTICSEARCH_CLUSTER_NAME
           value: {{ .Values.name | quote }}
         - name: ELASTICSEARCH_CLUSTER_HOSTS
           value: {{ template "elasticsearch.discovery.fullname" . }}
+        - name: ELASTICSEARCH_CLUSTER_MASTER_HOSTS
+          {{- $elasticsearchMasterFullname := include "elasticsearch.master.fullname" . }}
+          {{- $replicas := int .Values.master.replicas }}
+          value: {{range $i, $e := until $replicas }}{{ $elasticsearchMasterFullname }}-{{ $e }} {{ end }}
         {{- if .Values.plugins }}
         - name: ELASTICSEARCH_PLUGINS
           value: {{ .Values.plugins | quote }}
@@ -110,7 +114,7 @@ spec:
           httpGet:
             path: /_cluster/health?local=true
             port: 9200
-      {{- end }}
+        {{- end }}
         resources:
 {{ toYaml .Values.master.resources | indent 10 }}
         volumeMounts:

--- a/bitnami/elasticsearch/templates/master-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/master-statefulset.yaml
@@ -14,7 +14,7 @@ spec:
       app: {{ template "elasticsearch.name" . }}
       release: {{ .Release.Name | quote }}
       role: "master"
-  serviceName: "{{ template "elasticsearch.master.fullname" . }}"
+  serviceName: {{ template "elasticsearch.master.fullname" . }}
   replicas: {{ .Values.master.replicas }}
   template:
     metadata:
@@ -24,6 +24,7 @@ spec:
         release: {{ .Release.Name | quote }}
         role: "master"
     spec:
+      {{- include "elasticsearch.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}

--- a/bitnami/elasticsearch/values-production.yaml
+++ b/bitnami/elasticsearch/values-production.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/elasticsearch
-  tag: 6.7.1
+  tag: 7.0.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/elasticsearch
-  tag: 6.7.1
+  tag: 7.0.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

In order to use bitnami/elasticsearch:7 image in the chart, we need to make some changes. Basically, apart from the cluster hosts now we need to specify which nodes of the cluster can be master-eligible. It seems you cannot use a headless service so you need to specify the master nodes. 

**Benefits**

We can use the latest version of elasticsearch

**Possible drawbacks**

Unknown

**Applicable issues**

None

**Additional information**

Elasticsearch version 7 introduces several cluster and discovery changes and that affects the chart. 

- Cluster changes: https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#breaking_70_cluster_changes
- Discovery changes: https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#breaking_70_discovery_changes
