### PR TITLE
[bitnami/apache] Fix typo in the README.md

### DIFF
--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: apache
-version: 5.1.0
+version: 5.1.1
 appVersion: 2.4.39
 description: Chart for Apache HTTP Server
 keywords:

--- a/bitnami/apache/README.md
+++ b/bitnami/apache/README.md
@@ -68,8 +68,8 @@ The following tables lists the configurable parameters of the Apache chart and t
 | `ingress.secrets[0].key`         | TLS Secret Key                                   | `nil`                                                        |
 | `metrics.enabled`                | Start a side-car prometheus exporter             | `false`                                                      |
 | `metrics.image.registry`         | Apache exporter image registry                   | `docker.io`                                                  |
-| `metrics.image.repository`       | Apache exporter image name                       | `bitnami/apache-exporter`                                 |
-| `metrics.image.tag`              | Apache exporter image tag                        | `0.7.0-debian-9-r2`                                                     |
+| `metrics.image.repository`       | Apache exporter image name                       | `bitnami/apache-exporter`                                    |
+| `metrics.image.tag`              | Apache exporter image tag                        | `{TAG_NAME}`                                                 |
 | `metrics.image.pullPolicy`       | Apache exporter image pull policy                | `IfNotPresent`                                               |
 | `metrics.image.pullSecrets`      | Specify Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)      |
 | `metrics.podAnnotations`         | Additional annotations for Metrics exporter pod  | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |


### PR DESCRIPTION
Signed-off-by: Andrés Bono <andresbono@vmware.com>

**Description of the change**

Fixes typo in README.md

**Checklist** [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
