### PR TITLE
[bitnami/mariadb-galera] Allow to set additional containers

### DIFF
--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb-galera
-version: 0.2.8
+version: 0.3.0
 appVersion: 10.3.18
 description: MariaDB Galera is a multi-master database cluster solution for synchronous replication and high availability.
 keywords:

--- a/bitnami/mariadb-galera/README.md
+++ b/bitnami/mariadb-galera/README.md
@@ -127,7 +127,7 @@ The following table lists the configurable parameters of the MariaDB Galera char
 | `persistence.storageClass`           | Persistent Volume Storage Class                                                                                                                             | `nil`                                                             |
 | `persistence.accessModes`            | Persistent Volume Access Modes                                                                                                                              | `[ReadWriteOnce]`                                                 |
 | `persistence.size`                   | Persistent Volume Size                                                                                                                                      | `8Gi`                                                             |
-| `extraInitContainers`                | Additional init containers (this value is evaluated as a template)                                                                                          | `nil`                                                             |
+| `extraInitContainers`                | Additional init containers (this value is evaluated as a template)                                                                                          | `[]`                                                              |
 | `extraContainers`                    | Additional containers (this value is evaluated as a template)                                                                                               | `[]`                                                              |
 | `resources`                          | CPU/Memory resource requests/limits for node                                                                                                                | `{}`                                                              |
 | `livenessProbe.enabled`              | Turn on and off liveness probe                                                                                                                              | `true`                                                            |
