### PR TITLE
[bitnami/apache] Allow mounting httpd.conf through a config map

### DIFF
--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: apache
-version: 7.0.3
+version: 7.1.0
 appVersion: 2.4.41
 description: Chart for Apache HTTP Server
 keywords:

--- a/bitnami/apache/README.md
+++ b/bitnami/apache/README.md
@@ -47,7 +47,7 @@ The command removes all the Kubernetes components associated with the chart and 
 The following tables lists the configurable parameters of the Apache chart and their default values.
 
 | Parameter                        | Description                                             | Default                                                      |
-|----------------------------------|---------------------------------------------------------|--------------------------------------------------------------|
+| -------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------ |
 | `global.imageRegistry`           | Global Docker image registry                            | `nil`                                                        |
 | `global.imagePullSecrets`        | Global Docker registry secret names as an array         | `[]` (does not add image pull secrets to deployed pods)      |
 | `image.registry`                 | Apache Docker image registry                            | `docker.io`                                                  |
@@ -63,6 +63,8 @@ The following tables lists the configurable parameters of the Apache chart and t
 | `replicaCount`                   | Number of replicas of the Apache deployment             | `docker.io`                                                  |
 | `htdocsConfigMap`                | ConfigMap with the server static content                | `nil`                                                        |
 | `htdocsPVC`                      | PVC with the server static content                      | `nil`                                                        |
+| `vhostsConfigMap`                | ConfigMap with the virtual hosts content                | `nil`                                                        |
+| `httpdConfConfigMap`             | ConfigMap with the httpd.conf content                   | `nil`                                                        |
 | `cloneHtdocsFromGit.enabled`     | Get the server static content from a git repository     | `false`                                                      |
 | `cloneHtdocsFromGit.repository`  | Repository to clone static content from                 | `nil`                                                        |
 | `cloneHtdocsFromGit.branch`      | Branch inside the git repository                        | `nil`                                                        |

