### PR TITLE
[bitnami/kafka] Fix zookeeper name helper

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 3.0.14
+version: 3.0.15
 appVersion: 2.3.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/templates/_helpers.tpl
+++ b/bitnami/kafka/templates/_helpers.tpl
@@ -100,12 +100,17 @@ Also, we can't use a single if because lazy evaluation is not an option
 {{- end -}}
 {{- end -}}
 
+{{/*
 Create a default fully qualified zookeeper name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "kafka.zookeeper.fullname" -}}
+{{- if .Values.zookeeper.fullnameOverride -}}
+{{- .Values.zookeeper.fullnameOverride | trunc 24 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default "zookeeper" .Values.zookeeper.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
**Description of the change**
There was added `fullnameOverride` to bitnami/zookeeper chart in #1152 
This change must be synchronized with bitnami/kafka chart.

**Current state**
When set `zookeeper.fullnameOverride` property for kafka chart, zookeeper service is created properly. But the different one is used in `KAFKA_CFG_ZOOKEEPER_CONNECT` i.e. it is generated by `kafka.zookeeper.fullname` helper template. It causes kafka pod couldn't start.

**Benefits**
`zookeeper.fullnameOverride` property could be used and kafka would start properly.

**Possible drawbacks**

Probably, template helper from bitnami/zookeeper chart could be used ([zookeeper.fullname](https://github.com/bitnami/charts/blob/master/bitnami/zookeeper/templates/_helpers.tpl#L14)) to not duplicate code. I tried it with no success. Maybe someone know hot use it?

**Applicable issues**
  - referenced to #1141 

**Checklist** [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
  + no changes required
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
  + no changes required
