### PR TITLE
[bitnami/harbor] Fix apiVersion for nginx and pullPolicy for chartmusuem

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: harbor
-version: 2.6.8
+version: 2.6.9
 appVersion: 1.8.3
 description: Harbor is an an open source trusted cloud native registry project that stores, signs, and scans content
 keywords:

--- a/bitnami/harbor/requirements.lock
+++ b/bitnami/harbor/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 6.3.7
+  version: 6.3.9
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 9.1.11
+  version: 9.1.12
 digest: sha256:99c086e6c1e8c381e164fb75d158887bf9929a2babce2f2dd6778b71e3a7820f
-generated: 2019-09-18T15:04:52.862197988Z
+generated: "2019-09-23T07:10:06.148267436Z"

--- a/bitnami/harbor/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/bitnami/harbor/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -42,7 +42,7 @@ spec:
       containers:
       - name: chartmuseum
         image: "{{ template "harbor.chartMuseumImage" . }}"
-        imagePullPolicy: {{ .Values.chartMuseumImage.imagePullPolicy | quote }}
+        imagePullPolicy: {{ .Values.chartMuseumImage.pullPolicy | quote }}
         {{- if .Values.chartmuseum.livenessProbe.enabled }}
         livenessProbe:
           httpGet:

--- a/bitnami/harbor/templates/nginx/deployment.yaml
+++ b/bitnami/harbor/templates/nginx/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if ne .Values.service.type "Ingress" }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ template "harbor.nginx" . }}"

--- a/bitnami/harbor/templates/notary/notary-server.yaml
+++ b/bitnami/harbor/templates/notary/notary-server.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
       - name: notary-server
         image: "{{ template "harbor.notaryServerImage" . }}"
-        imagePullPolicy: {{ .Values.notaryServerImage.pullPolicy }}
+        imagePullPolicy: {{ .Values.notaryServerImage.pullPolicy | quote }}
         {{- if .Values.notary.server.resources }}
         resources: {{ toYaml .Values.notary.server.resources | nindent 10 }}
         {{- end }}

--- a/bitnami/harbor/templates/notary/notary-signer.yaml
+++ b/bitnami/harbor/templates/notary/notary-signer.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - name: notary-signer
         image: "{{ template "harbor.notarySignerImage" . }}"
-        imagePullPolicy: {{ .Values.notarySignerImage.pullPolicy }}
+        imagePullPolicy: {{ .Values.notarySignerImage.pullPolicy | quote }}
         {{- if .Values.notary.signer.resources }}
         resources:
           {{ toYaml .Values.notary.signer.resources | nindent 10 }}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

There are several deprecations in the API introduced in `K8s 1.16` (see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#deprecations-and-removals) which affect our manifests. The following APIs are no longer served by default:

- All resources under `apps/v1beta1` and `apps/v1beta2` - use `apps/v1` instead
- **daemonsets**, **deployments**, **replicasets** resources under `extensions/v1beta1` - use `apps/v1` instead
- **networkpolicies** resources under `extensions/v1beta1` - use `networking.k8s.io/v1` instead
- **podsecuritypolicies** resources under `extensions/v1beta1` - use `policy/v1beta1` instead

This PR address the changes to be done for NGINX on this chart. 

On the other hand, this PR fixes an issue with the imagePullPolicy setup in chartmusuem.

- fixes https://github.com/bitnami/charts/issues/1422

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)