### PR TITLE
[bitnami/harbor] Standardize imagePullSecrets on every deployment

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: harbor
-version: 2.5.3
+version: 2.5.4
 appVersion: 1.8.1
 description: Harbor is an an open source trusted cloud native registry project that stores, signs, and scans content
 keywords:

--- a/bitnami/harbor/requirements.lock
+++ b/bitnami/harbor/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 6.2.1
+  version: 6.3.2
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 9.0.2
+  version: 9.1.2
 digest: sha256:99c086e6c1e8c381e164fb75d158887bf9929a2babce2f2dd6778b71e3a7820f
-generated: "2019-08-16T11:50:41.33663+02:00"
+generated: 2019-08-23T10:43:01.4684+02:00

--- a/bitnami/harbor/templates/_helpers.tpl
+++ b/bitnami/harbor/templates/_helpers.tpl
@@ -568,7 +568,7 @@ imagePullSecrets:
 {{- range .Values.global.imagePullSecrets }}
   - name: {{ . }}
 {{- end }}
-{{- else if or .Values.harbor.coreImage.pullSecrets .Values.portalImage.pullSecrets .Values.jobserviceImage.pullSecrets .Values.registryImage.pullSecrets .Values.registryctlImage.pullSecrets .Values.nginxImage.pullSecrets .Values.volumePermissions.image.pullSecrets }}
+{{- else if or .Values.harbor.coreImage.pullSecrets .Values.portalImage.pullSecrets .Values.jobserviceImage.pullSecrets .Values.notaryServerImage.pullSecrets .Values.notarySignerImage.pullSecrets .Values.registryImage.pullSecrets .Values.registryctlImage.pullSecrets .Values.nginxImage.pullSecrets .Values.volumePermissions.image.pullSecrets }}
 imagePullSecrets:
 {{- range .Values.harbor.coreImage.pullSecrets }}
   - name: {{ . }}
@@ -577,6 +577,12 @@ imagePullSecrets:
   - name: {{ . }}
 {{- end }}
 {{- range .Values.jobserviceImage.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.notaryServerImage.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.notarySignerImage.pullSecrets }}
   - name: {{ . }}
 {{- end }}
 {{- range .Values.registryImage.pullSecrets }}
@@ -592,7 +598,7 @@ imagePullSecrets:
   - name: {{ . }}
 {{- end }}
 {{- end -}}
-{{- else if or .Values.harbor.coreImage.pullSecrets .Values.portalImage.pullSecrets .Values.jobserviceImage.pullSecrets .Values.registryImage.pullSecrets .Values.registryctlImage.pullSecrets .Values.nginxImage.pullSecrets .Values.volumePermissions.image.pullSecrets }}
+{{- else if or .Values.harbor.coreImage.pullSecrets .Values.portalImage.pullSecrets .Values.jobserviceImage.pullSecrets .Values.notaryServerImage.pullSecrets .Values.notarySignerImage.pullSecrets .Values.registryImage.pullSecrets .Values.registryctlImage.pullSecrets .Values.nginxImage.pullSecrets .Values.volumePermissions.image.pullSecrets }}
 imagePullSecrets:
 {{- range .Values.harbor.coreImage.pullSecrets }}
   - name: {{ . }}
@@ -601,6 +607,12 @@ imagePullSecrets:
   - name: {{ . }}
 {{- end }}
 {{- range .Values.jobserviceImage.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.notaryServerImage.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.notarySignerImage.pullSecrets }}
   - name: {{ . }}
 {{- end }}
 {{- range .Values.registryImage.pullSecrets }}

--- a/bitnami/harbor/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/bitnami/harbor/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -24,6 +24,7 @@ spec:
         {{ toYaml .Values.chartmuseum.podAnnotations | indent 8 }}
         {{- end }}
     spec:
+{{- include "harbor.imagePullSecrets" . | indent 6 }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
@@ -42,10 +43,6 @@ spec:
       - name: chartmuseum
         image: "{{ template "harbor.chartMuseumImage" . }}"
         imagePullPolicy: {{ .Values.chartMuseumImage.imagePullPolicy | quote }}
-        imagePullSecrets:
-        {{- range .Values.chartMuseumImage.pullSecrets }}
-          - name: {{ . }}
-        {{- end }}
         {{- if .Values.chartmuseum.livenessProbe.enabled }}
         livenessProbe:
           httpGet:

--- a/bitnami/harbor/templates/clair/clair-dpl.yaml
+++ b/bitnami/harbor/templates/clair/clair-dpl.yaml
@@ -23,10 +23,6 @@ spec:
       {{- end }}
     spec:
 {{- include "harbor.imagePullSecrets" . | indent 6 }}
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       containers:
       - name: clair
         image:  "{{ template "harbor.clairImage" . }}"

--- a/bitnami/harbor/templates/clair/clair-dpl.yaml
+++ b/bitnami/harbor/templates/clair/clair-dpl.yaml
@@ -22,6 +22,7 @@ spec:
         {{ toYaml .Values.clair.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
+{{- include "harbor.imagePullSecrets" . | indent 6 }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/bitnami/harbor/templates/core/core-dpl.yaml
+++ b/bitnami/harbor/templates/core/core-dpl.yaml
@@ -25,6 +25,7 @@ spec:
         {{- toYaml .Values.core.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
+{{- include "harbor.imagePullSecrets" . | indent 6 }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}

--- a/bitnami/harbor/templates/jobservice/jobservice-dpl.yaml
+++ b/bitnami/harbor/templates/jobservice/jobservice-dpl.yaml
@@ -23,6 +23,7 @@ spec:
         {{ toYaml .Values.jobservice.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
+{{- include "harbor.imagePullSecrets" . | indent 6 }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}

--- a/bitnami/harbor/templates/nginx/deployment.yaml
+++ b/bitnami/harbor/templates/nginx/deployment.yaml
@@ -29,6 +29,7 @@ spec:
         {{ toYaml .Values.nginx.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
+{{- include "harbor.imagePullSecrets" . | indent 6 }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}

--- a/bitnami/harbor/templates/notary/notary-server.yaml
+++ b/bitnami/harbor/templates/notary/notary-server.yaml
@@ -21,6 +21,7 @@ spec:
         {{ toYaml .Values.notary.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
+{{- include "harbor.imagePullSecrets" . | indent 6 }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}

--- a/bitnami/harbor/templates/notary/notary-signer.yaml
+++ b/bitnami/harbor/templates/notary/notary-signer.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/notary/notary-cm.yaml") . | sha256sum }}
     spec:
+{{- include "harbor.imagePullSecrets" . | indent 6 }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}

--- a/bitnami/harbor/templates/portal/portal-dpl.yaml
+++ b/bitnami/harbor/templates/portal/portal-dpl.yaml
@@ -20,6 +20,7 @@ spec:
         {{ toYaml .Values.portal.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
+{{- include "harbor.imagePullSecrets" . | indent 6 }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}

--- a/bitnami/harbor/templates/registry/registry-dpl.yaml
+++ b/bitnami/harbor/templates/registry/registry-dpl.yaml
@@ -24,6 +24,7 @@ spec:
         {{ toYaml .Values.registry.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
+{{- include "harbor.imagePullSecrets" . | indent 6 }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

This PR standardize how we set the **imagePullSecrets** on every deployment.

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