@@ -270,7 +270,7 @@ The chart mounts a [Persistent Volume](kubernetes.io/docs/user-guide/persistent-
 The feature allows for specifying a template string for a initContainer in the pod. Usecases include situations when you need some pre-run setup. For example, in IKS (IBM Cloud Kubernetes Service), non-root users do not have write permission on the volume mount path for NFS-powered file storage. So, you could use a initcontainer to `chown` the mount. See a example below, where we add an initContainer on the pod that reports to an external resource that the db is going to starting.
 `values.yaml`
 ```yaml
-extraInitContainers: |
+extraInitContainers:
 - name: initcontainer
   image: bitnami/minideb:stretch
   command: ["/bin/sh", "-c"]

--- a/bitnami/mariadb-galera/README.md
+++ b/bitnami/mariadb-galera/README.md
@@ -128,6 +128,7 @@ The following table lists the configurable parameters of the MariaDB Galera char
 | `persistence.accessModes`            | Persistent Volume Access Modes                                                                                                                              | `[ReadWriteOnce]`                                                 |
 | `persistence.size`                   | Persistent Volume Size                                                                                                                                      | `8Gi`                                                             |
 | `extraInitContainers`                | Additional init containers (this value is evaluated as a template)                                                                                          | `nil`                                                             |
+| `extraContainers`                    | Additional containers (this value is evaluated as a template)                                                                                               | `[]`                                                              |
 | `resources`                          | CPU/Memory resource requests/limits for node                                                                                                                | `{}`                                                              |
 | `livenessProbe.enabled`              | Turn on and off liveness probe                                                                                                                              | `true`                                                            |
 | `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                                                                                                                    | `120`                                                             |
@@ -275,6 +276,35 @@ extraInitContainers: |
   command: ["/bin/sh", "-c"]
   args:
     - install_packages curl && curl http://api-service.local/db/starting;
+```
+
+## Extra Containers
+
+The feature allows for specifying additional containers in the pod. Usecases include situations when you need to run some sidecar containers. For example, you can observe if mysql in pod is running and report to some service discovery software like eureka. Example:
+`values.yaml`
+```yaml
+extraContainers:
+- name: '{{ .Chart.Name }}-eureka-sidecar'
+  image: 'image:tag'
+  env:
+  - name: SERVICE_NAME
+    value: '{{ template "mariadb-galera.fullname" . }}'
+  - name: EUREKA_APP_NAME
+    value: '{{ template "mariadb-galera.name" . }}'
+  - name: MARIADB_USER
+    value: '{{ .Values.db.user }}'
+  - name: MARIADB_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: '{{ template "mariadb-galera.fullname" . }}'
+        key: mariadb-password
+  resources:
+    limits:
+      cpu: 100m
+      memory: 20Mi
+    requests:
+      cpu: 50m
+      memory: 10Mi
 ```
 
 ## Upgrading

--- a/bitnami/mariadb-galera/templates/statefulset.yaml
+++ b/bitnami/mariadb-galera/templates/statefulset.yaml
@@ -240,6 +240,8 @@ spec:
         resources:
 {{ toYaml .Values.metrics.resources | indent 10 }}
 {{- end }}
+{{ tpl (toYaml .Values.extraContainers) . | indent 6 }}
+
       volumes:
         {{- if or (.Files.Glob "files/my.cnf") .Values.mariadbConfiguration .Values.configurationConfigMap }}
         - name: mariadb-galera-config

--- a/bitnami/mariadb-galera/templates/statefulset.yaml
+++ b/bitnami/mariadb-galera/templates/statefulset.yaml
@@ -240,7 +240,9 @@ spec:
         resources:
 {{ toYaml .Values.metrics.resources | indent 10 }}
 {{- end }}
+{{- if .Values.extraContainers }}
 {{ tpl (toYaml .Values.extraContainers) . | indent 6 }}
+{{- end }}
       volumes:
         {{- if or (.Files.Glob "files/my.cnf") .Values.mariadbConfiguration .Values.configurationConfigMap }}
         - name: mariadb-galera-config

--- a/bitnami/mariadb-galera/templates/statefulset.yaml
+++ b/bitnami/mariadb-galera/templates/statefulset.yaml
@@ -76,7 +76,7 @@ spec:
 {{- include "mariadb-galera.imagePullSecrets" . | indent 6 }}
       {{- if .Values.extraInitContainers }}
       initContainers:
-{{ tpl .Values.extraInitContainers . | indent 6}}
+{{ tpl (toYaml .Values.extraInitContainers) . | indent 6 }}
       {{- end }}
       containers:
       - name: "mariadb-galera"

--- a/bitnami/mariadb-galera/templates/statefulset.yaml
+++ b/bitnami/mariadb-galera/templates/statefulset.yaml
@@ -241,7 +241,6 @@ spec:
 {{ toYaml .Values.metrics.resources | indent 10 }}
 {{- end }}
 {{ tpl (toYaml .Values.extraContainers) . | indent 6 }}
-
       volumes:
         {{- if or (.Files.Glob "files/my.cnf") .Values.mariadbConfiguration .Values.configurationConfigMap }}
         - name: mariadb-galera-config

--- a/bitnami/mariadb-galera/values-production.yaml
+++ b/bitnami/mariadb-galera/values-production.yaml
@@ -361,7 +361,7 @@ persistence:
 
 ## Additional init containers
 ##
-# extraInitContainers: |
+extraInitContainers: []
 # - name: do-something
 #   image: bitnami/minideb:stretch
 #   command: ['do', 'something']

--- a/bitnami/mariadb-galera/values-production.yaml
+++ b/bitnami/mariadb-galera/values-production.yaml
@@ -367,6 +367,7 @@ extraInitContainers: []
 #   command: ['do', 'something']
 
 ## Additional containers
+##
 extraContainers: []
 
 ## Configure resource requests and limits

--- a/bitnami/mariadb-galera/values-production.yaml
+++ b/bitnami/mariadb-galera/values-production.yaml
@@ -366,6 +366,8 @@ persistence:
 #   image: bitnami/minideb:stretch
 #   command: ['do', 'something']
 
+## Additional containers
+extraContainers: []
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/bitnami/mariadb-galera/values.yaml
+++ b/bitnami/mariadb-galera/values.yaml
@@ -361,7 +361,7 @@ persistence:
 
 ## Additional init containers
 ##
-# extraInitContainers: |
+extraInitContainers: []
 # - name: do-something
 #   image: bitnami/minideb:stretch
 #   command: ['do', 'something']

--- a/bitnami/mariadb-galera/values.yaml
+++ b/bitnami/mariadb-galera/values.yaml
@@ -367,6 +367,7 @@ extraInitContainers: []
 #   command: ['do', 'something']
 
 ## Additional containers
+##
 extraContainers: []
 
 ## Configure resource requests and limits

--- a/bitnami/mariadb-galera/values.yaml
+++ b/bitnami/mariadb-galera/values.yaml
@@ -366,6 +366,8 @@ persistence:
 #   image: bitnami/minideb:stretch
 #   command: ['do', 'something']
 
+## Additional containers
+extraContainers: []
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
<!-- Describe the scope of your change - i.e. what the change does. -->
Useful to set various sidecar containers. In our use case we use it to
register dynamically allocated service NodePort to eureka.

**Benefits**
<!-- What benefits will be realized by the code change? -->
Anyone willing to use additional containers can do so.

**Possible drawbacks**
<!-- Describe any known limitations with your change -->
I'm not aware of any. Nothing is used when not used (default is empty array => no additional container).

**Applicable issues**
<!-- Enter any applicable Issues here (You can reference an issue using #) -->
None

**Additional information**
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
It is pretty common for charts to have configurable sidecar containers. There are plenty charts in [charts repo](https://github.com/helm/charts) with configurable `extraContainers`:
```
✔ kra:~/git/charts/stable [master| …1]> grep -l extraContainers */values.yaml
airflow/values.yaml
drone/values.yaml
grafana/values.yaml
keycloak/values.yaml
kibana/values.yaml
memcached/values.yaml
nginx-ingress/values.yaml
prometheus-nats-exporter/values.yaml
prometheus-postgres-exporter/values.yaml
rabbitmq-ha/values.yaml
```
 
**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
