### PR TITLE
[bitnami/mariadb-galera] Fix mariadb-galera.serviceAccountName function

### DIFF
--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb-galera
-version: 0.2.6
+version: 0.2.7
 appVersion: 10.3.18
 description: MariaDB Galera is a multi-master database cluster solution for synchronous replication and high availability.
 keywords:

--- a/bitnami/mariadb-galera/templates/_helpers.tpl
+++ b/bitnami/mariadb-galera/templates/_helpers.tpl
@@ -101,7 +101,7 @@ Create the name of the service account to use
 */}}
 {{- define "mariadb-galera.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
-    {{ default (include "mariadb.fullname" .) .Values.serviceAccount.name }}
+    {{ default (include "mariadb-galera.fullname" .) .Values.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}

--- a/bitnami/mariadb-galera/values-production.yaml
+++ b/bitnami/mariadb-galera/values-production.yaml
@@ -84,7 +84,7 @@ serviceAccount:
   ##
   create: false
   ## The name of the ServiceAccount to use.
-  ## If not set and create is true, a name is generated using the mariadb.fullname template
+  ## If not set and create is true, a name is generated using the mariadb-galera.fullname template
   # name:
 
 ## Role Based Access

--- a/bitnami/mariadb-galera/values.yaml
+++ b/bitnami/mariadb-galera/values.yaml
@@ -84,7 +84,7 @@ serviceAccount:
   ##
   create: false
   ## The name of the ServiceAccount to use.
-  ## If not set and create is true, a name is generated using the mariadb.fullname template
+  ## If not set and create is true, a name is generated using the mariadb-galera.fullname template
   # name:
 
 ## Role Based Access


### PR DESCRIPTION
Replace `mariadb.fullname` with `mariadb-galera.fullname`

Signed-off-by: Matej Hasul <matej.hasul@gooddata.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Fix default value of `mariadb-galera.serviceAccountName` template function. Default is `mariadb.fullname` which is not declared anywhere in the chart. I believe this is only typo.

**Benefits**
Chart will correctly generated `serviceAccount` based on chart fullname.

**Possible drawbacks**
I'm not aware of any

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
None

**Additional information**
I've increased patch version of the chart because I believe this is only minor change.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
