### PR TITLE
[bitnami/kibana] Reduce the number of default Elasticsearch nodes

### DIFF
--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: kibana
 appVersion: 7.3.2
 description: Kibana is an open source, browser based analytics and search dashboard for Elasticsearch.
-version: 0.0.6
+version: 0.1.0
 keywords:
 - kibana
 - analitics

--- a/bitnami/kibana/README.md
+++ b/bitnami/kibana/README.md
@@ -134,6 +134,9 @@ The following tables lists the configurable parameters of the kibana chart and t
 | `metrics.service.annotations`                | Prometheus annotations for the Kibana service                                          | `{ prometheus.io/scrape: "true", prometheus.io/port: "80", prometheus.io/path: "_prometheus/metrics" }`                                                      |
 | `elasticsearch.enabled`                | Use bundled Elasticsearch                                           | `true`                                                      |
 | `elasticsearch.sysctlImage.enabled`                | Use sysctl image for bundled Elasticsearch                                           | `false`                                                      |
+| `elasticsearch.master.replicas`       | Desired number of Elasticsearch master-eligible nodes                                | `1`                                                          |
+| `elasticsearch.coordinating.replicas` | Desired number of Elasticsearch coordinating-only nodes                              | `1`                                                          |
+| `elasticsearch.data.replicas`         | Desired number of Elasticsearch data nodes                                           | `1`                                                          |
 | `elasticsearch.external.hosts`                | Array containing the hostnames for the already existing Elasticsearch instances                                          | `nil`                                                      |
 | `elasticsearch.external.port`                | Port for the accessing external Elasticsearch instances                                          | `nil`                                                      |
 
@@ -293,6 +296,17 @@ $ helm install --name my-release -f ./values-production.yaml --set elasticsearch
 ```diff
 - elasticsearch.enabled: true
 + elasticsearch.enabled: false
+```
+
+- Increase the number of default Elasticsearch nodes (if manually enabled)
+
+```diff
+- elasticsearch.master.replicas: 1
++ elasticsearch.master.replicas: 2
+- elasticsearch.coordinating.replicas: 1
++ elasticsearch.coordinating.replicas: 2
+- elasticsearch.data.replicas: 1
++ elasticsearch.data.replicas: 2
 ```
 
 - Enable metrics scraping

--- a/bitnami/kibana/values-production.yaml
+++ b/bitnami/kibana/values-production.yaml
@@ -314,6 +314,15 @@ elasticsearch:
   ## Enable sysctl image for the bundled Elasticsearch
   sysctlImage:
     enabled: false
+  ## Elasticsearch master-eligible node parameters
+  master:
+    replicas: 2
+  ## Elasticsearch coordinating-only node parameters
+  coordinating:
+    replicas: 2
+  ## Elasticsearch data node parameters
+  data:
+    replicas: 2
   ## Properties when enabled is false
   external:
     hosts:

--- a/bitnami/kibana/values-production.yaml
+++ b/bitnami/kibana/values-production.yaml
@@ -14,7 +14,7 @@ global: {}
 image:
   registry: docker.io
   repository: bitnami/kibana
-  tag: 7.3.2-debian-9-r19
+  tag: 7.3.2-debian-9-r20
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/kibana/values.yaml
+++ b/bitnami/kibana/values.yaml
@@ -314,6 +314,15 @@ elasticsearch:
   ## Enable sysctl image for the bundled Elasticsearch
   sysctlImage:
     enabled: false
+  ## Elasticsearch master-eligible node parameters
+  master:
+    replicas: 1
+  ## Elasticsearch coordinating-only node parameters
+  coordinating:
+    replicas: 1
+  ## Elasticsearch data node parameters
+  data:
+    replicas: 1
   ## Properties when enabled is false
   external:
     hosts:

--- a/bitnami/kibana/values.yaml
+++ b/bitnami/kibana/values.yaml
@@ -14,7 +14,7 @@ global: {}
 image:
   registry: docker.io
   repository: bitnami/kibana
-  tag: 7.3.2-debian-9-r19
+  tag: 7.3.2-debian-9-r20
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
**Description of the change**
Add some parameters to the `values.yaml` in order to be able to customize the number of Elasticsearch nodes that will be deployed:

- `elasticsearch.master.replicas`
- `elasticsearch.coordinating.replicas`
- `elasticsearch.data.replicas`

It also sets their default values to `1` instead of `2`.

**Benefits**
Much less resources needed to deploy the chart with the default settings.

**Possible drawbacks**
Existing deployments may see an unexpected reduction in the number of Elasticsearch nodes when upgrading.

**Additional information**
As the `values-production.yaml` disables the bundled Elasticsearch by default, I've set the same values as in the `values.yaml`.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files