### PR TITLE
Add ZOO_LOG_LEVEL env var

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zookeeper
-version: 2.2.0
+version: 2.2.1
 appVersion: 3.4.14
 description: A centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services for distributed applications.
 keywords:

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -43,7 +43,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Log level
 
-You can configure the Zookeeper log level using the `ZOO_LOG_LEVEL` environment variable. By default, it is set to `FALSE` because of each readiness prove produce an `INFO` message on connection and a `WARN` message on disconnection.
+You can configure the Zookeeper log level using the `ZOO_LOG_LEVEL` environment variable. By default, it is set to `ERROR` because of each readiness prove produce an `INFO` message on connection and a `WARN` message on disconnection.
 
 ## Configuration
 

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -43,7 +43,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Log level
 
-You can configure the Zookeeper log level using the `ZOO_LOG_LEVEL` environment variable. By default, it is set to `ERROR` because of each readiness prove produce an `INFO` message on connection and a `WARN` message on disconnection.
+You can configure the Zookeeper log level using the `ZOO_LOG_LEVEL` environment variable. By default, it is set to `ERROR` because of each readiness probe produce an `INFO` message on connection and a `WARN` message on disconnection.
 
 ## Configuration
 

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -41,6 +41,10 @@ $ helm delete my-release
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
+## Log level
+
+You can configure the Zookeeper log level using the `ZOO_LOG_LEVEL` environment variable. By default, it is set to `FALSE` because of each readiness prove produce an `INFO` message on connection and a `WARN` message on disconnection.
+
 ## Configuration
 
 The following tables lists the configurable parameters of the Zookeeper chart and their default values.
@@ -74,6 +78,7 @@ The following tables lists the configurable parameters of the Zookeeper chart an
 | `auth.serverUsers`                    | List of user to be created                                          | `[]`                                                     |
 | `auth.serverPasswords`                | List of passwords to assign to users when created                   | `[]`                                                     |
 | `heapSize`                            | Size in MB for the Java Heap options (Xmx and XMs)                  | `[]`                                                     |
+| `logLevel`                            | Log level of Zookeeper server                                       | `ERROR`                                                  |
 | `jvmFlags`                            | Default JVMFLAGS for the ZooKeeper process                          | `nil`                                                    |
 | `config`                              | Configure ZooKeeper with a custom zoo.conf file                     | `nil`                                                    |
 | `service.type`                        | Kubernetes Service type                                             | `ClusterIP`                                              |

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -115,6 +115,8 @@ spec:
         {{- end }}
         - name: ZOO_HEAP_SIZE
           value: {{ .Values.heapSize | quote }}
+        - name: ZOO_LOG_LEVEL
+          value: {{ .Values.logLevel | quote }}
         - name: ALLOW_ANONYMOUS_LOGIN
           value: {{ ternary "yes" "no" .Values.allowAnonymousLogin | quote }}
         {{- if .Values.jvmFlags }}

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/zookeeper
-  tag: 3.4.15
+  tag: 3.4.14
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/zookeeper
-  tag: 3.4.14
+  tag: 3.4.15
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -106,6 +106,10 @@ auth:
 ## Size in MB for the Java Heap options (Xmx and XMs). This env var is ignored if Xmx an Xms are configured via JVMFLAGS
 ##
 heapSize: 1024
+
+## Log level for the Zookeeper server. ERROR by default. Have in mind if you set it to INFO or WARN the ReadinessProve will produce a lot of logs.
+##
+logLevel: ERROR
 
 ## Default JVMFLAGS for the ZooKeeper process
 ##


### PR DESCRIPTION
Set the Zookeeper log level to `ERROR` to avoid the verbosity of the readiness probe.