### PR TITLE
[bitnami/nginx] Allow annotations for the service to utilize i.e. external-dns

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx
-version: 3.0.0
+version: 3.1.0
 appVersion: 1.16.0
 description: Chart for the nginx server
 keywords:

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -66,6 +66,7 @@ The following tables lists the configurable parameters of the NGINX Open Source 
 | `service.nodePorts.http`                 | Kubernetes http node port                  | `""`                                                    |
 | `service.externalTrafficPolicy`   | Enable client source IP preservation       | `Cluster`                                               |
 | `service.loadBalancerIP`   | LoadBalancer service IP address       | `""`                                               |
+| `service.annotations`   | 	Service annotations       | `{}`                                               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/nginx/templates/svc.yaml
+++ b/bitnami/nginx/templates/svc.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -31,7 +31,11 @@ image:
 ##
 service:
   type: LoadBalancer
-  # HTTP Port
+  ## Provide optional annotations to the service i.e. for external-dns
+  # annotations: 
+  #   external-dns.alpha.kubernetes.io/hostname: yourservicename.k8s.yourcompany.com
+  ##
+  ## HTTP Port
   port: 80
   ##
   ## loadBalancerIP:


### PR DESCRIPTION
Bitnami nginx helm chart currently lacks the functionality to add custom service annotations.
This feature is required to register external-dns names like: 

yourservicename.k8s.yourcompany.com

    service:
      annotations:
        external-dns.alpha.kubernetes.io/hostname: yourservicename.k8s.yourcompany.com

Scope of my changes: svc.yml template and readme.md
Run tests successfully on my local dev env.

