### PR TITLE
[bitnami/kafka] Kafka notes fix

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 4.0.1
+version: 4.0.2
 appVersion: 2.3.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/templates/NOTES.txt
+++ b/bitnami/kafka/templates/NOTES.txt
@@ -23,29 +23,29 @@ Kafka can be accessed via port 9092 on the following DNS name from within your c
 To create a topic run the following command:
 
     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "kafka.name" . }},app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=kafka" -o jsonpath="{.items[0].metadata.name}")
-    kubectl -n {{ .Release.Namespace }} exec -it $POD_NAME -- kafka-topics.sh --create --zookeeper {{  template "kafka.zookeeper.fullname" . }}:2181 --replication-factor 1 --partitions 1 --topic test
+    kubectl --namespace {{ .Release.Namespace }} exec -it $POD_NAME -- kafka-topics.sh --create --zookeeper {{  template "kafka.zookeeper.fullname" . }}:2181 --replication-factor 1 --partitions 1 --topic test
 
 To list all the topics run the following command:
 
     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "kafka.name" . }},app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=kafka" -o jsonpath="{.items[0].metadata.name}")
-    kubectl -n {{ .Release.Namespace }} exec -it $POD_NAME -- kafka-topics.sh --list --zookeeper {{  template "kafka.zookeeper.fullname" . }}:2181
+    kubectl --namespace {{ .Release.Namespace }} exec -it $POD_NAME -- kafka-topics.sh --list --zookeeper {{  template "kafka.zookeeper.fullname" . }}:2181
 
 To start a kafka producer run the following command:
 
     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "kafka.name" . }},app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=kafka" -o jsonpath="{.items[0].metadata.name}")
     {{- if .Values.auth.enabled }}
-    kubectl -n {{ .Release.Namespace }} exec -it $POD_NAME -- kafka-console-producer.sh --broker-list 127.0.0.1:9092 --topic test --producer.config /opt/bitnami/kafka/conf/producer.properties
+    kubectl --namespace {{ .Release.Namespace }} exec -it $POD_NAME -- kafka-console-producer.sh --broker-list 127.0.0.1:9092 --topic test --producer.config /opt/bitnami/kafka/conf/producer.properties
     {{- else }}
-    kubectl -n {{ .Release.Namespace }} exec -it $POD_NAME -- kafka-console-producer.sh --broker-list localhost:9092 --topic test
+    kubectl --namespace {{ .Release.Namespace }} exec -it $POD_NAME -- kafka-console-producer.sh --broker-list localhost:9092 --topic test
     {{- end }}
 
 To start a kafka consumer run the following command:
 
     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "kafka.name" . }},app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=kafka" -o jsonpath="{.items[0].metadata.name}")
     {{- if .Values.auth.enabled }}
-    kubectl -n {{ .Release.Namespace }} exec -it $POD_NAME -- kafka-console-consumer.sh --bootstrap-server 127.0.0.1:9092 --topic test --consumer.config /opt/bitnami/kafka/conf/consumer.properties
+    kubectl --namespace {{ .Release.Namespace }} exec -it $POD_NAME -- kafka-console-consumer.sh --bootstrap-server 127.0.0.1:9092 --topic test --consumer.config /opt/bitnami/kafka/conf/consumer.properties
     {{- else }}
-    kubectl -n {{ .Release.Namespace }} exec -it $POD_NAME -- kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic test --from-beginning
+    kubectl --namespace {{ .Release.Namespace }} exec -it $POD_NAME -- kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic test --from-beginning
     {{- end }}
 
 To connect to your Kafka server from outside the cluster execute the following commands:
@@ -80,7 +80,7 @@ To connect to your Kafka server from outside the cluster execute the following c
         You should get the content of that file and write it in your host machine:
 
         export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "kafka.name" . }},app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=kafka" -o jsonpath="{.items[0].metadata.name}")
