### PR TITLE
[bitnami/etcd] Fix 'unbound variable' issue when RBAC is set to false

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: etcd
-version: 3.1.0
+version: 3.1.1
 appVersion: 3.3.13
 description: etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines
 keywords:

--- a/bitnami/etcd/templates/scripts-configmap.yaml
+++ b/bitnami/etcd/templates/scripts-configmap.yaml
@@ -45,7 +45,7 @@ data:
     configure_rbac() {
         # When there's more than one replica, we can assume the 1st member
         # to be created is "{{ $etcdFullname }}-0" since a statefulset is used
-        if [[ -n "$ETCD_ROOT_PASSWORD" ]] && [[ "$HOSTNAME" == "{{ $etcdFullname }}-0" ]]; then
+        if [[ -n "${ETCD_ROOT_PASSWORD:-}" ]] && [[ "$HOSTNAME" == "{{ $etcdFullname }}-0" ]]; then
             echo "==> Configuring RBAC authentication!"
             etcd > /dev/null 2>&1 &
             ETCD_PID=$!


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

This PR fixes an issue in the Bash script with an unbound variable.

**Benefits**

The chart works when `auth.rbac.enabled=false`

**Possible drawbacks**

None

**Applicable issues**

- fixes https://github.com/bitnami/charts/issues/1260

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

