### PR TITLE
[bitnami/metrics-server] Specify extra arguments to metrics-server using declarative configuration

### DIFF
--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: metrics-server
-version: 3.0.1
+version: 3.0.2
 appVersion: 0.3.3
 description: Metrics Server is a cluster-wide aggregator of resource usage data. Metrics Server collects metrics from the Summary API, exposed by Kubelet on each node.
 keywords:

--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: metrics-server
-version: 3.0.2
+version: 3.1.0
 appVersion: 0.3.3
 description: Metrics Server is a cluster-wide aggregator of resource usage data. Metrics Server collects metrics from the Summary API, exposed by Kubelet on each node.
 keywords:

--- a/bitnami/metrics-server/README.md
+++ b/bitnami/metrics-server/README.md
@@ -58,6 +58,7 @@ The following tables lists the configurable parameters of the Metrics Server cha
 | `nameOverride`           | String to partially override metrics-server.fullname template with a string (will prepend the release name) | `nil`  |
 | `fullnameOverride`       | String to fully override metrics-server.fullname template with a string                                     | `nil`  |
 | `securePort`             | Port where metrics-server will be running                                   | `8443`                                 |
+| `extraArgumentss`        | Extra arguments to pass to metrics-server on start up                       | []                                     |
 | `service.type`           | Kubernetes Service type                                                     | `ClusterIP`                            |
 | `service.port`           | Kubernetes Service port                                                     | `443`                                  |
 | `service.annotations`    | Annotations for the Service                                                 | {}                                     |

--- a/bitnami/metrics-server/README.md
+++ b/bitnami/metrics-server/README.md
@@ -58,7 +58,7 @@ The following tables lists the configurable parameters of the Metrics Server cha
 | `nameOverride`           | String to partially override metrics-server.fullname template with a string (will prepend the release name) | `nil`  |
 | `fullnameOverride`       | String to fully override metrics-server.fullname template with a string                                     | `nil`  |
 | `securePort`             | Port where metrics-server will be running                                   | `8443`                                 |
-| `extraArgumentss`        | Extra arguments to pass to metrics-server on start up                       | []                                     |
+| `extraArgs`              | Extra arguments to pass to metrics-server on start up                       | []                                     |
 | `service.type`           | Kubernetes Service type                                                     | `ClusterIP`                            |
 | `service.port`           | Kubernetes Service port                                                     | `443`                                  |
 | `service.annotations`    | Annotations for the Service                                                 | {}                                     |

--- a/bitnami/metrics-server/README.md
+++ b/bitnami/metrics-server/README.md
@@ -58,7 +58,7 @@ The following tables lists the configurable parameters of the Metrics Server cha
 | `nameOverride`           | String to partially override metrics-server.fullname template with a string (will prepend the release name) | `nil`  |
 | `fullnameOverride`       | String to fully override metrics-server.fullname template with a string                                     | `nil`  |
 | `securePort`             | Port where metrics-server will be running                                   | `8443`                                 |
-| `extraArgs`              | Extra arguments to pass to metrics-server on start up                       | []                                     |
+| `extraArgs`              | Extra arguments to pass to metrics-server on start up                       | {}                                     |
 | `service.type`           | Kubernetes Service type                                                     | `ClusterIP`                            |
 | `service.port`           | Kubernetes Service port                                                     | `443`                                  |
 | `service.annotations`    | Annotations for the Service                                                 | {}                                     |

--- a/bitnami/metrics-server/templates/deployment.yaml
+++ b/bitnami/metrics-server/templates/deployment.yaml
@@ -36,6 +36,6 @@ spec:
         command:
         - metrics-server
         - --secure-port={{ .Values.securePort }}
-{{- if .Values.extraArguments }}
-{{ toYaml .Values.extraArguments | indent 8 }}
-{{- end }}
+      {{- range $key, $value := .Values.extraArgs }}
+        - --{{ $key }}={{ $value }}
+      {{- end }}

--- a/bitnami/metrics-server/templates/deployment.yaml
+++ b/bitnami/metrics-server/templates/deployment.yaml
@@ -36,3 +36,6 @@ spec:
         command:
         - metrics-server
         - --secure-port={{ .Values.securePort }}
+{{- if .Values.extraArguments }}
+{{ toYaml .Values.extraArguments | indent 8 }}
+{{- end }}

--- a/bitnami/metrics-server/values.yaml
+++ b/bitnami/metrics-server/values.yaml
@@ -57,6 +57,10 @@ apiService:
 ##
 securePort: 8443
 
+## A list of extra arguments to pass to the metrics-server
+##
+extraArguments: []
+
 service:
   type: ClusterIP
   port: 443

--- a/bitnami/metrics-server/values.yaml
+++ b/bitnami/metrics-server/values.yaml
@@ -57,9 +57,13 @@ apiService:
 ##
 securePort: 8443
 
-## A list of extra arguments to pass to the metrics-server
+## Extra arguments to pass to the metrics-server
 ##
-extraArguments: []
+extraArgs: {}
+  # To specify extra arguments, uncomment the following lines, adjust them as necessary,
+  # and remove the curly braces after 'extraArgs:'.
+  # kubelet-insecure-tls: true
+  # kubelet-preferred-address-types: InternalIP
 
 service:
   type: ClusterIP

--- a/bitnami/metrics-server/values.yaml
+++ b/bitnami/metrics-server/values.yaml
@@ -58,12 +58,13 @@ apiService:
 securePort: 8443
 
 ## Extra arguments to pass to the metrics-server
+## ref: https://github.com/kubernetes-incubator/metrics-server/blob/master/README.md#flags
+##
+## extraArgs:
+##   kubelet-insecure-tls: true
+##   kubelet-preferred-address-types: InternalIP
 ##
 extraArgs: {}
-  # To specify extra arguments, uncomment the following lines, adjust them as necessary,
-  # and remove the curly braces after 'extraArgs:'.
-  # kubelet-insecure-tls: true
-  # kubelet-preferred-address-types: InternalIP
 
 service:
   type: ClusterIP


### PR DESCRIPTION
**Description of the change**

This change provides a method to specify additional arguments for the metrics-server on start up by modifying the declarative configuration in values.yaml.

**Benefits**

This allows  flags to be consolidated in one place, values.yaml, for this service, instead of having to edit the values of the flags by hand after deployment, as suggested in the existing documentation.

**Possible drawbacks**

A poorly formed entry in the values.yaml could create errors on installation.

**Applicable issues**

#1365 

**Additional information**

The additional arguments can be specified in this way in values.yaml:
```
## A list of extra arguments to pass to the metrics-server
##
extraArguments: [
  "--kubelet-insecure-tls=true",
  "--kubelet-preferred-address-types=InternalIP"
]
```

**Checklist** [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