-        kubectl exec -it $POD_NAME -- cat /opt/bitnami/kafka/conf/kafka_jaas.conf >> kafka_jaas.conf
+        kubectl --namespace {{ .Release.Namespace }} exec -it $POD_NAME -- cat /opt/bitnami/kafka/conf/kafka_jaas.conf >> kafka_jaas.conf
 
         Finally, before using your client you need to export the following env var:
 

--- a/bitnami/kafka/templates/NOTES.txt
+++ b/bitnami/kafka/templates/NOTES.txt
@@ -23,29 +23,29 @@ Kafka can be accessed via port 9092 on the following DNS name from within your c
 To create a topic run the following command:
 
     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "kafka.name" . }},app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=kafka" -o jsonpath="{.items[0].metadata.name}")
-    kubectl exec -it $POD_NAME -- kafka-topics.sh --create --zookeeper {{  template "kafka.zookeeper.fullname" . }}:2181 --replication-factor 1 --partitions 1 --topic test
+    kubectl -n {{ .Release.Namespace }} exec -it $POD_NAME -- kafka-topics.sh --create --zookeeper {{  template "kafka.zookeeper.fullname" . }}:2181 --replication-factor 1 --partitions 1 --topic test
 
 To list all the topics run the following command:
 
     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "kafka.name" . }},app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=kafka" -o jsonpath="{.items[0].metadata.name}")
-    kubectl exec -it $POD_NAME -- kafka-topics.sh --list --zookeeper {{  template "kafka.zookeeper.fullname" . }}:2181
+    kubectl -n {{ .Release.Namespace }} exec -it $POD_NAME -- kafka-topics.sh --list --zookeeper {{  template "kafka.zookeeper.fullname" . }}:2181
 
 To start a kafka producer run the following command:
 
     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "kafka.name" . }},app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=kafka" -o jsonpath="{.items[0].metadata.name}")
     {{- if .Values.auth.enabled }}
-    kubectl exec -it $POD_NAME -- kafka-console-producer.sh --broker-list 127.0.0.1:9092 --topic test --producer.config /opt/bitnami/kafka/conf/producer.properties
+    kubectl -n {{ .Release.Namespace }} exec -it $POD_NAME -- kafka-console-producer.sh --broker-list 127.0.0.1:9092 --topic test --producer.config /opt/bitnami/kafka/conf/producer.properties
     {{- else }}
-    kubectl exec -it $POD_NAME -- kafka-console-producer.sh --broker-list localhost:9092 --topic test
+    kubectl -n {{ .Release.Namespace }} exec -it $POD_NAME -- kafka-console-producer.sh --broker-list localhost:9092 --topic test
     {{- end }}
 
 To start a kafka consumer run the following command:
 
     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "kafka.name" . }},app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=kafka" -o jsonpath="{.items[0].metadata.name}")
     {{- if .Values.auth.enabled }}
-    kubectl exec -it $POD_NAME -- kafka-console-consumer.sh --bootstrap-server 127.0.0.1:9092 --topic test --consumer.config /opt/bitnami/kafka/conf/consumer.properties
+    kubectl -n {{ .Release.Namespace }} exec -it $POD_NAME -- kafka-console-consumer.sh --bootstrap-server 127.0.0.1:9092 --topic test --consumer.config /opt/bitnami/kafka/conf/consumer.properties
     {{- else }}
-    kubectl exec -it $POD_NAME -- kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic test --from-beginning
+    kubectl -n {{ .Release.Namespace }} exec -it $POD_NAME -- kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic test --from-beginning
     {{- end }}
 
 To connect to your Kafka server from outside the cluster execute the following commands:


### PR DESCRIPTION
**Description of the change**

Added `-n namespace` to 'kubectl exec' commands in kafka helm chart notes.

**Benefits**

The generated code for Kafka helm chart will work also when the context switched to a different namespace (than namespace Kafka is deployed to).

**Possible drawbacks**

-

**Applicable issues**

-

**Additional information**

-

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
