### PR TITLE
[bitnami/apache] Use Apache bash container

### DIFF
--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: apache
-version: 6.1.0
+version: 7.0.0
 appVersion: 2.4.41
 description: Chart for Apache HTTP Server
 keywords:

--- a/bitnami/apache/README.md
+++ b/bitnami/apache/README.md
@@ -136,6 +136,10 @@ Bitnami will release a new chart updating its containers if a new version of the
 
 ## Notable changes
 
+### 7.0.0
+
+This release updates the Bitnami Apache container to `2.4.41-debian-9-r40`, which is based on Bash instead of Node.js.
+
 ### 6.0.0
 
 This release allows you to use your custom static applicaton. In order to do so, check [this section](#deploying-your-custom-web-application).

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/apache
-  tag: 2.4.41-debian-9-r22
+  tag: 2.4.41-debian-9-r40
   ## Specify a imagePullPolicy
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -31,7 +31,7 @@ image:
 git:
   registry: docker.io
   repository: bitnami/git
-  tag: 2.23.0-debian-9-r17
+  tag: 2.23.0-debian-9-r34
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -154,7 +154,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.7.0-debian-9-r43
+    tag: 0.7.0-debian-9-r60
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Signed-off-by: Alejandro Moreno <amoreno@bitnami.com>

**Description of the change**

Updates the chart to use the new Apache bash container. It is fully compatible with the current version of the chart.

**Additional information**

@bitnami-bot will update the PR with the correct version of the container.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
