### PR TITLE
[bitnami/nginx] Update nginx-exporter container

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx
-version: 4.3.0
+version: 4.3.1
 appVersion: 1.16.0
 description: Chart for the nginx server
 keywords:

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -181,7 +181,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/nginx-exporter
-    tag: 0.4.2-debian-9-r1
+    tag: 0.4.2-debian-9-r17
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Signed-off-by: Andrés Bono <andresbono@vmware.com>

**Description of the change**

The binary exporter is now placed in a different place. This new revision of the container creates a symbolic link to the previous location to ensure compatibility.

**Benefits**

Fixes #1341


**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] ~Variables are documented in the README.md~
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] ~If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files~
