### PR TITLE
Cassandra: Add support for overriding environment variables

### DIFF
--- a/bitnami/cassandra/templates/statefulset.yaml
+++ b/bitnami/cassandra/templates/statefulset.yaml
@@ -78,6 +78,9 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         env:
+        {{- if .Values.extraVars }}
+{{ toYaml .Values.extraVars | indent 8 }}
+        {{- end }}
         - name: CASSANDRA_CLUSTER_NAME
           value: {{ .Values.cluster.name }}
         - name: CASSANDRA_SEEDS

--- a/bitnami/cassandra/values.yaml
+++ b/bitnami/cassandra/values.yaml
@@ -89,6 +89,12 @@ resources: {}
   #   memory: 4Gi
   #   cpu: 2
 
+## Environment variables, to pass to the entry point
+##
+# extraVars:
+#   - name: NAMI_DEBUG
+#     value: --log-level trace
+
 ## Secret with keystore, keystore password, truststore, truststore password
 # tlsEncryptionSecretName:
 ## ConfigMap with custom cassandra configuration files. This overrides any other Cassandra configuration set in the chart


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Adds support for passing extra environment variables to Cassandra image using helm variable: extraVars.
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
At times we need to pass in additional environment variables to override Cassandra setting that is not available in the helm chart. Instead of adding all the options to the chart, we can add the environment variable that we need to override. (e.g: NAMI_DEBUG)

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
N/A

<!-- Describe any known limitations with your change -->

**Applicable issues**
N/A
<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**
N/A
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
