### PR TITLE
Fix truncate comment in helpers

### DIFF
--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: apache
-version: 5.1.1
+version: 5.1.2
 appVersion: 2.4.39
 description: Chart for Apache HTTP Server
 keywords:

--- a/bitnami/apache/templates/_helpers.tpl
+++ b/bitnami/apache/templates/_helpers.tpl
@@ -8,7 +8,7 @@ Expand the name of the chart.
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "apache.fullname" -}}
 {{- if .Values.fullnameOverride -}}

--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: memcached
-version: 2.1.0
+version: 2.1.1
 appVersion: 1.5.16
 description: Chart for Memcached
 keywords:

--- a/bitnami/memcached/templates/_helpers.tpl
+++ b/bitnami/memcached/templates/_helpers.tpl
@@ -8,7 +8,7 @@ Expand the name of the chart.
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "memcached.fullname" -}}
 {{- if .Values.fullnameOverride -}}

--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 1.1.3
+version: 1.1.4
 appVersion: 2019.7.24
 description: MinIO is an object storage server, compatible with Amazon S3 cloud storage service, mainly used for storing unstructured data (such as photos, videos, log files, etc.)
 keywords:

--- a/bitnami/minio/templates/_helpers.tpl
+++ b/bitnami/minio/templates/_helpers.tpl
@@ -9,7 +9,7 @@ Expand the name of the chart.
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "minio.fullname" -}}
 {{- if .Values.fullnameOverride -}}

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx
-version: 4.1.0
+version: 4.1.1
 appVersion: 1.16.0
 description: Chart for the nginx server
 keywords:

--- a/bitnami/nginx/templates/_helpers.tpl
+++ b/bitnami/nginx/templates/_helpers.tpl
@@ -8,7 +8,7 @@ Expand the name of the chart.
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "nginx.fullname" -}}
 {{- if .Values.fullnameOverride -}}

--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zookeeper
-version: 4.1.0
+version: 4.1.1
 appVersion: 3.5.5
 description: A centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services for distributed applications.
 keywords:

--- a/bitnami/zookeeper/templates/_helpers.tpl
+++ b/bitnami/zookeeper/templates/_helpers.tpl
@@ -8,7 +8,7 @@ Expand the name of the chart.
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "zookeeper.fullname" -}}


### PR DESCRIPTION
Fix truncate comment in helpers as we changed the value in the past but didn't update the comment, on this way, there are no 24 references (code or comment) anymore