### PR TITLE
[bitnami/harbor] Add Harbor Redis password when using redis chart dep…

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: harbor
-version: 2.5.2
+version: 2.5.3
 appVersion: 1.8.1
 description: Harbor is an an open source trusted cloud native registry project that stores, signs, and scans content
 keywords:

--- a/bitnami/harbor/templates/_helpers.tpl
+++ b/bitnami/harbor/templates/_helpers.tpl
@@ -227,8 +227,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "harbor.redis.rawPassword" -}}
-  {{- if and (eq .Values.redis.enabled false) .Values.externalRedis.password -}}
+  {{- if and (not .Values.redis.enabled) .Values.externalRedis.password -}}
     {{- .Values.externalRedis.password -}}
+  {{- end -}}
+  {{- if and .Values.redis.enabled .Values.redis.password -}}
+    {{- .Values.redis.password -}}
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
…endency

Signed-off-by: Miguel A. Cabrera Minagorri <macabrera@bitnami.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
There was a bug with the Redis password as it was only set to Harbor for the external Redis while if using the Redis Chart dependency and setting a Redis password ,the Harbor chart was not using it so it couldn't connect to Redis.
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
This PR allow to deploy Harbor Chart using the Redis Chart dependency with a custom password.
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

