### PR TITLE
[bitnami/etcd] Fix livenessProbe and readinessProbe

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: etcd
-version: 4.0.0
+version: 4.1.0
 appVersion: 3.3.13
 description: etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines
 keywords:

--- a/bitnami/etcd/templates/scripts-configmap.yaml
+++ b/bitnami/etcd/templates/scripts-configmap.yaml
@@ -94,7 +94,7 @@ data:
     ## Check wether the member was succesfully removed from the cluster
     should_add_new_member() {
         return_value=0
-        if (grep -E "^Member [a-z0-9]+ removed from cluster [a-z0-9]+$" "$(dirname "$ETCD_DATA_DIR")/member_removal.log" > /dev/null) || \
+        if (grep -E "^Member[[:space:]]+[a-z0-9]+ removed from cluster [a-z0-9]+$" "$(dirname "$ETCD_DATA_DIR")/member_removal.log" > /dev/null) || \
            ! ([[ -d "$ETCD_DATA_DIR/member/snap" ]] && [[ -f "$ETCD_DATA_DIR/member_id" ]]); then
             rm -rf $ETCD_DATA_DIR/*
         else
@@ -193,9 +193,6 @@ data:
 
     # Constants
     AUTH_OPTIONS="{{ $etcdAuthOptions }}"
-    ETCDCTL_ENDPOINTS="{{range $i, $e := until $replicaCount }}{{ $etcdClientProtocol }}://{{ $etcdFullname }}-{{ $e }}.{{ $etcdHeadlessServiceName }}.{{ $releaseNamespace }}.{{ $dnsBase }}:{{ $clientPort }},{{ end }}"
-    # Remove the last comma "," introduced in the string
-    export ETCDCTL_ENDPOINTS="$(sed 's/,/ /g' <<< $ETCDCTL_ENDPOINTS | awk '{$1=$1};1' | sed 's/ /,/g')"
 
     etcdctl $AUTH_OPTIONS endpoint health >/dev/null 2>&1
 {{- if .Values.disasterRecovery.enabled }}

--- a/bitnami/etcd/values-production.yaml
+++ b/bitnami/etcd/values-production.yaml
@@ -57,7 +57,7 @@ statefulset:
   ## Pod management policy
   ## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
   ##
-  podManagementPolicy: OrderedReady
+  podManagementPolicy: Parallel
   ## Number od replicas
   ##
   replicaCount: 3

--- a/bitnami/etcd/values.yaml
+++ b/bitnami/etcd/values.yaml
@@ -51,7 +51,7 @@ statefulset:
   ## Pod management policy
   ## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
   ##
-  podManagementPolicy: OrderedReady
+  podManagementPolicy: Parallel
   ## Number od replicas
   ##
   replicaCount: 1


### PR DESCRIPTION
**Description of the change**

This solves fundamental problems which resulted in the livenessProbe and readinessProbe features of the chart being broken.

The livenessProbe is fixed by removing the ETCDCTL_ENDPOINTS in the probes.sh script. This makes the check only execute against the one current/local node and not the whole cluster.

The readinessProbe is fixed by configuring the podManagementPolicy to Parallel instead of OrderedReady. 
ETCD is a system that needs to have all nodes up and running during bootstrap, otherwise it will fail. This is in contradiction with the behavior of a statefulSet when readinessProbe is configured, as the next pod will only start once the previous pod's readinessProbe succeeds. I first discarded this idea of changing the podManagementPolicy because I thought it would throw away the benefits of using a statefulSet in the first place. But I have found in the [documentation](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#parallel-pod-management) that:

> This option only affects the behavior for scaling operations. Updates are not affected.

Since this chart doesn't benefit from sequential scaling I think it's an adequate solution. For scaling this chart (beyond the initial config) everything would need to be redeployed anyway since the scripts and environment variables will change, so I conclude that regular scaling shouldn't be done here.

**Benefits**

The probes become usable, the cluster is able to bootstrap and doesn't fail completely if one node goes down.
I also improved a regex because I saw cases where additional whitespace was included due to shorter identifiers. This previously made the regex not match and the node couldn't start.

**Possible drawbacks**

I don't know of any.

**Applicable issues**

  - fixes #1286
  - fixes #1287 

**Additional information**

I wasn't sure what the new chart version should be; I decided to increase the minor rather than the patch version because this PR effectively adds functionality (features that were broken before work now).

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
