### PR TITLE
[bitnami/memcached] use the new bash based memcached image

### DIFF
--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: memcached
-version: 2.2.2
+version: 3.0.0
 appVersion: 1.5.18
 description: Chart for Memcached
 keywords:

--- a/bitnami/memcached/README.md
+++ b/bitnami/memcached/README.md
@@ -115,6 +115,12 @@ It is strongly recommended to use immutable tags in a production environment. Th
 
 Bitnami will release a new chart updating its containers if a new version of the main container, significant changes, or critical vulnerabilities exist.
 
+## Notable changes
+
+### 3.0.0
+
+This release uses the new bash based `bitnami/memcached` container which uses bash scripts for the start up logic of the container and is smaller in size.
+
 ## Upgrading
 
 ### To 1.0.0

--- a/bitnami/memcached/values-production.yaml
+++ b/bitnami/memcached/values-production.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/memcached
-  tag: 1.5.18-debian-9-r0
+  tag: 1.5.18-debian-9-r6
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/memcached
-  tag: 1.5.18-debian-9-r0
+  tag: 1.5.18-debian-9-r6
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
**Description of the change**

This PR updates the nami based memcached image with the bash based release.

**Benefits**

The bash based memcached image is smaller in size resulting in faster chart deployment.

**Possible drawbacks**

No known drawbacks

**Applicable issues**

None

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files