### PR TITLE
[bitnami/minio] Improve values validation

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.0.3
+version: 0.1.0
 appVersion: 2019.5.2
 description: MinIO is an object storage server, compatible with Amazon S3 cloud storage service, mainly used for storing unstructured data (such as photos, videos, log files, etc.)
 keywords:

--- a/bitnami/minio/templates/NOTES.txt
+++ b/bitnami/minio/templates/NOTES.txt
@@ -1,56 +1,3 @@
-{{- $replicaCount := int .Values.statefulset.replicaCount }}
-{{- if and (ne .Values.mode "distributed") (ne .Values.mode "standalone") }}
-################################################################################
-### ERROR: Invalid mode selected. Valid values are "distributed" and         ###
-### "standalone". Please set a valid mode (--set mode="xxxx")                ###
-################################################################################
-
-This deployment will be incomplete until you set a valid mode. To set the mode:
-
-1. Get the MinIO credentials:
-
-  export MINIO_ACCESS_KEY=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "minio.fullname" . }} -o jsonpath="{.data.access-key}" | base64 --decode)
-  export MINIO_SECRET_KEY=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "minio.fullname" . }} -o jsonpath="{.data.secret-key}" | base64 --decode)
-
-2. Set a valid mode (e.g. "standalone"):
-
-    export MODE="standalone"
-
-3. Complete your MinIO deployment by running :
-
-    helm upgrade {{ .Release.Name }} bitnami/{{ .Chart.Name }} \
-      {{- if .Values.global }}{{- if .Values.global.imagePullSecrets }}--set global.imagePullSecrets={{ .Values.global.imagePullSecrets }} \{{- end }}{{- end }}
-      --set mode=$MODE \
-      --set accessKey.password=$MINIO_ACCESS_KEY \
-      --set secretKey.password=$MINIO_SECRET_KEY
-
-{{- else if and (eq .Values.mode "distributed") (or (eq (mod $replicaCount 2) 1) (lt $replicaCount 4) (gt $replicaCount 32)) }}
-################################################################################
-### ERROR: Number of replicas must even, greater than 4 and lower than 32!!  ###
-### Please set a valid number of replicas (--set statefulset.replicaCount=X) ###
-################################################################################
-
-This deployment will be incomplete until you configure a valid number of replicas.
-To set the number or replicas:
-
-1. Get the MinIO credentials:
-
-  export MINIO_ACCESS_KEY=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "minio.fullname" . }} -o jsonpath="{.data.access-key}" | base64 --decode)
-  export MINIO_SECRET_KEY=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "minio.fullname" . }} -o jsonpath="{.data.secret-key}" | base64 --decode)
-
-2. Set a valid number or replicas (e.g. 4):
-
-  export REPLICA_COUNT=4
-
-3. Complete your MinIO deployment by running :
-
-  helm upgrade {{ .Release.Name }} bitnami/{{ .Chart.Name }} \
-    {{- if .Values.global }}{{- if .Values.global.imagePullSecrets }}--set global.imagePullSecrets={{ .Values.global.imagePullSecrets }} \{{- end }}{{- end }}
-    --set statefulset.replicaCount=$REPLICA_COUNT \
-    --set accessKey.password=$MINIO_ACCESS_KEY \
-    --set secretKey.password=$MINIO_SECRET_KEY
-
-{{- else }}
 ** Please be patient while the chart is being deployed **
 
 MinIO can be accessed via port {{ .Values.service.port }} on the following DNS name from within your cluster:
@@ -119,4 +66,5 @@ To access the MinIO web UI:
 
    WARN: MinIO Web UI is disabled.
 {{- end }}
-{{- end }}
+
+{{ include "minio.validateValues" . }}

--- a/bitnami/minio/templates/_helpers.tpl
+++ b/bitnami/minio/templates/_helpers.tpl
@@ -131,12 +131,12 @@ minio: mode
 {{- end -}}
 {{- end -}}
 
-{{/* Validate values of MinIO - number of replicas must even, greater than 4 and lower than 32 */}}
+{{/* Validate values of MinIO - number of replicas must be even, greater than 4 and lower than 32 */}}
 {{- define "minio.validateValues.replicaCount" -}}
 {{- $replicaCount := int .Values.statefulset.replicaCount }}
 {{- if and (eq .Values.mode "distributed") (or (eq (mod $replicaCount 2) 1) (lt $replicaCount 4) (gt $replicaCount 32)) -}}
 minio: replicaCount
-    Number of replicas must even, greater than 4 and lower than 32!!
+    Number of replicas must be even, greater than 4 and lower than 32!!
     Please set a valid number of replicas (--set statefulset.replicaCount=X)
 {{- end -}}
 {{- end -}}

--- a/bitnami/minio/templates/_helpers.tpl
+++ b/bitnami/minio/templates/_helpers.tpl
@@ -1,4 +1,5 @@
 {{/* vim: set filetype=mustache: */}}
+
 {{/*
 Expand the name of the chart.
 */}}
@@ -26,74 +27,31 @@ Create chart name and version as used by the chart label.
 Return the proper MinIO image name
 */}}
 {{- define "minio.image" -}}
