### PR TITLE
[bitnami/etcd] Fix conflict between ETCDCTL_ENDPOINTS env var and --endpoints

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: etcd
-version: 4.3.7
+version: 4.3.8
 appVersion: 3.4.1
 description: etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines
 keywords:

--- a/bitnami/etcd/templates/scripts-configmap.yaml
+++ b/bitnami/etcd/templates/scripts-configmap.yaml
@@ -76,7 +76,7 @@ data:
         local -r min_endpoints=$((({{ $replicaCount }} + 1)/2))
 
         for e in "${endpoints_array[@]}"; do
-            if [[ "$e" != "$ETCD_ADVERTISE_CLIENT_URLS" ]] && (unset -v ETCDCTL_ENDPOINTS; exec etcdctl $AUTH_OPTIONS  endpoint health --endpoints="$e"); then
+            if [[ "$e" != "$ETCD_ADVERTISE_CLIENT_URLS" ]] && (unset -v ETCDCTL_ENDPOINTS; etcdctl $AUTH_OPTIONS  endpoint health --endpoints="$e"); then
                 active_endpoints=$((active_endpoints + 1))
             fi
         done
@@ -132,14 +132,12 @@ data:
               --initial-cluster-token $ETCD_INITIAL_CLUSTER_TOKEN \
               --initial-advertise-peer-urls $ETCD_INITIAL_ADVERTISE_PEER_URLS 1>&3 2>&4
             store_member_id & 1>&3 2>&4
-
         else
             echo "==> There was no snapshot to perform data recovery!!" 1>&3 2>&4
             exit 1
         fi
 {{- else }}
         store_member_id & 1>&3 2>&4
-
         configure_rbac
 {{- end }}
     else
@@ -158,7 +156,6 @@ data:
                   --initial-cluster-token $ETCD_INITIAL_CLUSTER_TOKEN \
                   --initial-advertise-peer-urls $ETCD_INITIAL_ADVERTISE_PEER_URLS 1>&3 2>&4
                 store_member_id & 1>&3 2>&4
-
             else
                 echo "==> There was no snapshot to perform data recovery!!" 1>&3 2>&4
                 exit 1
@@ -174,7 +171,6 @@ data:
             echo "==> Loading env vars of existing cluster..." 1>&3 2>&4
             source "$ETCD_DATA_DIR/new_member_envs" 1>&3 2>&4
             store_member_id & 1>&3 2>&4
-
         else
             echo "==> Updating member in existing cluster..." 1>&3 2>&4
             etcdctl $AUTH_OPTIONS member update "$(cat "$ETCD_DATA_DIR/member_id")" --peer-urls="{{ $etcdPeerProtocol }}://${HOSTNAME}.{{ $etcdHeadlessServiceName }}.{{ .Release.Namespace }}.{{ $dnsBase }}:{{ $peerPort }}" 1>&3 2>&4

--- a/bitnami/etcd/templates/scripts-configmap.yaml
+++ b/bitnami/etcd/templates/scripts-configmap.yaml
@@ -51,6 +51,7 @@ data:
     store_member_id() {
         while ! etcdctl $AUTH_OPTIONS member list; do sleep 1; done
         etcdctl $AUTH_OPTIONS member list | grep "$HOSTNAME" | awk '{ print $1}' | awk -F "," '{ print $1}' > "$ETCD_DATA_DIR/member_id"
+        echo "==> Stored member id: $(cat ${ETCD_DATA_DIR}/member_id)" 1>&3 2>&4
         exit 0
     }
     ## Configure RBAC
@@ -75,7 +76,7 @@ data:
         local -r min_endpoints=$((({{ $replicaCount }} + 1)/2))
 
         for e in "${endpoints_array[@]}"; do
-            if [[ "$e" != "$ETCD_ADVERTISE_CLIENT_URLS" ]] && etcdctl $AUTH_OPTIONS  endpoint health --endpoints="$e"; then
+            if [[ "$e" != "$ETCD_ADVERTISE_CLIENT_URLS" ]] && (unset -v ETCDCTL_ENDPOINTS; exec etcdctl $AUTH_OPTIONS  endpoint health --endpoints="$e"); then
                 active_endpoints=$((active_endpoints + 1))
             fi
         done
@@ -130,13 +131,15 @@ data:
               --initial-cluster $ETCD_INITIAL_CLUSTER \
               --initial-cluster-token $ETCD_INITIAL_CLUSTER_TOKEN \
               --initial-advertise-peer-urls $ETCD_INITIAL_ADVERTISE_PEER_URLS 1>&3 2>&4
-            store_member_id &
+            store_member_id & 1>&3 2>&4
+
         else
             echo "==> There was no snapshot to perform data recovery!!" 1>&3 2>&4
             exit 1
         fi
 {{- else }}
-        store_member_id &
+        store_member_id & 1>&3 2>&4
+
         configure_rbac
 {{- end }}
     else
@@ -154,7 +157,8 @@ data:
                   --initial-cluster $ETCD_INITIAL_CLUSTER \
                   --initial-cluster-token $ETCD_INITIAL_CLUSTER_TOKEN \
                   --initial-advertise-peer-urls $ETCD_INITIAL_ADVERTISE_PEER_URLS 1>&3 2>&4
-                store_member_id &
+                store_member_id & 1>&3 2>&4
+
             else
                 echo "==> There was no snapshot to perform data recovery!!" 1>&3 2>&4
                 exit 1
@@ -169,7 +173,8 @@ data:
             sed -ie 's/^/export /' "$ETCD_DATA_DIR/new_member_envs"
             echo "==> Loading env vars of existing cluster..." 1>&3 2>&4
             source "$ETCD_DATA_DIR/new_member_envs" 1>&3 2>&4
-            store_member_id &
+            store_member_id & 1>&3 2>&4
+
         else
             echo "==> Updating member in existing cluster..." 1>&3 2>&4
             etcdctl $AUTH_OPTIONS member update "$(cat "$ETCD_DATA_DIR/member_id")" --peer-urls="{{ $etcdPeerProtocol }}://${HOSTNAME}.{{ $etcdHeadlessServiceName }}.{{ .Release.Namespace }}.{{ $dnsBase }}:{{ $peerPort }}" 1>&3 2>&4


### PR DESCRIPTION
**Description of the change**

etcdctl does not seem to support the use of both the `ETCDCTL_ENDPOINTS` environment variable and the `--endpoints` command line parameter in the `etcdctl endpoint health` call, it gives an error about how the setting is being shadowed.

Have unset the `ETCDCTL_ENDPOINTS` environment variable in a subshell so the unset only affects the execution of the `etcdctl endpoint health` call. This appears to work as intended now with minimal code changes.

Also added debug output in the setup.sh script to indicate the member id has successfully been stored.

**Benefits**

I tested that a pod in a 3 node cluster recovers from failure by running `kill -15 1` from within the pod to simulate a crash. The pod recovers correctly. Before this change, the `etcdctl endpoint health` call always fails and the pod goes into a crash loop.

The debug output gives greater confidence that the member id has been stored correctly.

**Possible drawbacks**

None known

**Applicable issues**

None

**Additional information**

None

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)