### PR TITLE
[bitnami/zookeeper] Mount emptyDir for ZooKeeper

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zookeeper
-version: 1.7.0
+version: 1.7.1
 appVersion: 3.4.14
 description: A centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services for distributed applications.
 keywords:

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -157,10 +157,8 @@ spec:
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         {{- end }}
         volumeMounts:
-        {{- if .Values.persistence.enabled }}
         - name: data
           mountPath: /bitnami/zookeeper
-        {{ end }}
         {{- if .Values.config }}
         - name: config
           mountPath: /opt/bitnami/zookeeper/conf/zoo.cfg


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

If persistence is disabled, mount the emptyDir volume instead.

**Benefits**

Even if persistence is disabled, an emptyDir is used.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

Previously the emptyDir was defined but not mounted. 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
