### PR TITLE
[bitnami/kafka] fix JMX metrics when auth disabled

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 3.0.12
+version: 3.0.13
 appVersion: 2.3.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -113,6 +113,10 @@ spec:
         - name: KAFKA_INTER_BROKER_LISTENER_NAME
           value: {{ .Values.interBrokerListenerName }}
         {{- end }}
+        {{- if .Values.metrics.jmx.enabled }}
+        - name: JMX_PORT
+          value: {{ .Values.metrics.jmx.jmxPort | quote }}
+        {{- end }}
         {{- if .Values.auth.enabled }}
         - name: KAFKA_OPTS
           value: "-Djava.security.auth.login.config=/opt/bitnami/kafka/conf/kafka_jaas.conf"
@@ -130,10 +134,6 @@ spec:
             secretKeyRef:
               name: {{ if .Values.auth.existingSecret }}{{ .Values.auth.existingSecret }}{{ else }}{{ template "kafka.fullname" . }}{{ end }}
               key: kafka-inter-broker-password
-        {{ if .Values.metrics.jmx.enabled }}
-        - name: JMX_PORT
-          value: {{ .Values.metrics.jmx.jmxPort | quote }}
-        {{- end }}
         {{- if .Values.auth.zookeeperUser }}
         - name: KAFKA_ZOOKEEPER_USER
           value: {{ .Values.auth.zookeeperUser | quote }}


### PR DESCRIPTION


<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This PR moves `JMX_PORT` env-var outside of `if .Values.auth.enabled` block.

**Benefits**

JMX can be used even when auth disabled.

**Possible drawbacks**

n/a
<!-- Describe any known limitations with your change -->

**Applicable issues**

n/a
<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

n/a
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).