### PR TITLE
[bitnami/kafka] Truncate the fullname of zookeeper fix. Should not be too small.

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 5.0.0
+version: 5.0.1
 appVersion: 2.3.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/templates/_helpers.tpl
+++ b/bitnami/kafka/templates/_helpers.tpl
@@ -102,14 +102,14 @@ Also, we can't use a single if because lazy evaluation is not an option
 
 {{/*
 Create a default fully qualified zookeeper name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "kafka.zookeeper.fullname" -}}
 {{- if .Values.zookeeper.fullnameOverride -}}
-{{- .Values.zookeeper.fullnameOverride | trunc 24 | trimSuffix "-" -}}
+{{- .Values.zookeeper.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default "zookeeper" .Values.zookeeper.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
**Description of the change**

Truncate the Fullname of ZooKeeper dependency at 63 chars in the Helm helpers.

**Benefits**

63 chars is the regular number of chars for maximum DNS in kubernetes fullnames. Can avoid unexpected errors when the fullname is between 24 and 63 chars.

**Possible drawbacks**

none

**Applicable issues**

none

**Additional information**

none

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
