### PR TITLE
[bitnami/jenkins] Allow configuring liveness and readiness probes

### DIFF
--- a/bitnami/jenkins/Chart.yaml
+++ b/bitnami/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: jenkins
-version: 3.0.1
+version: 3.1.0
 appVersion: 2.176.2
 description: The leading open source automation server
 keywords:

--- a/bitnami/jenkins/README.md
+++ b/bitnami/jenkins/README.md
@@ -45,54 +45,66 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the Jenkins chart and their default values.
 
-Parameter | Description | Default
---- | --- | ---
-`global.imageRegistry` | Global Docker image registry | `nil`
-`global.imagePullSecrets`  | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)
-`image.registry` | Jenkins image registry | `docker.io`
-`image.repository` | Jenkins Image name | `bitnami/jenkins`
-`image.tag` | Jenkins Image tag  | `{TAG_NAME}`
-`image.pullPolicy` | Jenkins image pull policy  | `IfNotPresent`
-`image.pullSecrets` | Specify docker-registry secret names as an array  | `[]` (does not add image pull secrets to deployed pods)
-`nameOverride` | String to partially override jenkins.fullname template with a string (will prepend the release name) | `nil`
-`fullnameOverride` | String to fully override jenkins.fullname template with a string | `nil`
-`jenkinsUser` | User of the application | `user`
-`jenkinsPassword` | Application password  | _random 10 character alphanumeric string_
-`jenkinsHome` | Jenkins home directory | `/opt/bitnami/jenkins/jenkins_home`
-`disableInitialization` | Allows to disable the initial Bitnami configuration for Jenkins  | `no`
-`javaOpts` | Customize JVM parameters | `nil`
-`service.type` | Kubernetes Service type | `LoadBalancer`
-`service.port` | Service HTTP port | `80`
-`service.httpsPort` | Service HTTPS port | `443`
-`service.nodePorts.http` | Kubernetes http node port | `""`
-`service.nodePorts.https` | Kubernetes https node port | `""`
-`service.externalTrafficPolicy` | Enable client source IP preservation | `Cluster`
-`service.loadBalancerIP` | LoadBalancer service IP address | `""`
-`ingress.enabled` | Enable ingress controller resource | `false`
-`ingress.annotations` | Ingress annotations | `[]`
-`ingress.certManager` | Add annotations for cert-manager | `false`
-`ingress.hosts[0].name` | Hostname to your jenkins installation  | `jenkins.local`
-`ingress.hosts[0].path` | Path within the url structure  | `/`
-`ingress.hosts[0].tls`| Utilize TLS backend in ingress | `false`
-`ingress.hosts[0].tlsHosts` | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`) | `nil`
-`ingress.hosts[0].tlsSecret` | TLS Secret (certificates) | `jenkins.local-tls-secret`
-`ingress.secrets[0].name`| TLS Secret Name | `nil`
-`ingress.secrets[0].certificate` | TLS Secret Certificate | `nil`
-`ingress.secrets[0].key` | TLS Secret Key | `nil`
-`persistence.enabled` | Enable persistence using PVC | `true`
-`persistence.storageClass`| PVC Storage Class for Jenkins volume | `nil` (uses alpha storage class annotation)
-`persistence.accessMode` | PVC Access Mode for Jenkins volume | `ReadWriteOnce`
-`persistence.size` | PVC Storage Request for Jenkins volume | `8Gi`
-`resources` | CPU/Memory resource requests/limits | Memory: `512Mi`, CPU: `300m`
-`podAnnotations` | Pod annotations | `{}`
-`metrics.enabled` | Start a side-car Jenkins prometheus exporter | `false`
-`metrics.image.registry` | Jenkins exporter image registry  | `docker.io`
-`metrics.image.repository` | Jenkins exporter image name | `tolleiv/jenkins_exporter`
-`metrics.image.tag` | Jenkins exporter image tag | `latest`
-`metrics.image.pullPolicy` | Image pull policy  | `IfNotPresent`
-`metrics.image.pullSecrets` | Specify docker-registry secret names as an array  | `[]` (does not add image pull secrets to deployed pods)
-`metrics.podAnnotations` | Additional annotations for Metrics exporter pod | `{prometheus.io/scrape: "true", prometheus.io/port: "9118"}`
-`metrics.resources` | Exporter resource requests/limit | Memory: `256Mi`, CPU: `100m`
+| Parameter                            | Description                                                                                          | Default                                                      |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `global.imageRegistry`               | Global Docker image registry                                                                         | `nil`                                                        |
+| `global.imagePullSecrets`            | Global Docker registry secret names as an array                                                      | `[]` (does not add image pull secrets to deployed pods)      |
+| `image.registry`                     | Jenkins image registry                                                                               | `docker.io`                                                  |
+| `image.repository`                   | Jenkins Image name                                                                                   | `bitnami/jenkins`                                            |
+| `image.tag`                          | Jenkins Image tag                                                                                    | `{TAG_NAME}`                                                 |
+| `image.pullPolicy`                   | Jenkins image pull policy                                                                            | `IfNotPresent`                                               |
+| `image.pullSecrets`                  | Specify docker-registry secret names as an array                                                     | `[]` (does not add image pull secrets to deployed pods)      |
+| `nameOverride`                       | String to partially override jenkins.fullname template with a string (will prepend the release name) | `nil`                                                        |
+| `fullnameOverride`                   | String to fully override jenkins.fullname template with a string                                     | `nil`                                                        |
+| `jenkinsUser`                        | User of the application                                                                              | `user`                                                       |
+| `jenkinsPassword`                    | Application password                                                                                 | _random 10 character alphanumeric string_                    |
+| `jenkinsHome`                        | Jenkins home directory                                                                               | `/opt/bitnami/jenkins/jenkins_home`                          |
+| `disableInitialization`              | Allows to disable the initial Bitnami configuration for Jenkins                                      | `no`                                                         |
+| `javaOpts`                           | Customize JVM parameters                                                                             | `nil`                                                        |
+| `service.type`                       | Kubernetes Service type                                                                              | `LoadBalancer`                                               |
+| `service.port`                       | Service HTTP port                                                                                    | `80`                                                         |
+| `service.httpsPort`                  | Service HTTPS port                                                                                   | `443`                                                        |
+| `service.nodePorts.http`             | Kubernetes http node port                                                                            | `""`                                                         |
+| `service.nodePorts.https`            | Kubernetes https node port                                                                           | `""`                                                         |
+| `service.externalTrafficPolicy`      | Enable client source IP preservation                                                                 | `Cluster`                                                    |
+| `service.loadBalancerIP`             | LoadBalancer service IP address                                                                      | `""`                                                         |
+| `livenessProbe.enabled`              | Turn on and off liveness probe                                                                       | `true`                                                       |
+| `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                                                             | `180`                                                       |
+| `livenessProbe.periodSeconds`        | How often to perform the probe                                                                       | `10`                                                         |
+| `livenessProbe.timeoutSeconds`       | When the probe times out                                                                             | `5`                                                          |
+| `livenessProbe.successThreshold`     | Minimum consecutive successes for the probe                                                          | `1`                                                          |
+| `livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe                                                           | `6`                                                          |
+| `readinessProbe.enabled`             | Turn on and off readiness probe                                                                      | `true`                                                       |
+| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                                                            | `30`                                                         |
+| `readinessProbe.periodSeconds`       | How often to perform the probe                                                                       | `5`                                                          |
+| `readinessProbe.timeoutSeconds`      | When the probe times out                                                                             | `3`                                                          |
+| `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe                                                          | `1`                                                          |
+| `readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe                                                           | `3`                                                          |
+| `ingress.enabled`                    | Enable ingress controller resource                                                                   | `false`                                                      |
+| `ingress.annotations`                | Ingress annotations                                                                                  | `[]`                                                         |
+| `ingress.certManager`                | Add annotations for cert-manager                                                                     | `false`                                                      |
+| `ingress.hosts[0].name`              | Hostname to your jenkins installation                                                                | `jenkins.local`                                              |
+| `ingress.hosts[0].path`              | Path within the url structure                                                                        | `/`                                                          |
+| `ingress.hosts[0].tls`               | Utilize TLS backend in ingress                                                                       | `false`                                                      |
+| `ingress.hosts[0].tlsHosts`          | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`)                 | `nil`                                                        |
+| `ingress.hosts[0].tlsSecret`         | TLS Secret (certificates)                                                                            | `jenkins.local-tls-secret`                                   |
+| `ingress.secrets[0].name`            | TLS Secret Name                                                                                      | `nil`                                                        |
+| `ingress.secrets[0].certificate`     | TLS Secret Certificate                                                                               | `nil`                                                        |
+| `ingress.secrets[0].key`             | TLS Secret Key                                                                                       | `nil`                                                        |
+| `persistence.enabled`                | Enable persistence using PVC                                                                         | `true`                                                       |
+| `persistence.storageClass`           | PVC Storage Class for Jenkins volume                                                                 | `nil` (uses alpha storage class annotation)                  |
+| `persistence.accessMode`             | PVC Access Mode for Jenkins volume                                                                   | `ReadWriteOnce`                                              |
+| `persistence.size`                   | PVC Storage Request for Jenkins volume                                                               | `8Gi`                                                        |
+| `resources`                          | CPU/Memory resource requests/limits                                                                  | Memory: `512Mi`, CPU: `300m`                                 |
+| `podAnnotations`                     | Pod annotations                                                                                      | `{}`                                                         |
+| `metrics.enabled`                    | Start a side-car Jenkins prometheus exporter                                                         | `false`                                                      |
+| `metrics.image.registry`             | Jenkins exporter image registry                                                                      | `docker.io`                                                  |
+| `metrics.image.repository`           | Jenkins exporter image name                                                                          | `tolleiv/jenkins_exporter`                                   |
+| `metrics.image.tag`                  | Jenkins exporter image tag                                                                           | `latest`                                                     |
+| `metrics.image.pullPolicy`           | Image pull policy                                                                                    | `IfNotPresent`                                               |
+| `metrics.image.pullSecrets`          | Specify docker-registry secret names as an array                                                     | `[]` (does not add image pull secrets to deployed pods)      |
+| `metrics.podAnnotations`             | Additional annotations for Metrics exporter pod                                                      | `{prometheus.io/scrape: "true", prometheus.io/port: "9118"}` |
+| `metrics.resources`                  | Exporter resource requests/limit                                                                     | Memory: `256Mi`, CPU: `100m`                                 |
 
 
 The above parameters map to the env variables defined in [bitnami/jenkins](http://github.com/bitnami/bitnami-docker-jenkins). For more information please refer to the [bitnami/jenkins](http://github.com/bitnami/bitnami-docker-jenkins) image documentation.

--- a/bitnami/jenkins/templates/deployment.yaml
+++ b/bitnami/jenkins/templates/deployment.yaml
@@ -54,20 +54,28 @@ spec:
           containerPort: 8080
         - name: https
           containerPort: 8443
+        {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
             path: /login
             port: http
-          initialDelaySeconds: 180
-          timeoutSeconds: 5
-          failureThreshold: 6
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
             path: /login
             port: http
-          initialDelaySeconds: 30
-          timeoutSeconds: 3
-          periodSeconds: 5
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+        {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:

--- a/bitnami/jenkins/values.yaml
+++ b/bitnami/jenkins/values.yaml
@@ -79,6 +79,24 @@ service:
   ##
   externalTrafficPolicy: Cluster
 
+## Configure liveness and readiness probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+##
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 180
+  periodSeconds: 10
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 6
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 5
+  timeoutSeconds: 3
+  successThreshold: 1
+  failureThreshold: 3
+
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##


### PR DESCRIPTION
Signed-off-by: tompizmor <tompizmor@gmail.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Liveness and readiness probes can now be configured from values.yaml. They can also be enabled or disables.

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

  - fixes #

**Additional information**

**Checklist** [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
