### PR TITLE
[bitnami/nginx] Add kubernetes resources option for nginx

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx
-version: 3.3.3
+version: 3.4.0
 appVersion: 1.16.0
 description: Chart for the nginx server
 keywords:

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -79,6 +79,7 @@ The following tables lists the configurable parameters of the NGINX Open Source 
 | `ingress.secrets[0].key`         | TLS Secret Key                                   | `nil`                                                        |
 | `livenessProbe`                  | Deployment Liveness Probe                        | See `values.yaml`                                            |
 | `readinessProbe`                 | Deployment Readiness Probe                       | See `values.yaml`                                            |
+| `resources`                      | Resource requests/limit                          | {}                                                           |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -45,6 +45,8 @@ spec:
         - name: nginx-server-block
           mountPath: /opt/bitnami/nginx/conf/server_blocks
         {{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 12 }}
 {{- if .Values.metrics.enabled }}
       - name: metrics
         image: {{ template "nginx.metrics.image" . }}

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -136,6 +136,11 @@ readinessProbe:
 ##
 podAnnotations: {}
 
+## Resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+# resources: {}
+
 ## Prometheus Exporter / Metrics
 ##
 metrics:


### PR DESCRIPTION
**Description of the change**
Add option to pass in kubernetes resources + limits for the *Nginx* container.  Interestingly, there already is a resources option for the sidecar prometheus exporter.

**Benefits**
Can apply kubernetes resources and/or limits to the Nginx container.  Consistency. 

**Possible drawbacks**
Can't think of any.

**Applicable issues**
n/a

**Additional information**
n/a

**Checklist** [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
