### PR TITLE
[bitnami/elasticsearch] Bump exporter version and fix issue with initContainer

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: elasticsearch
-version: 6.2.2
+version: 6.3.0
 appVersion: 7.3.0
 description: A highly scalable open-source full-text search and analytics engine
 keywords:

--- a/bitnami/elasticsearch/templates/coordinating-deploy.yaml
+++ b/bitnami/elasticsearch/templates/coordinating-deploy.yaml
@@ -62,7 +62,7 @@ spec:
       - name: sysctl
         image: {{ template "elasticsearch.sysctl.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-        command: ['sh', '-c', 'install_packages systemd && sysctl -w vm.max_map_count=262144 && sysctl -w fs.file-max=65536']
+        command: ['sh', '-c', 'install_packages systemd procps && sysctl -w vm.max_map_count=262144 && sysctl -w fs.file-max=65536']
         securityContext:
           privileged: true
       {{- end }}

--- a/bitnami/elasticsearch/templates/data-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/data-statefulset.yaml
@@ -72,7 +72,7 @@ spec:
       - name: sysctl
         image: {{ template "elasticsearch.sysctl.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-        command: ['sh', '-c', 'install_packages systemd && sysctl -w vm.max_map_count=262144 && sysctl -w fs.file-max=65536']
+        command: ['sh', '-c', 'install_packages systemd procps && sysctl -w vm.max_map_count=262144 && sysctl -w fs.file-max=65536']
         securityContext:
           privileged: true
       {{- end }}

--- a/bitnami/elasticsearch/templates/ingest-deploy.yaml
+++ b/bitnami/elasticsearch/templates/ingest-deploy.yaml
@@ -64,7 +64,7 @@ spec:
       - name: sysctl
         image: {{ template "elasticsearch.sysctl.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-        command: ['sh', '-c', 'install_packages systemd && sysctl -w vm.max_map_count=262144 && sysctl -w fs.file-max=65536']
+        command: ['sh', '-c', 'install_packages systemd procps && sysctl -w vm.max_map_count=262144 && sysctl -w fs.file-max=65536']
         securityContext:
           privileged: true
       {{- end }}

--- a/bitnami/elasticsearch/templates/master-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/master-statefulset.yaml
@@ -64,7 +64,7 @@ spec:
       - name: sysctl
         image: {{ template "elasticsearch.sysctl.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-        command: ['sh', '-c', 'install_packages systemd && sysctl -w vm.max_map_count=262144 && sysctl -w fs.file-max=65536']
+        command: ['sh', '-c', 'install_packages systemd procps && sysctl -w vm.max_map_count=262144 && sysctl -w fs.file-max=65536']
         securityContext:
           privileged: true
       {{- end }}

--- a/bitnami/elasticsearch/templates/metrics-deploy.yaml
+++ b/bitnami/elasticsearch/templates/metrics-deploy.yaml
@@ -36,7 +36,7 @@ spec:
         args: [ "-es.uri=http://{{ template "elasticsearch.coordinating.fullname" . }}:{{ .Values.coordinating.service.port }}", "-es.all=true" ]
         ports:
         - name: metrics
-          containerPort: 9108
+          containerPort: 9114
         livenessProbe:
           httpGet:
             path: /metrics

--- a/bitnami/elasticsearch/templates/metrics-svc.yaml
+++ b/bitnami/elasticsearch/templates/metrics-svc.yaml
@@ -15,7 +15,7 @@ spec:
   type: {{ .Values.metrics.service.type | quote }}
   ports:
   - name: metrics
-    port: 9108
+    port: 9114
     targetPort: metrics
   selector:
     app: {{ template "elasticsearch.name" . }}

--- a/bitnami/elasticsearch/values-production.yaml
+++ b/bitnami/elasticsearch/values-production.yaml
@@ -348,7 +348,7 @@ metrics:
   podAnnotations: {}
   annotations:
     prometheus.io/scrape: "true"
-    prometheus.io/port: "9108"
+    prometheus.io/port: "9114"
   service:
     type: ClusterIP
   resources:

--- a/bitnami/elasticsearch/values-production.yaml
+++ b/bitnami/elasticsearch/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/elasticsearch
-  tag: 7.3.0-debian-9-r0
+  tag: 7.3.0-debian-9-r7
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -336,7 +336,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch-exporter
-    tag: 1.0.2-debian-9-r356
+    tag: 1.1.0-debian-9-r0
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -348,7 +348,7 @@ metrics:
   podAnnotations: {}
   annotations:
     prometheus.io/scrape: "true"
-    prometheus.io/port: "9108"
+    prometheus.io/port: "9114"
   service:
     type: ClusterIP
   resources:

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/elasticsearch
-  tag: 7.3.0-debian-9-r0
+  tag: 7.3.0-debian-9-r7
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -336,7 +336,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch-exporter
-    tag: 1.0.2-debian-9-r356
+    tag: 1.1.0-debian-9-r0
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

This PR bumps the version of `elasticsearch-exporter` and adapts the port to be used. On the other hand, it fixes the `initContainer` since `sysctl` needs the package `procps`.

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
