### PR TITLE
[bitnami/grafana] Fix readiness probe

### DIFF
--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 0.0.1
+version: 0.0.2
 appVersion: "6.3.3"
 description: Grafana is an open source, feature rich metrics dashboard and graph editor for Graphite, Elasticsearch, OpenTSDB, Prometheus and InfluxDB.
 keywords:

--- a/bitnami/grafana/templates/deployment.yaml
+++ b/bitnami/grafana/templates/deployment.yaml
@@ -14,8 +14,8 @@ spec:
     metadata:
       labels: {{ include "grafana.labels" . | nindent 8 }}
       annotations:
-         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-         checksum/dashboard-provider: {{ include (print $.Template.BasePath "/dashboard-provider.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/dashboard-provider: {{ include (print $.Template.BasePath "/dashboard-provider.yaml") . | sha256sum }}
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}

--- a/bitnami/grafana/values-production.yaml
+++ b/bitnami/grafana/values-production.yaml
@@ -178,7 +178,7 @@ readinessProbe:
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 6
-successThreshold: 1
+  successThreshold: 1
 
 ## Service configuration
 ##

--- a/bitnami/grafana/values.yaml
+++ b/bitnami/grafana/values.yaml
@@ -178,7 +178,7 @@ readinessProbe:
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 6
-successThreshold: 1
+  successThreshold: 1
 
 ## Service configuration
 ##


### PR DESCRIPTION
Signed-off-by: Alejandro Moreno <amoreno@bitnami.com>

**Description of the change**
Fixes an indentation error affecting the readiness probes and a minor indentation error in the deployment annotations.

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
