### PR TITLE
[bitnami/nginx]: Adding `replicaCount` to NGINX chart

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx
-version: 4.2.1
+version: 4.3.0
 appVersion: 1.16.0
 description: Chart for the nginx server
 keywords:

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx
-version: 4.2.0
+version: 4.2.1
 appVersion: 1.16.0
 description: Chart for the nginx server
 keywords:

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -68,6 +68,7 @@ The following tables lists the configurable parameters of the NGINX Open Source 
 | `metrics.image.pullSecrets`      | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)      |
 | `metrics.podAnnotations`         | Additional annotations for Metrics exporter pod  | `{prometheus.io/scrape: "true", prometheus.io/port: "9113"}` |
 | `metrics.resources`              | Exporter resource requests/limit                 | {}                                                           |
+| `replicaCount`                   | Number of replicas to deploy                     | `1`                                                          |
 | `service.type`                   | Kubernetes Service type                          | `LoadBalancer`                                               |
 | `service.port`                   | Service HTTP port                                | `80`                                                         |
 | `service.nodePorts.http`         | Kubernetes http node port                        | `""`                                                         |

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -12,7 +12,7 @@ spec:
     matchLabels:
       app: {{ template "nginx.fullname" . }}
       release: "{{ .Release.Name }}"
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   template:
     metadata:
       labels:

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -34,6 +34,9 @@ image:
 ##
 # fullnameOverride:
 
+## Number of replicas to deploy
+replicaCount: 1
+
 ## Kubernetes configuration
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer
 ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Adding the `replicaCount` variable to the chart.

**Benefits**

Having this for `Deployment` templates is quite common; this enables HA for a given NGINX deployment.

**Possible drawbacks**

None; this is a non-breaking change, and is quite common among Helm charts.

**Applicable issues**

**N/A**

**Additional information**

**N/A**

**Checklist** [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
