### PR TITLE
[bitnami/memcached] Use bitnami/memcached-exporter

### DIFF
--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: memcached
-version: 2.0.0
+version: 2.1.0
 appVersion: 1.5.16
 description: Chart for Memcached
 keywords:

--- a/bitnami/memcached/README.md
+++ b/bitnami/memcached/README.md
@@ -45,33 +45,33 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the Memcached chart and their default values.
 
-|      Parameter              |             Description             |                          Default                          |
-|-----------------------------|-------------------------------------|---------------------------------------------------------- |
-| `global.imageRegistry`      | Global Docker image registry        | `nil`                                                     |
-| `global.imagePullSecrets`   | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
-| `image.registry`            | Memcached image registry            | `docker.io`                                               |
-| `image.repository`          | Memcached Image name                | `bitnami/memcached`                                       |
-| `image.tag`                 | Memcached Image tag                 | `{TAG_NAME}`                                              |
-| `image.pullPolicy`          | Memcached image pull policy         | `IfNotPresent`                                            |
-| `image.pullSecrets`         | Specify docker-registry secret names as an array          | `[]` (does not add image pull secrets to deployed pods)  |
-| `nameOverride`              | String to partially override memcached.fullname template with a string (will prepend the release name) | `nil`       |
-| `fullnameOverride`          | String to fully override memcached.fullname template with a string                                     | `nil`       |
-| `securityContext.enabled`   | Enable security context             | `true`                                                    |
-| `securityContext.fsGroup`   | Group ID for the container          | `1001`                                                    |
-| `securityContext.runAsUser` | User ID for the container           | `1001`                                                    |
-| `memcachedUsername`         | Memcached admin user                | `nil`                                                     |
-| `memcachedPassword`         | Memcached admin password            | `nil`                                                     |
-| `serviceType`               | Kubernetes Service type             | `ClusterIP`                                               |
-| `resources`                 | CPU/Memory resource requests/limits | Memory: `256Mi`, CPU: `250m`                              |
-| `clusterDomain`                    | Kubernetes cluster domain           | `cluster.local`                                           |
-| `metrics.enabled`                          | Start a side-car prometheus exporter                                                                           | `false`                                              |
-| `metrics.image.registry`                   | MongoDB exporter image registry                                                                                  | `docker.io`                                          |
-| `metrics.image.repository`                 | MongoDB exporter image name                                                                                      | `prom/memcached-exporter`                           |
-| `metrics.image.tag`                        | MongoDB exporter image tag                                                                                       | `v0.4.1`                                            |
-| `metrics.image.pullPolicy`                 | Image pull policy                                                                                              | `IfNotPresent`                                       |
-| `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                                                               | `[]` (does not add image pull secrets to deployed pods)  |
-| `metrics.podAnnotations`                   | Additional annotations for Metrics exporter pod                                                                | {}                                                   |
-| `metrics.resources`                        | Exporter resource requests/limit                                                                               | Memory: `256Mi`, CPU: `100m`                         |
+| Parameter                   | Description                                                                                            | Default                                                 |
+|-----------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `global.imageRegistry`      | Global Docker image registry                                                                           | `nil`                                                   |
+| `global.imagePullSecrets`   | Global Docker registry secret names as an array                                                        | `[]` (does not add image pull secrets to deployed pods) |
+| `image.registry`            | Memcached image registry                                                                               | `docker.io`                                             |
+| `image.repository`          | Memcached Image name                                                                                   | `bitnami/memcached`                                     |
+| `image.tag`                 | Memcached Image tag                                                                                    | `{TAG_NAME}`                                            |
+| `image.pullPolicy`          | Memcached image pull policy                                                                            | `IfNotPresent`                                          |
+| `image.pullSecrets`         | Specify docker-registry secret names as an array                                                       | `[]` (does not add image pull secrets to deployed pods) |
+| `nameOverride`              | String to partially override memcached.fullname template with a string (will prepend the release name) | `nil`                                                   |
+| `fullnameOverride`          | String to fully override memcached.fullname template with a string                                     | `nil`                                                   |
+| `securityContext.enabled`   | Enable security context                                                                                | `true`                                                  |
+| `securityContext.fsGroup`   | Group ID for the container                                                                             | `1001`                                                  |
+| `securityContext.runAsUser` | User ID for the container                                                                              | `1001`                                                  |
+| `memcachedUsername`         | Memcached admin user                                                                                   | `nil`                                                   |
+| `memcachedPassword`         | Memcached admin password                                                                               | `nil`                                                   |
+| `serviceType`               | Kubernetes Service type                                                                                | `ClusterIP`                                             |
+| `resources`                 | CPU/Memory resource requests/limits                                                                    | Memory: `256Mi`, CPU: `250m`                            |
+| `clusterDomain`             | Kubernetes cluster domain                                                                              | `cluster.local`                                         |
+| `metrics.enabled`           | Start a side-car prometheus exporter                                                                   | `false`                                                 |
+| `metrics.image.registry`    | Memcached exporter image registry                                                                      | `docker.io`                                             |
+| `metrics.image.repository`  | Memcached exporter image name                                                                          | `bitnami/memcached-exporter`                            |
+| `metrics.image.tag`         | Memcached exporter image tag                                                                           | `{TAG_NAME}`                                            |
+| `metrics.image.pullPolicy`  | Image pull policy                                                                                      | `IfNotPresent`                                          |
+| `metrics.image.pullSecrets` | Specify docker-registry secret names as an array                                                       | `[]` (does not add image pull secrets to deployed pods) |
+| `metrics.podAnnotations`    | Additional annotations for Metrics exporter pod                                                        | {}                                                      |
+| `metrics.resources`         | Exporter resource requests/limit                                                                       | Memory: `256Mi`, CPU: `100m`                            |
 
 
 The above parameters map to the env variables defined in [bitnami/memcached](http://github.com/bitnami/bitnami-docker-memcached). For more information please refer to the [bitnami/memcached](http://github.com/bitnami/bitnami-docker-memcached) image documentation.

--- a/bitnami/memcached/values-production.yaml
+++ b/bitnami/memcached/values-production.yaml
@@ -84,8 +84,8 @@ metrics:
   enabled: true
   image:
     registry: docker.io
-    repository: prom/memcached-exporter
-    tag: v0.4.1
+    repository: bitnami/memcached-exporter
+    tag: 0.5.0-debian-9-r1
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -84,8 +84,8 @@ metrics:
   enabled: false
   image:
     registry: docker.io
-    repository: prom/memcached-exporter
-    tag: v0.4.1
+    repository: bitnami/memcached-exporter
+    tag: 0.5.0-debian-9-r1
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Signed-off-by: Andrés Bono <andresbono@vmware.com>

**Description of the change**

This PR substitutes the image for the Memcached Prometheus exporter.

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
