### PR TITLE
[bitnami/nginx] Add ability to configure Liveness and Readiness Probes

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx
-version: 3.2.0
+version: 3.3.0
 appVersion: 1.16.0
 description: Chart for the nginx server
 keywords:

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -42,41 +42,51 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the NGINX Open Source chart and their default values.
 
-| Parameter                        | Description                                      | Default                                                      |
-| -------------------------------- | ------------------------------------------------ | ------------------------------------------------------------ |
-| `global.imageRegistry`           | Global Docker image registry                     | `nil`                                                        |
-| `global.imagePullSecrets`        | Global Docker registry secret names as an array  | `[]` (does not add image pull secrets to deployed pods)      |
-| `image.registry`                 | NGINX image registry                             | `docker.io`                                                  |
-| `image.repository`               | NGINX Image name                                 | `bitnami/nginx`                                              |
-| `image.tag`                      | NGINX Image tag                                  | `{VERSION}`                                                  |
-| `image.pullPolicy`               | NGINX image pull policy                          | `Always` if `imageTag` is `latest`, else `IfNotPresent`      |
-| `image.pullSecrets`              | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)      |
-| `serverBlock`                    | Custom NGINX server block                        | `nil`                                                        |
-| `podAnnotations`                 | Pod annotations                                  | `{}`                                                         |
-| `metrics.enabled`                | Start a side-car prometheus exporter             | `false`                                                      |
-| `metrics.image.registry`         | Promethus exporter image registry                | `docker.io`                                                  |
-| `metrics.image.repository`       | Promethus exporter image name                    | `nginx/nginx-prometheus-exporter`                            |
-| `metrics.image.tag`              | Promethus exporter image tag                     | `0.1.0`                                                      |
-| `metrics.image.pullPolicy`       | Image pull policy                                | `IfNotPresent`                                               |
-| `metrics.image.pullSecrets`      | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)      |
-| `metrics.podAnnotations`         | Additional annotations for Metrics exporter pod  | `{prometheus.io/scrape: "true", prometheus.io/port: "9113"}` |
-| `metrics.resources`              | Exporter resource requests/limit                 | {}                                                           |
-| `service.type`                   | Kubernetes Service type                          | `LoadBalancer`                                               |
-| `service.port`                   | Service HTTP port                                | `80`                                                         |
-| `service.nodePorts.http`         | Kubernetes http node port                        | `""`                                                         |
-| `service.externalTrafficPolicy`  | Enable client source IP preservation             | `Cluster`                                                    |
-| `service.loadBalancerIP`         | LoadBalancer service IP address                  | `""`                                                         |
-| `service.annotations`            | Service annotations                              | `{}`                                                         |
-| `ingress.enabled`                | Enable ingress controller resource               | `false`                                                      |
-| `ingress.certManager`            | Add annotations for cert-manager                 | `false`                                                      |
-| `ingress.annotations`            | Ingress annotations                              | `[]`                                                         |
-| `ingress.hosts[0].name`          | Hostname to your NGINX installation              | `nginx.local`                                                |
-| `ingress.hosts[0].path`          | Path within the url structure                    | `/`                                                          |
-| `ingress.tls[0].hosts[0]`        | TLS hosts                                        | `nginx.local`                                                |
-| `ingress.tls[0].secretName`      | TLS Secret (certificates)                        | `nginx.local-tls`                                            |
-| `ingress.secrets[0].name`        | TLS Secret Name                                  | `nil`                                                        |
-| `ingress.secrets[0].certificate` | TLS Secret Certificate                           | `nil`                                                        |
-| `ingress.secrets[0].key`         | TLS Secret Key                                   | `nil`                                                        |
+| Parameter                            | Description                                      | Default                                                      |
+| ------------------------------------ | ------------------------------------------------ | ------------------------------------------------------------ |
+| `global.imageRegistry`               | Global Docker image registry                     | `nil`                                                        |
+| `global.imagePullSecrets`            | Global Docker registry secret names as an array  | `[]` (does not add image pull secrets to deployed pods)      |
+| `image.registry`                     | NGINX image registry                             | `docker.io`                                                  |
+| `image.repository`                   | NGINX Image name                                 | `bitnami/nginx`                                              |
+| `image.tag`                          | NGINX Image tag                                  | `{VERSION}`                                                  |
+| `image.pullPolicy`                   | NGINX image pull policy                          | `Always` if `imageTag` is `latest`, else `IfNotPresent`      |
+| `image.pullSecrets`                  | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)      |
+| `serverBlock`                        | Custom NGINX server block                        | `nil`                                                        |
+| `podAnnotations`                     | Pod annotations                                  | `{}`                                                         |
+| `metrics.enabled`                    | Start a side-car prometheus exporter             | `false`                                                      |
+| `metrics.image.registry`             | Promethus exporter image registry                | `docker.io`                                                  |
+| `metrics.image.repository`           | Promethus exporter image name                    | `nginx/nginx-prometheus-exporter`                            |
+| `metrics.image.tag`                  | Promethus exporter image tag                     | `0.1.0`                                                      |
+| `metrics.image.pullPolicy`           | Image pull policy                                | `IfNotPresent`                                               |
+| `metrics.image.pullSecrets`          | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)      |
+| `metrics.podAnnotations`             | Additional annotations for Metrics exporter pod  | `{prometheus.io/scrape: "true", prometheus.io/port: "9113"}` |
+| `metrics.resources`                  | Exporter resource requests/limit                 | {}                                                           |
+| `service.type`                       | Kubernetes Service type                          | `LoadBalancer`                                               |
+| `service.port`                       | Service HTTP port                                | `80`                                                         |
+| `service.nodePorts.http`             | Kubernetes http node port                        | `""`                                                         |
+| `service.externalTrafficPolicy`      | Enable client source IP preservation             | `Cluster`                                                    |
+| `service.loadBalancerIP`             | LoadBalancer service IP address                  | `""`                                                         |
+| `service.annotations`                | Service annotations                              | `{}`                                                         |
+| `ingress.enabled`                    | Enable ingress controller resource               | `false`                                                      |
+| `ingress.certManager`                | Add annotations for cert-manager                 | `false`                                                      |
+| `ingress.annotations`                | Ingress annotations                              | `[]`                                                         |
+| `ingress.hosts[0].name`              | Hostname to your NGINX installation              | `nginx.local`                                                |
+| `ingress.hosts[0].path`              | Path within the url structure                    | `/`                                                          |
+| `ingress.tls[0].hosts[0]`            | TLS hosts                                        | `nginx.local`                                                |
+| `ingress.tls[0].secretName`          | TLS Secret (certificates)                        | `nginx.local-tls`                                            |
+| `ingress.secrets[0].name`            | TLS Secret Name                                  | `nil`                                                        |
+| `ingress.secrets[0].certificate`     | TLS Secret Certificate                           | `nil`                                                        |
+| `ingress.secrets[0].key`             | TLS Secret Key                                   | `nil`                                                        |
+| `livenessProbe.httpGet.path`         | Liveness Probe Path to check                     | `/`                                                          |
+| `livenessProbe.httpGet.port`         | Liveness Probe Port to use                       | `http`                                                       |
+| `livenessProbe.initialDelaySeconds`  | Liveness Probe initialDelaySeconds               | `30`                                                         |
+| `livenessProbe.timeoutSeconds`       | Liveness Probe timeoutSeconds                    | `5`                                                          |
+| `livenessProbe.failureThreshold`     | Liveness Probe failureThreshold                  | `6`                                                          |
+| `readinessProbe.httpGet.path`        | Readiness Probe Path to check                    | `/`                                                          |
+| `readinessProbe.httpGet.port`        | Readiness Probe Port to use                      | `http`                                                       |
+| `readinessProbe.initialDelaySeconds` | Readiness Probe initialDelaySeconds              | `5`                                                          |
+| `readinessProbe.timeoutSeconds`      | Readiness Probe timeoutSeconds                   | `3`                                                          |
+| `readinessProbe.periodSeconds`       | Readiness Probe periodSeconds                    | `5`                                                          |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -40,18 +40,18 @@ spec:
           containerPort: 8080
         livenessProbe:
           httpGet:
