### PR TITLE
[bitnami/jenkins] Use bitnami/jenkins-exporter

### DIFF
--- a/bitnami/jenkins/Chart.yaml
+++ b/bitnami/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: jenkins
-version: 3.1.0
+version: 3.2.0
 appVersion: 2.176.2
 description: The leading open source automation server
 keywords:

--- a/bitnami/jenkins/README.md
+++ b/bitnami/jenkins/README.md
@@ -99,8 +99,8 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 | `podAnnotations`                     | Pod annotations                                                                                      | `{}`                                                         |
 | `metrics.enabled`                    | Start a side-car Jenkins prometheus exporter                                                         | `false`                                                      |
 | `metrics.image.registry`             | Jenkins exporter image registry                                                                      | `docker.io`                                                  |
-| `metrics.image.repository`           | Jenkins exporter image name                                                                          | `tolleiv/jenkins_exporter`                                   |
-| `metrics.image.tag`                  | Jenkins exporter image tag                                                                           | `latest`                                                     |
+| `metrics.image.repository`           | Jenkins exporter image name                                                                          | `bitnami/jenkins-exporter`                                   |
+| `metrics.image.tag`                  | Jenkins exporter image tag                                                                           | `{TAG_NAME}`                                                 |
 | `metrics.image.pullPolicy`           | Image pull policy                                                                                    | `IfNotPresent`                                               |
 | `metrics.image.pullSecrets`          | Specify docker-registry secret names as an array                                                     | `[]` (does not add image pull secrets to deployed pods)      |
 | `metrics.podAnnotations`             | Additional annotations for Metrics exporter pod                                                      | `{prometheus.io/scrape: "true", prometheus.io/port: "9118"}` |

--- a/bitnami/jenkins/values.yaml
+++ b/bitnami/jenkins/values.yaml
@@ -181,8 +181,8 @@ metrics:
   enabled: false
   image:
     registry: docker.io
-    repository: tolleiv/jenkins_exporter
-    tag: latest
+    repository: bitnami/jenkins-exporter
+    tag: 0.20171225.0-debian-9-r3
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Signed-off-by: Andrés Bono <andresbono@vmware.com>

**Description of the change**

This PR substitutes the image for the Jenkins Prometheus exporter.

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