--- a/bitnami/apache/README.md
+++ b/bitnami/apache/README.md
@@ -128,7 +128,9 @@ In the following example you can deploy a example web application using git:
 helm install bitnami/apache --set cloneHtdocsFromGit.enabled=true --set cloneHtdocsFromGit.repository=https://github.com/mdn/beginner-html-site-styled.git --set cloneHtdocsFromGit.branch=master
 ```
 
-You may also want to mount different virtual host configurations. This can be done using the `vhostsConfigMap` value. This a pointer to a ConfigMap with the desired Apache virtual host configurations.
+To use your own `httpd.conf` file you can mount it using the `httpdConfConfigMap` parameter, which is the name of a Config Map with the contents of your `httpd.conf`. Additionaly, you can copy your `httpd.conf` to `/files/httpd.conf` in your current working directory to mount it to the container.
+
+You may also want to mount different virtual host configurations. This can be done using the `vhostsConfigMap` value. This is a pointer to a ConfigMap with the desired Apache virtual host configurations. You can also copy your virtual host configurations under the `files/vhosts/` directory in your current working directory to mount them as a Config Map to the container.
 
 ### [Rolling VS Immutable tags](https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/)
 

--- a/bitnami/apache/files/README.md
+++ b/bitnami/apache/files/README.md
@@ -1,0 +1,1 @@
+Copy here your `httpd.conf` file to use mount it as a config map.

--- a/bitnami/apache/files/vhosts/README.md
+++ b/bitnami/apache/files/vhosts/README.md
@@ -1,0 +1,1 @@
+Copy here your `*.conf` virtual host files to have them mounted to the container as a config map.

--- a/bitnami/apache/templates/_helpers.tpl
+++ b/bitnami/apache/templates/_helpers.tpl
@@ -195,3 +195,25 @@ Also, we can't use a single if because lazy evaluation is not an option
     {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Get the vhosts config map name.
+*/}}
+{{- define "apache.vhostsConfigMap" -}}
+{{- if .Values.vhostsConfigMap -}}
+    {{- printf "%s" (tpl .Values.vhostsConfigMap $) -}}
+{{- else -}}
+    {{- printf "%s-vhosts" (include "apache.fullname" . ) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the httpd.conf config map name.
+*/}}
+{{- define "apache.httpdConfConfigMap" -}}
+{{- if .Values.httpdConfConfigMap -}}
+    {{- printf "%s" (tpl .Values.httpdConfConfigMap $) -}}
+{{- else -}}
+    {{- printf "%s-httpd-conf" (include "apache.fullname" . ) -}}
+{{- end -}}
+{{- end -}}

--- a/bitnami/apache/templates/configmap-vhosts.yaml
+++ b/bitnami/apache/templates/configmap-vhosts.yaml
@@ -1,0 +1,13 @@
+{{- if and (.Files.Glob "files/vhosts/*.conf") (not .Values.vhostsConfigMap) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "apache.fullname" . }}-vhosts
+  labels:
+    app.kubernetes.io/name: {{ include "apache.fullname" . }}
+    helm.sh/chart: {{ include "apache.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+{{ (.Files.Glob "files/vhosts/*.conf").AsConfig | indent 2 }}
+{{ end }}

--- a/bitnami/apache/templates/configmap.yaml
+++ b/bitnami/apache/templates/configmap.yaml
@@ -1,0 +1,13 @@
+{{ if and (.Files.Glob "files/httpd.conf") (not .Values.httpdConfConfigMap) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "apache.fullname" . }}-httpd-conf
+  labels:
+    app.kubernetes.io/name: {{ include "apache.fullname" . }}
+    helm.sh/chart: {{ include "apache.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+{{ (.Files.Glob "files/httpd.conf").AsConfig | indent 2 }}
+{{ end }}

--- a/bitnami/apache/templates/deployment.yaml
+++ b/bitnami/apache/templates/deployment.yaml
@@ -106,6 +106,11 @@ spec:
         - name: vhosts
           mountPath: /vhosts
         {{- end }}
+        {{- if .Values.httpdConfConfigMap }}
+        - name: httpd-conf
+          mountPath: /opt/bitnami/apache/conf/httpd.conf
+          subPath: httpd.conf
+        {{- end }}
       {{- if .Values.metrics.enabled }}
       - name: metrics
         image: {{ template "apache.metrics.image" . }}
@@ -137,6 +142,11 @@ spec:
       - name: vhosts
         configMap:
           name: {{ .Values.vhostsConfigMap }}
+      {{- end }}
+      {{- if .Values.httpdConfConfigMap }}
+      - name: httpd-conf
+        configMap:
+          name: {{ .Values.httpdConfConfigMap }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:

--- a/bitnami/apache/templates/deployment.yaml
+++ b/bitnami/apache/templates/deployment.yaml
@@ -102,11 +102,11 @@ spec:
         - name: htdocs
           mountPath: /app
         {{- end }}
-        {{- if .Values.vhostsConfigMap }}
+        {{- if or (.Files.Glob "files/vhosts/*.conf") (.Values.vhostsConfigMap) }}
         - name: vhosts
           mountPath: /vhosts
         {{- end }}
-        {{- if .Values.httpdConfConfigMap }}
+        {{- if or (.Files.Glob "files/httpd.conf") (.Values.httpdConfConfigMap) }}
         - name: httpd-conf
           mountPath: /opt/bitnami/apache/conf/httpd.conf
           subPath: httpd.conf
@@ -138,15 +138,15 @@ spec:
       - name: htdocs
         {{- include "apache.htdocsVolume" . | nindent 8 }}
       {{- end }}
-      {{- if .Values.vhostsConfigMap }}
+      {{- if or (.Files.Glob "files/vhosts/*.conf") (.Values.vhostsConfigMap) }}
       - name: vhosts
         configMap:
-          name: {{ .Values.vhostsConfigMap }}
+          name: {{ include "apache.vhostsConfigMap" . }}
       {{- end }}
-      {{- if .Values.httpdConfConfigMap }}
+      {{- if or (.Files.Glob "files/httpd.conf") (.Values.httpdConfConfigMap) }}
       - name: httpd-conf
         configMap:
-          name: {{ .Values.httpdConfConfigMap }}
+          name: {{ include "apache.httpdConfConfigMap" . }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -48,11 +48,22 @@ cloneHtdocsFromGit:
   # branch:
   interval: 60
 
+## Name of a config map with the server static content
+##
 # htdocsConfigMap:
 
+## Name of a PVC with the server static content
+##
 # htdocsPVC:
 
+## Name of a config map with the virtual hosts content
+##
 # vhostsConfigMap:
+
+## Name of a config map with the httpd.conf file contents
+##
+# httpdConfConfigMap:
+
 ## String to partially override apache.fullname template (will maintain the release name)
 ##
 # nameOverride:


### PR DESCRIPTION
**Description of the change**
Allows the user to specify a config map with the `httpd.conf` file contents, which will be mounted to `/opt/bitnami/apache/conf/httpd.conf`.

**Benefits**
It's easier for users to mount their custom `httpd.conf`.

**Applicable issues**
  - fixes #1449 

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)