### PR TITLE
[bitnami/airflow] Use bitnami/airflow-exporter

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: airflow
-version: 2.0.0
+version: 2.1.0
 appVersion: 1.10.3
 description: Apache Airflow is a platform to programmatically author, schedule and monitor workflows.
 keywords:

--- a/bitnami/airflow/README.md
+++ b/bitnami/airflow/README.md
@@ -141,8 +141,8 @@ The following tables lists the configurable parameters of the Kafka chart and th
 | `externalRedis.password`                  | External Redis password                                                                     | `nil`                                                        |
 | `metrics.enabled`                         | Start a side-car prometheus exporter                                                        | `false`                                                      |
 | `metrics.image.registry`                  | Airflow exporter image registry                                                             | `docker.io`                                                  |
-| `metrics.image.repository`                | Airflow exporter image name                                                                 | `pbweb/airflow-prometheus-exporter`                          |
-| `metrics.image.tag`                       | Airflow exporter image tag                                                                  | `latest`                                                     |
+| `metrics.image.repository`                | Airflow exporter image name                                                                 | `bitnami/airflow-exporter`                                   |
+| `metrics.image.tag`                       | Airflow exporter image tag                                                                  | `{TAG_NAME}`                                                 |
 | `metrics.image.pullPolicy`                | Image pull policy                                                                           | `IfNotPresent`                                               |
 | `metrics.image.pullSecrets`               | Specify docker-registry secret names as an array                                            | `[]` (does not add image pull secrets to deployed pods)      |
 | `metrics.podAnnotations`                  | Additional annotations for Metrics exporter                                                 | `{prometheus.io/scrape: "true", prometheus.io/port: "9112"}` |

--- a/bitnami/airflow/values-production.yaml
+++ b/bitnami/airflow/values-production.yaml
@@ -338,8 +338,8 @@ metrics:
 
   image:
     registry: docker.io
-    repository: pbweb/airflow-prometheus-exporter
-    tag: latest
+    repository: bitnami/airflow-exporter
+    tag: 0.20180711.0-debian-9-r3
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/airflow/values.yaml
+++ b/bitnami/airflow/values.yaml
@@ -338,8 +338,8 @@ metrics:
 
   image:
     registry: docker.io
-    repository: pbweb/airflow-prometheus-exporter
-    tag: latest
+    repository: bitnami/airflow-exporter
+    tag: 0.20180711.0-debian-9-r3
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Signed-off-by: Andrés Bono <andresbono@vmware.com>

**Description of the change**

This PR substitutes the image for the Airflow Prometheus exporter.

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
