### PR TITLE
[bitnami/harbor] Add 'behindReverseProxy' config

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: harbor
-version: 2.1.1
+version: 2.2.0
 appVersion: 1.8.1
 description: Harbor is an an open source trusted cloud native registry project that stores, signs, and scans content
 keywords:

--- a/bitnami/harbor/README.md
+++ b/bitnami/harbor/README.md
@@ -182,6 +182,7 @@ The following table lists the configurable parameters of the Harbor chart and th
 | `nginx.tolerations`                                                         | Tolerations for pod assignment                                           | `[]` (The value is evaluated as a template)             |
 | `nginx.affinity`                                                            | Node/Pod affinities                                                      | `{}` (The value is evaluated as a template)             |
 | `nginx.podAnnotations`                                                      | Annotations to add to the nginx pod                                      | `{}`                                                    |
+| `nginx.behindReverseProxy`                                                  | If nginx is behind another reverse proxy, set to true                    | `false`                                                    |
 | **Portal**                                                                  |
 | `portalImage.registry`                                                      | Registry for portal image                                                | `docker.io`                                             |
 | `portalImage.repository`                                                    | Repository for portal image                                              | `bitnami/harbor-portal`                                 |

--- a/bitnami/harbor/templates/nginx/configmap-http.yaml
+++ b/bitnami/harbor/templates/nginx/configmap-http.yaml
@@ -53,8 +53,9 @@ data:
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-          # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
+          {{- if not .Values.nginx.behindReverseProxy }}
           proxy_set_header X-Forwarded-Proto $scheme;
+          {{- end }}
 
           proxy_buffering off;
           proxy_request_buffering off;
@@ -66,8 +67,9 @@ data:
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-          # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
+          {{- if not .Values.nginx.behindReverseProxy }}
           proxy_set_header X-Forwarded-Proto $scheme;
+          {{- end }}
 
           proxy_buffering off;
           proxy_request_buffering off;
@@ -79,8 +81,9 @@ data:
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-          # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
+          {{- if not .Values.nginx.behindReverseProxy }}
           proxy_set_header X-Forwarded-Proto $scheme;
+          {{- end }}
 
           proxy_buffering off;
           proxy_request_buffering off;
@@ -92,8 +95,9 @@ data:
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-          # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
+          {{- if not .Values.nginx.behindReverseProxy }}
           proxy_set_header X-Forwarded-Proto $scheme;
+          {{- end }}
 
           proxy_buffering off;
           proxy_request_buffering off;
@@ -109,8 +113,10 @@ data:
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-          # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
+          {{- if not .Values.nginx.behindReverseProxy }}
           proxy_set_header X-Forwarded-Proto $scheme;
+          {{- end }}
+
           proxy_buffering off;
           proxy_request_buffering off;
         }
@@ -121,8 +127,9 @@ data:
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-          # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
+          {{- if not .Values.nginx.behindReverseProxy }}
           proxy_set_header X-Forwarded-Proto $scheme;
+          {{- end }}
 
           proxy_buffering off;
           proxy_request_buffering off;

--- a/bitnami/harbor/templates/nginx/configmap-https.yaml
+++ b/bitnami/harbor/templates/nginx/configmap-https.yaml
@@ -73,8 +73,9 @@ data:
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-          # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
+          {{- if not .Values.nginx.behindReverseProxy }}
           proxy_set_header X-Forwarded-Proto $scheme;
+          {{- end }}
 
           proxy_buffering off;
           proxy_request_buffering off;
@@ -108,8 +109,9 @@ data:
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-          # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
+          {{- if not .Values.nginx.behindReverseProxy }}
           proxy_set_header X-Forwarded-Proto $scheme;
+          {{- end }}
 
           # Add Secure flag when serving HTTPS
           proxy_cookie_path / "/; secure";
@@ -124,8 +126,9 @@ data:
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-          # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
+          {{- if not .Values.nginx.behindReverseProxy }}
           proxy_set_header X-Forwarded-Proto $scheme;
+          {{- end }}
 
           proxy_buffering off;
           proxy_request_buffering off;
@@ -137,8 +140,9 @@ data:
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-          # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
+          {{- if not .Values.nginx.behindReverseProxy }}
           proxy_set_header X-Forwarded-Proto $scheme;
+          {{- end }}
 
           proxy_buffering off;
           proxy_request_buffering off;
@@ -150,8 +154,9 @@ data:
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-          # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
+          {{- if not .Values.nginx.behindReverseProxy }}
           proxy_set_header X-Forwarded-Proto $scheme;
+          {{- end }}
 
           proxy_buffering off;
           proxy_request_buffering off;
@@ -167,8 +172,10 @@ data:
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-          # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
+          {{- if not .Values.nginx.behindReverseProxy }}
           proxy_set_header X-Forwarded-Proto $scheme;
+          {{- end }}
+
           proxy_buffering off;
           proxy_request_buffering off;
         }
@@ -179,8 +186,9 @@ data:
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-          # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
+          {{- if not .Values.nginx.behindReverseProxy }}
           proxy_set_header X-Forwarded-Proto $scheme;
+          {{- end }}
 
           proxy_buffering off;
           proxy_request_buffering off;

--- a/bitnami/harbor/values-production.yaml
+++ b/bitnami/harbor/values-production.yaml
@@ -503,6 +503,10 @@ nginx:
   affinity: {}
   ## Additional deployment annotations
   podAnnotations: {}
+  ## When setting up Harbor behind another reverse proxy, such as a nginx instance, set this value to true
+  ## if the reverse proxy already provides the 'X-Forwarded-Proto' header field.
+  ## This is, for example, the case for the OpenShift HAProxy router.
+  behindReverseProxy: false
   ## Configure extra options for liveness and readiness probes
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
   ##

--- a/bitnami/harbor/values.yaml
+++ b/bitnami/harbor/values.yaml
@@ -503,6 +503,10 @@ nginx:
   affinity: {}
   ## Additional deployment annotations
   podAnnotations: {}
+  ## When setting up Harbor behind another reverse proxy, such as a nginx instance, set this value to true
+  ## if the reverse proxy already provides the 'X-Forwarded-Proto' header field.
+  ## This is, for example, the case for the OpenShift HAProxy router.
+  behindReverseProxy: false
   ## Configure extra options for liveness and readiness probes
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
   ##


### PR DESCRIPTION
This configuration value enables to exclude the 'proxy_set_header X-Forwarded-Proto $scheme;' setting from the nginx configuration so Harbor can be used behind other reverse proxy such as HAProxy.

The exclusion of the 'X-Forwarded-Proto' field from the header is already suggested in the current nginx config, so I just added a simple `if` around every occurrence of this field.

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
