### PR TITLE
[bitnami/harbor] Fix typo in Ingress configuration

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: harbor
-version: 2.0.0
+version: 2.0.1
 appVersion: 1.8.1
 description: Harbor is an an open source trusted cloud native registry project that stores, signs, and scans content
 keywords:

--- a/bitnami/harbor/templates/ingress/ingress.yaml
+++ b/bitnami/harbor/templates/ingress/ingress.yaml
@@ -1,14 +1,14 @@
 {{- if eq .Values.service.type "Ingress" }}
 {{- $ingress := .Values.service.ingress -}}
 {{- $tls := .Values.service.tls -}}
-{{- if eq .Values.expose.ingress.controller "gce" }}
+{{- if eq .Values.service.ingress.controller "gce" }}
   {{- $_ := set . "portal_path" "/*" -}}
   {{- $_ := set . "api_path" "/api/*" -}}
   {{- $_ := set . "service_path" "/service/*" -}}
   {{- $_ := set . "v2_path" "/v2/*" -}}
   {{- $_ := set . "chartrepo_path" "/chartrepo/*" -}}
   {{- $_ := set . "controller_path" "/c/*" -}}
-{{- else if eq .Values.expose.ingress.controller "ncp" }}
+{{- else if eq .Values.service.ingress.controller "ncp" }}
   {{- $_ := set . "portal_path" "/" -}}
   {{- $_ := set . "api_path" "/api/.*" -}}
   {{- $_ := set . "service_path" "/service/.*" -}}
@@ -56,7 +56,7 @@ spec:
     {{- end }}
   {{- end }}
   {{- end }}
-  {{- if eq .Values.expose.ingress.controller "ncp" }}
+  {{- if eq .Values.service.ingress.controller "ncp" }}
   backend:
     serviceName: "{{ template "harbor.portal" . }}"
     servicePort: http


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Fixes an error causing Helm chart not to get installed properly when enabling Ingress.

**Benefits**

Helm chart works properly with this change when using Ingress.

**Possible drawbacks**

None

**Applicable issues**

None


**Additional information**

None

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
