### PR TITLE
[bitnami/zookeeper] metrics exporter timeout

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zookeeper
-version: 2.1.0
+version: 2.2.0
 appVersion: 3.4.14
 description: A centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services for distributed applications.
 keywords:

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -113,6 +113,7 @@ The following tables lists the configurable parameters of the Zookeeper chart an
 | `metrics.podAnnotations`              | Additional annotations for Metrics exporter pod                     | `{prometheus.io/scrape: "true", prometheus.io/port: "9141"}` |
 | `metrics.resources`                   | Exporter resource requests/limit                                    | Memory: `256Mi`, CPU: `100m`                             |
 | `metrics.tolerations`                 | Exporter toleration labels for pod assignment                       | `[]`                                                     |
+| `metrics.timeoutSeconds`              | Timeout in seconds the exporter uses to scrape its targets          | 3                                                        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/zookeeper/templates/metrics-deployment.yaml
+++ b/bitnami/zookeeper/templates/metrics-deployment.yaml
@@ -39,6 +39,8 @@ spec:
         name: zookeeper-exporter
         command:
           - /usr/local/bin/zookeeper-exporter
+          - -timeout
+          - {{ .Values.metrics.timeoutSeconds | quote }}
           - -zk-list
           {{- $replicaCount := int .Values.replicaCount }}
           {{- $followerPort := int .Values.service.followerPort }}

--- a/bitnami/zookeeper/values-production.yaml
+++ b/bitnami/zookeeper/values-production.yaml
@@ -189,8 +189,8 @@ metrics:
 
   image:
     registry: docker.io
-    repository: javsalgar/zookeeper-exporter
-    tag: latest
+    repository: dabealu/zookeeper-exporter
+    tag: v0.1.0
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/zookeeper/values-production.yaml
+++ b/bitnami/zookeeper/values-production.yaml
@@ -205,6 +205,8 @@ metrics:
     prometheus.io/port: "9141"
   podLabels: {}
 
+  timeoutSeconds: 3
+
   ## Metrics exporter resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -189,8 +189,8 @@ metrics:
 
   image:
     registry: docker.io
-    repository: javsalgar/zookeeper-exporter
-    tag: latest
+    repository: dabealu/zookeeper-exporter
+    tag: v0.1.0
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -205,6 +205,8 @@ metrics:
     prometheus.io/port: "9141"
   podLabels: {}
 
+  timeoutSeconds: 3
+
   ## Metrics exporter resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##


### PR DESCRIPTION
**Description of the change**

Change the exporter image and set a connection timeout.

**Benefits**

Usually a metrics endpoint is scraped with an interval of between 10s - 1m, so a lower connection timeout makes sense. Also the default timeout for a scrape is 10s, which will be exceeded if even one ZK instance is down.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**


**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
