### PR TITLE
[bitnami/kafka] Service port should not be hardcoded

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 5.0.1
+version: 5.0.2
 appVersion: 2.3.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/templates/svc.yaml
+++ b/bitnami/kafka/templates/svc.yaml
@@ -21,7 +21,7 @@ spec:
   {{- end }}
   ports:
   - name: kafka
-    port: 9092
+    port: {{ .Values.service.port }}
     {{- if and .Values.service.nodePort (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) }}
     nodePort: {{ .Values.service.nodePort }}
     {{- end }}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

This PR allows the user to decide the port to use in the kafka service.

**Benefits**

Flexibility

**Possible drawbacks**

None

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

