### PR TITLE
[bitnami/spark] Change Spark default service webPort

### DIFF
--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.4.3
 description: Spark is a fast and general-purpose cluster computing system.
 name: spark
-version: 0.0.2
+version: 0.0.3
 icon: https://bitnami.com/assets/stacks/spark/img/spark-stack-220x234-1ea65541e9e427ca5b93300e61d4778576c7f679ae02addb86a2641b0ca70476.png
 home: https://spark.apache.org/
 sources:

--- a/bitnami/spark/README.md
+++ b/bitnami/spark/README.md
@@ -114,12 +114,14 @@ The following tables lists the configurable parameters of the spark chart and th
 | `security.ssl.protocol`                     | Set the SSL protocol                                                                        | `TLSv1.2`                                               |
 | `security.certificatesSecretName`           | Set the name of the secret that contains the certificates                                   | No default                                              |
 | `service.type`                              | Kubernetes Service type                                                                     | `ClusterIP`                                             |
-| `service.port`                              | spark client port                                                                           | `2379`                                                  |
+| `service.webPort`                           | Spark client port                                                                           | `80`                                                    |
+| `service.clusterPort`                       | Spark cluster port                                                                          | `7077`                                                  |
 | `service.nodePort`                          | Port to bind to for NodePort service type (client port)                                     | `nil`                                                   |
 | `service.annotations`                       | Annotations for spark service                                                               | {}                                                      |
 | `service.loadBalancerIP`                    | loadBalancerIP if spark service type is `LoadBalancer`                                      | `nil`                                                   |
-| `ingress.enabled`                           | Enable the use of the ingress controller to access the web UI                               | `false`                                                  |
+| `ingress.enabled`                           | Enable the use of the ingress controller to access the web UI                               | `false`                                                 |
 | `ingress.hosts`                             | Add hosts to the ingress controller with name and path                                      | `name: spark.local`, `path: /`                          |
+
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/bitnami/spark/templates/NOTES.txt
+++ b/bitnami/spark/templates/NOTES.txt
@@ -13,7 +13,7 @@
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "spark.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.webPort }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "spark.fullname" . }}-master-svc {{ default "8080" .Values.service.webPort }}:{{ default "8080" .Values.service.webPort }}
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "spark.fullname" . }}-master-svc {{ default "80" .Values.service.webPort }}:{{ default "80" .Values.service.webPort }}
   echo "Visit http://127.0.0.1:{{ .Values.service.webPort }} to use your application"
 {{- end }}
 {{- end }}

--- a/bitnami/spark/values-production.yaml
+++ b/bitnami/spark/values-production.yaml
@@ -230,7 +230,7 @@ security:
 service:
   type: ClusterIP
   clusterPort: 7077
-  webPort: 8080
+  webPort: 80
   ## Specify the NodePort value for the LoadBalancer and NodePort service types.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
   ##

--- a/bitnami/spark/values.yaml
+++ b/bitnami/spark/values.yaml
@@ -230,7 +230,7 @@ security:
 service:
   type: ClusterIP
   clusterPort: 7077
-  webPort: 8080
+  webPort: 80
   ## Specify the NodePort value for the LoadBalancer and NodePort service types.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
   ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Change the service default port from `8080` to `80`.
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
More intuitive for automate testing process.
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
