### PR TITLE
[bitnami/harbor] Fix ingress access for Notary service

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: harbor
-version: 2.1.0
+version: 2.1.1
 appVersion: 1.8.1
 description: Harbor is an an open source trusted cloud native registry project that stores, signs, and scans content
 keywords:

--- a/bitnami/harbor/requirements.lock
+++ b/bitnami/harbor/requirements.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 6.0.0
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 8.1.4
+  version: 8.1.5
 digest: sha256:ede675b32be35e162fd579435285659a802d0dbf0c79827200cbc621f7414e64
-generated: "2019-07-18T16:37:15.162736169+02:00"
+generated: "2019-07-23T13:39:31.954606+02:00"

--- a/bitnami/harbor/templates/notary/notary-svc.yaml
+++ b/bitnami/harbor/templates/notary/notary-svc.yaml
@@ -10,6 +10,7 @@ spec:
 {{- end }}
   ports:
   - port: 4443
+    targetPort: notary-server
   selector:
     {{ include "harbor.matchLabels" . | nindent 4 }}
     component: notary-server


### PR DESCRIPTION
Signed-off-by: tompizmor <tompizmor@gmail.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

The notary service was not properly configured as the targetPort was missing.

**Benefits**

Notary service works fine.

**Possible drawbacks**

None.

**Applicable issues**

  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
