### PR TITLE
[bitnami/magento] Set Elasticsearch image in values.

### DIFF
--- a/bitnami/magento/Chart.yaml
+++ b/bitnami/magento/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: magento
-version: 6.0.0
+version: 6.1.0
 appVersion: 2.3.2
 description: A feature-rich flexible e-commerce solution. It includes transaction options, multi-store functionality, loyalty programs, product categorization and shopper filtering, promotion rules, and more.
 keywords:

--- a/bitnami/magento/README.md
+++ b/bitnami/magento/README.md
@@ -93,6 +93,9 @@ The following table lists the configurable parameters of the Magento chart and t
 | `mariadb.db.user`                     | Database user to create                                                              | `bn_magento`                                                 |
 | `mariadb.db.password`                 | Password for the database                                                            | _random 10 character long alphanumeric string_               |
 | `elasticsearch.enabled`               | Use the Elasticsearch chart as search engine                                         | `true`                                                       |
+| `elasticsearch.image.registry`        | Elasticsearch image registry                                                         | `docker.io`                                                  |
+| `elasticsearch.image.repository`      | Elasticsearch image name                                                             | `bitnami/elasticsearch`                                      |
+| `elasticsearch.image.tag`             | Elasticsearch image tag                                                              | `{TAG_NAME}`                                                 |
 | `elasticsearch.sysctlImage.enabled`   | Enable kernel settings modifier image for Elasticsearch                              | `false`                                                      |
 | `elasticsearch.master.replicas`       | Desired number of Elasticsearch master-eligible nodes                                | `1`                                                          |
 | `elasticsearch.coordinating.replicas` | Desired number of Elasticsearch coordinating-only nodes                              | `1`                                                          |

--- a/bitnami/magento/values-production.yaml
+++ b/bitnami/magento/values-production.yaml
@@ -172,6 +172,10 @@ elasticsearch:
   ## Whether to deploy a elasticsearch server to use as magento's search engine
   ## To use an external server set this to false and configure the externalElasticsearch parameters
   enabled: true
+  ## Tag for the Bitnami Elasticsearch image to use
+  ## ref: https://github.com/bitnami/bitnami-docker-elasticsearch
+  image:
+    tag: 6.8.1-debian-9-r23
   ## Enable to perform the sysctl operation
   sysctlImage:
     enabled: false

--- a/bitnami/magento/values-production.yaml
+++ b/bitnami/magento/values-production.yaml
@@ -175,6 +175,8 @@ elasticsearch:
   ## Tag for the Bitnami Elasticsearch image to use
   ## ref: https://github.com/bitnami/bitnami-docker-elasticsearch
   image:
+    registry: docker.io
+    repository: bitnami/elasticsearch
     tag: 6.8.1-debian-9-r23
   ## Enable to perform the sysctl operation
   sysctlImage:

--- a/bitnami/magento/values.yaml
+++ b/bitnami/magento/values.yaml
@@ -172,6 +172,10 @@ elasticsearch:
   ## Whether to deploy a elasticsearch server to use as magento's search engine
   ## To use an external server set this to false and configure the externalElasticsearch parameters
   enabled: true
+  ## Tag for the Bitnami Elasticsearch image to use
+  ## ref: https://github.com/bitnami/bitnami-docker-elasticsearch
+  image:
+    tag: 6.8.1-debian-9-r23
   ## Enable to perform the sysctl operation
   sysctlImage:
     enabled: false

--- a/bitnami/magento/values.yaml
+++ b/bitnami/magento/values.yaml
@@ -175,6 +175,8 @@ elasticsearch:
   ## Tag for the Bitnami Elasticsearch image to use
   ## ref: https://github.com/bitnami/bitnami-docker-elasticsearch
   image:
+    registry: docker.io
+    repository: bitnami/elasticsearch
     tag: 6.8.1-debian-9-r23
   ## Enable to perform the sysctl operation
   sysctlImage:


### PR DESCRIPTION
**Description of the change**

The Elasticsearch image can now be set in the `values.yaml` file.

**Benefits**

- Ability to automatically update the image via CI/CD.
- Allow the user to specify a custom image.

**Possible drawbacks**

- Unexpected behaviour due to the use of a newer version may be possible, but it's not likely.

**Checklist** [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
