### PR TITLE
[bitnami/apache] Remove apache volume

### DIFF
--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: apache
-version: 4.2.4
+version: 4.3.0
 appVersion: 2.4.39
 description: Chart for Apache HTTP Server
 keywords:

--- a/bitnami/apache/templates/deployment.yaml
+++ b/bitnami/apache/templates/deployment.yaml
@@ -58,9 +58,6 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 3
           periodSeconds: 5
-        volumeMounts:
-        - name: apache-data
-          mountPath: /bitnami/apache
 {{- if .Values.metrics.enabled }}
       - name: metrics
         image: {{ template "apache.metrics.image" . }}
@@ -84,6 +81,3 @@ spec:
         resources:
   {{ toYaml .Values.metrics.resources | indent 10 }}
 {{- end }}
-      volumes:
-      - name: apache-data
-        emptyDir: {}

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/apache
-  tag: 2.4.39-debian-9-r31
+  tag: 2.4.39-debian-9-r40
   ## Specify a imagePullPolicy
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

The Apache configuration volume (_/bitnami/apache_) has been deprecated, and support for this feature will be dropped in the near future. Until then, the container will enable the Apache configuration from that volume if it exists. By default, and if the configuration volume does not exist, the configuration files will be regenerated each time the container is created. Users wanting to apply custom Apache configuration files are advised to mount a volume for the configuration at _/opt/bitnami/apache/conf_, or mount specific configuration files individually.

You can find more info in the container README: https://github.com/bitnami/bitnami-docker-apache/blob/master/README.md#notable-changes