### PR TITLE
[bitnami/minio] Use existing image tags and fix issue with global secrets

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 1.0.0
+version: 1.0.1
 appVersion: 2019.7.10
 description: MinIO is an object storage server, compatible with Amazon S3 cloud storage service, mainly used for storing unstructured data (such as photos, videos, log files, etc.)
 keywords:

--- a/bitnami/minio/templates/_helpers.tpl
+++ b/bitnami/minio/templates/_helpers.tpl
@@ -57,6 +57,7 @@ Return the proper Docker Image Registry Secret Names
 {{- define "minio.imagePullSecrets" -}}
 {{- $imagePullSecrets := coalesce .Values.global.imagePullSecrets .Values.image.pullSecrets -}}
 {{- if $imagePullSecrets }}
+imagePullSecrets:
 {{- range $imagePullSecrets }}
   - name: {{ . }}
 {{- end -}}

--- a/bitnami/minio/values-production.yaml
+++ b/bitnami/minio/values-production.yaml
@@ -18,7 +18,7 @@ global:
 image:
   registry: docker.io
   repository: bitnami/minio
-  tag: 2019.7.11-debian-9-r4
+  tag: 2019.7.10-debian-9-r6
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/minio/values.yaml
+++ b/bitnami/minio/values.yaml
@@ -18,7 +18,7 @@ global:
 image:
   registry: docker.io
   repository: bitnami/minio
-  tag: 2019.7.11-debian-9-r4
+  tag: 2019.7.10-debian-9-r6
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: tompizmor <tompizmor@gmail.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

- The chart was using the wrong image tags. They didn't exist.
- There was an issue when `global.imagePullSecrets` was specified. Fixed now.

**Benefits**

- No more `ImagePullBackOff` and `ErrImagePull` errors while deploying the chart.
- Possibility to use `global.imagePullSecrets` without errors


**Possible drawbacks**

None

**Applicable issues**

  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