-{{- $registryName := .Values.image.registry -}}
+{{- $registryName := coalesce .Values.global.imageRegistry .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
 {{- $tag := .Values.image.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
-{{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-{{- end -}}
+{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
 
 {{/*
 Return the proper MinIO Client image name
 */}}
 {{- define "minio.clientImage" -}}
-{{- $registryName := .Values.clientImage.registry -}}
+{{- $registryName := coalesce .Values.global.imageRegistry .Values.clientImage.registry -}}
 {{- $repositoryName := .Values.clientImage.repository -}}
 {{- $tag := .Values.clientImage.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
-{{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-{{- end -}}
+{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
 
 {{/*
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "minio.imagePullSecrets" -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
-Also, we can not use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets:
-{{- range .Values.global.imagePullSecrets }}
+{{- $imagePullSecrets := coalesce .Values.global.imagePullSecrets .Values.image.pullSecrets -}}
+{{- if $imagePullSecrets }}
+{{- range $imagePullSecrets }}
   - name: {{ . }}
-{{- end }}
-{{- else if .Values.image.pullSecrets }}
-imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
 {{- end -}}
-{{- else if .Values.image.pullSecrets }}
-imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
 {{- end -}}
 {{- end -}}
 
@@ -101,10 +59,9 @@ imagePullSecrets:
 Return MinIO accessKey
 */}}
 {{- define "minio.accessKey" -}}
-{{- if .Values.global.minio.accessKey }}
-    {{- .Values.global.minio.accessKey -}}
-{{- else if .Values.accessKey.password }}
-    {{- .Values.accessKey.password -}}
+{{- $accessKey := coalesce .Values.global.minio.accessKey .Values.accessKey.password -}}
+{{- if $accessKey }}
+    {{- $accessKey -}}
 {{- else if (not .Values.accessKey.forcePassword) }}
     {{- randAlphaNum 10 -}}
 {{- else -}}
@@ -116,10 +73,9 @@ Return MinIO accessKey
 Return MinIO secretKey
 */}}
 {{- define "minio.secretKey" -}}
-{{- if .Values.global.minio.secretKey }}
-    {{- .Values.global.minio.secretKey -}}
-{{- else if .Values.secretKey.password }}
-    {{- .Values.secretKey.password -}}
+{{- $secretKey := coalesce .Values.global.minio.secretKey .Values.secretKey.password -}}
+{{- if $secretKey }}
+    {{- $secretKey -}}
 {{- else if (not .Values.secretKey.forcePassword) }}
     {{- randAlphaNum 40 -}}
 {{- else -}}
@@ -152,12 +108,35 @@ Return true if a secret object should be created
 {{- end -}}
 
 {{/*
-Return the appropriate apiVersion for networkpolicy.
+Compile all warnings into a single message, and call fail.
 */}}
-{{- define "networkPolicy.apiVersion" -}}
-{{- if semverCompare ">=1.4-0, <1.7-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
-{{- print "networking.k8s.io/v1" -}}
+{{- define "minio.validateValues" -}}
+{{- $messages := list -}}
+{{- $messages := append $messages (include "minio.validateValues.mode" .) -}}
+{{- $messages := append $messages (include "minio.validateValues.replicaCount" .) -}}
+{{- $messages := without $messages "" -}}
+{{- $message := join "\n" $messages -}}
+
+{{- if $message -}}
+{{-   printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Validate values of MinIO - must provide a valid mode ("distributed" or "standalone") */}}
+{{- define "minio.validateValues.mode" -}}
+{{- if and (ne .Values.mode "distributed") (ne .Values.mode "standalone") -}}
+minio: mode
+    Invalid mode selected. Valid values are "distributed" and
+    "standalone". Please set a valid mode (--set mode="xxxx")
+{{- end -}}
+{{- end -}}
+
+{{/* Validate values of MinIO - number of replicas must even, greater than 4 and lower than 32 */}}
+{{- define "minio.validateValues.replicaCount" -}}
+{{- $replicaCount := int .Values.statefulset.replicaCount }}
+{{- if and (eq .Values.mode "distributed") (or (eq (mod $replicaCount 2) 1) (lt $replicaCount 4) (gt $replicaCount 32)) -}}
+minio: replicaCount
+    Number of replicas must even, greater than 4 and lower than 32!!
+    Please set a valid number of replicas (--set statefulset.replicaCount=X)
 {{- end -}}
 {{- end -}}

--- a/bitnami/minio/templates/deployment-standalone.yaml
+++ b/bitnami/minio/templates/deployment-standalone.yaml
@@ -89,11 +89,7 @@ spec:
           value: {{ .Values.defaultBuckets }}
         {{- end }}
         - name: MINIO_BROWSER
-          {{- if .Values.disableWebUI }}
-          value: "off"
-          {{- else }}
-          value: "on"
-          {{- end }}
+          value: {{ ternary "off" "on" .Values.disableWebUI }}
 {{- if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | indent 8 }}
 {{- end }}

--- a/bitnami/minio/templates/networkpolicy.yaml
+++ b/bitnami/minio/templates/networkpolicy.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.networkPolicy.enabled }}
 kind: NetworkPolicy
-apiVersion: {{ include "networkPolicy.apiVersion" . }}
+apiVersion: networking.k8s.io/v1
 metadata:
   name: {{ include "minio.fullname" . }}
   labels:

--- a/bitnami/minio/templates/statefulset.yaml
+++ b/bitnami/minio/templates/statefulset.yaml
@@ -104,11 +104,7 @@ spec:
               key: secret-key
         {{- end }}
         - name: MINIO_BROWSER
-          {{- if .Values.disableWebUI }}
-          value: "off"
-          {{- else }}
-          value: "on"
-          {{- end }}
+          value: {{ ternary "off" "on" .Values.disableWebUI }}
 {{- if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | indent 8 }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

This PR introduces a set of improvements in the **NOTES.txt** and **_helpers.tpl** to validate the values set by the user. It also removes complexity on some templates by assuming the `values.global` parameter is always set.

On the other hand, as reflected in the README.md, this chart is not supporting `K8s < 1.8` and, therefore, it's not necessary to calculate the NetworkPolicy API version based on that. 

**Benefits**

- Simplicity

**Possible drawbacks**

- Do not support `K8s < 1.8` anymore
