### PR TITLE
[bitnami/zookeeper] Publish DNS records for un-ready pods

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zookeeper
-version: 2.0.0
+version: 2.1.0
 appVersion: 3.4.14
 description: A centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services for distributed applications.
 keywords:

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -78,6 +78,7 @@ The following tables lists the configurable parameters of the Zookeeper chart an
 | `service.port`                        | ZooKeeper port                                                      | `2181`                                                   |
 | `service.followerPort`                | ZooKeeper follower port                                             | `2888`                                                   |
 | `service.electionPort`                | ZooKeeper election port                                             | `3888`                                                   |
+| `service.publishNotReadyAddresses`    | If the ZooKeeper headless service should publish DNS records for not ready pods | `true`                                      |
 | `securityContext.enabled`             | Enable security context (ZooKeeper master pod)                      | `true`                                                   |
 | `securityContext.fsGroup`             | Group ID for the container (ZooKeeper master pod)                   | `1001`                                                   |
 | `securityContext.runAsUser`           | User ID for the container (ZooKeeper master pod)                    | `1001`                                                   |

--- a/bitnami/zookeeper/templates/svc-headless.yaml
+++ b/bitnami/zookeeper/templates/svc-headless.yaml
@@ -11,6 +11,7 @@ metadata:
 spec:
   type: ClusterIP
   clusterIP: None
+  publishNotReadyAddresses: {{ .Values.service.publishNotReadyAddresses }}
   ports:
   - name: client
     port: 2181

--- a/bitnami/zookeeper/values-production.yaml
+++ b/bitnami/zookeeper/values-production.yaml
@@ -117,6 +117,7 @@ service:
   port: 2181
   followerPort: 2888
   electionPort: 3888
+  publishNotReadyAddresses: true
 
 ## Zookeeper Pod Security Context
 securityContext:

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -117,6 +117,7 @@ service:
   port: 2181
   followerPort: 2888
   electionPort: 3888
+  publishNotReadyAddresses: true
 
 ## Zookeeper Pod Security Context
 securityContext:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Publish DNS records for un-ready pods

**Benefits**

This helps to use DNS for service discovery of the ZooKeeper instances.
Even if a pod is not ready, the DNS record should be published, for
clients to discover it even before it comes ready.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
