### PR TITLE
[bitnami/kafka] Fix extraEnvVars example

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 3.0.8
+version: 3.0.9
 appVersion: 2.2.1
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/values-production.yaml
+++ b/bitnami/kafka/values-production.yaml
@@ -178,7 +178,7 @@ sslEndpointIdentificationAlgorithm: https
 ##
 # extraEnvVars:
 #   - name: KAFKA_CFG_BACKGROUND_THREADS
-#     value: 10
+#     value: "10"
 
 ## Authentication parameteres
 ## https://github.com/bitnami/bitnami-docker-kafka#security

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -178,7 +178,7 @@ sslEndpointIdentificationAlgorithm: https
 ##
 # extraEnvVars:
 #   - name: KAFKA_CFG_BACKGROUND_THREADS
-#     value: 10
+#     value: "10"
 
 ## Authentication parameteres
 ## https://github.com/bitnami/bitnami-docker-kafka#security


### PR DESCRIPTION
**Description of the change**

Change the example of use of the `extraEnvVars` option.

**Benefits**

Better documentation for our users

**Applicable issues**

#1251 

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
