### PR TITLE
[bitnami/apache] Replace lusotycoon/apache-exporter with bitnami/apache-exporter

### DIFF
--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: apache
-version: 5.0.0
+version: 5.0.1
 appVersion: 2.4.39
 description: Chart for Apache HTTP Server
 keywords:

--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: apache
-version: 5.0.1
+version: 5.1.0
 appVersion: 2.4.39
 description: Chart for Apache HTTP Server
 keywords:

--- a/bitnami/apache/README.md
+++ b/bitnami/apache/README.md
@@ -68,8 +68,8 @@ The following tables lists the configurable parameters of the Apache chart and t
 | `ingress.secrets[0].key`         | TLS Secret Key                                   | `nil`                                                        |
 | `metrics.enabled`                | Start a side-car prometheus exporter             | `false`                                                      |
 | `metrics.image.registry`         | Apache exporter image registry                   | `docker.io`                                                  |
-| `metrics.image.repository`       | Apache exporter image name                       | `lusotycoon/apache-exporter`                                 |
-| `metrics.image.tag`              | Apache exporter image tag                        | `v0.5.0`                                                     |
+| `metrics.image.repository`       | Apache exporter image name                       | `bitnami/apache-exporter`                                 |
+| `metrics.image.tag`              | Apache exporter image tag                        | `0.7.0-debian-9-r2`                                                     |
 | `metrics.image.pullPolicy`       | Apache exporter image pull policy                | `IfNotPresent`                                               |
 | `metrics.image.pullSecrets`      | Specify Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)      |
 | `metrics.podAnnotations`         | Additional annotations for Metrics exporter pod  | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -91,8 +91,8 @@ metrics:
   enabled: false
   image:
     registry: docker.io
-    repository: lusotycoon/apache-exporter
-    tag: v0.5.0
+    repository: bitnami/apache-exporter
+    tag: 0.7.0-debian-9-r2
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION

Signed-off-by: Marcos Bjoerkelund <marcos@bitnami.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Bitnami now builds an Apache Exporter based on the Lusitaniae/apache_exporter project. This PR updates this chart to use that container image.

**Benefits**

The Apache Exporter image used in Bitnami charts is now maintained by Bitnami, meaning it is up-to-date, protected against security issues, etc.

**Possible drawbacks**

None.

**Applicable issues**

None.

**Additional information**

None.

**Checklist** [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