-            path: /
-            port: http
-          initialDelaySeconds: 30
-          timeoutSeconds: 5
-          failureThreshold: 6
+            path: {{ .Values.livenessProbe.httpGet.path }}
+            port: {{ .Values.livenessProbe.httpGet.port }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
         readinessProbe:
           httpGet:
-            path: /
-            port: http
-          initialDelaySeconds: 5
-          timeoutSeconds: 3
-          periodSeconds: 5
+            path: {{ .Values.readinessProbe.httpGet.path }}
+            port: {{ .Values.readinessProbe.httpGet.port }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
         volumeMounts:
         {{- if .Values.serverBlock }}
         - name: nginx-server-block

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -110,6 +110,27 @@ ingress:
 #     }
 #   }
 
+## Liveness Probe
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+##
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 6
+
+## Readiness Probe
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 5
+  timeoutSeconds: 3
+  periodSeconds: 5
+
 ## Pod annotations
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Adds the ability to configure the Liveness and Readiness Probes

**Benefits**

The user is able to configure the Liveness and Readiness Probes to their liking

**Possible drawbacks**

None. The defaults identically match the previous hard-coded values in the Deployment template.

**Applicable issues**

None that are open.

**Additional information**

Documentation updates still need to be done, but I wanted to get this out there to get some eyeballs on it.
