### PR TITLE
[chart/zookeeper] swicth zookeeper-export image to Bitnami asset `bitnami/zookeeper-exporter`

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zookeeper
-version: 4.1.1
+version: 4.1.2
 appVersion: 3.5.5
 description: A centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services for distributed applications.
 keywords:

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -220,8 +220,8 @@ metrics:
 
   image:
     registry: docker.io
-    repository: dabealu/zookeeper-exporter
-    tag: v0.1.0
+    repository: bitnami/zookeeper-exporter
+    tag: 0.1.1-debian-9-r0
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**

Replaces alpine based `dabealu/zookeeper-exporter` with `bitnami/minideb:stretch` based 
bitnami asset excercising greater control over security updates.

**Benefits**

**Possible drawbacks**

None

**Applicable issues**

None 

**Additional information**

**Checklist** [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files