### PR TITLE
[bitnami/zookeeper] Remove exporter pod from services

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zookeeper
-version: 1.6.0
+version: 1.6.1
 appVersion: 3.4.14
 description: A centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services for distributed applications.
 keywords:

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: {{ template "zookeeper.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/component: {{ template "zookeeper.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
 spec:
   serviceName: {{ template "zookeeper.fullname" . }}-headless
@@ -24,6 +25,7 @@ spec:
     matchLabels:
       app: {{ template "zookeeper.name" . }}
       release: {{ .Release.Name | quote }}
+      app.kubernetes.io/component: {{ template "zookeeper.name" . }}
   template:
     metadata:
       name: "{{ template "zookeeper.fullname" . }}"
@@ -32,6 +34,7 @@ spec:
         chart: {{ template "zookeeper.chart" . }}
         release: {{ .Release.Name | quote }}
         heritage: {{ .Release.Service | quote }}
+        app.kubernetes.io/component: {{ template "zookeeper.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
     spec:
 {{- include "zookeeper.imagePullSecrets" . | indent 6 }}

--- a/bitnami/zookeeper/templates/svc-headless.yaml
+++ b/bitnami/zookeeper/templates/svc-headless.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: {{ template "zookeeper.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/component: {{ template "zookeeper.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
 spec:
   type: ClusterIP
@@ -24,3 +25,4 @@ spec:
   selector:
     app: {{ template "zookeeper.name" . }}
     release: {{ .Release.Name | quote }}
+    app.kubernetes.io/component: {{ template "zookeeper.name" . }}

--- a/bitnami/zookeeper/templates/svc.yaml
+++ b/bitnami/zookeeper/templates/svc.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: {{ template "zookeeper.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/component: {{ template "zookeeper.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
 spec:
   type: {{ .Values.service.type }}
@@ -23,3 +24,4 @@ spec:
   selector:
     app: {{ template "zookeeper.name" . }}
     release: {{ .Release.Name | quote }}
+    app.kubernetes.io/component: {{ template "zookeeper.name" . }}


### PR DESCRIPTION
Set the appropriate `component` label on the ZooKeeper pods and
services.

Signed-off-by: Simon Rüegg <simon.ruegg@vshn.ch>

Duplicates #1127

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Set the appropriate `component` label to exclude the ZooKeeper exporter pod from the ZooKeeper service and headless-service.

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
