### PR TITLE
[bitnami/node][bitnami/airflow] Update dependencies

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: airflow
-version: 2.1.1
+version: 3.0.0
 appVersion: 1.10.3
 description: Apache Airflow is a platform to programmatically author, schedule and monitor workflows.
 keywords:

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: airflow
 version: 3.0.0
-appVersion: 1.10.3
+appVersion: 1.10.4
 description: Apache Airflow is a platform to programmatically author, schedule and monitor workflows.
 keywords:
 - apache

--- a/bitnami/airflow/requirements.lock
+++ b/bitnami/airflow/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 5.3.10
+  version: 6.2.1
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 8.0.14
-digest: sha256:a4b2cebc9661bcabbe4c453ee4567fdb80e44d181503e5ea7150815985890c1a
-generated: 2019-07-01T10:23:17.555976932Z
+  version: 9.0.3
+digest: sha256:99c086e6c1e8c381e164fb75d158887bf9929a2babce2f2dd6778b71e3a7820f
+generated: "2019-08-19T15:38:27.155019+02:00"

--- a/bitnami/airflow/requirements.yaml
+++ b/bitnami/airflow/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
-  version: 5.x.x
+  version: 6.x.x
   repository: https://charts.bitnami.com/bitnami
   condition: postgresql.enabled
 - name: redis
-  version: 8.x.x
+  version: 9.x.x
   repository: https://charts.bitnami.com/bitnami
   condition: redis.enabled

--- a/bitnami/airflow/values-production.yaml
+++ b/bitnami/airflow/values-production.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/airflow
-  tag: 1.10.3-debian-9-r52
+  tag: 1.10.4-debian-9-r1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -37,7 +37,7 @@ image:
 schedulerImage:
   registry: docker.io
   repository: bitnami/airflow-scheduler
-  tag: 1.10.3-debian-9-r61
+  tag: 1.10.4-debian-9-r13
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -61,7 +61,7 @@ schedulerImage:
 workerImage:
   registry: docker.io
   repository: bitnami/airflow-worker
-  tag: 1.10.3-debian-9-r60
+  tag: 1.10.4-debian-9-r13
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -85,7 +85,7 @@ workerImage:
 git:
   registry: docker.io
   repository: bitnami/git
-  tag: 2.22.0-debian-9-r23
+  tag: 2.23.0-debian-9-r3
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -339,7 +339,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/airflow-exporter
-    tag: 0.20180711.0-debian-9-r3
+    tag: 0.20180711.0-debian-9-r10
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/airflow/values.yaml
+++ b/bitnami/airflow/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/airflow
-  tag: 1.10.3-debian-9-r52
+  tag: 1.10.4-debian-9-r1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -37,7 +37,7 @@ image:
 schedulerImage:
   registry: docker.io
   repository: bitnami/airflow-scheduler
-  tag: 1.10.3-debian-9-r61
+  tag: 1.10.4-debian-9-r13
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -61,7 +61,7 @@ schedulerImage:
 workerImage:
   registry: docker.io
   repository: bitnami/airflow-worker
-  tag: 1.10.3-debian-9-r60
+  tag: 1.10.4-debian-9-r13
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -85,7 +85,7 @@ workerImage:
 git:
   registry: docker.io
   repository: bitnami/git
-  tag: 2.22.0-debian-9-r23
+  tag: 2.23.0-debian-9-r3
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -339,7 +339,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/airflow-exporter
-    tag: 0.20180711.0-debian-9-r3
+    tag: 0.20180711.0-debian-9-r10
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/node/Chart.yaml
+++ b/bitnami/node/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node
-version: 10.0.4
+version: 11.0.0
 appVersion: 10.16.3
 description: Event-driven I/O server-side JavaScript environment based on V8
 keywords:

--- a/bitnami/node/requirements.lock
+++ b/bitnami/node/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mongodb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.3.1
+  version: 7.1.1
 - name: bitnami-common
   repository: https://charts.bitnami.com/bitnami
   version: 0.0.8
-digest: sha256:0ffa0d97651319c83df4558b3dd502b0b5f5bb6491e74fa0340a7e473f2eb2ac
-generated: 2019-07-31T21:29:11.312731078Z
+digest: sha256:ef3a38fc3e846e18d2f0f1f326772092287a5ac289a4db640216a2717b081efd
+generated: "2019-08-19T15:37:13.617886+02:00"

--- a/bitnami/node/requirements.yaml
+++ b/bitnami/node/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: mongodb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.x.x
+  version: 7.x.x
   condition: mongodb.install
 - name: bitnami-common
   repository: https://charts.bitnami.com/bitnami

--- a/bitnami/node/values.yaml
+++ b/bitnami/node/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/node
-  tag: 10.16.3-debian-9-r0
+  tag: 10.16.3-debian-9-r4
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -58,7 +58,7 @@ volumePermissions:
 git:
   registry: docker.io
   repository: bitnami/git
-  tag: 2.22.1-debian-9-r4
+  tag: 2.23.0-debian-9-r3
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

This PR update the dependencies of Node and Airflow helm charts. As a consequence, it bumps the major version of both charts.

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)