### PR TITLE
[bitnami/kafka] Fix Service port hardcoded

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 5.0.2
+version: 5.0.3
 appVersion: 2.3.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/templates/svc-headless.yaml
+++ b/bitnami/kafka/templates/svc-headless.yaml
@@ -13,7 +13,7 @@ spec:
   clusterIP: None
   ports:
   - name: kafka
-    port: 9092
+    port: {{ .Values.service.port }}
     targetPort: kafka
   selector:
     app.kubernetes.io/name: {{ template "kafka.name" . }}


### PR DESCRIPTION
**Description of the change**

This PR allows the user to decide the port to use in the kafka service.


**Benefits**

Flexibility
**Possible drawbacks**

None
**Applicable issues**

**Checklist** [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
