### PR TITLE
[bitnami/kafka] Fix mapping value for resources.

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 4.0.0
+version: 4.0.1
 appVersion: 2.3.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/values-production.yaml
+++ b/bitnami/kafka/values-production.yaml
@@ -282,7 +282,7 @@ affinity: {}
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##
-resources:
+resources: {}
 #  limits:
 #    cpu: 200m
 #    memory: 1Gi

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -282,7 +282,7 @@ affinity: {}
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##
-resources:
+resources: {}
 #  limits:
 #    cpu: 200m
 #    memory: 1Gi


### PR DESCRIPTION
**Description of the change**

This change will add a default type for the *resources* defaut value.

**Benefits**

Will prevent Helm to log the following warning:

```
Warning: Building values map for chart 'kafka'. Skipped value (map[]) for 'resources', as it is not a table.
```

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

None

**Checklist** [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
