### PR TITLE
[bitnami/*] Fix broken links to NGINX Ingress Annotations docs

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: airflow
-version: 3.1.9
+version: 3.1.10
 appVersion: 1.10.5
 description: Apache Airflow is a platform to programmatically author, schedule and monitor workflows.
 keywords:

--- a/bitnami/airflow/values-production.yaml
+++ b/bitnami/airflow/values-production.yaml
@@ -212,7 +212,7 @@ ingress:
 
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   ##
   ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set

--- a/bitnami/airflow/values.yaml
+++ b/bitnami/airflow/values.yaml
@@ -212,7 +212,7 @@ ingress:
 
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   ##
   ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set

--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: apache
-version: 7.0.2
+version: 7.0.3
 appVersion: 2.4.41
 description: Chart for Apache HTTP Server
 keywords:

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -108,7 +108,7 @@ ingress:
 
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   ##
   ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set

--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: consul
-version: 6.0.1
+version: 6.0.2
 appVersion: 1.6.1
 description: Highly available and distributed service discovery and key-value store designed with support for the modern data center to make distributed systems and configuration easy.
 home: https://www.consul.io/

--- a/bitnami/consul/README.md
+++ b/bitnami/consul/README.md
@@ -203,7 +203,7 @@ HashiCorp Consul will be connected to at port 443.  The actual secret that
 However, please note that if TLS is enabled, the ingress record will not
 work until this secret exists.
 
-For annotations, please see [this document](https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md).
+For annotations, please see [this document](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md).
 Not all annotations are supported by all ingress controllers, but this
 document does a good job of indicating which annotation is supported by
 many popular ingress controllers.

--- a/bitnami/consul/values-production.yaml
+++ b/bitnami/consul/values-production.yaml
@@ -179,7 +179,7 @@ ingress:
 
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   ##
   ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set

--- a/bitnami/consul/values.yaml
+++ b/bitnami/consul/values.yaml
@@ -179,7 +179,7 @@ ingress:
 
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   ##
   ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set

--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 0.0.4
+version: 0.0.5
 appVersion: "6.3.3"
 description: Grafana is an open source, feature rich metrics dashboard and graph editor for Graphite, Elasticsearch, OpenTSDB, Prometheus and InfluxDB.
 keywords:

--- a/bitnami/grafana/values-production.yaml
+++ b/bitnami/grafana/values-production.yaml
@@ -214,7 +214,7 @@ ingress:
 
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   ##
   ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set

--- a/bitnami/grafana/values.yaml
+++ b/bitnami/grafana/values.yaml
@@ -214,7 +214,7 @@ ingress:
 
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   ##
   ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set

--- a/bitnami/jenkins/Chart.yaml
+++ b/bitnami/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: jenkins
-version: 3.4.3
+version: 3.4.4
 appVersion: 2.190.1
 description: The leading open source automation server
 keywords:

--- a/bitnami/jenkins/values.yaml
+++ b/bitnami/jenkins/values.yaml
@@ -136,7 +136,7 @@ ingress:
 
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   ##
   ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set

--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kibana
-appVersion: 7.3.2
+appVersion: 7.3.3
 description: Kibana is an open source, browser based analytics and search dashboard for Elasticsearch.
 version: 0.0.5
 keywords:

--- a/bitnami/kibana/values-production.yaml
+++ b/bitnami/kibana/values-production.yaml
@@ -215,7 +215,7 @@ ingress:
 
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   ##
   ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set

--- a/bitnami/kibana/values.yaml
+++ b/bitnami/kibana/values.yaml
@@ -215,7 +215,7 @@ ingress:
 
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   ##
   ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set

--- a/bitnami/magento/Chart.yaml
+++ b/bitnami/magento/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: magento
-version: 8.3.3
+version: 8.3.4
 appVersion: 2.3.2
 description: A feature-rich flexible e-commerce solution. It includes transaction options, multi-store functionality, loyalty programs, product categorization and shopper filtering, promotion rules, and more.
 keywords:

--- a/bitnami/magento/values-production.yaml
+++ b/bitnami/magento/values-production.yaml
@@ -286,7 +286,7 @@ ingress:
 
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   ##
   ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set

--- a/bitnami/magento/values.yaml
+++ b/bitnami/magento/values.yaml
@@ -286,7 +286,7 @@ ingress:
 
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   ##
   ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set

--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 1.2.14
+version: 1.2.15
 appVersion: 2019.10.2
 description: MinIO is an object storage server, compatible with Amazon S3 cloud storage service, mainly used for storing unstructured data (such as photos, videos, log files, etc.)
 keywords:

--- a/bitnami/minio/values-production.yaml
+++ b/bitnami/minio/values-production.yaml
@@ -262,7 +262,7 @@ ingress:
 
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   ##
   ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set

--- a/bitnami/minio/values.yaml
+++ b/bitnami/minio/values.yaml
@@ -256,7 +256,7 @@ ingress:
 
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   ##
   ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx
-version: 4.3.7
+version: 4.3.8
 appVersion: 1.16.1
 description: Chart for the nginx server
 keywords:

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -72,7 +72,7 @@ ingress:
 
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   ##
   ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set

--- a/bitnami/node/Chart.yaml
+++ b/bitnami/node/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node
-version: 11.2.3
+version: 11.2.4
 appVersion: 10.16.3
 description: Event-driven I/O server-side JavaScript environment based on V8
 keywords:

--- a/bitnami/node/values.yaml
+++ b/bitnami/node/values.yaml
@@ -191,7 +191,7 @@ ingress:
 
     ## Ingress annotations done as key:value pairs
     ## For a full list of possible ingress annotations, please see
-    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
     ##
     ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
     annotations:

--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: tomcat
-version: 5.0.0
+version: 5.0.1
 appVersion: 9.0.26
 description: Chart for Apache Tomcat
 keywords:

--- a/bitnami/tomcat/values.yaml
+++ b/bitnami/tomcat/values.yaml
@@ -133,7 +133,7 @@ ingress:
 
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   ##
   ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

The NGINX Ingress Controller annotations documentation was moved from:

- https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md

to:

- https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md

This PR address this change

**Checklist**

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
