### PR TITLE
[bitnami/nginx] Use bitnami/nginx-exporter

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx
-version: 4.0.0
+version: 4.1.0
 appVersion: 1.16.0
 description: Chart for the nginx server
 keywords:

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -57,8 +57,8 @@ The following tables lists the configurable parameters of the NGINX Open Source 
 | `podAnnotations`                 | Pod annotations                                  | `{}`                                                         |
 | `metrics.enabled`                | Start a side-car prometheus exporter             | `false`                                                      |
 | `metrics.image.registry`         | Promethus exporter image registry                | `docker.io`                                                  |
-| `metrics.image.repository`       | Promethus exporter image name                    | `nginx/nginx-prometheus-exporter`                            |
-| `metrics.image.tag`              | Promethus exporter image tag                     | `0.1.0`                                                      |
+| `metrics.image.repository`       | Promethus exporter image name                    | `bitnami/nginx-exporter`                                     |
+| `metrics.image.tag`              | Promethus exporter image tag                     | `{TAG_NAME}`                                                 |
 | `metrics.image.pullPolicy`       | Image pull policy                                | `IfNotPresent`                                               |
 | `metrics.image.pullSecrets`      | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)      |
 | `metrics.podAnnotations`         | Additional annotations for Metrics exporter pod  | `{prometheus.io/scrape: "true", prometheus.io/port: "9113"}` |

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -155,8 +155,8 @@ metrics:
   enabled: false
   image:
     registry: docker.io
-    repository: nginx/nginx-prometheus-exporter
-    tag: 0.1.0
+    repository: bitnami/nginx-exporter
+    tag: 0.4.2-debian-9-r1
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Signed-off-by: Andrés Bono <andresbono@vmware.com>

**Description of the change**

This PR substitutes the image for the NGINX Prometheus exporter.

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
