### PR TITLE
[bitnami/jenkins] Fix ingress on Jenkins

### DIFF
--- a/bitnami/jenkins/Chart.yaml
+++ b/bitnami/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: jenkins
-version: 2.3.7
+version: 2.3.8
 appVersion: 2.176.1
 description: The leading open source automation server
 keywords:

--- a/bitnami/jenkins/templates/NOTES.txt
+++ b/bitnami/jenkins/templates/NOTES.txt
@@ -5,30 +5,30 @@
 
 {{- if contains "NodePort" .Values.service.type }}
 
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "jenkins.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo "Jenkins URL: http://$NODE_IP:$NODE_PORT/"
 
 {{- else if contains "LoadBalancer" .Values.service.type }}
 
-** Please ensure an external IP is associated to the {{ template "fullname" . }} service before proceeding **
-** Watch the status using: kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "fullname" . }} **
+** Please ensure an external IP is associated to the {{ template "jenkins.fullname" . }} service before proceeding **
+** Watch the status using: kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "jenkins.fullname" . }} **
 
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "jenkins.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
 {{- $port:=.Values.service.port | toString }}
   echo "Jenkins URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}/"
 
 {{- else if contains "ClusterIP"  .Values.service.type }}
 
   echo "Jenkins URL: http://127.0.0.1:8080/"
-  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "fullname" . }} 8080:{{ .Values.service.port }}
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "jenkins.fullname" . }} 8080:{{ .Values.service.port }}
 
 {{- end }}
 
 2. Login with the following credentials
 
   echo Username: {{ .Values.jenkinsUser }}
-  echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.jenkins-password}" | base64 --decode)
+  echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "jenkins.fullname" . }} -o jsonpath="{.data.jenkins-password}" | base64 --decode)
 
 {{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
 

--- a/bitnami/jenkins/templates/_helpers.tpl
+++ b/bitnami/jenkins/templates/_helpers.tpl
@@ -7,10 +7,17 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "jenkins.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "jenkins.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/bitnami/jenkins/templates/deployment.yaml
+++ b/bitnami/jenkins/templates/deployment.yaml
@@ -1,22 +1,22 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "jenkins.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "jenkins.fullname" . }}
+    chart: {{ include "jenkins.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
   selector:
     matchLabels:
-      app: {{ template "fullname" . }}
+      app: {{ template "jenkins.fullname" . }}
       release: "{{ .Release.Name }}"
   template:
     metadata:
       labels:
-        app: {{ template "fullname" . }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        app: {{ template "jenkins.fullname" . }}
+        chart: {{ include "jenkins.chart" . }}
         release: "{{ .Release.Name }}"
 {{- if or .Values.podAnnotations .Values.metrics.enabled }}
       annotations:
@@ -39,7 +39,7 @@ spec:
         - name: JENKINS_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}
+              name: {{ template "jenkins.fullname" . }}
               key: jenkins-password
         - name: JENKINS_HOME
           value: {{ .Values.jenkinsHome | quote }}
@@ -84,7 +84,7 @@ spec:
         - name: JENKINS_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}
+              name: {{ template "jenkins.fullname" . }}
               key: jenkins-password
         ports:
         - name: metrics
@@ -108,7 +108,7 @@ spec:
       - name: jenkins-data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
-          claimName: {{ template "fullname" . }}
+          claimName: {{ template "jenkins.fullname" . }}
       {{- else }}
         emptyDir: {}
       {{- end }}

--- a/bitnami/jenkins/templates/ingress.yaml
+++ b/bitnami/jenkins/templates/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "jenkins.fullname" . }}
   labels:
     app: "{{ template "jenkins.fullname" . }}"
-    chart: "{{ template "jenkins.chart" . }}"
+    chart: {{ include "jenkins.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
   annotations:
@@ -23,7 +23,7 @@ spec:
       paths:
       - path: {{ default "/" .path }}
         backend:
-          serviceName: {{ template "fullname" $ }}
+          serviceName: {{ template "jenkins.fullname" $ }}
           servicePort: http
   {{- end }}
   tls:

--- a/bitnami/jenkins/templates/pvc.yaml
+++ b/bitnami/jenkins/templates/pvc.yaml
@@ -2,10 +2,10 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "jenkins.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "jenkins.fullname" . }}
+    chart: {{ include "jenkins.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:

--- a/bitnami/jenkins/templates/secrets.yaml
+++ b/bitnami/jenkins/templates/secrets.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "jenkins.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "jenkins.fullname" . }}
+    chart: {{ include "jenkins.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque

--- a/bitnami/jenkins/templates/svc.yaml
+++ b/bitnami/jenkins/templates/svc.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "jenkins.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "jenkins.fullname" . }}
+    chart: {{ include "jenkins.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
@@ -29,4 +29,4 @@ spec:
       nodePort: {{ .Values.service.nodePorts.https }}
       {{- end }}
   selector:
-    app: {{ template "fullname" . }}
+    app: {{ template "jenkins.fullname" . }}


### PR DESCRIPTION
Signed-off-by: Miguel A. Cabrera Minagorri <macabrera@bitnami.com>

The `ingress.yaml` file on Jenkins was using templates that didn't exist. This PR changes those templates to the existing ones.

**Checklist** [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
