### PR TITLE
[bitnami/prometheus-operator] new chart

### DIFF
--- a/bitnami/prometheus-operator/.helmignore
+++ b/bitnami/prometheus-operator/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/bitnami/prometheus-operator/Chart.yaml
+++ b/bitnami/prometheus-operator/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+appVersion: 0.33.0
+description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
+name: prometheus-operator
+version: 0.1.0
+keywords:
+- prometheus
+- alertmanager
+- operator
+- monitoring
+home: https://github.com/coreos/prometheus-operator/
+icon: https://bitnami.com/assets/stacks/prometheus-operator/img/prometheus-operator-stack-220x234.png
+sources:
+- https://github.com/bitnami/bitnami-docker-prometheus-operator
+- https://github.com/coreos/prometheus-operator/
+maintainers:
+- name: Bitnami
+  email: containers@bitnami.com
+engine: gotpl

--- a/bitnami/prometheus-operator/README.md
+++ b/bitnami/prometheus-operator/README.md
@@ -1,0 +1,337 @@
+# Prometheus Operator
+
+[Prometheus Operator](https://github.com/coreos/prometheus-operator/) provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
+
+## TL;DR
+
+```bash
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm install bitnami/prometheus-operator
+```
+
+## Introduction
+
+This chart bootstraps [Prometheus Operator](https://github.com/bitnami/bitnami-docker-prometheus-operator) on [Kubernetes](http://kubernetes.io) using the [Helm](https://helm.sh) package manager.
+
+Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters.
+
+## Prerequisites
+
+- Kubernetes 1.12+
+- Helm 2.11+ or Helm 3.0-beta3+
+
+## Installing the Chart
+
+Add the `bitnami` charts repo to Helm:
+
+```bash
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+```
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release bitnami/prometheus-operator
+```
+
+The command deploys Prometheus Operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` release:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release. Use the flag `--purge` to delete all history too.
+
+## Configuration
+
+The following table lists the configurable parameters of the Prometheus Operator chart and their default values.
+
+### Global Configuration
+
+|         Parameter         |                                                  Description                                                   |                         Default                         |
+|---------------------------|----------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `global.imageRegistry`    | Global Docker image registry                                                                                   | `nil`                                                   |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array                                                                | `[]` (does not add image pull secrets to deployed pods) |
+| `global.storageClass`     | Global storage class for dynamic provisioning                                                                  | `nil`                                                   |
+| `global.labels`           | Additional labels to apply to all resource                                                                     | `{}`                                                    |
+| `nameOverride`            | String to partially override `prometheus-operator.name` template with a string (will prepend the release name) | `nil`                                                   |
+| `fullnameOverride`        | String to fully override `prometheus-operator.fullname` template with a string                                 | `nil`                                                   |
+| `rbac.create`             | Wether to create & use RBAC resources or not                                                                   | `true`                                                  |
+| `rbac.apiVersion`         | Version of the RBAC API                                                                                        | `v1beta1`                                               |
+| `rbac.pspEnabled`         | PodSecurityPolicy                                                                                              | `true`                                                  |
+
+### Prometheus Operator Configuration
+
+|                       Parameter                       |                                     Description                                      |                               Default                                |
+|-------------------------------------------------------|--------------------------------------------------------------------------------------|----------------------------------------------------------------------|
+| `operator.enabled`                                    | Deploy Prometheus Operator to the cluster                                            | `true`                                                               |
+| `operator.image.registry`                             | Prometheus Operator image registry                                                   | `docker.io`                                                          |
+| `operator.image.repository`                           | Prometheus Operator Image name                                                       | `bitnami/prometheus-operator`                                        |
+| `operator.image.tag`                                  | Prometheus Operator Image tag                                                        | `{TAG_NAME}`                                                         |
+| `operator.image.pullPolicy`                           | Prometheus Operator image pull policy                                                | `IfNotPresent`                                                       |
+| `operator.image.pullSecrets`                          | Specify docker-registry secret names as an array                                     | `[]` (does not add image pull secrets to deployed pods)              |
+| `operator.serviceAccount.create`                      | Specify whether to create a ServiceAccount for Prometheus Operator                   | `true`                                                               |
+| `operator.serviceAccount.name`                        | The name of the ServiceAccount to create                                             | Generated using the `prometheus-operator.operator.fullname` template |
+| `operator.schedulerName`                              | Name of the k8s scheduler (other than default)                                       | `nil`                                                                |
+| `operator.securityContext.enabled`                    | Enable security context                                                              | `true`                                                               |
+| `operator.securityContext.fsGroup`                    | Group ID for the container filesystem                                                | `1001`                                                               |
+| `operator.securityContext.runAsUser`                  | User ID for the container                                                            | `1001`                                                               |
+| `operator.service.type`                               | Kubernetes service type                                                              | `ClusterIP`                                                          |
+| `operator.service.port`                               | Prometheus Operator service port                                                     | `8080`                                                               |
+| `operator.service.clusterIP`                          | Specific cluster IP when service type is cluster IP. Use `None` for headless service | `nil`                                                                |
+| `operator.service.nodePort`                           | Kubernetes Service nodePort                                                          | `nil`                                                                |
+| `operator.service.loadBalancerIP`                     | `loadBalancerIP` if service type is `LoadBalancer`                                   | `nil`                                                                |
+| `operator.service.loadBalancerSourceRanges`           | Address that are allowed when svc is `LoadBalancer`                                  | `[]`                                                                 |
+| `operator.service.annotations`                        | Additional annotations for Prometheus Operator service                               | `{}`                                                                 |
+| `operator.serviceMonitor.interval`                    | Scrape interval (use by default, falling back to Prometheus' default)                | `nil`                                                                |
+| `operator.serviceMonitor.metricRelabelings`           | Metric relabeling                                                                    | `[]`                                                                 |
+| `operator.serviceMonitor.relabelings`                 | Relabel configs                                                                      | `[]`                                                                 |
+| `operator.resources`                                  | CPU/Memory resource requests/limits for node                                         | `{}`                                                                 |
+| `operator.podAnnotations`                             | Pod annotations                                                                      | `{}`                                                                 |
+| `operator.nodeAffinity`                               | Node Affinity (this value is evaluated as a template)                                | `{}`                                                                 |
+| `operator.podAntiAffinity`                            | Pod anti-affinity policy                                                             | `soft`                                                               |
+| `operator.podAffinity`                                | Affinity, in addition to antiAffinity (this value is evaluated as a template)        | `{}`                                                                 |
+| `operator.nodeSelector`                               | Node labels for pod assignment (this value is evaluated as a template)               | `{}`                                                                 |
+| `operator.tolerations`                                | List of node taints to tolerate (this value is evaluated as a template)              | `[]`                                                                 |
+| `operator.livenessProbe.enabled`                      | Turn on and off liveness probe                                                       | `true`                                                               |
+| `operator.livenessProbe.initialDelaySeconds`          | Delay before liveness probe is initiated                                             | `120`                                                                |
+| `operator.livenessProbe.periodSeconds`                | How often to perform the probe                                                       | `10`                                                                 |
+| `operator.livenessProbe.timeoutSeconds`               | When the probe times out                                                             | `5`                                                                  |
+| `operator.livenessProbe.failureThreshold`             | Minimum consecutive failures for the probe                                           | `6`                                                                  |
+| `operator.livenessProbe.successThreshold`             | Minimum consecutive successes for the probe                                          | `1`                                                                  |
+| `operator.readinessProbe.enabled`                     | Turn on and off readiness probe                                                      | `true`                                                               |
+| `operator.readinessProbe.initialDelaySeconds`         | Delay before readiness probe is initiated                                            | `30`                                                                 |
+| `operator.readinessProbe.periodSeconds`               | How often to perform the probe                                                       | `10`                                                                 |
+| `operator.readinessProbe.timeoutSeconds`              | When the probe times out                                                             | `5`                                                                  |
+| `operator.readinessProbe.failureThreshold`            | Minimum consecutive failures for the probe                                           | `6`                                                                  |
+| `operator.readinessProbe.successThreshold`            | Minimum consecutive successes for the probe                                          | `1`                                                                  |
+| `operator.logLevel`                                   | Log Level                                                                            | `info`                                                               |
+| `operator.logFormat`                                  | Log Format                                                                           | `logfmt`                                                             |
+| `operator.kubeletService.enabled`                     | Whether to maintain a service for scraping kubelets                                  | `true`                                                               |
+| `operator.kubeletService.namespace`                   | Namespace to deploy the kubelet service                                              | `kube-system`                                                        |
+| `operator.configmapReload.image.registry`             | ConfigMap Reload image registry                                                      | `docker.io`                                                          |
+| `operator.configmapReload.image.repository`           | ConfigMap Reload Image name                                                          | `bitnami/configmap-reload`                                           |
+| `operator.configmapReload.image.tag`                  | ConfigMap Reload Image tag                                                           | `{TAG_NAME}`                                                         |
+| `operator.configmapReload.image.pullPolicy`           | ConfigMap Reload image pull policy                                                   | `IfNotPresent`                                                       |
+| `operator.configmapReload.image.pullSecrets`          | Specify docker-registry secret names as an array                                     | `[]` (does not add image pull secrets to deployed pods)              |
+| `operator.prometheusConfigReloader.image.registry`    | Prometheus Config Reloader image registry                                            | `docker.io`                                                          |
+| `operator.prometheusConfigReloader.image.repository`  | Prometheus Config Reloader Image name                                                | `bitnami/configmap-reload`                                           |
+| `operator.prometheusConfigReloader.image.tag`         | Prometheus Config Reloader Image tag                                                 | `{TAG_NAME}`                                                         |
+| `operator.prometheusConfigReloader.image.pullPolicy`  | Prometheus Config Reloader image pull policy                                         | `IfNotPresent`                                                       |
+| `operator.prometheusConfigReloader.image.pullSecrets` | Specify docker-registry secret names as an array                                     | `[]` (does not add image pull secrets to deployed pods)              |
+
+### Prometheus Configuration
+
+|                   Parameter                   |                                     Description                                      |                                Default                                 |
+|-----------------------------------------------|--------------------------------------------------------------------------------------|------------------------------------------------------------------------|
+| `prometheus.enabled`                          | Deploy Prometheus to the cluster                                                     | `true`                                                                 |
+| `prometheus.image.registry`                   | Prometheus image registry                                                            | `docker.io`                                                            |
+| `prometheus.image.repository`                 | Prometheus Image name                                                                | `bitnami/prometheus`                                                   |
+| `prometheus.image.tag`                        | Prometheus Image tag                                                                 | `{TAG_NAME}`                                                           |
+| `prometheus.image.pullSecrets`                | Specify docker-registry secret names as an array                                     | `[]` (does not add image pull secrets to deployed pods)                |
+| `prometheus.serviceAccount.create`            | Specify whether to create a ServiceAccount for Prometheus                            | `true`                                                                 |
+| `prometheus.serviceAccount.name`              | The name of the ServiceAccount to create                                             | Generated using the `prometheus-operator.prometheus.fullname` template |
+| `prometheus.securityContext.enabled`          | Enable security context                                                              | `true`                                                                 |
+| `prometheus.securityContext.fsGroup`          | Group ID for the container filesystem                                                | `1001`                                                                 |
+| `prometheus.securityContext.runAsUser`        | User ID for the container                                                            | `1001`                                                                 |
+| `prometheus.podDisruptionBudget.enabled`      | Create a pod disruption budget for Prometheus                                        | `true`                                                                 |
+| `prometheus.podDisruptionBudget.minAvailable` | Minimum number / percentage of pods that should remain scheduled                     | `1`                                                                    |
+| `prometheus.podDisruptionBudget.minAvailable` | Maximum number / percentage of pods that may be made unavailable                     | `nil`                                                                  |
+| `prometheus.service.type`                     | Kubernetes service type                                                              | `ClusterIP`                                                            |
+| `prometheus.service.port`                     | Prometheus service port                                                              | `9090`                                                                 |
+| `prometheus.service.clusterIP`                | Specific cluster IP when service type is cluster IP. Use `None` for headless service | `nil`                                                                  |
+| `prometheus.service.nodePort`                 | Kubernetes Service nodePort                                                          | `nil`                                                                  |
+| `prometheus.service.loadBalancerIP`           | `loadBalancerIP` if service type is `LoadBalancer`                                   | `nil`                                                                  |
+| `prometheus.service.loadBalancerSourceRanges` | Address that are allowed when svc is `LoadBalancer`                                  | `[]`                                                                   |
+| `prometheus.service.annotations`              | Additional annotations for Prometheus service                                        | `{}`                                                                   |
+| `prometheus.serviceMonitor.interval`          | Scrape interval (use by default, falling back to Prometheus' default)                | `nil`                                                                  |
+| `prometheus.serviceMonitor.metricRelabelings` | Metric relabeling                                                                    | `[]`                                                                   |
+| `prometheus.serviceMonitor.relabelings`       | Relabel configs                                                                      | `[]`                                                                   |
+| `prometheus.ingress.enabled`                  | Enable ingress controller resource                                                   | `false`                                                                |
+| `prometheus.ingress.certManager`              | Add annotations for cert-manager                                                     | `false`                                                                |
+| `prometheus.ingress.annotations`              | Ingress annotations                                                                  | `[]`                                                                   |
+| `prometheus.ingress.hosts[0].name`            | Hostname to your Prometheus installation                                             | `prometheus.local`                                                     |
+| `prometheus.ingress.hosts[0].path`            | Path within the url structure                                                        | `/`                                                                    |
+| `prometheus.ingress.tls[0].hosts[0]`          | TLS hosts                                                                            | `prometheus.local`                                                     |
+| `prometheus.ingress.tls[0].secretName`        | TLS Secret (certificates)                                                            | `prometheus.local-tls`                                                 |
+| `prometheus.resources`                        | CPU/Memory resource requests/limits for node                                         | `{}`                                                                   |
+| `prometheus.nodeAffinity`                     | Node Affinity (this value is evaluated as a template)                                | `{}`                                                                   |
+| `prometheus.podAntiAffinity`                  | Pod anti-affinity policy                                                             | `soft`                                                                 |
+| `prometheus.podAffinity`                      | Affinity, in addition to antiAffinity (this value is evaluated as a template)        | `{}`                                                                   |
+| `prometheus.nodeSelector`                     | Node labels for pod assignment (this value is evaluated as a template)               | `{}`                                                                   |
+| `prometheus.tolerations`                      | List of node taints to tolerate (this value is evaluated as a template)              | `[]`                                                                   |
+| `prometheus.replicaCount`                     | Number of Prometheus replicas desired                                                | `1`                                                                    |
+| `prometheus.logLevel`                         | Log level for Prometheus                                                             | `info`                                                                 |
+| `prometheus.logFormat`                        | Log format for Prometheus                                                            | `logfmt`                                                               |
+| `prometheus.podMetadata`                      | Standard object’s metadata                                                           | `{}`                                                                   |
+| `prometheus.scrapeInterval`                   | Interval between consecutive scrapes                                                 | ``                                                                     |
+| `prometheus.evaluationInterval`               | Interval between consecutive evaluations                                             | ``                                                                     |
+| `prometheus.listenLocal`                      | ListenLocal makes the Prometheus server listen on loopback                           | `false`                                                                |
+| `prometheus.enableAdminAPI`                   | Enable Prometheus adminitrative API                                                  | `false`                                                                |
+| `prometheus.alertingEndpoints`                | Alertmanagers to which alerts will be sent                                           | `[]`                                                                   |
+| `prometheus.externalLabels`                   | External labels to add to any time series                                            | `{}`                                                                   |
+| `prometheus.replicaExternalLabelName`         | Name of the external label used to denote replica name                               | ``                                                                     |
+| `prometheus.replicaExternalLabelNameClear`    | Clear external label used to denote replica name                                     | `false`                                                                |
+| `prometheus.prometheusExternalLabelName`      | Name of the external label used to denote Prometheus instance name                   | ``                                                                     |
+| `prometheus.prometheusExternalLabelNameClear` | Clear external label used to denote Prometheus instance name                         | `false`                                                                |
+| `prometheus.secrets`                          | Secrets that should be mounted into the Prometheus Pods                              | `[]`                                                                   |
+| `prometheus.configMaps`                       | ConfigMaps that should be mounted into the Prometheus Pods                           | `[]`                                                                   |
+| `prometheus.querySpec`                        | The query command line flags when starting Prometheus                                | `{}`                                                                   |
+| `prometheus.ruleNamespaceSelector`            | Namespaces to be selected for PrometheusRules discovery                              | `{}`                                                                   |
+| `prometheus.ruleSelector`                     | PrometheusRules to be selected for target discovery                                  | `{}`                                                                   |
+| `prometheus.serviceMonitorSelector`           | If {}, select all ServiceMonitors                                                    | `{}`                                                                   |
+| `prometheus.serviceMonitorNamespaceSelector`  | Namespaces to be selected for ServiceMonitor discovery                               | `{}`                                                                   |
+| `prometheus.retention`                        | Metrics retention days                                                               | `10d`                                                                  |
+| `prometheus.retentionSize`                    | Maximum size of metrics                                                              | ``                                                                     |
+| `prometheus.walCompression`                   | Enable compression of the write-ahead log using Snappy                               | `false`                                                                |
+| `prometheus.paused`                           | If true, the Operator won't process any Prometheus configuration changes             | `false`                                                                |
+| `prometheus.remoteRead`                       | The remote_read spec configuration for Prometheus                                    | `[]`                                                                   |
+| `prometheus.remoteWrite`                      | The remote_write spec configuration for Prometheus                                   | `[]`                                                                   |
+| `prometheus.storageSpec`                      | Prometheus StorageSpec for persistent data                                           | `{}`                                                                   |
+| `prometheus.priorityClassName`                | Priority class assigned to the Pods                                                  | ``                                                                     |
+| `prometheus.containers`                       | Containers allows injecting additional containers                                    | `[]`                                                                   |
+| `prometheus.additionalScrapeConfigsExternal`  | Enable additional scrape configs that are managed externally to this chart           | `false`                                                                |
+
+### Alertmanager Configuration
+
+|                    Parameter                    |                                                    Description                                                     |                                                                                                                       Default                                                                                                                       |
+|-------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `alertmanager.enabled`                          | Deploy Alertmanager to the cluster                                                                                 | `true`                                                                                                                                                                                                                                              |
+| `alertmanager.image.registry`                   | Prometheus image registry                                                                                          | `docker.io`                                                                                                                                                                                                                                         |
+| `alertmanager.image.repository`                 | Prometheus Image name                                                                                              | `bitnami/alertmanager`                                                                                                                                                                                                                              |
+| `alertmanager.image.tag`                        | Prometheus Image tag                                                                                               | `{TAG_NAME}`                                                                                                                                                                                                                                        |
+| `alertmanager.image.pullSecrets`                | Specify docker-registry secret names as an array                                                                   | `[]` (does not add image pull secrets to deployed pods)                                                                                                                                                                                             |
+| `alertmanager.serviceAccount.create`            | Specify whether to create a ServiceAccount for Alertmanager                                                        | `true`                                                                                                                                                                                                                                              |
+| `alertmanager.serviceAccount.name`              | The name of the ServiceAccount to create                                                                           | Generated using the `prometheus-operator.alertmanager.fullname` template                                                                                                                                                                            |
+| `alertmanager.securityContext.enabled`          | Enable security context                                                                                            | `true`                                                                                                                                                                                                                                              |
+| `alertmanager.securityContext.fsGroup`          | Group ID for the container filesystem                                                                              | `1001`                                                                                                                                                                                                                                              |
+| `alertmanager.securityContext.runAsUser`        | User ID for the container                                                                                          | `1001`                                                                                                                                                                                                                                              |
+| `alertmanager.podDisruptionBudget.enabled`      | Create a pod disruption budget for Alertmanager                                                                    | `true`                                                                                                                                                                                                                                              |
+| `alertmanager.podDisruptionBudget.minAvailable` | Minimum number / percentage of pods that should remain scheduled                                                   | `1`                                                                                                                                                                                                                                                 |
+| `alertmanager.podDisruptionBudget.minAvailable` | Maximum number / percentage of pods that may be made unavailable                                                   | `nil`                                                                                                                                                                                                                                               |
+| `alertmanager.service.type`                     | Kubernetes service type                                                                                            | `ClusterIP`                                                                                                                                                                                                                                         |
+| `alertmanager.service.port`                     | Alertmanager service port                                                                                          | `9093`                                                                                                                                                                                                                                              |
+| `alertmanager.service.clusterIP`                | Specific cluster IP when service type is cluster IP. Use `None` for headless service                               | `nil`                                                                                                                                                                                                                                               |
+| `alertmanager.service.nodePort`                 | Kubernetes Service nodePort                                                                                        | `nil`                                                                                                                                                                                                                                               |
+| `alertmanager.service.loadBalancerIP`           | `loadBalancerIP` if service type is `LoadBalancer`                                                                 | `nil`                                                                                                                                                                                                                                               |
+| `alertmanager.service.loadBalancerSourceRanges` | Address that are allowed when svc is `LoadBalancer`                                                                | `[]`                                                                                                                                                                                                                                                |
+| `alertmanager.service.annotations`              | Additional annotations for Alertmanager service                                                                    | `{}`                                                                                                                                                                                                                                                |
+| `alertmanager.serviceMonitor.interval`          | Scrape interval (use by default, falling back to Prometheus' default)                                              | `nil`                                                                                                                                                                                                                                               |
+| `alertmanager.serviceMonitor.metricRelabelings` | Metric relabeling                                                                                                  | `[]`                                                                                                                                                                                                                                                |
+| `alertmanager.serviceMonitor.relabelings`       | Relabel configs                                                                                                    | `[]`                                                                                                                                                                                                                                                |
+| `alertmanager.ingress.enabled`                  | Enable ingress controller resource                                                                                 | `false`                                                                                                                                                                                                                                             |
+| `alertmanager.ingress.certManager`              | Add annotations for cert-manager                                                                                   | `false`                                                                                                                                                                                                                                             |
+| `alertmanager.ingress.annotations`              | Ingress annotations                                                                                                | `[]`                                                                                                                                                                                                                                                |
+| `alertmanager.ingress.hosts[0].name`            | Hostname to your Alertmanager installation                                                                         | `alertmanager.local`                                                                                                                                                                                                                                |
+| `alertmanager.ingress.hosts[0].path`            | Path within the url structure                                                                                      | `/`                                                                                                                                                                                                                                                 |
+| `alertmanager.ingress.tls[0].hosts[0]`          | TLS hosts                                                                                                          | `alertmanager.local`                                                                                                                                                                                                                                |
+| `alertmanager.ingress.tls[0].secretName`        | TLS Secret (certificates)                                                                                          | `alertmanager.local-tls`                                                                                                                                                                                                                            |
+| `alertmanager.resources`                        | CPU/Memory resource requests/limits for node                                                                       | `{}`                                                                                                                                                                                                                                                |
+| `alertmanager.nodeAffinity`                     | Node Affinity (this value is evaluated as a template)                                                              | `{}`                                                                                                                                                                                                                                                |
+| `alertmanager.podAntiAffinity`                  | Pod anti-affinity policy                                                                                           | `soft`                                                                                                                                                                                                                                              |
+| `alertmanager.podAffinity`                      | Affinity, in addition to antiAffinity (this value is evaluated as a template)                                      | `{}`                                                                                                                                                                                                                                                |
+| `alertmanager.nodeSelector`                     | Node labels for pod assignment (this value is evaluated as a template)                                             | `{}`                                                                                                                                                                                                                                                |
+| `alertmanager.tolerations`                      | List of node taints to tolerate (this value is evaluated as a template)                                            | `[]`                                                                                                                                                                                                                                                |
+| `alertmanager.config`                           | Alertmanager configuration directive                                                                               | `{"global":{"resolve_timeout":"5m"},"route":{"group_by":["job"],"group_wait":"30s","group_interval":"5m","repeat_interval":"12h","receiver":"null","routes":[{"match":{"alertname":"Watchdog"},"receiver":"null"}]},"receivers":[{"name":"null"}]}` |
+| `alertmanager.replicaCount`                     | Number of Alertmanager replicas desired                                                                            | `1`                                                                                                                                                                                                                                                 |
+| `alertmanager.logLevel`                         | Log level for Alertmanager                                                                                         | `info`                                                                                                                                                                                                                                              |
+| `alertmanager.logFormat`                        | Log format for Alertmanager                                                                                        | `logfmt`                                                                                                                                                                                                                                            |
+| `alertmanager.podMetadata`                      | Standard object’s metadata                                                                                         | `{}`                                                                                                                                                                                                                                                |
+| `alertmanager.secrets`                          | Secrets that should be mounted into the Alertmanager Pods                                                          | `[]`                                                                                                                                                                                                                                                |
+| `alertmanager.configMaps`                       | ConfigMaps that should be mounted into the Alertmanager Pods                                                       | `[]`                                                                                                                                                                                                                                                |
+| `alertmanager.retention`                        | Metrics retention days                                                                                             | `10d`                                                                                                                                                                                                                                               |
+| `alertmanager.storageSpec`                      | Alertmanager StorageSpec for persistent data                                                                       | `{}`                                                                                                                                                                                                                                                |
+| `alertmanager.paused`                           | If true, the Operator won't process any Alertmanager configuration changes                                         | `false`                                                                                                                                                                                                                                             |
+| `alertmanager.listenLocal`                      | ListenLocal makes the Alertmanager server listen on loopback                                                       | `false`                                                                                                                                                                                                                                             |
+| `alertmanager.containers`                       | Containers allows injecting additional containers                                                                  | `[]`                                                                                                                                                                                                                                                |
+| `alertmanager.priorityClassName`                | Priority class assigned to the Pods                                                                                | ``                                                                                                                                                                                                                                                  |
+| `alertmanager.additionalPeers`                  | AdditionalPeers allows injecting a set of additional Alertmanagers to peer with to form a highly available cluster | `[]`                                                                                                                                                                                                                                                |
+
+The above parameters map to the env variables defined in [bitnami/prometheus-operator](http://github.com/bitnami/bitnami-docker-prometheus-operator). For more information please refer to the [bitnami/prometheus-operator](http://github.com/bitnami/bitnami-docker-prometheus-operator) image documentation.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name my-release \
+  --set operator.logLevel=debug \
+  --set prometheus.replicaCount=5 \
+    bitnami/prometheus-operator
+```
+
+The above command sets the Prometheus Operator `logLevel` to `debug`. Additionally it sets the `prometheus.replicaCount` to `5`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml bitnami/prometheus-operator
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+### Production configuration
+
+This chart includes a `values-production.yaml` file where you can find some parameters oriented to production configuration in comparison to the regular `values.yaml`.
+
+```console
+$ helm install --name my-release -f ./values-production.yaml bitnami/prometheus-operator
+```
+
+- Modify the Log level for Prometheus Operator:
+
+```diff
+-   logLevel: info
++   logLevel: error
+```
+
+- Increase the number of days to retain metrics:
+
+```diff
+-   retention: 10d
++   retention: 30d
+```
+
+- Increase the number of Alertmanager replicas:
+
+```diff
+-   replicaCount: 1
++   replicaCount: 3
+```
+
+- Modify the Log level for Alertmanager:
+
+```diff
+-   logLevel: info
++   logLevel: error
+```
+
+- Increase the number of Prometheus replicas:
+
+```diff
+-   replicaCount: 1
++   replicaCount: 3
+```
+
+- Modify the Log level for Prometheus:
+
+```diff
+-   logLevel: info
++   logLevel: error
+```
+
+### [Rolling VS Immutable tags](https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/)
+
+It is strongly recommended to use immutable tags in a production environment. This ensures your deployment does not change automatically if the same tag is updated with a different image.
+
+Bitnami will release a new chart updating its containers if a new version of the main container, significant changes, or critical vulnerabilities exist.
+
+## Upgrading
+
+```bash
+$ helm upgrade my-release bitnami/prometheus-operator
+```

--- a/bitnami/prometheus-operator/templates/NOTES.txt
+++ b/bitnami/prometheus-operator/templates/NOTES.txt
@@ -1,0 +1,96 @@
+** Please be patient while the chart is being deployed **
+
+Watch the Prometheus Operator Deployment status using the command:
+
+    kubectl get deploy -w --namespace {{ .Release.Namespace }} -l app.kubernetes.io/name={{ template "prometheus-operator.operator.name" . }},app.kubernetes.io/instance={{ .Release.Name }}
+
+{{- if .Values.prometheus.enabled }}
+
+Watch the Prometheus StatefulSet status using the command:
+
+    kubectl get sts -w --namespace {{ .Release.Namespace }} -l app.kubernetes.io/name={{ template "prometheus-operator.prometheus.name" . }},app.kubernetes.io/instance={{ .Release.Name }}
+
+Prometheus can be accessed via port "{{ .Values.prometheus.service.port }}" on the following DNS name from within your cluster:
+
+    {{ template "prometheus-operator.prometheus.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+
+To access Prometheus from outside the cluster execute the following commands:
+
+{{- if .Values.prometheus.ingress.enabled }}
+
+  You should be able to access your new Prometheus installation through
+
+  {{- range .Values.prometheus.ingress.hosts }}
+  {{ if .tls }}https{{ else }}http{{ end }}://{{ .name }}
+  {{- end }}
+
+{{- else if contains "LoadBalancer" .Values.prometheus.service.type }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "prometheus-operator.prometheus.fullname" . }}'
+
+{{- $port:=.Values.prometheus.service.port | toString }}
+
+    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "prometheus-operator.prometheus.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+    echo "Prometheus URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.prometheus.service.port }}{{ end }}/"
+
+{{- else if contains "ClusterIP"  .Values.prometheus.service.type }}
+
+    echo "Prometheus URL: http://127.0.0.1:9090/"
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "prometheus-operator.prometheus.fullname" . }} 9090:{{ .Values.prometheus.service.port }}
+
+{{- else if contains "NodePort" .Values.prometheus.service.type }}
+
+    export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "prometheus-operator.prometheus.fullname" . }})
+    export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    echo "Prometheus URL: http://$NODE_IP:$NODE_PORT/"
+
+{{- end }}
+{{- end }}
+
+{{- if .Values.alertmanager.enabled }}
+
+Watch the Alertmanager StatefulSet status using the command:
+
+    kubectl get sts -w --namespace {{ .Release.Namespace }} -l app.kubernetes.io/name={{ template "prometheus-operator.alertmanager.name" . }},app.kubernetes.io/instance={{ .Release.Name }}
+
+Alertmanager can be accessed via port "{{ .Values.alertmanager.service.port }}" on the following DNS name from within your cluster:
+
+    {{ template "prometheus-operator.alertmanager.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+
+To access Alertmanager from outside the cluster execute the following commands:
+
+{{- if .Values.alertmanager.ingress.enabled }}
+
+  You should be able to access your new Prometheus installation through
+
+  {{- range .Values.alertmanager.ingress.hosts }}
+  {{ if .tls }}https{{ else }}http{{ end }}://{{ .name }}
+  {{- end }}
+
+{{- else if contains "LoadBalancer" .Values.alertmanager.service.type }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "prometheus-operator.alertmanager.fullname" . }}'
+
+{{- $port:=.Values.alertmanager.service.port | toString }}
+
+    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "prometheus-operator.alertmanager.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+    echo "Alertmanager URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.alertmanager.service.port }}{{ end }}/"
+
+{{- else if contains "ClusterIP"  .Values.alertmanager.service.type }}
+
+    echo "Alertmanager URL: http://127.0.0.1:9093/"
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "prometheus-operator.alertmanager.fullname" . }} 9093:{{ .Values.alertmanager.service.port }}
+
+{{- else if contains "NodePort" .Values.alertmanager.service.type }}
+
+    export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "prometheus-operator.alertmanager.fullname" . }})
+    export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    echo "Alertmanager URL: http://$NODE_IP:$NODE_PORT/"
+
+{{- end }}
+{{- end }}
+
+{{ include "prometheus-operator.validateValues" . }}
+{{ include "prometheus-operator.checkRollingTags" . }}

--- a/bitnami/prometheus-operator/templates/_helpers.tpl
+++ b/bitnami/prometheus-operator/templates/_helpers.tpl
@@ -1,0 +1,423 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "prometheus-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 50 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Name suffixed with operator */}}
+{{- define "prometheus-operator.operator.name" -}}
+{{- printf "%s-operator" (include "prometheus-operator.name" .) -}}
+{{- end }}
+
+{{/* Name suffixed with prometheus */}}
+{{- define "prometheus-operator.prometheus.name" -}}
+{{- printf "%s-prometheus" (include "prometheus-operator.name" .) -}}
+{{- end }}
+
+{{/* Name suffixed with alertmanager */}}
+{{- define "prometheus-operator.alertmanager.name" -}}
+{{- printf "%s-alertmanager" (include "prometheus-operator.name" .) -}}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "prometheus-operator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 26 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 26 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 26 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Fullname suffixed with operator */}}
+{{- define "prometheus-operator.operator.fullname" -}}
+{{- printf "%s-operator" (include "prometheus-operator.fullname" .) -}}
+{{- end }}
+
+{{/* Fullname suffixed with prometheus */}}
+{{- define "prometheus-operator.prometheus.fullname" -}}
+{{- printf "%s-prometheus" (include "prometheus-operator.fullname" .) -}}
+{{- end }}
+
+{{/* Fullname suffixed with alertmanager */}}
+{{- define "prometheus-operator.alertmanager.fullname" -}}
+{{- printf "%s-alertmanager" (include "prometheus-operator.fullname" .) -}}
+{{- end }}
+
+{{- define "prometheus-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common Labels
+*/}}
+{{- define "prometheus-operator.labels" -}}
+app.kubernetes.io/name: {{ include "prometheus-operator.name" . }}
+helm.sh/chart: {{ include "prometheus-operator.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.global.labels }}
+{{ toYaml .Values.global.labels }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Labels for operator
+*/}}
+{{- define "prometheus-operator.operator.labels" -}}
+{{ include "prometheus-operator.labels" . }}
+app.kubernetes.io/component: operator
+{{- end -}}
+
+{{/*
+Labels for prometheus
+*/}}
+{{- define "prometheus-operator.prometheus.labels" -}}
+{{ include "prometheus-operator.labels" . }}
+app.kubernetes.io/component: prometheus
+{{- end -}}
+
+{{/*
+Labels for alertmanager
+*/}}
+{{- define "prometheus-operator.alertmanager.labels" -}}
+{{ include "prometheus-operator.labels" . }}
+app.kubernetes.io/component: alertmanager
+{{- end -}}
+
+{{/*
+Common matchLabels
+*/}}
+{{- define "prometheus-operator.matchLabels" -}}
+app.kubernetes.io/name: {{ include "prometheus-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+matchLabels for operator
+*/}}
+{{- define "prometheus-operator.operator.matchLabels" -}}
+{{ include "prometheus-operator.matchLabels" . }}
+app.kubernetes.io/component: operator
+{{- end -}}
+
+{{/*
+matchLabels for prometheus
+*/}}
+{{- define "prometheus-operator.prometheus.matchLabels" -}}
+{{ include "prometheus-operator.matchLabels" . }}
+app.kubernetes.io/component: prometheus
+{{- end -}}
+
+{{/*
+matchLabels for alertmanager
+*/}}
+{{- define "prometheus-operator.alertmanager.matchLabels" -}}
+{{ include "prometheus-operator.matchLabels" . }}
+app.kubernetes.io/component: alertmanager
+{{- end -}}
+
+{{/*
+Return the proper Prometheus Operator image name
+*/}}
+{{- define "prometheus-operator.image" -}}
+{{- $registryName := .Values.operator.image.registry -}}
+{{- $repositoryName := .Values.operator.image.repository -}}
+{{- $tag := .Values.operator.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Prometheus Operator Reloader image name
+*/}}
+{{- define "prometheus-operator.prometheusConfigReloader.image" -}}
+{{- $registryName := .Values.operator.prometheusConfigReloader.image.registry -}}
+{{- $repositoryName := .Values.operator.prometheusConfigReloader.image.repository -}}
+{{- $tag := .Values.operator.prometheusConfigReloader.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper ConfigMap Reload image name
+*/}}
+{{- define "prometheus-operator.configmapReload.image" -}}
+{{- $registryName := .Values.operator.configmapReload.image.registry -}}
+{{- $repositoryName := .Values.operator.configmapReload.image.repository -}}
+{{- $tag := .Values.operator.configmapReload.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Prometheus BaseImage name
+*/}}
+{{- define "prometheus-operator.prometheus.baseImage" -}}
+{{- $registryName := .Values.prometheus.image.registry -}}
+{{- $repositoryName := .Values.prometheus.image.repository -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s" .Values.global.imageRegistry $repositoryName -}}
+    {{- else -}}
+        {{- printf "%s/%s" $registryName $repositoryName -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s" $registryName $repositoryName -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Alertmanager BaseImage name
+*/}}
+{{- define "prometheus-operator.alertmanager.baseImage" -}}
+{{- $registryName := .Values.alertmanager.image.registry -}}
+{{- $repositoryName := .Values.alertmanager.image.repository -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s" .Values.global.imageRegistry $repositoryName -}}
+    {{- else -}}
+        {{- printf "%s/%s" $registryName $repositoryName -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s" $registryName $repositoryName -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "prometheus-operator.tplValue" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "prometheus-operator.tplValue" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}
+
+{{/*
+Create the name of the operator service account to use
+*/}}
+{{- define "prometheus-operator.operator.serviceAccountName" -}}
+{{- if .Values.operator.serviceAccount.create -}}
+    {{ default (include "prometheus-operator.operator.fullname" .) .Values.operator.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.operator.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the prometheus service account to use
+*/}}
+{{- define "prometheus-operator.prometheus.serviceAccountName" -}}
+{{- if .Values.prometheus.serviceAccount.create -}}
+    {{ default (include "prometheus-operator.prometheus.fullname" .) .Values.prometheus.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.prometheus.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the alertmanager service account to use
+*/}}
+{{- define "prometheus-operator.alertmanager.serviceAccountName" -}}
+{{- if .Values.alertmanager.serviceAccount.create -}}
+    {{ default (include "prometheus-operator.alertmanager.fullname" .) .Values.alertmanager.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.alertmanager.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names for Prometheus Operator image
+*/}}
+{{- define "prometheus-operator.operator.imagePullSecrets" -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
+Also, we can not use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- else if .Values.operator.image.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.operator.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end -}}
+{{- else if .Values.operator.image.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.operator.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names for Prometheus image
+*/}}
+{{- define "prometheus-operator.prometheus.imagePullSecrets" -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
+Also, we can not use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- else if .Values.prometheus.image.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.prometheus.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end -}}
+{{- else if .Values.prometheus.image.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.prometheus.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names for Alertmanager image
+*/}}
+{{- define "prometheus-operator.alertmanager.imagePullSecrets" -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
+Also, we can not use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- else if .Values.alertmanager.image.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.alertmanager.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end -}}
+{{- else if .Values.alertmanager.image.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.alertmanager.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for PodSecurityPolicy.
+*/}}
+{{- define "podSecurityPolicy.apiVersion" -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "policy/v1beta1" -}}
+{{- else -}}
+{{- print "extensions/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Check if there are rolling tags in the images
+*/}}
+{{- define "prometheus-operator.checkRollingTags" -}}
+{{- if and (contains "bitnami/" .Values.operator.image.repository) (not (.Values.operator.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
+WARNING: Rolling tag detected ({{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
++info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
+{{- end }}
+{{- if and (contains "bitnami/" .Values.operator.configmapReload.image.repository) (not (.Values.operator.configmapReload.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
+WARNING: Rolling tag detected ({{ .Values.operator.configmapReload.image.repository }}:{{ .Values.operator.configmapReload.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
++info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
+{{- end }}
+{{- if and (contains "bitnami/" .Values.operator.prometheusConfigReloader.image.repository) (not (.Values.operator.prometheusConfigReloader.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
+WARNING: Rolling tag detected ({{ .Values.operator.prometheusConfigReloader.image.repository }}:{{ .Values.operator.prometheusConfigReloader.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
++info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
+{{- end }}
+{{- if and (contains "bitnami/" .Values.prometheus.image.repository) (not (.Values.prometheus.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
+WARNING: Rolling tag detected ({{ .Values.prometheus.image.repository }}:{{ .Values.prometheus.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
++info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
+{{- end }}
+{{- if and (contains "bitnami/" .Values.alertmanager.image.repository) (not (.Values.alertmanager.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
+WARNING: Rolling tag detected ({{ .Values.alertmanager.image.repository }}:{{ .Values.alertmanager.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
++info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
+{{- end }}
+{{- end -}}
+
+{{/*
+Compile all warnings into a single message, and call fail.
+*/}}
+{{- define "prometheus-operator.validateValues" -}}
+{{- $messages := list -}}
+{{- $messages := without $messages "" -}}
+{{- $message := join "\n" $messages -}}
+
+{{- if $message -}}
+{{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+{{- end -}}

--- a/bitnami/prometheus-operator/templates/alertmanager/alertmanager.yaml
+++ b/bitnami/prometheus-operator/templates/alertmanager/alertmanager.yaml
@@ -1,0 +1,81 @@
+{{- if .Values.alertmanager.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: Alertmanager
+metadata:
+  name: {{ template "prometheus-operator.alertmanager.fullname" . }}
+  labels: {{- include "prometheus-operator.alertmanager.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.alertmanager.replicaCount }}
+  serviceAccountName: {{ template "prometheus-operator.alertmanager.serviceAccountName" . }}
+  {{- if .Values.alertmanager.image }}
+  baseImage: {{ template "prometheus-operator.alertmanager.baseImage" . }}
+  version: {{ .Values.alertmanager.image.tag }}
+  {{- end }}
+  listenLocal: {{ .Values.alertmanager.listenLocal }}
+  {{- if and .Values.alertmanager.ingress.enabled .Values.alertmanager.ingress.hosts }}
+  externalUrl: {{ if .Values.alertmanager.ingress.tls }}https{{else}}http{{ end }}://{{ (index .Values.alertmanager.ingress.hosts 0).name }}/
+  {{- else }}
+  externalUrl: http://{{ template "prometheus-operator.alertmanager.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.alertmanager.service.port }}
+  {{- end }}
+  paused: {{ .Values.alertmanager.paused }}
+  logFormat: {{ .Values.alertmanager.logFormat }}
+  logLevel: {{ .Values.alertmanager.logLevel }}
+  retention: {{ .Values.alertmanager.retention }}
+  {{- if .Values.alertmanager.secrets }}
+  secrets: {{- include "prometheus-operator.tplValue" (dict "value" .Values.alertmanager.secrets "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.alertmanager.configMaps }}
+  configMaps: {{- include "prometheus-operator.tplValue" (dict "value" .Values.alertmanager.configMaps "context" $) | nindent 4 }}
+  {{- end }}
+  resources: {{- toYaml .Values.alertmanager.resources | nindent 4 }}
+  routePrefix: "/"
+{{- if .Values.alertmanager.securityContext.enabled }}
+securityContext:
+  runAsUser: {{ .Values.alertmanager.securityContext.runAsUser }}
+  fsGroup: {{ .Values.alertmanager.securityContext.fsGroup }}
+{{- end }}
+  {{- if .Values.alertmanager.storageSpec }}
+  storage: {{- include "prometheus-operator.tplValue" (dict "value" .Values.alertmanager.storageSpec "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.alertmanager.podMetadata }}
+  podMetadata: {{- include "prometheus-operator.tplValue" (dict "value" .Values.alertmanager.podMetadata "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.alertmanager.nodeSelector }}
+  nodeSelector: {{- include "prometheus-operator.tplValue" (dict "value" .Values.alertmanager.nodeSelector "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.alertmanager.tolerations }}
+  tolerations: {{- include "prometheus-operator.tplValue" (dict "value" .Values.alertmanager.tolerations "context" $) | nindent 4 }}
+  {{- end }}
+  affinity:
+    {{- if .Values.alertmanager.nodeAffinity }}
+    nodeAffinity: {{- include "prometheus-operator.tplValue" (dict "value" .Values.alertmanager.nodeAffinity "context" $) | nindent 6 }}
+    {{- end }}
+    {{- if eq .Values.alertmanager.podAntiAffinity "hard" }}
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: "kubernetes.io/hostname"
+        labelSelector:
+          matchLabels: {{- include "prometheus-operator.alertmanager.matchLabels" . | nindent 12 }}
+    {{- else if eq .Values.alertmanager.podAntiAffinity "soft" }}
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          topologyKey: "kubernetes.io/hostname"
+          labelSelector:
+            matchLabels: {{- include "prometheus-operator.alertmanager.matchLabels" . | nindent 14 }}
+    {{- end }}
+    {{- if .Values.alertmanager.podAffinity }}
+    podAffinity: {{- include "prometheus-operator.tplValue" (dict "value" .Values.alertmanager.podAffinity "context" $) | nindent 6 }}
+    {{- end }}
+{{- include "prometheus-operator.alertmanager.imagePullSecrets" . | indent 2 }}
+  {{- if .Values.alertmanager.containers }}
+  containers: {{- include "prometheus-operator.tplValue" (dict "value" .Values.alertmanager.containers "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.alertmanager.priorityClassName }}
+  priorityClassName: {{ .Values.alertmanager.priorityClassName }}
+  {{- end }}
+  {{- if .Values.alertmanager.additionalPeers }}
+  additionalPeers: {{ .Values.alertmanager.additionalPeers }}
+  {{- end }}
+{{- end }}

--- a/bitnami/prometheus-operator/templates/alertmanager/ingress.yaml
+++ b/bitnami/prometheus-operator/templates/alertmanager/ingress.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.alertmanager.enabled .Values.alertmanager.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "prometheus-operator.alertmanager.fullname" . }}
+  labels: {{- include "prometheus-operator.alertmanager.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.alertmanager.ingress.certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- range $key, $value := .Values.alertmanager.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+  {{- range .Values.alertmanager.ingress.hosts }}
+  - host: {{ .name }}
+    http:
+      paths:
+      - path: {{ default "/" .path }}
+        backend:
+          serviceName: {{ template "prometheus-operator.alertmanager.fullname" $ }}
+          servicePort: http
+  {{- end }}
+  {{- if .Values.alertmanager.ingress.tls }}
+  tls:
+{{ toYaml .Values.alertmanager.ingress.tls | indent 4 }}
+  {{- end }}
+{{- end -}}

--- a/bitnami/prometheus-operator/templates/alertmanager/pdb.yaml
+++ b/bitnami/prometheus-operator/templates/alertmanager/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.alertmanager.enabled .Values.alertmanager.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "prometheus-operator.alertmanager.fullname" . }}
+  labels: {{- include "prometheus-operator.alertmanager.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: alertmanager
+      alertmanager: {{ template "prometheus-operator.alertmanager.fullname" . }}
+  {{- if .Values.alertmanager.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.alertmanager.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.alertmanager.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.alertmanager.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end }}

--- a/bitnami/prometheus-operator/templates/alertmanager/psp-clusterrole.yaml
+++ b/bitnami/prometheus-operator/templates/alertmanager/psp-clusterrole.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.alertmanager.enabled .Values.rbac.create .Values.rbac.pspEnabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "prometheus-operator.alertmanager.fullname" . }}-psp
+  labels: {{- include "prometheus-operator.alertmanager.labels" . | nindent 4 }}
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs: ['use']
+  resourceNames:
+  - {{ template "prometheus-operator.alertmanager.fullname" . }}
+{{- end }}

--- a/bitnami/prometheus-operator/templates/alertmanager/psp-clusterrolebinding.yaml
+++ b/bitnami/prometheus-operator/templates/alertmanager/psp-clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.alertmanager.enabled .Values.rbac.create .Values.rbac.pspEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "prometheus-operator.alertmanager.fullname" . }}-psp
+  labels: {{- include "prometheus-operator.alertmanager.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "prometheus-operator.alertmanager.fullname" . }}-psp
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "prometheus-operator.alertmanager.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/bitnami/prometheus-operator/templates/alertmanager/psp.yaml
+++ b/bitnami/prometheus-operator/templates/alertmanager/psp.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.alertmanager.enabled .Values.rbac.create .Values.rbac.pspEnabled }}
+apiVersion: {{ template "podSecurityPolicy.apiVersion" . }}
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "prometheus-operator.alertmanager.fullname" . }}
+  labels: {{- include "prometheus-operator.alertmanager.labels" . | nindent 4 }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+  - ALL
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1001
+      max: 1001
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1001
+      max: 1001
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1001
+      max: 1001
+{{- end }}

--- a/bitnami/prometheus-operator/templates/alertmanager/secrets.yaml
+++ b/bitnami/prometheus-operator/templates/alertmanager/secrets.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.alertmanager.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alertmanager-{{ template "prometheus-operator.alertmanager.fullname" . }}
+  labels: {{- include "prometheus-operator.alertmanager.labels" . | nindent 4 }}
+data:
+  alertmanager.yaml: {{ toYaml .Values.alertmanager.config | b64enc | quote }}
+{{- end }}

--- a/bitnami/prometheus-operator/templates/alertmanager/service.yaml
+++ b/bitnami/prometheus-operator/templates/alertmanager/service.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.alertmanager.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "prometheus-operator.alertmanager.fullname" . }}
+  labels: {{- include "prometheus-operator.alertmanager.labels" . | nindent 4 }}
+  {{- with .Values.alertmanager.service.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.alertmanager.service.type }}
+  {{- if and .Values.alertmanager.service.loadBalancerIP (eq .Values.alertmanager.service.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.alertmanager.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.alertmanager.service.type "LoadBalancer") .Values.alertmanager.service.loadBalancerSourceRanges }}
+  {{- with .Values.alertmanager.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+  {{- if and (eq .Values.alertmanager.service.type "ClusterIP") .Values.alertmanager.service.clusterIP }}
+  clusterIP: {{ .Values.alertmanager.service.clusterIP }}
+  {{- end }}
+  ports:
+  - name: http
+    port: {{ .Values.alertmanager.service.port }}
+    targetPort: 9093
+    {{- if and .Values.alertmanager.service.nodePort (or (eq .Values.alertmanager.service.type "NodePort") (eq .Values.alertmanager.service.type "LoadBalancer")) }}
+    nodePort: {{ .Values.alertmanager.service.nodePort }}
+    {{- end }}
+  selector:
+    app: alertmanager
+    alertmanager: {{ template "prometheus-operator.alertmanager.fullname" . }}
+{{- end }}

--- a/bitnami/prometheus-operator/templates/alertmanager/serviceaccount.yaml
+++ b/bitnami/prometheus-operator/templates/alertmanager/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if and .Values.alertmanager.enabled .Values.alertmanager.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "prometheus-operator.alertmanager.serviceAccountName" . }}
+  labels: {{- include "prometheus-operator.alertmanager.labels" . | nindent 4 }}
+{{- include "prometheus-operator.alertmanager.imagePullSecrets" . }}
+{{- end }}

--- a/bitnami/prometheus-operator/templates/alertmanager/servicemonitor.yaml
+++ b/bitnami/prometheus-operator/templates/alertmanager/servicemonitor.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.alertmanager.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "prometheus-operator.alertmanager.fullname" . }}
+  labels: {{- include "prometheus-operator.alertmanager.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels: {{- include "prometheus-operator.alertmanager.matchLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+  - port: http
+    {{- if .Values.alertmanager.serviceMonitor.interval }}
+    interval: {{ .Values.alertmanager.serviceMonitor.interval }}
+    {{- end }}
+    path: "/metrics"
+{{- if .Values.alertmanager.serviceMonitor.metricRelabelings }}
+    metricRelabelings: {{- include "prometheus-operator.tplValue" ( dict "value" .Values.alertmanager.serviceMonitor.metricRelabelings "context" $) | nindent 6 }}
+{{- end }}
+{{- if .Values.alertmanager.serviceMonitor.relabelings }}
+    relabelings: {{- toYaml .Values.alertmanager.serviceMonitor.relabelings | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus-operator/clusterrole.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/clusterrole.yaml
@@ -1,0 +1,72 @@
+{{- if and .Values.operator.enabled .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "prometheus-operator.operator.fullname" . }}
+  labels: {{- include "prometheus-operator.operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - alertmanagers
+  - prometheuses
+  - prometheuses/finalizers
+  - alertmanagers/finalizers
+  - servicemonitors
+  - podmonitors
+  - prometheusrules
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - services/finalizers
+  - endpoints
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus-operator/clusterrolebinding.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.operator.enabled .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "prometheus-operator.operator.fullname" . }}
+  labels: {{- include "prometheus-operator.operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "prometheus-operator.operator.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "prometheus-operator.operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus-operator/crd-alertmanager.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/crd-alertmanager.yaml
@@ -1,0 +1,4696 @@
+{{- if .Values.operator.enabled -}}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: alertmanagers.monitoring.coreos.com
+  labels: {{- include "prometheus-operator.operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: monitoring.coreos.com
+  names:
+    kind: Alertmanager
+    plural: alertmanagers
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        spec:
+          description: 'AlertmanagerSpec is a specification of the desired behavior
+            of the Alertmanager cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          properties:
+            additionalPeers:
+              description: AdditionalPeers allows injecting a set of additional Alertmanagers
+                to peer with to form a highly available cluster.
+              items:
+                type: string
+              type: array
+            affinity:
+              description: Affinity is a group of affinity scheduling rules.
+              properties:
+                nodeAffinity:
+                  description: Node affinity is a group of node affinity scheduling
+                    rules.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node matches the corresponding matchExpressions; the
+                        node(s) with the highest sum are the most preferred.
+                      items:
+                        description: An empty preferred scheduling term matches all
+                          objects with implicit weight 0 (i.e. it's a no-op). A null
+                          preferred scheduling term matches no objects (i.e. is also
+                          a no-op).
+                        properties:
+                          preference:
+                            description: A null or empty node selector term matches
+                              no objects. The requirements of them are ANDed. The
+                              TopologySelectorTerm type implements a subset of the
+                              NodeSelectorTerm.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                            type: object
+                          weight:
+                            description: Weight associated with matching the corresponding
+                              nodeSelectorTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - weight
+                        - preference
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: A node selector represents the union of the results
+                        of one or more label queries over a set of nodes; that is,
+                        it represents the OR of the selectors represented by the node
+                        selector terms.
+                      properties:
+                        nodeSelectorTerms:
+                          description: Required. A list of node selector terms. The
+                            terms are ORed.
+                          items:
+                            description: A null or empty node selector term matches
+                              no objects. The requirements of them are ANDed. The
+                              TopologySelectorTerm type implements a subset of the
+                              NodeSelectorTerm.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                            type: object
+                          type: array
+                      required:
+                      - nodeSelectorTerms
+                      type: object
+                  type: object
+                podAffinity:
+                  description: Pod affinity is a group of inter pod affinity scheduling
+                    rules.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node has pods which matches the corresponding podAffinityTerm;
+                        the node(s) with the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: A label selector is a label query over
+                                  a set of resources. The result of matchLabels and
+                                  matchExpressions are ANDed. An empty label selector
+                                  matches all objects. A null label selector matches
+                                  no objects.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - weight
+                        - podAffinityTerm
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the affinity requirements specified by this
+                        field are not met at scheduling time, the pod will not be
+                        scheduled onto the node. If the affinity requirements specified
+                        by this field cease to be met at some point during pod execution
+                        (e.g. due to a pod label update), the system may or may not
+                        try to eventually evict the pod from its node. When there
+                        are multiple elements, the lists of nodes corresponding to
+                        each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label selector is a label query over a
+                              set of resources. The result of matchLabels and matchExpressions
+                              are ANDed. An empty label selector matches all objects.
+                              A null label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                        type: object
+                      type: array
+                  type: object
+                podAntiAffinity:
+                  description: Pod anti affinity is a group of inter pod anti affinity
+                    scheduling rules.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the anti-affinity expressions specified by this
+                        field, but it may choose a node that violates one or more
+                        of the expressions. The node that is most preferred is the
+                        one with the greatest sum of weights, i.e. for each node that
+                        meets all of the scheduling requirements (resource request,
+                        requiredDuringScheduling anti-affinity expressions, etc.),
+                        compute a sum by iterating through the elements of this field
+                        and adding "weight" to the sum if the node has pods which
+                        matches the corresponding podAffinityTerm; the node(s) with
+                        the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: A label selector is a label query over
+                                  a set of resources. The result of matchLabels and
+                                  matchExpressions are ANDed. An empty label selector
+                                  matches all objects. A null label selector matches
+                                  no objects.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - weight
+                        - podAffinityTerm
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the anti-affinity requirements specified by
+                        this field are not met at scheduling time, the pod will not
+                        be scheduled onto the node. If the anti-affinity requirements
+                        specified by this field cease to be met at some point during
+                        pod execution (e.g. due to a pod label update), the system
+                        may or may not try to eventually evict the pod from its node.
+                        When there are multiple elements, the lists of nodes corresponding
+                        to each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label selector is a label query over a
+                              set of resources. The result of matchLabels and matchExpressions
+                              are ANDed. An empty label selector matches all objects.
+                              A null label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                        type: object
+                      type: array
+                  type: object
+              type: object
+            baseImage:
+              description: Base image that is used to deploy pods, without tag.
+              type: string
+            configMaps:
+              description: ConfigMaps is a list of ConfigMaps in the same namespace
+                as the Alertmanager object, which shall be mounted into the Alertmanager
+                Pods. The ConfigMaps are mounted into /etc/alertmanager/configmaps/<configmap-name>.
+              items:
+                type: string
+              type: array
+            containers:
+              description: Containers allows injecting additional containers. This
+                is meant to allow adding an authentication proxy to an Alertmanager
+                pod.
+              items:
+                description: A single application container that you want to run within
+                  a pod.
+                properties:
+                  args:
+                    description: 'Arguments to the entrypoint. The docker image''s
+                      CMD is used if this is not provided. Variable references $(VAR_NAME)
+                      are expanded using the container''s environment. If a variable
+                      cannot be resolved, the reference in the input string will be
+                      unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                      $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                      regardless of whether the variable exists or not. Cannot be
+                      updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    description: 'Entrypoint array. Not executed within a shell. The
+                      docker image''s ENTRYPOINT is used if this is not provided.
+                      Variable references $(VAR_NAME) are expanded using the container''s
+                      environment. If a variable cannot be resolved, the reference
+                      in the input string will be unchanged. The $(VAR_NAME) syntax
+                      can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                      will never be expanded, regardless of whether the variable exists
+                      or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    description: List of environment variables to set in the container.
+                      Cannot be updated.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: EnvVarSource represents a source for the value
+                            of an EnvVar.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key from a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: ObjectFieldSelector selects an APIVersioned
+                                field of an object.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: ResourceFieldSelector represents container
+                                resources (cpu, memory) and their output format
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor: {}
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  envFrom:
+                    description: List of sources to populate environment variables
+                      in the container. The keys defined within a source must be a
+                      C_IDENTIFIER. All invalid keys will be reported as an event
+                      when the container is starting. When a key exists in multiple
+                      sources, the value associated with the last source will take
+                      precedence. Values defined by an Env with a duplicate key will
+                      take precedence. Cannot be updated.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: |-
+                            ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
+
+                            The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: |-
+                            SecretEnvSource selects a Secret to populate the environment variables with.
+
+                            The contents of the target Secret's Data field will represent the key-value pairs as environment variables.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                      type: object
+                    type: array
+                  image:
+                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                      This field is optional to allow higher level config management
+                      to default or override container images in workload controllers
+                      like Deployments and StatefulSets.'
+                    type: string
+                  imagePullPolicy:
+                    description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                      Defaults to Always if :latest tag is specified, or IfNotPresent
+                      otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                    type: string
+                  lifecycle:
+                    description: Lifecycle describes actions that the management system
+                      should take in response to container lifecycle events. For the
+                      PostStart and PreStop lifecycle handlers, management of the
+                      container blocks until the action is complete, unless the container
+                      process fails, in which case the handler is aborted.
+                    properties:
+                      postStart:
+                        description: Handler defines a specific action that should
+                          be taken
+                        properties:
+                          exec:
+                            description: ExecAction describes a "run in container"
+                              action.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGetAction describes an action based on
+                              HTTP Get requests.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          tcpSocket:
+                            description: TCPSocketAction describes an action based
+                              on opening a socket
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                            required:
+                            - port
+                            type: object
+                        type: object
+                      preStop:
+                        description: Handler defines a specific action that should
+                          be taken
+                        properties:
+                          exec:
+                            description: ExecAction describes a "run in container"
+                              action.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGetAction describes an action based on
+                              HTTP Get requests.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          tcpSocket:
+                            description: TCPSocketAction describes an action based
+                              on opening a socket
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                            required:
+                            - port
+                            type: object
+                        type: object
+                    type: object
+                  livenessProbe:
+                    description: Probe describes a health check to be performed against
+                      a container to determine whether it is alive or ready to receive
+                      traffic.
+                    properties:
+                      exec:
+                        description: ExecAction describes a "run in container" action.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGetAction describes an action based on HTTP
+                          Get requests.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocketAction describes an action based on
+                          opening a socket
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                        required:
+                        - port
+                        type: object
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                    type: object
+                  name:
+                    description: Name of the container specified as a DNS_LABEL. Each
+                      container in a pod must have a unique name (DNS_LABEL). Cannot
+                      be updated.
+                    type: string
+                  ports:
+                    description: List of ports to expose from the container. Exposing
+                      a port here gives the system additional information about the
+                      network connections a container uses, but is primarily informational.
+                      Not specifying a port here DOES NOT prevent that port from being
+                      exposed. Any port which is listening on the default "0.0.0.0"
+                      address inside a container will be accessible from the network.
+                      Cannot be updated.
+                    items:
+                      description: ContainerPort represents a network port in a single
+                        container.
+                      properties:
+                        containerPort:
+                          description: Number of port to expose on the pod's IP address.
+                            This must be a valid port number, 0 < x < 65536.
+                          format: int32
+                          type: integer
+                        hostIP:
+                          description: What host IP to bind the external port to.
+                          type: string
+                        hostPort:
+                          description: Number of port to expose on the host. If specified,
+                            this must be a valid port number, 0 < x < 65536. If HostNetwork
+                            is specified, this must match ContainerPort. Most containers
+                            do not need this.
+                          format: int32
+                          type: integer
+                        name:
+                          description: If specified, this must be an IANA_SVC_NAME
+                            and unique within the pod. Each named port in a pod must
+                            have a unique name. Name for the port that can be referred
+                            to by services.
+                          type: string
+                        protocol:
+                          description: Protocol for port. Must be UDP, TCP, or SCTP.
+                            Defaults to "TCP".
+                          type: string
+                      required:
+                      - containerPort
+                      type: object
+                    type: array
+                  readinessProbe:
+                    description: Probe describes a health check to be performed against
+                      a container to determine whether it is alive or ready to receive
+                      traffic.
+                    properties:
+                      exec:
+                        description: ExecAction describes a "run in container" action.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGetAction describes an action based on HTTP
+                          Get requests.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocketAction describes an action based on
+                          opening a socket
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                        required:
+                        - port
+                        type: object
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                    type: object
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  securityContext:
+                    description: SecurityContext holds security configuration that
+                      will be applied to a container. Some fields are present in both
+                      SecurityContext and PodSecurityContext.  When both are set,
+                      the values in SecurityContext take precedence.
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: Adds and removes POSIX capabilities from running
+                          containers.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: SELinuxOptions are the labels to be applied to
+                          the container
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      windowsOptions:
+                        description: WindowsSecurityContextOptions contain Windows-specific
+                          options and credentials.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                        type: object
+                    type: object
+                  stdin:
+                    description: Whether this container should allocate a buffer for
+                      stdin in the container runtime. If this is not set, reads from
+                      stdin in the container will always result in EOF. Default is
+                      false.
+                    type: boolean
+                  stdinOnce:
+                    description: Whether the container runtime should close the stdin
+                      channel after it has been opened by a single attach. When stdin
+                      is true the stdin stream will remain open across multiple attach
+                      sessions. If stdinOnce is set to true, stdin is opened on container
+                      start, is empty until the first client attaches to stdin, and
+                      then remains open and accepts data until the client disconnects,
+                      at which time stdin is closed and remains closed until the container
+                      is restarted. If this flag is false, a container processes that
+                      reads from stdin will never receive an EOF. Default is false
+                    type: boolean
+                  terminationMessagePath:
+                    description: 'Optional: Path at which the file to which the container''s
+                      termination message will be written is mounted into the container''s
+                      filesystem. Message written is intended to be brief final status,
+                      such as an assertion failure message. Will be truncated by the
+                      node if greater than 4096 bytes. The total message length across
+                      all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                      Cannot be updated.'
+                    type: string
+                  terminationMessagePolicy:
+                    description: Indicate how the termination message should be populated.
+                      File will use the contents of terminationMessagePath to populate
+                      the container status message on both success and failure. FallbackToLogsOnError
+                      will use the last chunk of container log output if the termination
+                      message file is empty and the container exited with an error.
+                      The log output is limited to 2048 bytes or 80 lines, whichever
+                      is smaller. Defaults to File. Cannot be updated.
+                    type: string
+                  tty:
+                    description: Whether this container should allocate a TTY for
+                      itself, also requires 'stdin' to be true. Default is false.
+                    type: boolean
+                  volumeDevices:
+                    description: volumeDevices is the list of block devices to be
+                      used by the container. This is a beta feature.
+                    items:
+                      description: volumeDevice describes a mapping of a raw block
+                        device within a container.
+                      properties:
+                        devicePath:
+                          description: devicePath is the path inside of the container
+                            that the device will be mapped to.
+                          type: string
+                        name:
+                          description: name must match the name of a persistentVolumeClaim
+                            in the pod
+                          type: string
+                      required:
+                      - name
+                      - devicePath
+                      type: object
+                    type: array
+                  volumeMounts:
+                    description: Pod volumes to mount into the container's filesystem.
+                      Cannot be updated.
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      properties:
+                        mountPath:
+                          description: Path within the container at which the volume
+                            should be mounted.  Must not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: mountPropagation determines how mounts are
+                            propagated from the host to container and the other way
+                            around. When not set, MountPropagationNone is used. This
+                            field is beta in 1.10.
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: Mounted read-only if true, read-write otherwise
+                            (false or unspecified). Defaults to false.
+                          type: boolean
+                        subPath:
+                          description: Path within the volume from which the container's
+                            volume should be mounted. Defaults to "" (volume's root).
+                          type: string
+                        subPathExpr:
+                          description: Expanded path within the volume from which
+                            the container's volume should be mounted. Behaves similarly
+                            to SubPath but environment variable references $(VAR_NAME)
+                            are expanded using the container's environment. Defaults
+                            to "" (volume's root). SubPathExpr and SubPath are mutually
+                            exclusive. This field is beta in 1.15.
+                          type: string
+                      required:
+                      - name
+                      - mountPath
+                      type: object
+                    type: array
+                  workingDir:
+                    description: Container's working directory. If not specified,
+                      the container runtime's default will be used, which might be
+                      configured in the container image. Cannot be updated.
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            externalUrl:
+              description: The external URL the Alertmanager instances will be available
+                under. This is necessary to generate correct URLs. This is necessary
+                if Alertmanager is not served from root of a DNS name.
+              type: string
+            image:
+              description: Image if specified has precedence over baseImage, tag and
+                sha combinations. Specifying the version is still necessary to ensure
+                the Prometheus Operator knows what version of Alertmanager is being
+                configured.
+              type: string
+            imagePullSecrets:
+              description: An optional list of references to secrets in the same namespace
+                to use for pulling prometheus and alertmanager images from registries
+                see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod
+              items:
+                description: LocalObjectReference contains enough information to let
+                  you locate the referenced object inside the same namespace.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                type: object
+              type: array
+            initContainers:
+              description: 'InitContainers allows adding initContainers to the pod
+                definition. Those can be used to e.g. fetch secrets for injection
+                into the Alertmanager configuration from external sources. Any errors
+                during the execution of an initContainer will lead to a restart of
+                the Pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+                Using initContainers for any use case other then secret fetching is
+                entirely outside the scope of what the maintainers will support and
+                by doing so, you accept that this behaviour may break at any time
+                without notice.'
+              items:
+                description: A single application container that you want to run within
+                  a pod.
+                properties:
+                  args:
+                    description: 'Arguments to the entrypoint. The docker image''s
+                      CMD is used if this is not provided. Variable references $(VAR_NAME)
+                      are expanded using the container''s environment. If a variable
+                      cannot be resolved, the reference in the input string will be
+                      unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                      $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                      regardless of whether the variable exists or not. Cannot be
+                      updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    description: 'Entrypoint array. Not executed within a shell. The
+                      docker image''s ENTRYPOINT is used if this is not provided.
+                      Variable references $(VAR_NAME) are expanded using the container''s
+                      environment. If a variable cannot be resolved, the reference
+                      in the input string will be unchanged. The $(VAR_NAME) syntax
+                      can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                      will never be expanded, regardless of whether the variable exists
+                      or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    description: List of environment variables to set in the container.
+                      Cannot be updated.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: EnvVarSource represents a source for the value
+                            of an EnvVar.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key from a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: ObjectFieldSelector selects an APIVersioned
+                                field of an object.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: ResourceFieldSelector represents container
+                                resources (cpu, memory) and their output format
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor: {}
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  envFrom:
+                    description: List of sources to populate environment variables
+                      in the container. The keys defined within a source must be a
+                      C_IDENTIFIER. All invalid keys will be reported as an event
+                      when the container is starting. When a key exists in multiple
+                      sources, the value associated with the last source will take
+                      precedence. Values defined by an Env with a duplicate key will
+                      take precedence. Cannot be updated.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: |-
+                            ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
+
+                            The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: |-
+                            SecretEnvSource selects a Secret to populate the environment variables with.
+
+                            The contents of the target Secret's Data field will represent the key-value pairs as environment variables.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                      type: object
+                    type: array
+                  image:
+                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                      This field is optional to allow higher level config management
+                      to default or override container images in workload controllers
+                      like Deployments and StatefulSets.'
+                    type: string
+                  imagePullPolicy:
+                    description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                      Defaults to Always if :latest tag is specified, or IfNotPresent
+                      otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                    type: string
+                  lifecycle:
+                    description: Lifecycle describes actions that the management system
+                      should take in response to container lifecycle events. For the
+                      PostStart and PreStop lifecycle handlers, management of the
+                      container blocks until the action is complete, unless the container
+                      process fails, in which case the handler is aborted.
+                    properties:
+                      postStart:
+                        description: Handler defines a specific action that should
+                          be taken
+                        properties:
+                          exec:
+                            description: ExecAction describes a "run in container"
+                              action.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGetAction describes an action based on
+                              HTTP Get requests.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          tcpSocket:
+                            description: TCPSocketAction describes an action based
+                              on opening a socket
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                            required:
+                            - port
+                            type: object
+                        type: object
+                      preStop:
+                        description: Handler defines a specific action that should
+                          be taken
+                        properties:
+                          exec:
+                            description: ExecAction describes a "run in container"
+                              action.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGetAction describes an action based on
+                              HTTP Get requests.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          tcpSocket:
+                            description: TCPSocketAction describes an action based
+                              on opening a socket
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                            required:
+                            - port
+                            type: object
+                        type: object
+                    type: object
+                  livenessProbe:
+                    description: Probe describes a health check to be performed against
+                      a container to determine whether it is alive or ready to receive
+                      traffic.
+                    properties:
+                      exec:
+                        description: ExecAction describes a "run in container" action.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGetAction describes an action based on HTTP
+                          Get requests.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocketAction describes an action based on
+                          opening a socket
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                        required:
+                        - port
+                        type: object
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                    type: object
+                  name:
+                    description: Name of the container specified as a DNS_LABEL. Each
+                      container in a pod must have a unique name (DNS_LABEL). Cannot
+                      be updated.
+                    type: string
+                  ports:
+                    description: List of ports to expose from the container. Exposing
+                      a port here gives the system additional information about the
+                      network connections a container uses, but is primarily informational.
+                      Not specifying a port here DOES NOT prevent that port from being
+                      exposed. Any port which is listening on the default "0.0.0.0"
+                      address inside a container will be accessible from the network.
+                      Cannot be updated.
+                    items:
+                      description: ContainerPort represents a network port in a single
+                        container.
+                      properties:
+                        containerPort:
+                          description: Number of port to expose on the pod's IP address.
+                            This must be a valid port number, 0 < x < 65536.
+                          format: int32
+                          type: integer
+                        hostIP:
+                          description: What host IP to bind the external port to.
+                          type: string
+                        hostPort:
+                          description: Number of port to expose on the host. If specified,
+                            this must be a valid port number, 0 < x < 65536. If HostNetwork
+                            is specified, this must match ContainerPort. Most containers
+                            do not need this.
+                          format: int32
+                          type: integer
+                        name:
+                          description: If specified, this must be an IANA_SVC_NAME
+                            and unique within the pod. Each named port in a pod must
+                            have a unique name. Name for the port that can be referred
+                            to by services.
+                          type: string
+                        protocol:
+                          description: Protocol for port. Must be UDP, TCP, or SCTP.
+                            Defaults to "TCP".
+                          type: string
+                      required:
+                      - containerPort
+                      type: object
+                    type: array
+                  readinessProbe:
+                    description: Probe describes a health check to be performed against
+                      a container to determine whether it is alive or ready to receive
+                      traffic.
+                    properties:
+                      exec:
+                        description: ExecAction describes a "run in container" action.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGetAction describes an action based on HTTP
+                          Get requests.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocketAction describes an action based on
+                          opening a socket
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                        required:
+                        - port
+                        type: object
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                    type: object
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  securityContext:
+                    description: SecurityContext holds security configuration that
+                      will be applied to a container. Some fields are present in both
+                      SecurityContext and PodSecurityContext.  When both are set,
+                      the values in SecurityContext take precedence.
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: Adds and removes POSIX capabilities from running
+                          containers.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: SELinuxOptions are the labels to be applied to
+                          the container
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      windowsOptions:
+                        description: WindowsSecurityContextOptions contain Windows-specific
+                          options and credentials.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                        type: object
+                    type: object
+                  stdin:
+                    description: Whether this container should allocate a buffer for
+                      stdin in the container runtime. If this is not set, reads from
+                      stdin in the container will always result in EOF. Default is
+                      false.
+                    type: boolean
+                  stdinOnce:
+                    description: Whether the container runtime should close the stdin
+                      channel after it has been opened by a single attach. When stdin
+                      is true the stdin stream will remain open across multiple attach
+                      sessions. If stdinOnce is set to true, stdin is opened on container
+                      start, is empty until the first client attaches to stdin, and
+                      then remains open and accepts data until the client disconnects,
+                      at which time stdin is closed and remains closed until the container
+                      is restarted. If this flag is false, a container processes that
+                      reads from stdin will never receive an EOF. Default is false
+                    type: boolean
+                  terminationMessagePath:
+                    description: 'Optional: Path at which the file to which the container''s
+                      termination message will be written is mounted into the container''s
+                      filesystem. Message written is intended to be brief final status,
+                      such as an assertion failure message. Will be truncated by the
+                      node if greater than 4096 bytes. The total message length across
+                      all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                      Cannot be updated.'
+                    type: string
+                  terminationMessagePolicy:
+                    description: Indicate how the termination message should be populated.
+                      File will use the contents of terminationMessagePath to populate
+                      the container status message on both success and failure. FallbackToLogsOnError
+                      will use the last chunk of container log output if the termination
+                      message file is empty and the container exited with an error.
+                      The log output is limited to 2048 bytes or 80 lines, whichever
+                      is smaller. Defaults to File. Cannot be updated.
+                    type: string
+                  tty:
+                    description: Whether this container should allocate a TTY for
+                      itself, also requires 'stdin' to be true. Default is false.
+                    type: boolean
+                  volumeDevices:
+                    description: volumeDevices is the list of block devices to be
+                      used by the container. This is a beta feature.
+                    items:
+                      description: volumeDevice describes a mapping of a raw block
+                        device within a container.
+                      properties:
+                        devicePath:
+                          description: devicePath is the path inside of the container
+                            that the device will be mapped to.
+                          type: string
+                        name:
+                          description: name must match the name of a persistentVolumeClaim
+                            in the pod
+                          type: string
+                      required:
+                      - name
+                      - devicePath
+                      type: object
+                    type: array
+                  volumeMounts:
+                    description: Pod volumes to mount into the container's filesystem.
+                      Cannot be updated.
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      properties:
+                        mountPath:
+                          description: Path within the container at which the volume
+                            should be mounted.  Must not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: mountPropagation determines how mounts are
+                            propagated from the host to container and the other way
+                            around. When not set, MountPropagationNone is used. This
+                            field is beta in 1.10.
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: Mounted read-only if true, read-write otherwise
+                            (false or unspecified). Defaults to false.
+                          type: boolean
+                        subPath:
+                          description: Path within the volume from which the container's
+                            volume should be mounted. Defaults to "" (volume's root).
+                          type: string
+                        subPathExpr:
+                          description: Expanded path within the volume from which
+                            the container's volume should be mounted. Behaves similarly
+                            to SubPath but environment variable references $(VAR_NAME)
+                            are expanded using the container's environment. Defaults
+                            to "" (volume's root). SubPathExpr and SubPath are mutually
+                            exclusive. This field is beta in 1.15.
+                          type: string
+                      required:
+                      - name
+                      - mountPath
+                      type: object
+                    type: array
+                  workingDir:
+                    description: Container's working directory. If not specified,
+                      the container runtime's default will be used, which might be
+                      configured in the container image. Cannot be updated.
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            listenLocal:
+              description: ListenLocal makes the Alertmanager server listen on loopback,
+                so that it does not bind against the Pod IP. Note this is only for
+                the Alertmanager UI, not the gossip communication.
+              type: boolean
+            logFormat:
+              description: Log format for Alertmanager to be configured with.
+              type: string
+            logLevel:
+              description: Log level for Alertmanager to be configured with.
+              type: string
+            nodeSelector:
+              description: Define which Nodes the Pods are scheduled on.
+              type: object
+            paused:
+              description: If set to true all actions on the underlaying managed objects
+                are not goint to be performed, except for delete actions.
+              type: boolean
+            podMetadata:
+              description: ObjectMeta is metadata that all persisted resources must
+                have, which includes all objects users must create.
+              properties:
+                annotations:
+                  description: 'Annotations is an unstructured key value map stored
+                    with a resource that may be set by external tools to store and
+                    retrieve arbitrary metadata. They are not queryable and should
+                    be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                  type: object
+                clusterName:
+                  description: The name of the cluster which the object belongs to.
+                    This is used to distinguish resources with same name and namespace
+                    in different clusters. This field is not set anywhere right now
+                    and apiserver is going to ignore it if set in create or update
+                    request.
+                  type: string
+                creationTimestamp:
+                  description: Time is a wrapper around time.Time which supports correct
+                    marshaling to YAML and JSON.  Wrappers are provided for many of
+                    the factory methods that the time package offers.
+                  format: date-time
+                  type: string
+                deletionGracePeriodSeconds:
+                  description: Number of seconds allowed for this object to gracefully
+                    terminate before it will be removed from the system. Only set
+                    when deletionTimestamp is also set. May only be shortened. Read-only.
+                  format: int64
+                  type: integer
+                deletionTimestamp:
+                  description: Time is a wrapper around time.Time which supports correct
+                    marshaling to YAML and JSON.  Wrappers are provided for many of
+                    the factory methods that the time package offers.
+                  format: date-time
+                  type: string
+                finalizers:
+                  description: Must be empty before the object is deleted from the
+                    registry. Each entry is an identifier for the responsible component
+                    that will remove the entry from the list. If the deletionTimestamp
+                    of the object is non-nil, entries in this list can only be removed.
+                  items:
+                    type: string
+                  type: array
+                generateName:
+                  description: |-
+                    GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
+                    If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+
+                    Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+                  type: string
+                generation:
+                  description: A sequence number representing a specific generation
+                    of the desired state. Populated by the system. Read-only.
+                  format: int64
+                  type: integer
+                initializers:
+                  description: Initializers tracks the progress of initialization.
+                  properties:
+                    pending:
+                      description: Pending is a list of initializers that must execute
+                        in order before this object is visible. When the last pending
+                        initializer is removed, and no failing result is set, the
+                        initializers struct will be set to nil and the object is considered
+                        as initialized and visible to all clients.
+                      items:
+                        description: Initializer is information about an initializer
+                          that has not yet completed.
+                        properties:
+                          name:
+                            description: name of the process that is responsible for
+                              initializing this object.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    result:
+                      description: Status is a return value for calls that don't return
+                        other objects.
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of
+                            this representation of an object. Servers should convert
+                            recognized schemas to the latest internal value, and may
+                            reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                          type: string
+                        code:
+                          description: Suggested HTTP return code for this status,
+                            0 if not set.
+                          format: int32
+                          type: integer
+                        details:
+                          description: StatusDetails is a set of additional properties
+                            that MAY be set by the server to provide additional information
+                            about a response. The Reason field of a Status object
+                            defines what attributes will be set. Clients must ignore
+                            fields that do not match the defined type of each attribute,
+                            and should assume that any attribute may be empty, invalid,
+                            or under defined.
+                          properties:
+                            causes:
+                              description: The Causes array includes more details
+                                associated with the StatusReason failure. Not all
+                                StatusReasons may provide detailed causes.
+                              items:
+                                description: StatusCause provides more information
+                                  about an api.Status failure, including cases when
+                                  multiple errors are encountered.
+                                properties:
+                                  field:
+                                    description: |-
+                                      The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+
+                                      Examples:
+                                        "name" - the field "name" on the current resource
+                                        "items[0].name" - the field "name" on the first array entry in "items"
+                                    type: string
+                                  message:
+                                    description: A human-readable description of the
+                                      cause of the error.  This field may be presented
+                                      as-is to a reader.
+                                    type: string
+                                  reason:
+                                    description: A machine-readable description of
+                                      the cause of the error. If this value is empty
+                                      there is no information available.
+                                    type: string
+                                type: object
+                              type: array
+                            group:
+                              description: The group attribute of the resource associated
+                                with the status StatusReason.
+                              type: string
+                            kind:
+                              description: 'The kind attribute of the resource associated
+                                with the status StatusReason. On some operations may
+                                differ from the requested resource Kind. More info:
+                                https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: The name attribute of the resource associated
+                                with the status StatusReason (when there is a single
+                                name which can be described).
+                              type: string
+                            retryAfterSeconds:
+                              description: If specified, the time in seconds before
+                                the operation should be retried. Some errors may indicate
+                                the client must take an alternate action - for those
+                                errors this field may indicate how long to wait before
+                                taking the alternate action.
+                              format: int32
+                              type: integer
+                            uid:
+                              description: 'UID of the resource. (when there is a
+                                single resource which can be described). More info:
+                                http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                          type: object
+                        kind:
+                          description: 'Kind is a string value representing the REST
+                            resource this object represents. Servers may infer this
+                            from the endpoint the client submits requests to. Cannot
+                            be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                          type: string
+                        message:
+                          description: A human-readable description of the status
+                            of this operation.
+                          type: string
+                        metadata:
+                          description: ListMeta describes metadata that synthetic
+                            resources must have, including lists and various status
+                            objects. A resource may have only one of {ObjectMeta,
+                            ListMeta}.
+                          properties:
+                            continue:
+                              description: continue may be set if the user set a limit
+                                on the number of items returned, and indicates that
+                                the server has more data available. The value is opaque
+                                and may be used to issue another request to the endpoint
+                                that served this list to retrieve the next set of
+                                available objects. Continuing a consistent list may
+                                not be possible if the server configuration has changed
+                                or more than a few minutes have passed. The resourceVersion
+                                field returned when using this continue value will
+                                be identical to the value in the first response, unless
+                                you have received this token from an error message.
+                              type: string
+                            remainingItemCount:
+                              description: |-
+                                remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.
+
+                                This field is alpha and can be changed or removed without notice.
+                              format: int64
+                              type: integer
+                            resourceVersion:
+                              description: 'String that identifies the server''s internal
+                                version of this object that can be used by clients
+                                to determine when objects have changed. Value must
+                                be treated as opaque by clients and passed unmodified
+                                back to the server. Populated by the system. Read-only.
+                                More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            selfLink:
+                              description: selfLink is a URL representing this object.
+                                Populated by the system. Read-only.
+                              type: string
+                          type: object
+                        reason:
+                          description: A machine-readable description of why this
+                            operation is in the "Failure" status. If this value is
+                            empty there is no information available. A Reason clarifies
+                            an HTTP status code but does not override it.
+                          type: string
+                        status:
+                          description: 'Status of the operation. One of: "Success"
+                            or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                          type: string
+                      type: object
+                  required:
+                  - pending
+                  type: object
+                labels:
+                  description: 'Map of string keys and values that can be used to
+                    organize and categorize (scope and select) objects. May match
+                    selectors of replication controllers and services. More info:
+                    http://kubernetes.io/docs/user-guide/labels'
+                  type: object
+                managedFields:
+                  description: |-
+                    ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+
+                    This field is alpha and can be changed or removed without notice.
+                  items:
+                    description: ManagedFieldsEntry is a workflow-id, a FieldSet and
+                      the group version of the resource that the fieldset applies
+                      to.
+                    properties:
+                      apiVersion:
+                        description: APIVersion defines the version of this resource
+                          that this field set applies to. The format is "group/version"
+                          just like the top-level APIVersion field. It is necessary
+                          to track the version of a field set because it cannot be
+                          automatically converted.
+                        type: string
+                      fields:
+                        description: 'Fields stores a set of fields in a data structure
+                          like a Trie. To understand how this is used, see: https://github.com/kubernetes-sigs/structured-merge-diff'
+                        type: object
+                      manager:
+                        description: Manager is an identifier of the workflow managing
+                          these fields.
+                        type: string
+                      operation:
+                        description: Operation is the type of operation which lead
+                          to this ManagedFieldsEntry being created. The only valid
+                          values for this field are 'Apply' and 'Update'.
+                        type: string
+                      time:
+                        description: Time is a wrapper around time.Time which supports
+                          correct marshaling to YAML and JSON.  Wrappers are provided
+                          for many of the factory methods that the time package offers.
+                        format: date-time
+                        type: string
+                    type: object
+                  type: array
+                name:
+                  description: 'Name must be unique within a namespace. Is required
+                    when creating resources, although some resources may allow a client
+                    to request the generation of an appropriate name automatically.
+                    Name is primarily intended for creation idempotence and configuration
+                    definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
+                    Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                  type: string
+                ownerReferences:
+                  description: List of objects depended by this object. If ALL objects
+                    in the list have been deleted, this object will be garbage collected.
+                    If this object is managed by a controller, then an entry in this
+                    list will point to this controller, with the controller field
+                    set to true. There cannot be more than one managing controller.
+                  items:
+                    description: OwnerReference contains enough information to let
+                      you identify an owning object. An owning object must be in the
+                      same namespace as the dependent, or be cluster-scoped, so there
+                      is no namespace field.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      blockOwnerDeletion:
+                        description: If true, AND if the owner has the "foregroundDeletion"
+                          finalizer, then the owner cannot be deleted from the key-value
+                          store until this reference is removed. Defaults to false.
+                          To set this field, a user needs "delete" permission of the
+                          owner, otherwise 422 (Unprocessable Entity) will be returned.
+                        type: boolean
+                      controller:
+                        description: If true, this reference points to the managing
+                          controller.
+                        type: boolean
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - uid
+                    type: object
+                  type: array
+                resourceVersion:
+                  description: |-
+                    An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
+                    Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+                  type: string
+                selfLink:
+                  description: SelfLink is a URL representing this object. Populated
+                    by the system. Read-only.
+                  type: string
+                uid:
+                  description: |-
+                    UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
+                    Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                  type: string
+              type: object
+            portName:
+              description: Port name used for the pods and governing service. This
+                defaults to web
+              type: string
+            priorityClassName:
+              description: Priority class assigned to the Pods
+              type: string
+            replicas:
+              description: Size is the expected size of the alertmanager cluster.
+                The controller will eventually make the size of the running cluster
+                equal to the expected size.
+              format: int32
+              type: integer
+            resources:
+              description: ResourceRequirements describes the compute resource requirements.
+              properties:
+                limits:
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+              type: object
+            retention:
+              description: Time duration Alertmanager shall retain data for. Default
+                is '120h', and must match the regular expression `[0-9]+(ms|s|m|h)`
+                (milliseconds seconds minutes hours).
+              type: string
+            routePrefix:
+              description: The route prefix Alertmanager registers HTTP handlers for.
+                This is useful, if using ExternalURL and a proxy is rewriting HTTP
+                routes of a request, and the actual ExternalURL is still true, but
+                the server serves requests under a different route prefix. For example
+                for use with `kubectl proxy`.
+              type: string
+            secrets:
+              description: Secrets is a list of Secrets in the same namespace as the
+                Alertmanager object, which shall be mounted into the Alertmanager
+                Pods. The Secrets are mounted into /etc/alertmanager/secrets/<secret-name>.
+              items:
+                type: string
+              type: array
+            securityContext:
+              description: PodSecurityContext holds pod-level security attributes
+                and common container settings. Some fields are also present in container.securityContext.  Field
+                values of container.securityContext take precedence over field values
+                of PodSecurityContext.
+              properties:
+                fsGroup:
+                  description: |-
+                    A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                    1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                    If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                  format: int64
+                  type: integer
+                runAsGroup:
+                  description: The GID to run the entrypoint of the container process.
+                    Uses runtime default if unset. May also be set in SecurityContext.  If
+                    set in both SecurityContext and PodSecurityContext, the value
+                    specified in SecurityContext takes precedence for that container.
+                  format: int64
+                  type: integer
+                runAsNonRoot:
+                  description: Indicates that the container must run as a non-root
+                    user. If true, the Kubelet will validate the image at runtime
+                    to ensure that it does not run as UID 0 (root) and fail to start
+                    the container if it does. If unset or false, no such validation
+                    will be performed. May also be set in SecurityContext.  If set
+                    in both SecurityContext and PodSecurityContext, the value specified
+                    in SecurityContext takes precedence.
+                  type: boolean
+                runAsUser:
+                  description: The UID to run the entrypoint of the container process.
+                    Defaults to user specified in image metadata if unspecified. May
+                    also be set in SecurityContext.  If set in both SecurityContext
+                    and PodSecurityContext, the value specified in SecurityContext
+                    takes precedence for that container.
+                  format: int64
+                  type: integer
+                seLinuxOptions:
+                  description: SELinuxOptions are the labels to be applied to the
+                    container
+                  properties:
+                    level:
+                      description: Level is SELinux level label that applies to the
+                        container.
+                      type: string
+                    role:
+                      description: Role is a SELinux role label that applies to the
+                        container.
+                      type: string
+                    type:
+                      description: Type is a SELinux type label that applies to the
+                        container.
+                      type: string
+                    user:
+                      description: User is a SELinux user label that applies to the
+                        container.
+                      type: string
+                  type: object
+                supplementalGroups:
+                  description: A list of groups applied to the first process run in
+                    each container, in addition to the container's primary GID.  If
+                    unspecified, no groups will be added to any container.
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                sysctls:
+                  description: Sysctls hold a list of namespaced sysctls used for
+                    the pod. Pods with unsupported sysctls (by the container runtime)
+                    might fail to launch.
+                  items:
+                    description: Sysctl defines a kernel parameter to be set
+                    properties:
+                      name:
+                        description: Name of a property to set
+                        type: string
+                      value:
+                        description: Value of a property to set
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                windowsOptions:
+                  description: WindowsSecurityContextOptions contain Windows-specific
+                    options and credentials.
+                  properties:
+                    gmsaCredentialSpec:
+                      description: GMSACredentialSpec is where the GMSA admission
+                        webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                        inlines the contents of the GMSA credential spec named by
+                        the GMSACredentialSpecName field. This field is alpha-level
+                        and is only honored by servers that enable the WindowsGMSA
+                        feature flag.
+                      type: string
+                    gmsaCredentialSpecName:
+                      description: GMSACredentialSpecName is the name of the GMSA
+                        credential spec to use. This field is alpha-level and is only
+                        honored by servers that enable the WindowsGMSA feature flag.
+                      type: string
+                  type: object
+              type: object
+            serviceAccountName:
+              description: ServiceAccountName is the name of the ServiceAccount to
+                use to run the Prometheus Pods.
+              type: string
+            sha:
+              description: SHA of Alertmanager container image to be deployed. Defaults
+                to the value of `version`. Similar to a tag, but the SHA explicitly
+                deploys an immutable container image. Version and Tag are ignored
+                if SHA is set.
+              type: string
+            storage:
+              description: StorageSpec defines the configured storage for a group
+                Prometheus servers. If neither `emptyDir` nor `volumeClaimTemplate`
+                is specified, then by default an [EmptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir)
+                will be used.
+              properties:
+                emptyDir:
+                  description: Represents an empty directory for a pod. Empty directory
+                    volumes support ownership management and SELinux relabeling.
+                  properties:
+                    medium:
+                      description: 'What type of storage medium should back this directory.
+                        The default is "" which means to use the node''s default medium.
+                        Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                      type: string
+                    sizeLimit: {}
+                  type: object
+                volumeClaimTemplate:
+                  description: PersistentVolumeClaim is a user's request for and claim
+                    to a persistent volume
+                  properties:
+                    apiVersion:
+                      description: 'APIVersion defines the versioned schema of this
+                        representation of an object. Servers should convert recognized
+                        schemas to the latest internal value, and may reject unrecognized
+                        values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                      type: string
+                    kind:
+                      description: 'Kind is a string value representing the REST resource
+                        this object represents. Servers may infer this from the endpoint
+                        the client submits requests to. Cannot be updated. In CamelCase.
+                        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                      type: string
+                    metadata:
+                      description: ObjectMeta is metadata that all persisted resources
+                        must have, which includes all objects users must create.
+                      properties:
+                        annotations:
+                          description: 'Annotations is an unstructured key value map
+                            stored with a resource that may be set by external tools
+                            to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: http://kubernetes.io/docs/user-guide/annotations'
+                          type: object
+                        clusterName:
+                          description: The name of the cluster which the object belongs
+                            to. This is used to distinguish resources with same name
+                            and namespace in different clusters. This field is not
+                            set anywhere right now and apiserver is going to ignore
+                            it if set in create or update request.
+                          type: string
+                        creationTimestamp:
+                          description: Time is a wrapper around time.Time which supports
+                            correct marshaling to YAML and JSON.  Wrappers are provided
+                            for many of the factory methods that the time package
+                            offers.
+                          format: date-time
+                          type: string
+                        deletionGracePeriodSeconds:
+                          description: Number of seconds allowed for this object to
+                            gracefully terminate before it will be removed from the
+                            system. Only set when deletionTimestamp is also set. May
+                            only be shortened. Read-only.
+                          format: int64
+                          type: integer
+                        deletionTimestamp:
+                          description: Time is a wrapper around time.Time which supports
+                            correct marshaling to YAML and JSON.  Wrappers are provided
+                            for many of the factory methods that the time package
+                            offers.
+                          format: date-time
+                          type: string
+                        finalizers:
+                          description: Must be empty before the object is deleted
+                            from the registry. Each entry is an identifier for the
+                            responsible component that will remove the entry from
+                            the list. If the deletionTimestamp of the object is non-nil,
+                            entries in this list can only be removed.
+                          items:
+                            type: string
+                          type: array
+                        generateName:
+                          description: |-
+                            GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
+                            If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+
+                            Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+                          type: string
+                        generation:
+                          description: A sequence number representing a specific generation
+                            of the desired state. Populated by the system. Read-only.
+                          format: int64
+                          type: integer
+                        initializers:
+                          description: Initializers tracks the progress of initialization.
+                          properties:
+                            pending:
+                              description: Pending is a list of initializers that
+                                must execute in order before this object is visible.
+                                When the last pending initializer is removed, and
+                                no failing result is set, the initializers struct
+                                will be set to nil and the object is considered as
+                                initialized and visible to all clients.
+                              items:
+                                description: Initializer is information about an initializer
+                                  that has not yet completed.
+                                properties:
+                                  name:
+                                    description: name of the process that is responsible
+                                      for initializing this object.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            result:
+                              description: Status is a return value for calls that
+                                don't return other objects.
+                              properties:
+                                apiVersion:
+                                  description: 'APIVersion defines the versioned schema
+                                    of this representation of an object. Servers should
+                                    convert recognized schemas to the latest internal
+                                    value, and may reject unrecognized values. More
+                                    info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                                  type: string
+                                code:
+                                  description: Suggested HTTP return code for this
+                                    status, 0 if not set.
+                                  format: int32
+                                  type: integer
+                                details:
+                                  description: StatusDetails is a set of additional
+                                    properties that MAY be set by the server to provide
+                                    additional information about a response. The Reason
+                                    field of a Status object defines what attributes
+                                    will be set. Clients must ignore fields that do
+                                    not match the defined type of each attribute,
+                                    and should assume that any attribute may be empty,
+                                    invalid, or under defined.
+                                  properties:
+                                    causes:
+                                      description: The Causes array includes more
+                                        details associated with the StatusReason failure.
+                                        Not all StatusReasons may provide detailed
+                                        causes.
+                                      items:
+                                        description: StatusCause provides more information
+                                          about an api.Status failure, including cases
+                                          when multiple errors are encountered.
+                                        properties:
+                                          field:
+                                            description: |-
+                                              The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+
+                                              Examples:
+                                                "name" - the field "name" on the current resource
+                                                "items[0].name" - the field "name" on the first array entry in "items"
+                                            type: string
+                                          message:
+                                            description: A human-readable description
+                                              of the cause of the error.  This field
+                                              may be presented as-is to a reader.
+                                            type: string
+                                          reason:
+                                            description: A machine-readable description
+                                              of the cause of the error. If this value
+                                              is empty there is no information available.
+                                            type: string
+                                        type: object
+                                      type: array
+                                    group:
+                                      description: The group attribute of the resource
+                                        associated with the status StatusReason.
+                                      type: string
+                                    kind:
+                                      description: 'The kind attribute of the resource
+                                        associated with the status StatusReason. On
+                                        some operations may differ from the requested
+                                        resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: The name attribute of the resource
+                                        associated with the status StatusReason (when
+                                        there is a single name which can be described).
+                                      type: string
+                                    retryAfterSeconds:
+                                      description: If specified, the time in seconds
+                                        before the operation should be retried. Some
+                                        errors may indicate the client must take an
+                                        alternate action - for those errors this field
+                                        may indicate how long to wait before taking
+                                        the alternate action.
+                                      format: int32
+                                      type: integer
+                                    uid:
+                                      description: 'UID of the resource. (when there
+                                        is a single resource which can be described).
+                                        More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                      type: string
+                                  type: object
+                                kind:
+                                  description: 'Kind is a string value representing
+                                    the REST resource this object represents. Servers
+                                    may infer this from the endpoint the client submits
+                                    requests to. Cannot be updated. In CamelCase.
+                                    More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                  type: string
+                                message:
+                                  description: A human-readable description of the
+                                    status of this operation.
+                                  type: string
+                                metadata:
+                                  description: ListMeta describes metadata that synthetic
+                                    resources must have, including lists and various
+                                    status objects. A resource may have only one of
+                                    {ObjectMeta, ListMeta}.
+                                  properties:
+                                    continue:
+                                      description: continue may be set if the user
+                                        set a limit on the number of items returned,
+                                        and indicates that the server has more data
+                                        available. The value is opaque and may be
+                                        used to issue another request to the endpoint
+                                        that served this list to retrieve the next
+                                        set of available objects. Continuing a consistent
+                                        list may not be possible if the server configuration
+                                        has changed or more than a few minutes have
+                                        passed. The resourceVersion field returned
+                                        when using this continue value will be identical
+                                        to the value in the first response, unless
+                                        you have received this token from an error
+                                        message.
+                                      type: string
+                                    remainingItemCount:
+                                      description: |-
+                                        remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.
+
+                                        This field is alpha and can be changed or removed without notice.
+                                      format: int64
+                                      type: integer
+                                    resourceVersion:
+                                      description: 'String that identifies the server''s
+                                        internal version of this object that can be
+                                        used by clients to determine when objects
+                                        have changed. Value must be treated as opaque
+                                        by clients and passed unmodified back to the
+                                        server. Populated by the system. Read-only.
+                                        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                                      type: string
+                                    selfLink:
+                                      description: selfLink is a URL representing
+                                        this object. Populated by the system. Read-only.
+                                      type: string
+                                  type: object
+                                reason:
+                                  description: A machine-readable description of why
+                                    this operation is in the "Failure" status. If
+                                    this value is empty there is no information available.
+                                    A Reason clarifies an HTTP status code but does
+                                    not override it.
+                                  type: string
+                                status:
+                                  description: 'Status of the operation. One of: "Success"
+                                    or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                                  type: string
+                              type: object
+                          required:
+                          - pending
+                          type: object
+                        labels:
+                          description: 'Map of string keys and values that can be
+                            used to organize and categorize (scope and select) objects.
+                            May match selectors of replication controllers and services.
+                            More info: http://kubernetes.io/docs/user-guide/labels'
+                          type: object
+                        managedFields:
+                          description: |-
+                            ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+
+                            This field is alpha and can be changed or removed without notice.
+                          items:
+                            description: ManagedFieldsEntry is a workflow-id, a FieldSet
+                              and the group version of the resource that the fieldset
+                              applies to.
+                            properties:
+                              apiVersion:
+                                description: APIVersion defines the version of this
+                                  resource that this field set applies to. The format
+                                  is "group/version" just like the top-level APIVersion
+                                  field. It is necessary to track the version of a
+                                  field set because it cannot be automatically converted.
+                                type: string
+                              fields:
+                                description: 'Fields stores a set of fields in a data
+                                  structure like a Trie. To understand how this is
+                                  used, see: https://github.com/kubernetes-sigs/structured-merge-diff'
+                                type: object
+                              manager:
+                                description: Manager is an identifier of the workflow
+                                  managing these fields.
+                                type: string
+                              operation:
+                                description: Operation is the type of operation which
+                                  lead to this ManagedFieldsEntry being created. The
+                                  only valid values for this field are 'Apply' and
+                                  'Update'.
+                                type: string
+                              time:
+                                description: Time is a wrapper around time.Time which
+                                  supports correct marshaling to YAML and JSON.  Wrappers
+                                  are provided for many of the factory methods that
+                                  the time package offers.
+                                format: date-time
+                                type: string
+                            type: object
+                          type: array
+                        name:
+                          description: 'Name must be unique within a namespace. Is
+                            required when creating resources, although some resources
+                            may allow a client to request the generation of an appropriate
+                            name automatically. Name is primarily intended for creation
+                            idempotence and configuration definition. Cannot be updated.
+                            More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
+                            Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                          type: string
+                        ownerReferences:
+                          description: List of objects depended by this object. If
+                            ALL objects in the list have been deleted, this object
+                            will be garbage collected. If this object is managed by
+                            a controller, then an entry in this list will point to
+                            this controller, with the controller field set to true.
+                            There cannot be more than one managing controller.
+                          items:
+                            description: OwnerReference contains enough information
+                              to let you identify an owning object. An owning object
+                              must be in the same namespace as the dependent, or be
+                              cluster-scoped, so there is no namespace field.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              blockOwnerDeletion:
+                                description: If true, AND if the owner has the "foregroundDeletion"
+                                  finalizer, then the owner cannot be deleted from
+                                  the key-value store until this reference is removed.
+                                  Defaults to false. To set this field, a user needs
+                                  "delete" permission of the owner, otherwise 422
+                                  (Unprocessable Entity) will be returned.
+                                type: boolean
+                              controller:
+                                description: If true, this reference points to the
+                                  managing controller.
+                                type: boolean
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                type: string
+                            required:
+                            - apiVersion
+                            - kind
+                            - name
+                            - uid
+                            type: object
+                          type: array
+                        resourceVersion:
+                          description: |-
+                            An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
+                            Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+                          type: string
+                        selfLink:
+                          description: SelfLink is a URL representing this object.
+                            Populated by the system. Read-only.
+                          type: string
+                        uid:
+                          description: |-
+                            UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
+                            Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                          type: string
+                      type: object
+                    spec:
+                      description: PersistentVolumeClaimSpec describes the common
+                        attributes of storage devices and allows a Source for provider-specific
+                        attributes
+                      properties:
+                        accessModes:
+                          description: 'AccessModes contains the desired access modes
+                            the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                          items:
+                            type: string
+                          type: array
+                        dataSource:
+                          description: TypedLocalObjectReference contains enough information
+                            to let you locate the typed referenced object inside the
+                            same namespace.
+                          properties:
+                            apiGroup:
+                              description: APIGroup is the group for the resource
+                                being referenced. If APIGroup is not specified, the
+                                specified Kind must be in the core API group. For
+                                any other third-party types, APIGroup is required.
+                              type: string
+                            kind:
+                              description: Kind is the type of resource being referenced
+                              type: string
+                            name:
+                              description: Name is the name of resource being referenced
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
+                        resources:
+                          description: ResourceRequirements describes the compute
+                            resource requirements.
+                          properties:
+                            limits:
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        selector:
+                          description: A label selector is a label query over a set
+                            of resources. The result of matchLabels and matchExpressions
+                            are ANDed. An empty label selector matches all objects.
+                            A null label selector matches no objects.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        storageClassName:
+                          description: 'Name of the StorageClass required by the claim.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                          type: string
+                        volumeMode:
+                          description: volumeMode defines what type of volume is required
+                            by the claim. Value of Filesystem is implied when not
+                            included in claim spec. This is a beta feature.
+                          type: string
+                        volumeName:
+                          description: VolumeName is the binding reference to the
+                            PersistentVolume backing this claim.
+                          type: string
+                      type: object
+                    status:
+                      description: PersistentVolumeClaimStatus is the current status
+                        of a persistent volume claim.
+                      properties:
+                        accessModes:
+                          description: 'AccessModes contains the actual access modes
+                            the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                          items:
+                            type: string
+                          type: array
+                        capacity:
+                          description: Represents the actual resources of the underlying
+                            volume.
+                          type: object
+                        conditions:
+                          description: Current Condition of persistent volume claim.
+                            If underlying persistent volume is being resized then
+                            the Condition will be set to 'ResizeStarted'.
+                          items:
+                            description: PersistentVolumeClaimCondition contails details
+                              about state of pvc
+                            properties:
+                              lastProbeTime:
+                                description: Time is a wrapper around time.Time which
+                                  supports correct marshaling to YAML and JSON.  Wrappers
+                                  are provided for many of the factory methods that
+                                  the time package offers.
+                                format: date-time
+                                type: string
+                              lastTransitionTime:
+                                description: Time is a wrapper around time.Time which
+                                  supports correct marshaling to YAML and JSON.  Wrappers
+                                  are provided for many of the factory methods that
+                                  the time package offers.
+                                format: date-time
+                                type: string
+                              message:
+                                description: Human-readable message indicating details
+                                  about last transition.
+                                type: string
+                              reason:
+                                description: Unique, this should be a short, machine
+                                  understandable string that gives the reason for
+                                  condition's last transition. If it reports "ResizeStarted"
+                                  that means the underlying persistent volume is being
+                                  resized.
+                                type: string
+                              status:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                            - type
+                            - status
+                            type: object
+                          type: array
+                        phase:
+                          description: Phase represents the current phase of PersistentVolumeClaim.
+                          type: string
+                      type: object
+                  type: object
+              type: object
+            tag:
+              description: Tag of Alertmanager container image to be deployed. Defaults
+                to the value of `version`. Version is ignored if Tag is set.
+              type: string
+            tolerations:
+              description: If specified, the pod's tolerations.
+              items:
+                description: The pod this Toleration is attached to tolerates any
+                  taint that matches the triple <key,value,effect> using the matching
+                  operator <operator>.
+                properties:
+                  effect:
+                    description: Effect indicates the taint effect to match. Empty
+                      means match all taint effects. When specified, allowed values
+                      are NoSchedule, PreferNoSchedule and NoExecute.
+                    type: string
+                  key:
+                    description: Key is the taint key that the toleration applies
+                      to. Empty means match all taint keys. If the key is empty, operator
+                      must be Exists; this combination means to match all values and
+                      all keys.
+                    type: string
+                  operator:
+                    description: Operator represents a key's relationship to the value.
+                      Valid operators are Exists and Equal. Defaults to Equal. Exists
+                      is equivalent to wildcard for value, so that a pod can tolerate
+                      all taints of a particular category.
+                    type: string
+                  tolerationSeconds:
+                    description: TolerationSeconds represents the period of time the
+                      toleration (which must be of effect NoExecute, otherwise this
+                      field is ignored) tolerates the taint. By default, it is not
+                      set, which means tolerate the taint forever (do not evict).
+                      Zero and negative values will be treated as 0 (evict immediately)
+                      by the system.
+                    format: int64
+                    type: integer
+                  value:
+                    description: Value is the taint value the toleration matches to.
+                      If the operator is Exists, the value should be empty, otherwise
+                      just a regular string.
+                    type: string
+                type: object
+              type: array
+            version:
+              description: Version the cluster should be on.
+              type: string
+            volumeMounts:
+              description: VolumeMounts allows configuration of additional VolumeMounts
+                on the output StatefulSet definition. VolumeMounts specified will
+                be appended to other VolumeMounts in the alertmanager container, that
+                are generated as a result of StorageSpec objects.
+              items:
+                description: VolumeMount describes a mounting of a Volume within a
+                  container.
+                properties:
+                  mountPath:
+                    description: Path within the container at which the volume should
+                      be mounted.  Must not contain ':'.
+                    type: string
+                  mountPropagation:
+                    description: mountPropagation determines how mounts are propagated
+                      from the host to container and the other way around. When not
+                      set, MountPropagationNone is used. This field is beta in 1.10.
+                    type: string
+                  name:
+                    description: This must match the Name of a Volume.
+                    type: string
+                  readOnly:
+                    description: Mounted read-only if true, read-write otherwise (false
+                      or unspecified). Defaults to false.
+                    type: boolean
+                  subPath:
+                    description: Path within the volume from which the container's
+                      volume should be mounted. Defaults to "" (volume's root).
+                    type: string
+                  subPathExpr:
+                    description: Expanded path within the volume from which the container's
+                      volume should be mounted. Behaves similarly to SubPath but environment
+                      variable references $(VAR_NAME) are expanded using the container's
+                      environment. Defaults to "" (volume's root). SubPathExpr and
+                      SubPath are mutually exclusive. This field is beta in 1.15.
+                    type: string
+                required:
+                - name
+                - mountPath
+                type: object
+              type: array
+            volumes:
+              description: Volumes allows configuration of additional volumes on the
+                output StatefulSet definition. Volumes specified will be appended
+                to other volumes that are generated as a result of StorageSpec objects.
+              items:
+                description: Volume represents a named volume in a pod that may be
+                  accessed by any container in the pod.
+                properties:
+                  awsElasticBlockStore:
+                    description: |-
+                      Represents a Persistent Disk resource in AWS.
+
+                      An AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        type: string
+                      partition:
+                        description: 'The partition in the volume that you want to
+                          mount. If omitted, the default is to mount by volume name.
+                          Examples: For volume /dev/sda1, you specify the partition
+                          as "1". Similarly, the volume partition for /dev/sda is
+                          "0" (or you can leave the property empty).'
+                        format: int32
+                        type: integer
+                      readOnly:
+                        description: 'Specify "true" to force and set the ReadOnly
+                          property in VolumeMounts to "true". If omitted, the default
+                          is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        type: boolean
+                      volumeID:
+                        description: 'Unique ID of the persistent disk resource in
+                          AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  azureDisk:
+                    description: AzureDisk represents an Azure Data Disk mount on
+                      the host and bind mount to the pod.
+                    properties:
+                      cachingMode:
+                        description: 'Host Caching mode: None, Read Only, Read Write.'
+                        type: string
+                      diskName:
+                        description: The Name of the data disk in the blob storage
+                        type: string
+                      diskURI:
+                        description: The URI the data disk in the blob storage
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      kind:
+                        description: 'Expected values Shared: multiple blob disks
+                          per storage account  Dedicated: single blob disk per storage
+                          account  Managed: azure managed data disk (only in managed
+                          availability set). defaults to shared'
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                    required:
+                    - diskName
+                    - diskURI
+                    type: object
+                  azureFile:
+                    description: AzureFile represents an Azure File Service mount
+                      on the host and bind mount to the pod.
+                    properties:
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretName:
+                        description: the name of secret that contains Azure Storage
+                          Account Name and Key
+                        type: string
+                      shareName:
+                        description: Share Name
+                        type: string
+                    required:
+                    - secretName
+                    - shareName
+                    type: object
+                  cephfs:
+                    description: Represents a Ceph Filesystem mount that lasts the
+                      lifetime of a pod Cephfs volumes do not support ownership management
+                      or SELinux relabeling.
+                    properties:
+                      monitors:
+                        description: 'Required: Monitors is a collection of Ceph monitors
+                          More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                        items:
+                          type: string
+                        type: array
+                      path:
+                        description: 'Optional: Used as the mounted root, rather than
+                          the full Ceph tree, default is /'
+                        type: string
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts. More
+                          info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                        type: boolean
+                      secretFile:
+                        description: 'Optional: SecretFile is the path to key ring
+                          for User, default is /etc/ceph/user.secret More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                        type: string
+                      secretRef:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        type: object
+                      user:
+                        description: 'Optional: User is the rados user name, default
+                          is admin More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                        type: string
+                    required:
+                    - monitors
+                    type: object
+                  cinder:
+                    description: Represents a cinder volume resource in Openstack.
+                      A Cinder volume must exist before mounting to a container. The
+                      volume must also be in the same region as the kubelet. Cinder
+                      volumes support ownership management and SELinux relabeling.
+                    properties:
+                      fsType:
+                        description: 'Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Examples: "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md'
+                        type: string
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts. More
+                          info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md'
+                        type: boolean
+                      secretRef:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        type: object
+                      volumeID:
+                        description: 'volume id used to identify the volume in cinder
+                          More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md'
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  configMap:
+                    description: |-
+                      Adapts a ConfigMap into a volume.
+
+                      The contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: If unspecified, each key-value pair in the Data
+                          field of the referenced ConfigMap will be projected into
+                          the volume as a file whose name is the key and content is
+                          the value. If specified, the listed keys will be projected
+                          into the specified paths, and unlisted keys will not be
+                          present. If a key is specified which is not present in the
+                          ConfigMap, the volume setup will error unless it is marked
+                          optional. Paths must be relative and may not contain the
+                          '..' path or start with '..'.
+                        items:
+                          description: Maps a string key to a path within a volume.
+                          properties:
+                            key:
+                              description: The key to project.
+                              type: string
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              format: int32
+                              type: integer
+                            path:
+                              description: The relative path of the file to map the
+                                key to. May not be an absolute path. May not contain
+                                the path element '..'. May not start with the string
+                                '..'.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          type: object
+                        type: array
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      optional:
+                        description: Specify whether the ConfigMap or its keys must
+                          be defined
+                        type: boolean
+                    type: object
+                  csi:
+                    description: Represents a source location of a volume to mount,
+                      managed by an external CSI driver
+                    properties:
+                      driver:
+                        description: Driver is the name of the CSI driver that handles
+                          this volume. Consult with your admin for the correct name
+                          as registered in the cluster.
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Ex. "ext4", "xfs",
+                          "ntfs". If not provided, the empty value is passed to the
+                          associated CSI driver which will determine the default filesystem
+                          to apply.
+                        type: string
+                      nodePublishSecretRef:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        type: object
+                      readOnly:
+                        description: Specifies a read-only configuration for the volume.
+                          Defaults to false (read/write).
+                        type: boolean
+                      volumeAttributes:
+                        description: VolumeAttributes stores driver-specific properties
+                          that are passed to the CSI driver. Consult your driver's
+                          documentation for supported values.
+                        type: object
+                    required:
+                    - driver
+                    type: object
+                  downwardAPI:
+                    description: DownwardAPIVolumeSource represents a volume containing
+                      downward API info. Downward API volumes support ownership management
+                      and SELinux relabeling.
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: Items is a list of downward API volume file
+                        items:
+                          description: DownwardAPIVolumeFile represents information
+                            to create the file containing the pod field
+                          properties:
+                            fieldRef:
+                              description: ObjectFieldSelector selects an APIVersioned
+                                field of an object.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              format: int32
+                              type: integer
+                            path:
+                              description: 'Required: Path is  the relative path name
+                                of the file to be created. Must not be absolute or
+                                contain the ''..'' path. Must be utf-8 encoded. The
+                                first item of the relative path must not start with
+                                ''..'''
+                              type: string
+                            resourceFieldRef:
+                              description: ResourceFieldSelector represents container
+                                resources (cpu, memory) and their output format
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor: {}
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                          required:
+                          - path
+                          type: object
+                        type: array
+                    type: object
+                  emptyDir:
+                    description: Represents an empty directory for a pod. Empty directory
+                      volumes support ownership management and SELinux relabeling.
+                    properties:
+                      medium:
+                        description: 'What type of storage medium should back this
+                          directory. The default is "" which means to use the node''s
+                          default medium. Must be an empty string (default) or Memory.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                        type: string
+                      sizeLimit: {}
+                    type: object
+                  fc:
+                    description: Represents a Fibre Channel volume. Fibre Channel
+                      volumes can only be mounted as read/write once. Fibre Channel
+                      volumes support ownership management and SELinux relabeling.
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      lun:
+                        description: 'Optional: FC target lun number'
+                        format: int32
+                        type: integer
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts.'
+                        type: boolean
+                      targetWWNs:
+                        description: 'Optional: FC target worldwide names (WWNs)'
+                        items:
+                          type: string
+                        type: array
+                      wwids:
+                        description: 'Optional: FC volume world wide identifiers (wwids)
+                          Either wwids or combination of targetWWNs and lun must be
+                          set, but not both simultaneously.'
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  flexVolume:
+                    description: FlexVolume represents a generic volume resource that
+                      is provisioned/attached using an exec based plugin.
+                    properties:
+                      driver:
+                        description: Driver is the name of the driver to use for this
+                          volume.
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". The default filesystem depends on FlexVolume
+                          script.
+                        type: string
+                      options:
+                        description: 'Optional: Extra command options if any.'
+                        type: object
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts.'
+                        type: boolean
+                      secretRef:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        type: object
+                    required:
+                    - driver
+                    type: object
+                  flocker:
+                    description: Represents a Flocker volume mounted by the Flocker
+                      agent. One and only one of datasetName and datasetUUID should
+                      be set. Flocker volumes do not support ownership management
+                      or SELinux relabeling.
+                    properties:
+                      datasetName:
+                        description: Name of the dataset stored as metadata -> name
+                          on the dataset for Flocker should be considered as deprecated
+                        type: string
+                      datasetUUID:
+                        description: UUID of the dataset. This is unique identifier
+                          of a Flocker dataset
+                        type: string
+                    type: object
+                  gcePersistentDisk:
+                    description: |-
+                      Represents a Persistent Disk resource in Google Compute Engine.
+
+                      A GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: string
+                      partition:
+                        description: 'The partition in the volume that you want to
+                          mount. If omitted, the default is to mount by volume name.
+                          Examples: For volume /dev/sda1, you specify the partition
+                          as "1". Similarly, the volume partition for /dev/sda is
+                          "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        format: int32
+                        type: integer
+                      pdName:
+                        description: 'Unique name of the PD resource in GCE. Used
+                          to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: boolean
+                    required:
+                    - pdName
+                    type: object
+                  gitRepo:
+                    description: |-
+                      Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.
+
+                      DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.
+                    properties:
+                      directory:
+                        description: Target directory name. Must not contain or start
+                          with '..'.  If '.' is supplied, the volume directory will
+                          be the git repository.  Otherwise, if specified, the volume
+                          will contain the git repository in the subdirectory with
+                          the given name.
+                        type: string
+                      repository:
+                        description: Repository URL
+                        type: string
+                      revision:
+                        description: Commit hash for the specified revision.
+                        type: string
+                    required:
+                    - repository
+                    type: object
+                  glusterfs:
+                    description: Represents a Glusterfs mount that lasts the lifetime
+                      of a pod. Glusterfs volumes do not support ownership management
+                      or SELinux relabeling.
+                    properties:
+                      endpoints:
+                        description: 'EndpointsName is the endpoint name that details
+                          Glusterfs topology. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod'
+                        type: string
+                      path:
+                        description: 'Path is the Glusterfs volume path. More info:
+                          https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the Glusterfs volume
+                          to be mounted with read-only permissions. Defaults to false.
+                          More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod'
+                        type: boolean
+                    required:
+                    - endpoints
+                    - path
+                    type: object
+                  hostPath:
+                    description: Represents a host path mapped into a pod. Host path
+                      volumes do not support ownership management or SELinux relabeling.
+                    properties:
+                      path:
+                        description: 'Path of the directory on the host. If the path
+                          is a symlink, it will follow the link to the real path.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        type: string
+                      type:
+                        description: 'Type for HostPath Volume Defaults to "" More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        type: string
+                    required:
+                    - path
+                    type: object
+                  iscsi:
+                    description: Represents an ISCSI disk. ISCSI volumes can only
+                      be mounted as read/write once. ISCSI volumes support ownership
+                      management and SELinux relabeling.
+                    properties:
+                      chapAuthDiscovery:
+                        description: whether support iSCSI Discovery CHAP authentication
+                        type: boolean
+                      chapAuthSession:
+                        description: whether support iSCSI Session CHAP authentication
+                        type: boolean
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                        type: string
+                      initiatorName:
+                        description: Custom iSCSI Initiator Name. If initiatorName
+                          is specified with iscsiInterface simultaneously, new iSCSI
+                          interface <target portal>:<volume name> will be created
+                          for the connection.
+                        type: string
+                      iqn:
+                        description: Target iSCSI Qualified Name.
+                        type: string
+                      iscsiInterface:
+                        description: iSCSI Interface Name that uses an iSCSI transport.
+                          Defaults to 'default' (tcp).
+                        type: string
+                      lun:
+                        description: iSCSI Target Lun number.
+                        format: int32
+                        type: integer
+                      portals:
+                        description: iSCSI Target Portal List. The portal is either
+                          an IP or ip_addr:port if the port is other than default
+                          (typically TCP ports 860 and 3260).
+                        items:
+                          type: string
+                        type: array
+                      readOnly:
+                        description: ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false.
+                        type: boolean
+                      secretRef:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        type: object
+                      targetPortal:
+                        description: iSCSI Target Portal. The Portal is either an
+                          IP or ip_addr:port if the port is other than default (typically
+                          TCP ports 860 and 3260).
+                        type: string
+                    required:
+                    - targetPortal
+                    - iqn
+                    - lun
+                    type: object
+                  name:
+                    description: 'Volume''s name. Must be a DNS_LABEL and unique within
+                      the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  nfs:
+                    description: Represents an NFS mount that lasts the lifetime of
+                      a pod. NFS volumes do not support ownership management or SELinux
+                      relabeling.
+                    properties:
+                      path:
+                        description: 'Path that is exported by the NFS server. More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the NFS export to be
+                          mounted with read-only permissions. Defaults to false. More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: boolean
+                      server:
+                        description: 'Server is the hostname or IP address of the
+                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: string
+                    required:
+                    - server
+                    - path
+                    type: object
+                  persistentVolumeClaim:
+                    description: PersistentVolumeClaimVolumeSource references the
+                      user's PVC in the same namespace. This volume finds the bound
+                      PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource
+                      is, essentially, a wrapper around another type of volume that
+                      is owned by someone else (the system).
+                    properties:
+                      claimName:
+                        description: 'ClaimName is the name of a PersistentVolumeClaim
+                          in the same namespace as the pod using this volume. More
+                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        type: string
+                      readOnly:
+                        description: Will force the ReadOnly setting in VolumeMounts.
+                          Default false.
+                        type: boolean
+                    required:
+                    - claimName
+                    type: object
+                  photonPersistentDisk:
+                    description: Represents a Photon Controller persistent disk resource.
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      pdID:
+                        description: ID that identifies Photon Controller persistent
+                          disk
+                        type: string
+                    required:
+                    - pdID
+                    type: object
+                  portworxVolume:
+                    description: PortworxVolumeSource represents a Portworx volume
+                      resource.
+                    properties:
+                      fsType:
+                        description: FSType represents the filesystem type to mount
+                          Must be a filesystem type supported by the host operating
+                          system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                          if unspecified.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      volumeID:
+                        description: VolumeID uniquely identifies a Portworx volume
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  projected:
+                    description: Represents a projected volume source
+                    properties:
+                      defaultMode:
+                        description: Mode bits to use on created files by default.
+                          Must be a value between 0 and 0777. Directories within the
+                          path are not affected by this setting. This might be in
+                          conflict with other options that affect the file mode, like
+                          fsGroup, and the result can be other mode bits set.
+                        format: int32
+                        type: integer
+                      sources:
+                        description: list of volume projections
+                        items:
+                          description: Projection that may be projected along with
+                            other supported volume types
+                          properties:
+                            configMap:
+                              description: |-
+                                Adapts a ConfigMap into a projected volume.
+
+                                The contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.
+                              properties:
+                                items:
+                                  description: If unspecified, each key-value pair
+                                    in the Data field of the referenced ConfigMap
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the ConfigMap, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    keys must be defined
+                                  type: boolean
+                              type: object
+                            downwardAPI:
+                              description: Represents downward API info for projecting
+                                into a projected volume. Note that this is identical
+                                to a downwardAPI volume source without the default
+                                mode.
+                              properties:
+                                items:
+                                  description: Items is a list of DownwardAPIVolume
+                                    file
+                                  items:
+                                    description: DownwardAPIVolumeFile represents
+                                      information to create the file containing the
+                                      pod field
+                                    properties:
+                                      fieldRef:
+                                        description: ObjectFieldSelector selects an
+                                          APIVersioned field of an object.
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: 'Required: Path is  the relative
+                                          path name of the file to be created. Must
+                                          not be absolute or contain the ''..'' path.
+                                          Must be utf-8 encoded. The first item of
+                                          the relative path must not start with ''..'''
+                                        type: string
+                                      resourceFieldRef:
+                                        description: ResourceFieldSelector represents
+                                          container resources (cpu, memory) and their
+                                          output format
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor: {}
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                    required:
+                                    - path
+                                    type: object
+                                  type: array
+                              type: object
+                            secret:
+                              description: |-
+                                Adapts a secret into a projected volume.
+
+                                The contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.
+                              properties:
+                                items:
+                                  description: If unspecified, each key-value pair
+                                    in the Data field of the referenced Secret will
+                                    be projected into the volume as a file whose name
+                                    is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the Secret, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              type: object
+                            serviceAccountToken:
+                              description: ServiceAccountTokenProjection represents
+                                a projected service account token volume. This projection
+                                can be used to insert a service account token into
+                                the pods runtime filesystem for use against APIs (Kubernetes
+                                API Server or otherwise).
+                              properties:
+                                audience:
+                                  description: Audience is the intended audience of
+                                    the token. A recipient of a token must identify
+                                    itself with an identifier specified in the audience
+                                    of the token, and otherwise should reject the
+                                    token. The audience defaults to the identifier
+                                    of the apiserver.
+                                  type: string
+                                expirationSeconds:
+                                  description: ExpirationSeconds is the requested
+                                    duration of validity of the service account token.
+                                    As the token approaches expiration, the kubelet
+                                    volume plugin will proactively rotate the service
+                                    account token. The kubelet will start trying to
+                                    rotate the token if the token is older than 80
+                                    percent of its time to live or if the token is
+                                    older than 24 hours.Defaults to 1 hour and must
+                                    be at least 10 minutes.
+                                  format: int64
+                                  type: integer
+                                path:
+                                  description: Path is the path relative to the mount
+                                    point of the file to project the token into.
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                          type: object
+                        type: array
+                    required:
+                    - sources
+                    type: object
+                  quobyte:
+                    description: Represents a Quobyte mount that lasts the lifetime
+                      of a pod. Quobyte volumes do not support ownership management
+                      or SELinux relabeling.
+                    properties:
+                      group:
+                        description: Group to map volume access to Default is no group
+                        type: string
+                      readOnly:
+                        description: ReadOnly here will force the Quobyte volume to
+                          be mounted with read-only permissions. Defaults to false.
+                        type: boolean
+                      registry:
+                        description: Registry represents a single or multiple Quobyte
+                          Registry services specified as a string as host:port pair
+                          (multiple entries are separated with commas) which acts
+                          as the central registry for volumes
+                        type: string
+                      tenant:
+                        description: Tenant owning the given Quobyte volume in the
+                          Backend Used with dynamically provisioned Quobyte volumes,
+                          value is set by the plugin
+                        type: string
+                      user:
+                        description: User to map volume access to Defaults to serivceaccount
+                          user
+                        type: string
+                      volume:
+                        description: Volume is a string that references an already
+                          created Quobyte volume by name.
+                        type: string
+                    required:
+                    - registry
+                    - volume
+                    type: object
+                  rbd:
+                    description: Represents a Rados Block Device mount that lasts
+                      the lifetime of a pod. RBD volumes support ownership management
+                      and SELinux relabeling.
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                        type: string
+                      image:
+                        description: 'The rados image name. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      keyring:
+                        description: 'Keyring is the path to key ring for RBDUser.
+                          Default is /etc/ceph/keyring. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      monitors:
+                        description: 'A collection of Ceph monitors. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                        items:
+                          type: string
+                        type: array
+                      pool:
+                        description: 'The rados pool name. Default is rbd. More info:
+                          https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                        type: boolean
+                      secretRef:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        type: object
+                      user:
+                        description: 'The rados user name. Default is admin. More
+                          info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                    required:
+                    - monitors
+                    - image
+                    type: object
+                  scaleIO:
+                    description: ScaleIOVolumeSource represents a persistent ScaleIO
+                      volume
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Default is "xfs".
+                        type: string
+                      gateway:
+                        description: The host address of the ScaleIO API Gateway.
+                        type: string
+                      protectionDomain:
+                        description: The name of the ScaleIO Protection Domain for
+                          the configured storage.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretRef:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        type: object
+                      sslEnabled:
+                        description: Flag to enable/disable SSL communication with
+                          Gateway, default false
+                        type: boolean
+                      storageMode:
+                        description: Indicates whether the storage for a volume should
+                          be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                        type: string
+                      storagePool:
+                        description: The ScaleIO Storage Pool associated with the
+                          protection domain.
+                        type: string
+                      system:
+                        description: The name of the storage system as configured
+                          in ScaleIO.
+                        type: string
+                      volumeName:
+                        description: The name of a volume already created in the ScaleIO
+                          system that is associated with this volume source.
+                        type: string
+                    required:
+                    - gateway
+                    - system
+                    - secretRef
+                    type: object
+                  secret:
+                    description: |-
+                      Adapts a Secret into a volume.
+
+                      The contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: If unspecified, each key-value pair in the Data
+                          field of the referenced Secret will be projected into the
+                          volume as a file whose name is the key and content is the
+                          value. If specified, the listed keys will be projected into
+                          the specified paths, and unlisted keys will not be present.
+                          If a key is specified which is not present in the Secret,
+                          the volume setup will error unless it is marked optional.
+                          Paths must be relative and may not contain the '..' path
+                          or start with '..'.
+                        items:
+                          description: Maps a string key to a path within a volume.
+                          properties:
+                            key:
+                              description: The key to project.
+                              type: string
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              format: int32
+                              type: integer
+                            path:
+                              description: The relative path of the file to map the
+                                key to. May not be an absolute path. May not contain
+                                the path element '..'. May not start with the string
+                                '..'.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          type: object
+                        type: array
+                      optional:
+                        description: Specify whether the Secret or its keys must be
+                          defined
+                        type: boolean
+                      secretName:
+                        description: 'Name of the secret in the pod''s namespace to
+                          use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                        type: string
+                    type: object
+                  storageos:
+                    description: Represents a StorageOS persistent volume resource.
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretRef:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        type: object
+                      volumeName:
+                        description: VolumeName is the human-readable name of the
+                          StorageOS volume.  Volume names are only unique within a
+                          namespace.
+                        type: string
+                      volumeNamespace:
+                        description: VolumeNamespace specifies the scope of the volume
+                          within StorageOS.  If no namespace is specified then the
+                          Pod's namespace will be used.  This allows the Kubernetes
+                          name scoping to be mirrored within StorageOS for tighter
+                          integration. Set VolumeName to any name to override the
+                          default behaviour. Set to "default" if you are not using
+                          namespaces within StorageOS. Namespaces that do not pre-exist
+                          within StorageOS will be created.
+                        type: string
+                    type: object
+                  vsphereVolume:
+                    description: Represents a vSphere volume resource.
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      storagePolicyID:
+                        description: Storage Policy Based Management (SPBM) profile
+                          ID associated with the StoragePolicyName.
+                        type: string
+                      storagePolicyName:
+                        description: Storage Policy Based Management (SPBM) profile
+                          name.
+                        type: string
+                      volumePath:
+                        description: Path that identifies vSphere volume vmdk
+                        type: string
+                    required:
+                    - volumePath
+                    type: object
+                required:
+                - name
+                type: object
+              type: array
+          type: object
+        status:
+          description: 'AlertmanagerStatus is the most recent observed status of the
+            Alertmanager cluster. Read-only. Not included when requesting from the
+            apiserver, only from the Prometheus Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          properties:
+            availableReplicas:
+              description: Total number of available pods (ready for at least minReadySeconds)
+                targeted by this Alertmanager cluster.
+              format: int32
+              type: integer
+            paused:
+              description: Represents whether any actions on the underlaying managed
+                objects are being performed. Only delete actions will be performed.
+              type: boolean
+            replicas:
+              description: Total number of non-terminated pods targeted by this Alertmanager
+                cluster (their labels match the selector).
+              format: int32
+              type: integer
+            unavailableReplicas:
+              description: Total number of unavailable pods targeted by this Alertmanager
+                cluster.
+              format: int32
+              type: integer
+            updatedReplicas:
+              description: Total number of non-terminated pods targeted by this Alertmanager
+                cluster that have the desired version spec.
+              format: int32
+              type: integer
+          required:
+          - paused
+          - replicas
+          - updatedReplicas
+          - availableReplicas
+          - unavailableReplicas
+          type: object
+      type: object
+  version: v1
+{{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus-operator/crd-podmonitor.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/crd-podmonitor.yaml
@@ -1,0 +1,240 @@
+{{- if .Values.operator.enabled -}}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: podmonitors.monitoring.coreos.com
+  labels: {{- include "prometheus-operator.operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: monitoring.coreos.com
+  names:
+    kind: PodMonitor
+    plural: podmonitors
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        spec:
+          description: PodMonitorSpec contains specification parameters for a PodMonitor.
+          properties:
+            jobLabel:
+              description: The label to use to retrieve the job name from.
+              type: string
+            namespaceSelector:
+              description: NamespaceSelector is a selector for selecting either all
+                namespaces or a list of namespaces.
+              properties:
+                any:
+                  description: Boolean describing whether all namespaces are selected
+                    in contrast to a list restricting them.
+                  type: boolean
+                matchNames:
+                  description: List of namespace names.
+                  items:
+                    type: string
+                  type: array
+              type: object
+            podMetricsEndpoints:
+              description: A list of endpoints allowed as part of this PodMonitor.
+              items:
+                description: PodMetricsEndpoint defines a scrapeable endpoint of a
+                  Kubernetes Pod serving Prometheus metrics.
+                properties:
+                  honorLabels:
+                    description: HonorLabels chooses the metric's labels on collisions
+                      with target labels.
+                    type: boolean
+                  interval:
+                    description: Interval at which metrics should be scraped
+                    type: string
+                  metricRelabelings:
+                    description: MetricRelabelConfigs to apply to samples before ingestion.
+                    items:
+                      description: 'RelabelConfig allows dynamic rewriting of the
+                        label set, being applied to samples before ingestion. It defines
+                        `<metric_relabel_configs>`-section of Prometheus configuration.
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                      properties:
+                        action:
+                          description: Action to perform based on regex matching.
+                            Default is 'replace'
+                          type: string
+                        modulus:
+                          description: Modulus to take of the hash of the source label
+                            values.
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched. defailt is '(.*)'
+                          type: string
+                        replacement:
+                          description: Replacement value against which a regex replace
+                            is performed if the regular expression matches. Regex
+                            capture groups are available. Default is '$1'
+                          type: string
+                        separator:
+                          description: Separator placed between concatenated source
+                            label values. default is ';'.
+                          type: string
+                        sourceLabels:
+                          description: The source labels select values from existing
+                            labels. Their content is concatenated using the configured
+                            separator and matched against the configured regular expression
+                            for the replace, keep, and drop actions.
+                          items:
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: Label to which the resulting value is written
+                            in a replace action. It is mandatory for replace actions.
+                            Regex capture groups are available.
+                          type: string
+                      type: object
+                    type: array
+                  params:
+                    description: Optional HTTP URL parameters
+                    type: object
+                  path:
+                    description: HTTP path to scrape for metrics.
+                    type: string
+                  port:
+                    description: Name of the port this endpoint refers to. Mutually
+                      exclusive with targetPort.
+                    type: string
+                  proxyUrl:
+                    description: ProxyURL eg http://proxyserver:2195 Directs scrapes
+                      to proxy through this endpoint.
+                    type: string
+                  relabelings:
+                    description: 'RelabelConfigs to apply to samples before ingestion.
+                      More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                    items:
+                      description: 'RelabelConfig allows dynamic rewriting of the
+                        label set, being applied to samples before ingestion. It defines
+                        `<metric_relabel_configs>`-section of Prometheus configuration.
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                      properties:
+                        action:
+                          description: Action to perform based on regex matching.
+                            Default is 'replace'
+                          type: string
+                        modulus:
+                          description: Modulus to take of the hash of the source label
+                            values.
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched. defailt is '(.*)'
+                          type: string
+                        replacement:
+                          description: Replacement value against which a regex replace
+                            is performed if the regular expression matches. Regex
+                            capture groups are available. Default is '$1'
+                          type: string
+                        separator:
+                          description: Separator placed between concatenated source
+                            label values. default is ';'.
+                          type: string
+                        sourceLabels:
+                          description: The source labels select values from existing
+                            labels. Their content is concatenated using the configured
+                            separator and matched against the configured regular expression
+                            for the replace, keep, and drop actions.
+                          items:
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: Label to which the resulting value is written
+                            in a replace action. It is mandatory for replace actions.
+                            Regex capture groups are available.
+                          type: string
+                      type: object
+                    type: array
+                  scheme:
+                    description: HTTP scheme to use for scraping.
+                    type: string
+                  scrapeTimeout:
+                    description: Timeout after which the scrape is ended
+                    type: string
+                  targetPort:
+                    anyOf:
+                    - type: string
+                    - type: integer
+                type: object
+              type: array
+            podTargetLabels:
+              description: PodTargetLabels transfers labels on the Kubernetes Pod
+                onto the target.
+              items:
+                type: string
+              type: array
+            sampleLimit:
+              description: SampleLimit defines per-scrape limit on number of scraped
+                samples that will be accepted.
+              format: int64
+              type: integer
+            selector:
+              description: A label selector is a label query over a set of resources.
+                The result of matchLabels and matchExpressions are ANDed. An empty
+                label selector matches all objects. A null label selector matches
+                no objects.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+          required:
+          - podMetricsEndpoints
+          - selector
+          type: object
+      type: object
+  version: v1
+{{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus-operator/crd-prometheus.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/crd-prometheus.yaml
@@ -1,0 +1,5501 @@
+{{- if .Values.operator.enabled -}}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: prometheuses.monitoring.coreos.com
+  labels: {{- include "prometheus-operator.operator.labels" . | nindent 4}}
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: monitoring.coreos.com
+  names:
+    kind: Prometheus
+    plural: prometheuses
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        spec:
+          description: 'PrometheusSpec is a specification of the desired behavior
+            of the Prometheus cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          properties:
+            additionalAlertManagerConfigs:
+              description: SecretKeySelector selects a key of a Secret.
+              properties:
+                key:
+                  description: The key of the secret to select from.  Must be a valid
+                    secret key.
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                optional:
+                  description: Specify whether the Secret or its key must be defined
+                  type: boolean
+              required:
+              - key
+              type: object
+            additionalAlertRelabelConfigs:
+              description: SecretKeySelector selects a key of a Secret.
+              properties:
+                key:
+                  description: The key of the secret to select from.  Must be a valid
+                    secret key.
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                optional:
+                  description: Specify whether the Secret or its key must be defined
+                  type: boolean
+              required:
+              - key
+              type: object
+            additionalScrapeConfigs:
+              description: SecretKeySelector selects a key of a Secret.
+              properties:
+                key:
+                  description: The key of the secret to select from.  Must be a valid
+                    secret key.
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                optional:
+                  description: Specify whether the Secret or its key must be defined
+                  type: boolean
+              required:
+              - key
+              type: object
+            affinity:
+              description: Affinity is a group of affinity scheduling rules.
+              properties:
+                nodeAffinity:
+                  description: Node affinity is a group of node affinity scheduling
+                    rules.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node matches the corresponding matchExpressions; the
+                        node(s) with the highest sum are the most preferred.
+                      items:
+                        description: An empty preferred scheduling term matches all
+                          objects with implicit weight 0 (i.e. it's a no-op). A null
+                          preferred scheduling term matches no objects (i.e. is also
+                          a no-op).
+                        properties:
+                          preference:
+                            description: A null or empty node selector term matches
+                              no objects. The requirements of them are ANDed. The
+                              TopologySelectorTerm type implements a subset of the
+                              NodeSelectorTerm.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                            type: object
+                          weight:
+                            description: Weight associated with matching the corresponding
+                              nodeSelectorTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - weight
+                        - preference
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: A node selector represents the union of the results
+                        of one or more label queries over a set of nodes; that is,
+                        it represents the OR of the selectors represented by the node
+                        selector terms.
+                      properties:
+                        nodeSelectorTerms:
+                          description: Required. A list of node selector terms. The
+                            terms are ORed.
+                          items:
+                            description: A null or empty node selector term matches
+                              no objects. The requirements of them are ANDed. The
+                              TopologySelectorTerm type implements a subset of the
+                              NodeSelectorTerm.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements
+                                  by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements
+                                  by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the
+                                        operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be
+                                        empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will
+                                        be interpreted as an integer. This array is
+                                        replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                            type: object
+                          type: array
+                      required:
+                      - nodeSelectorTerms
+                      type: object
+                  type: object
+                podAffinity:
+                  description: Pod affinity is a group of inter pod affinity scheduling
+                    rules.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node has pods which matches the corresponding podAffinityTerm;
+                        the node(s) with the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: A label selector is a label query over
+                                  a set of resources. The result of matchLabels and
+                                  matchExpressions are ANDed. An empty label selector
+                                  matches all objects. A null label selector matches
+                                  no objects.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - weight
+                        - podAffinityTerm
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the affinity requirements specified by this
+                        field are not met at scheduling time, the pod will not be
+                        scheduled onto the node. If the affinity requirements specified
+                        by this field cease to be met at some point during pod execution
+                        (e.g. due to a pod label update), the system may or may not
+                        try to eventually evict the pod from its node. When there
+                        are multiple elements, the lists of nodes corresponding to
+                        each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label selector is a label query over a
+                              set of resources. The result of matchLabels and matchExpressions
+                              are ANDed. An empty label selector matches all objects.
+                              A null label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                        type: object
+                      type: array
+                  type: object
+                podAntiAffinity:
+                  description: Pod anti affinity is a group of inter pod anti affinity
+                    scheduling rules.
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the anti-affinity expressions specified by this
+                        field, but it may choose a node that violates one or more
+                        of the expressions. The node that is most preferred is the
+                        one with the greatest sum of weights, i.e. for each node that
+                        meets all of the scheduling requirements (resource request,
+                        requiredDuringScheduling anti-affinity expressions, etc.),
+                        compute a sum by iterating through the elements of this field
+                        and adding "weight" to the sum if the node has pods which
+                        matches the corresponding podAffinityTerm; the node(s) with
+                        the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: A label selector is a label query over
+                                  a set of resources. The result of matchLabels and
+                                  matchExpressions are ANDed. An empty label selector
+                                  matches all objects. A null label selector matches
+                                  no objects.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - weight
+                        - podAffinityTerm
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the anti-affinity requirements specified by
+                        this field are not met at scheduling time, the pod will not
+                        be scheduled onto the node. If the anti-affinity requirements
+                        specified by this field cease to be met at some point during
+                        pod execution (e.g. due to a pod label update), the system
+                        may or may not try to eventually evict the pod from its node.
+                        When there are multiple elements, the lists of nodes corresponding
+                        to each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label selector is a label query over a
+                              set of resources. The result of matchLabels and matchExpressions
+                              are ANDed. An empty label selector matches all objects.
+                              A null label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                        type: object
+                      type: array
+                  type: object
+              type: object
+            alerting:
+              description: AlertingSpec defines parameters for alerting configuration
+                of Prometheus servers.
+              properties:
+                alertmanagers:
+                  description: AlertmanagerEndpoints Prometheus should fire alerts
+                    against.
+                  items:
+                    description: AlertmanagerEndpoints defines a selection of a single
+                      Endpoints object containing alertmanager IPs to fire alerts
+                      against.
+                    properties:
+                      bearerTokenFile:
+                        description: BearerTokenFile to read from filesystem to use
+                          when authenticating to Alertmanager.
+                        type: string
+                      name:
+                        description: Name of Endpoints object in Namespace.
+                        type: string
+                      namespace:
+                        description: Namespace of Endpoints object.
+                        type: string
+                      pathPrefix:
+                        description: Prefix for the HTTP path alerts are pushed to.
+                        type: string
+                      port:
+                        anyOf:
+                        - type: string
+                        - type: integer
+                      scheme:
+                        description: Scheme to use when firing alerts.
+                        type: string
+                      tlsConfig:
+                        description: TLSConfig specifies TLS configuration parameters.
+                        properties:
+                          caFile:
+                            description: The CA cert to use for the targets.
+                            type: string
+                          certFile:
+                            description: The client cert file for the targets.
+                            type: string
+                          insecureSkipVerify:
+                            description: Disable target certificate validation.
+                            type: boolean
+                          keyFile:
+                            description: The client key file for the targets.
+                            type: string
+                          serverName:
+                            description: Used to verify the hostname for the targets.
+                            type: string
+                        type: object
+                    required:
+                    - namespace
+                    - name
+                    - port
+                    type: object
+                  type: array
+              required:
+              - alertmanagers
+              type: object
+            apiserverConfig:
+              description: 'APIServerConfig defines a host and auth methods to access
+                apiserver. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config'
+              properties:
+                basicAuth:
+                  description: 'BasicAuth allow an endpoint to authenticate over basic
+                    authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                  properties:
+                    password:
+                      description: SecretKeySelector selects a key of a Secret.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                    username:
+                      description: SecretKeySelector selects a key of a Secret.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                  type: object
+                bearerToken:
+                  description: Bearer token for accessing apiserver.
+                  type: string
+                bearerTokenFile:
+                  description: File to read bearer token for accessing apiserver.
+                  type: string
+                host:
+                  description: Host of apiserver. A valid string consisting of a hostname
+                    or IP followed by an optional port number
+                  type: string
+                tlsConfig:
+                  description: TLSConfig specifies TLS configuration parameters.
+                  properties:
+                    caFile:
+                      description: The CA cert to use for the targets.
+                      type: string
+                    certFile:
+                      description: The client cert file for the targets.
+                      type: string
+                    insecureSkipVerify:
+                      description: Disable target certificate validation.
+                      type: boolean
+                    keyFile:
+                      description: The client key file for the targets.
+                      type: string
+                    serverName:
+                      description: Used to verify the hostname for the targets.
+                      type: string
+                  type: object
+              required:
+              - host
+              type: object
+            baseImage:
+              description: Base image to use for a Prometheus deployment.
+              type: string
+            configMaps:
+              description: ConfigMaps is a list of ConfigMaps in the same namespace
+                as the Prometheus object, which shall be mounted into the Prometheus
+                Pods. The ConfigMaps are mounted into /etc/prometheus/configmaps/<configmap-name>.
+              items:
+                type: string
+              type: array
+            containers:
+              description: 'Containers allows injecting additional containers or modifying
+                operator generated containers. This can be used to allow adding an
+                authentication proxy to a Prometheus pod or to change the behavior
+                of an operator generated container. Containers described here modify
+                an operator generated container if they share the same name and modifications
+                are done via a strategic merge patch. The current container names
+                are: `prometheus`, `prometheus-config-reloader`, `rules-configmap-reloader`,
+                and `thanos-sidecar`. Overriding containers is entirely outside the
+                scope of what the maintainers will support and by doing so, you accept
+                that this behaviour may break at any time without notice.'
+              items:
+                description: A single application container that you want to run within
+                  a pod.
+                properties:
+                  args:
+                    description: 'Arguments to the entrypoint. The docker image''s
+                      CMD is used if this is not provided. Variable references $(VAR_NAME)
+                      are expanded using the container''s environment. If a variable
+                      cannot be resolved, the reference in the input string will be
+                      unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                      $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                      regardless of whether the variable exists or not. Cannot be
+                      updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    description: 'Entrypoint array. Not executed within a shell. The
+                      docker image''s ENTRYPOINT is used if this is not provided.
+                      Variable references $(VAR_NAME) are expanded using the container''s
+                      environment. If a variable cannot be resolved, the reference
+                      in the input string will be unchanged. The $(VAR_NAME) syntax
+                      can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                      will never be expanded, regardless of whether the variable exists
+                      or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    description: List of environment variables to set in the container.
+                      Cannot be updated.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: EnvVarSource represents a source for the value
+                            of an EnvVar.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key from a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: ObjectFieldSelector selects an APIVersioned
+                                field of an object.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: ResourceFieldSelector represents container
+                                resources (cpu, memory) and their output format
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor: {}
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  envFrom:
+                    description: List of sources to populate environment variables
+                      in the container. The keys defined within a source must be a
+                      C_IDENTIFIER. All invalid keys will be reported as an event
+                      when the container is starting. When a key exists in multiple
+                      sources, the value associated with the last source will take
+                      precedence. Values defined by an Env with a duplicate key will
+                      take precedence. Cannot be updated.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: |-
+                            ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
+
+                            The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: |-
+                            SecretEnvSource selects a Secret to populate the environment variables with.
+
+                            The contents of the target Secret's Data field will represent the key-value pairs as environment variables.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                      type: object
+                    type: array
+                  image:
+                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                      This field is optional to allow higher level config management
+                      to default or override container images in workload controllers
+                      like Deployments and StatefulSets.'
+                    type: string
+                  imagePullPolicy:
+                    description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                      Defaults to Always if :latest tag is specified, or IfNotPresent
+                      otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                    type: string
+                  lifecycle:
+                    description: Lifecycle describes actions that the management system
+                      should take in response to container lifecycle events. For the
+                      PostStart and PreStop lifecycle handlers, management of the
+                      container blocks until the action is complete, unless the container
+                      process fails, in which case the handler is aborted.
+                    properties:
+                      postStart:
+                        description: Handler defines a specific action that should
+                          be taken
+                        properties:
+                          exec:
+                            description: ExecAction describes a "run in container"
+                              action.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGetAction describes an action based on
+                              HTTP Get requests.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          tcpSocket:
+                            description: TCPSocketAction describes an action based
+                              on opening a socket
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                            required:
+                            - port
+                            type: object
+                        type: object
+                      preStop:
+                        description: Handler defines a specific action that should
+                          be taken
+                        properties:
+                          exec:
+                            description: ExecAction describes a "run in container"
+                              action.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGetAction describes an action based on
+                              HTTP Get requests.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          tcpSocket:
+                            description: TCPSocketAction describes an action based
+                              on opening a socket
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                            required:
+                            - port
+                            type: object
+                        type: object
+                    type: object
+                  livenessProbe:
+                    description: Probe describes a health check to be performed against
+                      a container to determine whether it is alive or ready to receive
+                      traffic.
+                    properties:
+                      exec:
+                        description: ExecAction describes a "run in container" action.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGetAction describes an action based on HTTP
+                          Get requests.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocketAction describes an action based on
+                          opening a socket
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                        required:
+                        - port
+                        type: object
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                    type: object
+                  name:
+                    description: Name of the container specified as a DNS_LABEL. Each
+                      container in a pod must have a unique name (DNS_LABEL). Cannot
+                      be updated.
+                    type: string
+                  ports:
+                    description: List of ports to expose from the container. Exposing
+                      a port here gives the system additional information about the
+                      network connections a container uses, but is primarily informational.
+                      Not specifying a port here DOES NOT prevent that port from being
+                      exposed. Any port which is listening on the default "0.0.0.0"
+                      address inside a container will be accessible from the network.
+                      Cannot be updated.
+                    items:
+                      description: ContainerPort represents a network port in a single
+                        container.
+                      properties:
+                        containerPort:
+                          description: Number of port to expose on the pod's IP address.
+                            This must be a valid port number, 0 < x < 65536.
+                          format: int32
+                          type: integer
+                        hostIP:
+                          description: What host IP to bind the external port to.
+                          type: string
+                        hostPort:
+                          description: Number of port to expose on the host. If specified,
+                            this must be a valid port number, 0 < x < 65536. If HostNetwork
+                            is specified, this must match ContainerPort. Most containers
+                            do not need this.
+                          format: int32
+                          type: integer
+                        name:
+                          description: If specified, this must be an IANA_SVC_NAME
+                            and unique within the pod. Each named port in a pod must
+                            have a unique name. Name for the port that can be referred
+                            to by services.
+                          type: string
+                        protocol:
+                          description: Protocol for port. Must be UDP, TCP, or SCTP.
+                            Defaults to "TCP".
+                          type: string
+                      required:
+                      - containerPort
+                      type: object
+                    type: array
+                  readinessProbe:
+                    description: Probe describes a health check to be performed against
+                      a container to determine whether it is alive or ready to receive
+                      traffic.
+                    properties:
+                      exec:
+                        description: ExecAction describes a "run in container" action.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGetAction describes an action based on HTTP
+                          Get requests.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocketAction describes an action based on
+                          opening a socket
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                        required:
+                        - port
+                        type: object
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                    type: object
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  securityContext:
+                    description: SecurityContext holds security configuration that
+                      will be applied to a container. Some fields are present in both
+                      SecurityContext and PodSecurityContext.  When both are set,
+                      the values in SecurityContext take precedence.
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: Adds and removes POSIX capabilities from running
+                          containers.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: SELinuxOptions are the labels to be applied to
+                          the container
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      windowsOptions:
+                        description: WindowsSecurityContextOptions contain Windows-specific
+                          options and credentials.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                        type: object
+                    type: object
+                  stdin:
+                    description: Whether this container should allocate a buffer for
+                      stdin in the container runtime. If this is not set, reads from
+                      stdin in the container will always result in EOF. Default is
+                      false.
+                    type: boolean
+                  stdinOnce:
+                    description: Whether the container runtime should close the stdin
+                      channel after it has been opened by a single attach. When stdin
+                      is true the stdin stream will remain open across multiple attach
+                      sessions. If stdinOnce is set to true, stdin is opened on container
+                      start, is empty until the first client attaches to stdin, and
+                      then remains open and accepts data until the client disconnects,
+                      at which time stdin is closed and remains closed until the container
+                      is restarted. If this flag is false, a container processes that
+                      reads from stdin will never receive an EOF. Default is false
+                    type: boolean
+                  terminationMessagePath:
+                    description: 'Optional: Path at which the file to which the container''s
+                      termination message will be written is mounted into the container''s
+                      filesystem. Message written is intended to be brief final status,
+                      such as an assertion failure message. Will be truncated by the
+                      node if greater than 4096 bytes. The total message length across
+                      all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                      Cannot be updated.'
+                    type: string
+                  terminationMessagePolicy:
+                    description: Indicate how the termination message should be populated.
+                      File will use the contents of terminationMessagePath to populate
+                      the container status message on both success and failure. FallbackToLogsOnError
+                      will use the last chunk of container log output if the termination
+                      message file is empty and the container exited with an error.
+                      The log output is limited to 2048 bytes or 80 lines, whichever
+                      is smaller. Defaults to File. Cannot be updated.
+                    type: string
+                  tty:
+                    description: Whether this container should allocate a TTY for
+                      itself, also requires 'stdin' to be true. Default is false.
+                    type: boolean
+                  volumeDevices:
+                    description: volumeDevices is the list of block devices to be
+                      used by the container. This is a beta feature.
+                    items:
+                      description: volumeDevice describes a mapping of a raw block
+                        device within a container.
+                      properties:
+                        devicePath:
+                          description: devicePath is the path inside of the container
+                            that the device will be mapped to.
+                          type: string
+                        name:
+                          description: name must match the name of a persistentVolumeClaim
+                            in the pod
+                          type: string
+                      required:
+                      - name
+                      - devicePath
+                      type: object
+                    type: array
+                  volumeMounts:
+                    description: Pod volumes to mount into the container's filesystem.
+                      Cannot be updated.
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      properties:
+                        mountPath:
+                          description: Path within the container at which the volume
+                            should be mounted.  Must not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: mountPropagation determines how mounts are
+                            propagated from the host to container and the other way
+                            around. When not set, MountPropagationNone is used. This
+                            field is beta in 1.10.
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: Mounted read-only if true, read-write otherwise
+                            (false or unspecified). Defaults to false.
+                          type: boolean
+                        subPath:
+                          description: Path within the volume from which the container's
+                            volume should be mounted. Defaults to "" (volume's root).
+                          type: string
+                        subPathExpr:
+                          description: Expanded path within the volume from which
+                            the container's volume should be mounted. Behaves similarly
+                            to SubPath but environment variable references $(VAR_NAME)
+                            are expanded using the container's environment. Defaults
+                            to "" (volume's root). SubPathExpr and SubPath are mutually
+                            exclusive. This field is beta in 1.15.
+                          type: string
+                      required:
+                      - name
+                      - mountPath
+                      type: object
+                    type: array
+                  workingDir:
+                    description: Container's working directory. If not specified,
+                      the container runtime's default will be used, which might be
+                      configured in the container image. Cannot be updated.
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            enableAdminAPI:
+              description: 'Enable access to prometheus web admin API. Defaults to
+                the value of `false`. WARNING: Enabling the admin APIs enables mutating
+                endpoints, to delete data, shutdown Prometheus, and more. Enabling
+                this should be done with care and the user is advised to add additional
+                authentication authorization via a proxy to ensure only clients authorized
+                to perform these actions can do so. For more information see https://prometheus.io/docs/prometheus/latest/querying/api/#tsdb-admin-apis'
+              type: boolean
+            evaluationInterval:
+              description: Interval between consecutive evaluations.
+              type: string
+            externalLabels:
+              description: The labels to add to any time series or alerts when communicating
+                with external systems (federation, remote storage, Alertmanager).
+              type: object
+            externalUrl:
+              description: The external URL the Prometheus instances will be available
+                under. This is necessary to generate correct URLs. This is necessary
+                if Prometheus is not served from root of a DNS name.
+              type: string
+            image:
+              description: Image if specified has precedence over baseImage, tag and
+                sha combinations. Specifying the version is still necessary to ensure
+                the Prometheus Operator knows what version of Prometheus is being
+                configured.
+              type: string
+            imagePullSecrets:
+              description: An optional list of references to secrets in the same namespace
+                to use for pulling prometheus and alertmanager images from registries
+                see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod
+              items:
+                description: LocalObjectReference contains enough information to let
+                  you locate the referenced object inside the same namespace.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                type: object
+              type: array
+            initContainers:
+              description: 'InitContainers allows adding initContainers to the pod
+                definition. Those can be used to e.g. fetch secrets for injection
+                into the Prometheus configuration from external sources. Any errors
+                during the execution of an initContainer will lead to a restart of
+                the Pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+                Using initContainers for any use case other then secret fetching is
+                entirely outside the scope of what the maintainers will support and
+                by doing so, you accept that this behaviour may break at any time
+                without notice.'
+              items:
+                description: A single application container that you want to run within
+                  a pod.
+                properties:
+                  args:
+                    description: 'Arguments to the entrypoint. The docker image''s
+                      CMD is used if this is not provided. Variable references $(VAR_NAME)
+                      are expanded using the container''s environment. If a variable
+                      cannot be resolved, the reference in the input string will be
+                      unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                      $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                      regardless of whether the variable exists or not. Cannot be
+                      updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    description: 'Entrypoint array. Not executed within a shell. The
+                      docker image''s ENTRYPOINT is used if this is not provided.
+                      Variable references $(VAR_NAME) are expanded using the container''s
+                      environment. If a variable cannot be resolved, the reference
+                      in the input string will be unchanged. The $(VAR_NAME) syntax
+                      can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                      will never be expanded, regardless of whether the variable exists
+                      or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    description: List of environment variables to set in the container.
+                      Cannot be updated.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: EnvVarSource represents a source for the value
+                            of an EnvVar.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key from a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: ObjectFieldSelector selects an APIVersioned
+                                field of an object.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: ResourceFieldSelector represents container
+                                resources (cpu, memory) and their output format
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor: {}
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  envFrom:
+                    description: List of sources to populate environment variables
+                      in the container. The keys defined within a source must be a
+                      C_IDENTIFIER. All invalid keys will be reported as an event
+                      when the container is starting. When a key exists in multiple
+                      sources, the value associated with the last source will take
+                      precedence. Values defined by an Env with a duplicate key will
+                      take precedence. Cannot be updated.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: |-
+                            ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
+
+                            The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: |-
+                            SecretEnvSource selects a Secret to populate the environment variables with.
+
+                            The contents of the target Secret's Data field will represent the key-value pairs as environment variables.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                      type: object
+                    type: array
+                  image:
+                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                      This field is optional to allow higher level config management
+                      to default or override container images in workload controllers
+                      like Deployments and StatefulSets.'
+                    type: string
+                  imagePullPolicy:
+                    description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                      Defaults to Always if :latest tag is specified, or IfNotPresent
+                      otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                    type: string
+                  lifecycle:
+                    description: Lifecycle describes actions that the management system
+                      should take in response to container lifecycle events. For the
+                      PostStart and PreStop lifecycle handlers, management of the
+                      container blocks until the action is complete, unless the container
+                      process fails, in which case the handler is aborted.
+                    properties:
+                      postStart:
+                        description: Handler defines a specific action that should
+                          be taken
+                        properties:
+                          exec:
+                            description: ExecAction describes a "run in container"
+                              action.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGetAction describes an action based on
+                              HTTP Get requests.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          tcpSocket:
+                            description: TCPSocketAction describes an action based
+                              on opening a socket
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                            required:
+                            - port
+                            type: object
+                        type: object
+                      preStop:
+                        description: Handler defines a specific action that should
+                          be taken
+                        properties:
+                          exec:
+                            description: ExecAction describes a "run in container"
+                              action.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGetAction describes an action based on
+                              HTTP Get requests.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          tcpSocket:
+                            description: TCPSocketAction describes an action based
+                              on opening a socket
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: string
+                                - type: integer
+                            required:
+                            - port
+                            type: object
+                        type: object
+                    type: object
+                  livenessProbe:
+                    description: Probe describes a health check to be performed against
+                      a container to determine whether it is alive or ready to receive
+                      traffic.
+                    properties:
+                      exec:
+                        description: ExecAction describes a "run in container" action.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGetAction describes an action based on HTTP
+                          Get requests.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocketAction describes an action based on
+                          opening a socket
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                        required:
+                        - port
+                        type: object
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                    type: object
+                  name:
+                    description: Name of the container specified as a DNS_LABEL. Each
+                      container in a pod must have a unique name (DNS_LABEL). Cannot
+                      be updated.
+                    type: string
+                  ports:
+                    description: List of ports to expose from the container. Exposing
+                      a port here gives the system additional information about the
+                      network connections a container uses, but is primarily informational.
+                      Not specifying a port here DOES NOT prevent that port from being
+                      exposed. Any port which is listening on the default "0.0.0.0"
+                      address inside a container will be accessible from the network.
+                      Cannot be updated.
+                    items:
+                      description: ContainerPort represents a network port in a single
+                        container.
+                      properties:
+                        containerPort:
+                          description: Number of port to expose on the pod's IP address.
+                            This must be a valid port number, 0 < x < 65536.
+                          format: int32
+                          type: integer
+                        hostIP:
+                          description: What host IP to bind the external port to.
+                          type: string
+                        hostPort:
+                          description: Number of port to expose on the host. If specified,
+                            this must be a valid port number, 0 < x < 65536. If HostNetwork
+                            is specified, this must match ContainerPort. Most containers
+                            do not need this.
+                          format: int32
+                          type: integer
+                        name:
+                          description: If specified, this must be an IANA_SVC_NAME
+                            and unique within the pod. Each named port in a pod must
+                            have a unique name. Name for the port that can be referred
+                            to by services.
+                          type: string
+                        protocol:
+                          description: Protocol for port. Must be UDP, TCP, or SCTP.
+                            Defaults to "TCP".
+                          type: string
+                      required:
+                      - containerPort
+                      type: object
+                    type: array
+                  readinessProbe:
+                    description: Probe describes a health check to be performed against
+                      a container to determine whether it is alive or ready to receive
+                      traffic.
+                    properties:
+                      exec:
+                        description: ExecAction describes a "run in container" action.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGetAction describes an action based on HTTP
+                          Get requests.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocketAction describes an action based on
+                          opening a socket
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                        required:
+                        - port
+                        type: object
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                    type: object
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  securityContext:
+                    description: SecurityContext holds security configuration that
+                      will be applied to a container. Some fields are present in both
+                      SecurityContext and PodSecurityContext.  When both are set,
+                      the values in SecurityContext take precedence.
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: Adds and removes POSIX capabilities from running
+                          containers.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: SELinuxOptions are the labels to be applied to
+                          the container
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      windowsOptions:
+                        description: WindowsSecurityContextOptions contain Windows-specific
+                          options and credentials.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use. This field is alpha-level
+                              and is only honored by servers that enable the WindowsGMSA
+                              feature flag.
+                            type: string
+                        type: object
+                    type: object
+                  stdin:
+                    description: Whether this container should allocate a buffer for
+                      stdin in the container runtime. If this is not set, reads from
+                      stdin in the container will always result in EOF. Default is
+                      false.
+                    type: boolean
+                  stdinOnce:
+                    description: Whether the container runtime should close the stdin
+                      channel after it has been opened by a single attach. When stdin
+                      is true the stdin stream will remain open across multiple attach
+                      sessions. If stdinOnce is set to true, stdin is opened on container
+                      start, is empty until the first client attaches to stdin, and
+                      then remains open and accepts data until the client disconnects,
+                      at which time stdin is closed and remains closed until the container
+                      is restarted. If this flag is false, a container processes that
+                      reads from stdin will never receive an EOF. Default is false
+                    type: boolean
+                  terminationMessagePath:
+                    description: 'Optional: Path at which the file to which the container''s
+                      termination message will be written is mounted into the container''s
+                      filesystem. Message written is intended to be brief final status,
+                      such as an assertion failure message. Will be truncated by the
+                      node if greater than 4096 bytes. The total message length across
+                      all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                      Cannot be updated.'
+                    type: string
+                  terminationMessagePolicy:
+                    description: Indicate how the termination message should be populated.
+                      File will use the contents of terminationMessagePath to populate
+                      the container status message on both success and failure. FallbackToLogsOnError
+                      will use the last chunk of container log output if the termination
+                      message file is empty and the container exited with an error.
+                      The log output is limited to 2048 bytes or 80 lines, whichever
+                      is smaller. Defaults to File. Cannot be updated.
+                    type: string
+                  tty:
+                    description: Whether this container should allocate a TTY for
+                      itself, also requires 'stdin' to be true. Default is false.
+                    type: boolean
+                  volumeDevices:
+                    description: volumeDevices is the list of block devices to be
+                      used by the container. This is a beta feature.
+                    items:
+                      description: volumeDevice describes a mapping of a raw block
+                        device within a container.
+                      properties:
+                        devicePath:
+                          description: devicePath is the path inside of the container
+                            that the device will be mapped to.
+                          type: string
+                        name:
+                          description: name must match the name of a persistentVolumeClaim
+                            in the pod
+                          type: string
+                      required:
+                      - name
+                      - devicePath
+                      type: object
+                    type: array
+                  volumeMounts:
+                    description: Pod volumes to mount into the container's filesystem.
+                      Cannot be updated.
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      properties:
+                        mountPath:
+                          description: Path within the container at which the volume
+                            should be mounted.  Must not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: mountPropagation determines how mounts are
+                            propagated from the host to container and the other way
+                            around. When not set, MountPropagationNone is used. This
+                            field is beta in 1.10.
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: Mounted read-only if true, read-write otherwise
+                            (false or unspecified). Defaults to false.
+                          type: boolean
+                        subPath:
+                          description: Path within the volume from which the container's
+                            volume should be mounted. Defaults to "" (volume's root).
+                          type: string
+                        subPathExpr:
+                          description: Expanded path within the volume from which
+                            the container's volume should be mounted. Behaves similarly
+                            to SubPath but environment variable references $(VAR_NAME)
+                            are expanded using the container's environment. Defaults
+                            to "" (volume's root). SubPathExpr and SubPath are mutually
+                            exclusive. This field is beta in 1.15.
+                          type: string
+                      required:
+                      - name
+                      - mountPath
+                      type: object
+                    type: array
+                  workingDir:
+                    description: Container's working directory. If not specified,
+                      the container runtime's default will be used, which might be
+                      configured in the container image. Cannot be updated.
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            listenLocal:
+              description: ListenLocal makes the Prometheus server listen on loopback,
+                so that it does not bind against the Pod IP.
+              type: boolean
+            logFormat:
+              description: Log format for Prometheus to be configured with.
+              type: string
+            logLevel:
+              description: Log level for Prometheus to be configured with.
+              type: string
+            nodeSelector:
+              description: Define which Nodes the Pods are scheduled on.
+              type: object
+            paused:
+              description: When a Prometheus deployment is paused, no actions except
+                for deletion will be performed on the underlying objects.
+              type: boolean
+            podMetadata:
+              description: ObjectMeta is metadata that all persisted resources must
+                have, which includes all objects users must create.
+              properties:
+                annotations:
+                  description: 'Annotations is an unstructured key value map stored
+                    with a resource that may be set by external tools to store and
+                    retrieve arbitrary metadata. They are not queryable and should
+                    be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                  type: object
+                clusterName:
+                  description: The name of the cluster which the object belongs to.
+                    This is used to distinguish resources with same name and namespace
+                    in different clusters. This field is not set anywhere right now
+                    and apiserver is going to ignore it if set in create or update
+                    request.
+                  type: string
+                creationTimestamp:
+                  description: Time is a wrapper around time.Time which supports correct
+                    marshaling to YAML and JSON.  Wrappers are provided for many of
+                    the factory methods that the time package offers.
+                  format: date-time
+                  type: string
+                deletionGracePeriodSeconds:
+                  description: Number of seconds allowed for this object to gracefully
+                    terminate before it will be removed from the system. Only set
+                    when deletionTimestamp is also set. May only be shortened. Read-only.
+                  format: int64
+                  type: integer
+                deletionTimestamp:
+                  description: Time is a wrapper around time.Time which supports correct
+                    marshaling to YAML and JSON.  Wrappers are provided for many of
+                    the factory methods that the time package offers.
+                  format: date-time
+                  type: string
+                finalizers:
+                  description: Must be empty before the object is deleted from the
+                    registry. Each entry is an identifier for the responsible component
+                    that will remove the entry from the list. If the deletionTimestamp
+                    of the object is non-nil, entries in this list can only be removed.
+                  items:
+                    type: string
+                  type: array
+                generateName:
+                  description: |-
+                    GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
+                    If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+
+                    Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+                  type: string
+                generation:
+                  description: A sequence number representing a specific generation
+                    of the desired state. Populated by the system. Read-only.
+                  format: int64
+                  type: integer
+                initializers:
+                  description: Initializers tracks the progress of initialization.
+                  properties:
+                    pending:
+                      description: Pending is a list of initializers that must execute
+                        in order before this object is visible. When the last pending
+                        initializer is removed, and no failing result is set, the
+                        initializers struct will be set to nil and the object is considered
+                        as initialized and visible to all clients.
+                      items:
+                        description: Initializer is information about an initializer
+                          that has not yet completed.
+                        properties:
+                          name:
+                            description: name of the process that is responsible for
+                              initializing this object.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    result:
+                      description: Status is a return value for calls that don't return
+                        other objects.
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of
+                            this representation of an object. Servers should convert
+                            recognized schemas to the latest internal value, and may
+                            reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                          type: string
+                        code:
+                          description: Suggested HTTP return code for this status,
+                            0 if not set.
+                          format: int32
+                          type: integer
+                        details:
+                          description: StatusDetails is a set of additional properties
+                            that MAY be set by the server to provide additional information
+                            about a response. The Reason field of a Status object
+                            defines what attributes will be set. Clients must ignore
+                            fields that do not match the defined type of each attribute,
+                            and should assume that any attribute may be empty, invalid,
+                            or under defined.
+                          properties:
+                            causes:
+                              description: The Causes array includes more details
+                                associated with the StatusReason failure. Not all
+                                StatusReasons may provide detailed causes.
+                              items:
+                                description: StatusCause provides more information
+                                  about an api.Status failure, including cases when
+                                  multiple errors are encountered.
+                                properties:
+                                  field:
+                                    description: |-
+                                      The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+
+                                      Examples:
+                                        "name" - the field "name" on the current resource
+                                        "items[0].name" - the field "name" on the first array entry in "items"
+                                    type: string
+                                  message:
+                                    description: A human-readable description of the
+                                      cause of the error.  This field may be presented
+                                      as-is to a reader.
+                                    type: string
+                                  reason:
+                                    description: A machine-readable description of
+                                      the cause of the error. If this value is empty
+                                      there is no information available.
+                                    type: string
+                                type: object
+                              type: array
+                            group:
+                              description: The group attribute of the resource associated
+                                with the status StatusReason.
+                              type: string
+                            kind:
+                              description: 'The kind attribute of the resource associated
+                                with the status StatusReason. On some operations may
+                                differ from the requested resource Kind. More info:
+                                https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: The name attribute of the resource associated
+                                with the status StatusReason (when there is a single
+                                name which can be described).
+                              type: string
+                            retryAfterSeconds:
+                              description: If specified, the time in seconds before
+                                the operation should be retried. Some errors may indicate
+                                the client must take an alternate action - for those
+                                errors this field may indicate how long to wait before
+                                taking the alternate action.
+                              format: int32
+                              type: integer
+                            uid:
+                              description: 'UID of the resource. (when there is a
+                                single resource which can be described). More info:
+                                http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                          type: object
+                        kind:
+                          description: 'Kind is a string value representing the REST
+                            resource this object represents. Servers may infer this
+                            from the endpoint the client submits requests to. Cannot
+                            be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                          type: string
+                        message:
+                          description: A human-readable description of the status
+                            of this operation.
+                          type: string
+                        metadata:
+                          description: ListMeta describes metadata that synthetic
+                            resources must have, including lists and various status
+                            objects. A resource may have only one of {ObjectMeta,
+                            ListMeta}.
+                          properties:
+                            continue:
+                              description: continue may be set if the user set a limit
+                                on the number of items returned, and indicates that
+                                the server has more data available. The value is opaque
+                                and may be used to issue another request to the endpoint
+                                that served this list to retrieve the next set of
+                                available objects. Continuing a consistent list may
+                                not be possible if the server configuration has changed
+                                or more than a few minutes have passed. The resourceVersion
+                                field returned when using this continue value will
+                                be identical to the value in the first response, unless
+                                you have received this token from an error message.
+                              type: string
+                            remainingItemCount:
+                              description: |-
+                                remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.
+
+                                This field is alpha and can be changed or removed without notice.
+                              format: int64
+                              type: integer
+                            resourceVersion:
+                              description: 'String that identifies the server''s internal
+                                version of this object that can be used by clients
+                                to determine when objects have changed. Value must
+                                be treated as opaque by clients and passed unmodified
+                                back to the server. Populated by the system. Read-only.
+                                More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            selfLink:
+                              description: selfLink is a URL representing this object.
+                                Populated by the system. Read-only.
+                              type: string
+                          type: object
+                        reason:
+                          description: A machine-readable description of why this
+                            operation is in the "Failure" status. If this value is
+                            empty there is no information available. A Reason clarifies
+                            an HTTP status code but does not override it.
+                          type: string
+                        status:
+                          description: 'Status of the operation. One of: "Success"
+                            or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                          type: string
+                      type: object
+                  required:
+                  - pending
+                  type: object
+                labels:
+                  description: 'Map of string keys and values that can be used to
+                    organize and categorize (scope and select) objects. May match
+                    selectors of replication controllers and services. More info:
+                    http://kubernetes.io/docs/user-guide/labels'
+                  type: object
+                managedFields:
+                  description: |-
+                    ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+
+                    This field is alpha and can be changed or removed without notice.
+                  items:
+                    description: ManagedFieldsEntry is a workflow-id, a FieldSet and
+                      the group version of the resource that the fieldset applies
+                      to.
+                    properties:
+                      apiVersion:
+                        description: APIVersion defines the version of this resource
+                          that this field set applies to. The format is "group/version"
+                          just like the top-level APIVersion field. It is necessary
+                          to track the version of a field set because it cannot be
+                          automatically converted.
+                        type: string
+                      fields:
+                        description: 'Fields stores a set of fields in a data structure
+                          like a Trie. To understand how this is used, see: https://github.com/kubernetes-sigs/structured-merge-diff'
+                        type: object
+                      manager:
+                        description: Manager is an identifier of the workflow managing
+                          these fields.
+                        type: string
+                      operation:
+                        description: Operation is the type of operation which lead
+                          to this ManagedFieldsEntry being created. The only valid
+                          values for this field are 'Apply' and 'Update'.
+                        type: string
+                      time:
+                        description: Time is a wrapper around time.Time which supports
+                          correct marshaling to YAML and JSON.  Wrappers are provided
+                          for many of the factory methods that the time package offers.
+                        format: date-time
+                        type: string
+                    type: object
+                  type: array
+                name:
+                  description: 'Name must be unique within a namespace. Is required
+                    when creating resources, although some resources may allow a client
+                    to request the generation of an appropriate name automatically.
+                    Name is primarily intended for creation idempotence and configuration
+                    definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
+                    Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                  type: string
+                ownerReferences:
+                  description: List of objects depended by this object. If ALL objects
+                    in the list have been deleted, this object will be garbage collected.
+                    If this object is managed by a controller, then an entry in this
+                    list will point to this controller, with the controller field
+                    set to true. There cannot be more than one managing controller.
+                  items:
+                    description: OwnerReference contains enough information to let
+                      you identify an owning object. An owning object must be in the
+                      same namespace as the dependent, or be cluster-scoped, so there
+                      is no namespace field.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      blockOwnerDeletion:
+                        description: If true, AND if the owner has the "foregroundDeletion"
+                          finalizer, then the owner cannot be deleted from the key-value
+                          store until this reference is removed. Defaults to false.
+                          To set this field, a user needs "delete" permission of the
+                          owner, otherwise 422 (Unprocessable Entity) will be returned.
+                        type: boolean
+                      controller:
+                        description: If true, this reference points to the managing
+                          controller.
+                        type: boolean
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - uid
+                    type: object
+                  type: array
+                resourceVersion:
+                  description: |-
+                    An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
+                    Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+                  type: string
+                selfLink:
+                  description: SelfLink is a URL representing this object. Populated
+                    by the system. Read-only.
+                  type: string
+                uid:
+                  description: |-
+                    UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
+                    Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                  type: string
+              type: object
+            podMonitorNamespaceSelector:
+              description: A label selector is a label query over a set of resources.
+                The result of matchLabels and matchExpressions are ANDed. An empty
+                label selector matches all objects. A null label selector matches
+                no objects.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            podMonitorSelector:
+              description: A label selector is a label query over a set of resources.
+                The result of matchLabels and matchExpressions are ANDed. An empty
+                label selector matches all objects. A null label selector matches
+                no objects.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            portName:
+              description: Port name used for the pods and governing service. This
+                defaults to web
+              type: string
+            priorityClassName:
+              description: Priority class assigned to the Pods
+              type: string
+            prometheusExternalLabelName:
+              description: Name of Prometheus external label used to denote Prometheus
+                instance name. Defaults to the value of `prometheus`. External label
+                will _not_ be added when value is set to empty string (`""`).
+              type: string
+            query:
+              description: QuerySpec defines the query command line flags when starting
+                Prometheus.
+              properties:
+                lookbackDelta:
+                  description: The delta difference allowed for retrieving metrics
+                    during expression evaluations.
+                  type: string
+                maxConcurrency:
+                  description: Number of concurrent queries that can be run at once.
+                  format: int32
+                  type: integer
+                maxSamples:
+                  description: Maximum number of samples a single query can load into
+                    memory. Note that queries will fail if they would load more samples
+                    than this into memory, so this also limits the number of samples
+                    a query can return.
+                  format: int32
+                  type: integer
+                timeout:
+                  description: Maximum time a query may take before being aborted.
+                  type: string
+              type: object
+            remoteRead:
+              description: If specified, the remote_read spec. This is an experimental
+                feature, it may change in any upcoming release in a breaking way.
+              items:
+                description: RemoteReadSpec defines the remote_read configuration
+                  for prometheus.
+                properties:
+                  basicAuth:
+                    description: 'BasicAuth allow an endpoint to authenticate over
+                      basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                    properties:
+                      password:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                      username:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                    type: object
+                  bearerToken:
+                    description: bearer token for remote read.
+                    type: string
+                  bearerTokenFile:
+                    description: File to read bearer token for remote read.
+                    type: string
+                  proxyUrl:
+                    description: Optional ProxyURL
+                    type: string
+                  readRecent:
+                    description: Whether reads should be made for queries for time
+                      ranges that the local storage should have complete data for.
+                    type: boolean
+                  remoteTimeout:
+                    description: Timeout for requests to the remote read endpoint.
+                    type: string
+                  requiredMatchers:
+                    description: An optional list of equality matchers which have
+                      to be present in a selector to query the remote read endpoint.
+                    type: object
+                  tlsConfig:
+                    description: TLSConfig specifies TLS configuration parameters.
+                    properties:
+                      caFile:
+                        description: The CA cert to use for the targets.
+                        type: string
+                      certFile:
+                        description: The client cert file for the targets.
+                        type: string
+                      insecureSkipVerify:
+                        description: Disable target certificate validation.
+                        type: boolean
+                      keyFile:
+                        description: The client key file for the targets.
+                        type: string
+                      serverName:
+                        description: Used to verify the hostname for the targets.
+                        type: string
+                    type: object
+                  url:
+                    description: The URL of the endpoint to send samples to.
+                    type: string
+                required:
+                - url
+                type: object
+              type: array
+            remoteWrite:
+              description: If specified, the remote_write spec. This is an experimental
+                feature, it may change in any upcoming release in a breaking way.
+              items:
+                description: RemoteWriteSpec defines the remote_write configuration
+                  for prometheus.
+                properties:
+                  basicAuth:
+                    description: 'BasicAuth allow an endpoint to authenticate over
+                      basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                    properties:
+                      password:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                      username:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                    type: object
+                  bearerToken:
+                    description: File to read bearer token for remote write.
+                    type: string
+                  bearerTokenFile:
+                    description: File to read bearer token for remote write.
+                    type: string
+                  proxyUrl:
+                    description: Optional ProxyURL
+                    type: string
+                  queueConfig:
+                    description: QueueConfig allows the tuning of remote_write queue_config
+                      parameters. This object is referenced in the RemoteWriteSpec
+                      object.
+                    properties:
+                      batchSendDeadline:
+                        description: BatchSendDeadline is the maximum time a sample
+                          will wait in buffer.
+                        type: string
+                      capacity:
+                        description: Capacity is the number of samples to buffer per
+                          shard before we start dropping them.
+                        format: int32
+                        type: integer
+                      maxBackoff:
+                        description: MaxBackoff is the maximum retry delay.
+                        type: string
+                      maxRetries:
+                        description: MaxRetries is the maximum number of times to
+                          retry a batch on recoverable errors.
+                        format: int32
+                        type: integer
+                      maxSamplesPerSend:
+                        description: MaxSamplesPerSend is the maximum number of samples
+                          per send.
+                        format: int32
+                        type: integer
+                      maxShards:
+                        description: MaxShards is the maximum number of shards, i.e.
+                          amount of concurrency.
+                        format: int32
+                        type: integer
+                      minBackoff:
+                        description: MinBackoff is the initial retry delay. Gets doubled
+                          for every retry.
+                        type: string
+                      minShards:
+                        description: MinShards is the minimum number of shards, i.e.
+                          amount of concurrency.
+                        format: int32
+                        type: integer
+                    type: object
+                  remoteTimeout:
+                    description: Timeout for requests to the remote write endpoint.
+                    type: string
+                  tlsConfig:
+                    description: TLSConfig specifies TLS configuration parameters.
+                    properties:
+                      caFile:
+                        description: The CA cert to use for the targets.
+                        type: string
+                      certFile:
+                        description: The client cert file for the targets.
+                        type: string
+                      insecureSkipVerify:
+                        description: Disable target certificate validation.
+                        type: boolean
+                      keyFile:
+                        description: The client key file for the targets.
+                        type: string
+                      serverName:
+                        description: Used to verify the hostname for the targets.
+                        type: string
+                    type: object
+                  url:
+                    description: The URL of the endpoint to send samples to.
+                    type: string
+                  writeRelabelConfigs:
+                    description: The list of remote write relabel configurations.
+                    items:
+                      description: 'RelabelConfig allows dynamic rewriting of the
+                        label set, being applied to samples before ingestion. It defines
+                        `<metric_relabel_configs>`-section of Prometheus configuration.
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                      properties:
+                        action:
+                          description: Action to perform based on regex matching.
+                            Default is 'replace'
+                          type: string
+                        modulus:
+                          description: Modulus to take of the hash of the source label
+                            values.
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched. defailt is '(.*)'
+                          type: string
+                        replacement:
+                          description: Replacement value against which a regex replace
+                            is performed if the regular expression matches. Regex
+                            capture groups are available. Default is '$1'
+                          type: string
+                        separator:
+                          description: Separator placed between concatenated source
+                            label values. default is ';'.
+                          type: string
+                        sourceLabels:
+                          description: The source labels select values from existing
+                            labels. Their content is concatenated using the configured
+                            separator and matched against the configured regular expression
+                            for the replace, keep, and drop actions.
+                          items:
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: Label to which the resulting value is written
+                            in a replace action. It is mandatory for replace actions.
+                            Regex capture groups are available.
+                          type: string
+                      type: object
+                    type: array
+                required:
+                - url
+                type: object
+              type: array
+            replicaExternalLabelName:
+              description: Name of Prometheus external label used to denote replica
+                name. Defaults to the value of `prometheus_replica`. External label
+                will _not_ be added when value is set to empty string (`""`).
+              type: string
+            replicas:
+              description: Number of instances to deploy for a Prometheus deployment.
+              format: int32
+              type: integer
+            resources:
+              description: ResourceRequirements describes the compute resource requirements.
+              properties:
+                limits:
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+              type: object
+            retention:
+              description: Time duration Prometheus shall retain data for. Default
+                is '24h', and must match the regular expression `[0-9]+(ms|s|m|h|d|w|y)`
+                (milliseconds seconds minutes hours days weeks years).
+              type: string
+            retentionSize:
+              description: Maximum amount of disk space used by blocks.
+              type: string
+            routePrefix:
+              description: The route prefix Prometheus registers HTTP handlers for.
+                This is useful, if using ExternalURL and a proxy is rewriting HTTP
+                routes of a request, and the actual ExternalURL is still true, but
+                the server serves requests under a different route prefix. For example
+                for use with `kubectl proxy`.
+              type: string
+            ruleNamespaceSelector:
+              description: A label selector is a label query over a set of resources.
+                The result of matchLabels and matchExpressions are ANDed. An empty
+                label selector matches all objects. A null label selector matches
+                no objects.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            ruleSelector:
+              description: A label selector is a label query over a set of resources.
+                The result of matchLabels and matchExpressions are ANDed. An empty
+                label selector matches all objects. A null label selector matches
+                no objects.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            rules:
+              description: /--rules.*/ command-line arguments
+              properties:
+                alert:
+                  description: /--rules.alert.*/ command-line arguments
+                  properties:
+                    forGracePeriod:
+                      description: Minimum duration between alert and restored 'for'
+                        state. This is maintained only for alerts with configured
+                        'for' time greater than grace period.
+                      type: string
+                    forOutageTolerance:
+                      description: Max time to tolerate prometheus outage for restoring
+                        'for' state of alert.
+                      type: string
+                    resendDelay:
+                      description: Minimum amount of time to wait before resending
+                        an alert to Alertmanager.
+                      type: string
+                  type: object
+              type: object
+            scrapeInterval:
+              description: Interval between consecutive scrapes.
+              type: string
+            secrets:
+              description: Secrets is a list of Secrets in the same namespace as the
+                Prometheus object, which shall be mounted into the Prometheus Pods.
+                The Secrets are mounted into /etc/prometheus/secrets/<secret-name>.
+              items:
+                type: string
+              type: array
+            securityContext:
+              description: PodSecurityContext holds pod-level security attributes
+                and common container settings. Some fields are also present in container.securityContext.  Field
+                values of container.securityContext take precedence over field values
+                of PodSecurityContext.
+              properties:
+                fsGroup:
+                  description: |-
+                    A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                    1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                    If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                  format: int64
+                  type: integer
+                runAsGroup:
+                  description: The GID to run the entrypoint of the container process.
+                    Uses runtime default if unset. May also be set in SecurityContext.  If
+                    set in both SecurityContext and PodSecurityContext, the value
+                    specified in SecurityContext takes precedence for that container.
+                  format: int64
+                  type: integer
+                runAsNonRoot:
+                  description: Indicates that the container must run as a non-root
+                    user. If true, the Kubelet will validate the image at runtime
+                    to ensure that it does not run as UID 0 (root) and fail to start
+                    the container if it does. If unset or false, no such validation
+                    will be performed. May also be set in SecurityContext.  If set
+                    in both SecurityContext and PodSecurityContext, the value specified
+                    in SecurityContext takes precedence.
+                  type: boolean
+                runAsUser:
+                  description: The UID to run the entrypoint of the container process.
+                    Defaults to user specified in image metadata if unspecified. May
+                    also be set in SecurityContext.  If set in both SecurityContext
+                    and PodSecurityContext, the value specified in SecurityContext
+                    takes precedence for that container.
+                  format: int64
+                  type: integer
+                seLinuxOptions:
+                  description: SELinuxOptions are the labels to be applied to the
+                    container
+                  properties:
+                    level:
+                      description: Level is SELinux level label that applies to the
+                        container.
+                      type: string
+                    role:
+                      description: Role is a SELinux role label that applies to the
+                        container.
+                      type: string
+                    type:
+                      description: Type is a SELinux type label that applies to the
+                        container.
+                      type: string
+                    user:
+                      description: User is a SELinux user label that applies to the
+                        container.
+                      type: string
+                  type: object
+                supplementalGroups:
+                  description: A list of groups applied to the first process run in
+                    each container, in addition to the container's primary GID.  If
+                    unspecified, no groups will be added to any container.
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                sysctls:
+                  description: Sysctls hold a list of namespaced sysctls used for
+                    the pod. Pods with unsupported sysctls (by the container runtime)
+                    might fail to launch.
+                  items:
+                    description: Sysctl defines a kernel parameter to be set
+                    properties:
+                      name:
+                        description: Name of a property to set
+                        type: string
+                      value:
+                        description: Value of a property to set
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                windowsOptions:
+                  description: WindowsSecurityContextOptions contain Windows-specific
+                    options and credentials.
+                  properties:
+                    gmsaCredentialSpec:
+                      description: GMSACredentialSpec is where the GMSA admission
+                        webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                        inlines the contents of the GMSA credential spec named by
+                        the GMSACredentialSpecName field. This field is alpha-level
+                        and is only honored by servers that enable the WindowsGMSA
+                        feature flag.
+                      type: string
+                    gmsaCredentialSpecName:
+                      description: GMSACredentialSpecName is the name of the GMSA
+                        credential spec to use. This field is alpha-level and is only
+                        honored by servers that enable the WindowsGMSA feature flag.
+                      type: string
+                  type: object
+              type: object
+            serviceAccountName:
+              description: ServiceAccountName is the name of the ServiceAccount to
+                use to run the Prometheus Pods.
+              type: string
+            serviceMonitorNamespaceSelector:
+              description: A label selector is a label query over a set of resources.
+                The result of matchLabels and matchExpressions are ANDed. An empty
+                label selector matches all objects. A null label selector matches
+                no objects.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            serviceMonitorSelector:
+              description: A label selector is a label query over a set of resources.
+                The result of matchLabels and matchExpressions are ANDed. An empty
+                label selector matches all objects. A null label selector matches
+                no objects.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            sha:
+              description: SHA of Prometheus container image to be deployed. Defaults
+                to the value of `version`. Similar to a tag, but the SHA explicitly
+                deploys an immutable container image. Version and Tag are ignored
+                if SHA is set.
+              type: string
+            storage:
+              description: StorageSpec defines the configured storage for a group
+                Prometheus servers. If neither `emptyDir` nor `volumeClaimTemplate`
+                is specified, then by default an [EmptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir)
+                will be used.
+              properties:
+                emptyDir:
+                  description: Represents an empty directory for a pod. Empty directory
+                    volumes support ownership management and SELinux relabeling.
+                  properties:
+                    medium:
+                      description: 'What type of storage medium should back this directory.
+                        The default is "" which means to use the node''s default medium.
+                        Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                      type: string
+                    sizeLimit: {}
+                  type: object
+                volumeClaimTemplate:
+                  description: PersistentVolumeClaim is a user's request for and claim
+                    to a persistent volume
+                  properties:
+                    apiVersion:
+                      description: 'APIVersion defines the versioned schema of this
+                        representation of an object. Servers should convert recognized
+                        schemas to the latest internal value, and may reject unrecognized
+                        values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                      type: string
+                    kind:
+                      description: 'Kind is a string value representing the REST resource
+                        this object represents. Servers may infer this from the endpoint
+                        the client submits requests to. Cannot be updated. In CamelCase.
+                        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                      type: string
+                    metadata:
+                      description: ObjectMeta is metadata that all persisted resources
+                        must have, which includes all objects users must create.
+                      properties:
+                        annotations:
+                          description: 'Annotations is an unstructured key value map
+                            stored with a resource that may be set by external tools
+                            to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: http://kubernetes.io/docs/user-guide/annotations'
+                          type: object
+                        clusterName:
+                          description: The name of the cluster which the object belongs
+                            to. This is used to distinguish resources with same name
+                            and namespace in different clusters. This field is not
+                            set anywhere right now and apiserver is going to ignore
+                            it if set in create or update request.
+                          type: string
+                        creationTimestamp:
+                          description: Time is a wrapper around time.Time which supports
+                            correct marshaling to YAML and JSON.  Wrappers are provided
+                            for many of the factory methods that the time package
+                            offers.
+                          format: date-time
+                          type: string
+                        deletionGracePeriodSeconds:
+                          description: Number of seconds allowed for this object to
+                            gracefully terminate before it will be removed from the
+                            system. Only set when deletionTimestamp is also set. May
+                            only be shortened. Read-only.
+                          format: int64
+                          type: integer
+                        deletionTimestamp:
+                          description: Time is a wrapper around time.Time which supports
+                            correct marshaling to YAML and JSON.  Wrappers are provided
+                            for many of the factory methods that the time package
+                            offers.
+                          format: date-time
+                          type: string
+                        finalizers:
+                          description: Must be empty before the object is deleted
+                            from the registry. Each entry is an identifier for the
+                            responsible component that will remove the entry from
+                            the list. If the deletionTimestamp of the object is non-nil,
+                            entries in this list can only be removed.
+                          items:
+                            type: string
+                          type: array
+                        generateName:
+                          description: |-
+                            GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
+                            If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+
+                            Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+                          type: string
+                        generation:
+                          description: A sequence number representing a specific generation
+                            of the desired state. Populated by the system. Read-only.
+                          format: int64
+                          type: integer
+                        initializers:
+                          description: Initializers tracks the progress of initialization.
+                          properties:
+                            pending:
+                              description: Pending is a list of initializers that
+                                must execute in order before this object is visible.
+                                When the last pending initializer is removed, and
+                                no failing result is set, the initializers struct
+                                will be set to nil and the object is considered as
+                                initialized and visible to all clients.
+                              items:
+                                description: Initializer is information about an initializer
+                                  that has not yet completed.
+                                properties:
+                                  name:
+                                    description: name of the process that is responsible
+                                      for initializing this object.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            result:
+                              description: Status is a return value for calls that
+                                don't return other objects.
+                              properties:
+                                apiVersion:
+                                  description: 'APIVersion defines the versioned schema
+                                    of this representation of an object. Servers should
+                                    convert recognized schemas to the latest internal
+                                    value, and may reject unrecognized values. More
+                                    info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                                  type: string
+                                code:
+                                  description: Suggested HTTP return code for this
+                                    status, 0 if not set.
+                                  format: int32
+                                  type: integer
+                                details:
+                                  description: StatusDetails is a set of additional
+                                    properties that MAY be set by the server to provide
+                                    additional information about a response. The Reason
+                                    field of a Status object defines what attributes
+                                    will be set. Clients must ignore fields that do
+                                    not match the defined type of each attribute,
+                                    and should assume that any attribute may be empty,
+                                    invalid, or under defined.
+                                  properties:
+                                    causes:
+                                      description: The Causes array includes more
+                                        details associated with the StatusReason failure.
+                                        Not all StatusReasons may provide detailed
+                                        causes.
+                                      items:
+                                        description: StatusCause provides more information
+                                          about an api.Status failure, including cases
+                                          when multiple errors are encountered.
+                                        properties:
+                                          field:
+                                            description: |-
+                                              The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+
+                                              Examples:
+                                                "name" - the field "name" on the current resource
+                                                "items[0].name" - the field "name" on the first array entry in "items"
+                                            type: string
+                                          message:
+                                            description: A human-readable description
+                                              of the cause of the error.  This field
+                                              may be presented as-is to a reader.
+                                            type: string
+                                          reason:
+                                            description: A machine-readable description
+                                              of the cause of the error. If this value
+                                              is empty there is no information available.
+                                            type: string
+                                        type: object
+                                      type: array
+                                    group:
+                                      description: The group attribute of the resource
+                                        associated with the status StatusReason.
+                                      type: string
+                                    kind:
+                                      description: 'The kind attribute of the resource
+                                        associated with the status StatusReason. On
+                                        some operations may differ from the requested
+                                        resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: The name attribute of the resource
+                                        associated with the status StatusReason (when
+                                        there is a single name which can be described).
+                                      type: string
+                                    retryAfterSeconds:
+                                      description: If specified, the time in seconds
+                                        before the operation should be retried. Some
+                                        errors may indicate the client must take an
+                                        alternate action - for those errors this field
+                                        may indicate how long to wait before taking
+                                        the alternate action.
+                                      format: int32
+                                      type: integer
+                                    uid:
+                                      description: 'UID of the resource. (when there
+                                        is a single resource which can be described).
+                                        More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                      type: string
+                                  type: object
+                                kind:
+                                  description: 'Kind is a string value representing
+                                    the REST resource this object represents. Servers
+                                    may infer this from the endpoint the client submits
+                                    requests to. Cannot be updated. In CamelCase.
+                                    More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                  type: string
+                                message:
+                                  description: A human-readable description of the
+                                    status of this operation.
+                                  type: string
+                                metadata:
+                                  description: ListMeta describes metadata that synthetic
+                                    resources must have, including lists and various
+                                    status objects. A resource may have only one of
+                                    {ObjectMeta, ListMeta}.
+                                  properties:
+                                    continue:
+                                      description: continue may be set if the user
+                                        set a limit on the number of items returned,
+                                        and indicates that the server has more data
+                                        available. The value is opaque and may be
+                                        used to issue another request to the endpoint
+                                        that served this list to retrieve the next
+                                        set of available objects. Continuing a consistent
+                                        list may not be possible if the server configuration
+                                        has changed or more than a few minutes have
+                                        passed. The resourceVersion field returned
+                                        when using this continue value will be identical
+                                        to the value in the first response, unless
+                                        you have received this token from an error
+                                        message.
+                                      type: string
+                                    remainingItemCount:
+                                      description: |-
+                                        remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.
+
+                                        This field is alpha and can be changed or removed without notice.
+                                      format: int64
+                                      type: integer
+                                    resourceVersion:
+                                      description: 'String that identifies the server''s
+                                        internal version of this object that can be
+                                        used by clients to determine when objects
+                                        have changed. Value must be treated as opaque
+                                        by clients and passed unmodified back to the
+                                        server. Populated by the system. Read-only.
+                                        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                                      type: string
+                                    selfLink:
+                                      description: selfLink is a URL representing
+                                        this object. Populated by the system. Read-only.
+                                      type: string
+                                  type: object
+                                reason:
+                                  description: A machine-readable description of why
+                                    this operation is in the "Failure" status. If
+                                    this value is empty there is no information available.
+                                    A Reason clarifies an HTTP status code but does
+                                    not override it.
+                                  type: string
+                                status:
+                                  description: 'Status of the operation. One of: "Success"
+                                    or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                                  type: string
+                              type: object
+                          required:
+                          - pending
+                          type: object
+                        labels:
+                          description: 'Map of string keys and values that can be
+                            used to organize and categorize (scope and select) objects.
+                            May match selectors of replication controllers and services.
+                            More info: http://kubernetes.io/docs/user-guide/labels'
+                          type: object
+                        managedFields:
+                          description: |-
+                            ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+
+                            This field is alpha and can be changed or removed without notice.
+                          items:
+                            description: ManagedFieldsEntry is a workflow-id, a FieldSet
+                              and the group version of the resource that the fieldset
+                              applies to.
+                            properties:
+                              apiVersion:
+                                description: APIVersion defines the version of this
+                                  resource that this field set applies to. The format
+                                  is "group/version" just like the top-level APIVersion
+                                  field. It is necessary to track the version of a
+                                  field set because it cannot be automatically converted.
+                                type: string
+                              fields:
+                                description: 'Fields stores a set of fields in a data
+                                  structure like a Trie. To understand how this is
+                                  used, see: https://github.com/kubernetes-sigs/structured-merge-diff'
+                                type: object
+                              manager:
+                                description: Manager is an identifier of the workflow
+                                  managing these fields.
+                                type: string
+                              operation:
+                                description: Operation is the type of operation which
+                                  lead to this ManagedFieldsEntry being created. The
+                                  only valid values for this field are 'Apply' and
+                                  'Update'.
+                                type: string
+                              time:
+                                description: Time is a wrapper around time.Time which
+                                  supports correct marshaling to YAML and JSON.  Wrappers
+                                  are provided for many of the factory methods that
+                                  the time package offers.
+                                format: date-time
+                                type: string
+                            type: object
+                          type: array
+                        name:
+                          description: 'Name must be unique within a namespace. Is
+                            required when creating resources, although some resources
+                            may allow a client to request the generation of an appropriate
+                            name automatically. Name is primarily intended for creation
+                            idempotence and configuration definition. Cannot be updated.
+                            More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
+                            Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                          type: string
+                        ownerReferences:
+                          description: List of objects depended by this object. If
+                            ALL objects in the list have been deleted, this object
+                            will be garbage collected. If this object is managed by
+                            a controller, then an entry in this list will point to
+                            this controller, with the controller field set to true.
+                            There cannot be more than one managing controller.
+                          items:
+                            description: OwnerReference contains enough information
+                              to let you identify an owning object. An owning object
+                              must be in the same namespace as the dependent, or be
+                              cluster-scoped, so there is no namespace field.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              blockOwnerDeletion:
+                                description: If true, AND if the owner has the "foregroundDeletion"
+                                  finalizer, then the owner cannot be deleted from
+                                  the key-value store until this reference is removed.
+                                  Defaults to false. To set this field, a user needs
+                                  "delete" permission of the owner, otherwise 422
+                                  (Unprocessable Entity) will be returned.
+                                type: boolean
+                              controller:
+                                description: If true, this reference points to the
+                                  managing controller.
+                                type: boolean
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                type: string
+                            required:
+                            - apiVersion
+                            - kind
+                            - name
+                            - uid
+                            type: object
+                          type: array
+                        resourceVersion:
+                          description: |-
+                            An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
+                            Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+                          type: string
+                        selfLink:
+                          description: SelfLink is a URL representing this object.
+                            Populated by the system. Read-only.
+                          type: string
+                        uid:
+                          description: |-
+                            UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
+                            Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                          type: string
+                      type: object
+                    spec:
+                      description: PersistentVolumeClaimSpec describes the common
+                        attributes of storage devices and allows a Source for provider-specific
+                        attributes
+                      properties:
+                        accessModes:
+                          description: 'AccessModes contains the desired access modes
+                            the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                          items:
+                            type: string
+                          type: array
+                        dataSource:
+                          description: TypedLocalObjectReference contains enough information
+                            to let you locate the typed referenced object inside the
+                            same namespace.
+                          properties:
+                            apiGroup:
+                              description: APIGroup is the group for the resource
+                                being referenced. If APIGroup is not specified, the
+                                specified Kind must be in the core API group. For
+                                any other third-party types, APIGroup is required.
+                              type: string
+                            kind:
+                              description: Kind is the type of resource being referenced
+                              type: string
+                            name:
+                              description: Name is the name of resource being referenced
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
+                        resources:
+                          description: ResourceRequirements describes the compute
+                            resource requirements.
+                          properties:
+                            limits:
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        selector:
+                          description: A label selector is a label query over a set
+                            of resources. The result of matchLabels and matchExpressions
+                            are ANDed. An empty label selector matches all objects.
+                            A null label selector matches no objects.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        storageClassName:
+                          description: 'Name of the StorageClass required by the claim.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                          type: string
+                        volumeMode:
+                          description: volumeMode defines what type of volume is required
+                            by the claim. Value of Filesystem is implied when not
+                            included in claim spec. This is a beta feature.
+                          type: string
+                        volumeName:
+                          description: VolumeName is the binding reference to the
+                            PersistentVolume backing this claim.
+                          type: string
+                      type: object
+                    status:
+                      description: PersistentVolumeClaimStatus is the current status
+                        of a persistent volume claim.
+                      properties:
+                        accessModes:
+                          description: 'AccessModes contains the actual access modes
+                            the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                          items:
+                            type: string
+                          type: array
+                        capacity:
+                          description: Represents the actual resources of the underlying
+                            volume.
+                          type: object
+                        conditions:
+                          description: Current Condition of persistent volume claim.
+                            If underlying persistent volume is being resized then
+                            the Condition will be set to 'ResizeStarted'.
+                          items:
+                            description: PersistentVolumeClaimCondition contails details
+                              about state of pvc
+                            properties:
+                              lastProbeTime:
+                                description: Time is a wrapper around time.Time which
+                                  supports correct marshaling to YAML and JSON.  Wrappers
+                                  are provided for many of the factory methods that
+                                  the time package offers.
+                                format: date-time
+                                type: string
+                              lastTransitionTime:
+                                description: Time is a wrapper around time.Time which
+                                  supports correct marshaling to YAML and JSON.  Wrappers
+                                  are provided for many of the factory methods that
+                                  the time package offers.
+                                format: date-time
+                                type: string
+                              message:
+                                description: Human-readable message indicating details
+                                  about last transition.
+                                type: string
+                              reason:
+                                description: Unique, this should be a short, machine
+                                  understandable string that gives the reason for
+                                  condition's last transition. If it reports "ResizeStarted"
+                                  that means the underlying persistent volume is being
+                                  resized.
+                                type: string
+                              status:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                            - type
+                            - status
+                            type: object
+                          type: array
+                        phase:
+                          description: Phase represents the current phase of PersistentVolumeClaim.
+                          type: string
+                      type: object
+                  type: object
+              type: object
+            tag:
+              description: Tag of Prometheus container image to be deployed. Defaults
+                to the value of `version`. Version is ignored if Tag is set.
+              type: string
+            thanos:
+              description: ThanosSpec defines parameters for a Prometheus server within
+                a Thanos deployment.
+              properties:
+                baseImage:
+                  description: Thanos base image if other than default.
+                  type: string
+                image:
+                  description: Image if specified has precedence over baseImage, tag
+                    and sha combinations. Specifying the version is still necessary
+                    to ensure the Prometheus Operator knows what version of Thanos
+                    is being configured.
+                  type: string
+                objectStorageConfig:
+                  description: SecretKeySelector selects a key of a Secret.
+                  properties:
+                    key:
+                      description: The key of the secret to select from.  Must be
+                        a valid secret key.
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    optional:
+                      description: Specify whether the Secret or its key must be defined
+                      type: boolean
+                  required:
+                  - key
+                  type: object
+                resources:
+                  description: ResourceRequirements describes the compute resource
+                    requirements.
+                  properties:
+                    limits:
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                sha:
+                  description: SHA of Thanos container image to be deployed. Defaults
+                    to the value of `version`. Similar to a tag, but the SHA explicitly
+                    deploys an immutable container image. Version and Tag are ignored
+                    if SHA is set.
+                  type: string
+                tag:
+                  description: Tag of Thanos sidecar container image to be deployed.
+                    Defaults to the value of `version`. Version is ignored if Tag
+                    is set.
+                  type: string
+                version:
+                  description: Version describes the version of Thanos to use.
+                  type: string
+              type: object
+            tolerations:
+              description: If specified, the pod's tolerations.
+              items:
+                description: The pod this Toleration is attached to tolerates any
+                  taint that matches the triple <key,value,effect> using the matching
+                  operator <operator>.
+                properties:
+                  effect:
+                    description: Effect indicates the taint effect to match. Empty
+                      means match all taint effects. When specified, allowed values
+                      are NoSchedule, PreferNoSchedule and NoExecute.
+                    type: string
+                  key:
+                    description: Key is the taint key that the toleration applies
+                      to. Empty means match all taint keys. If the key is empty, operator
+                      must be Exists; this combination means to match all values and
+                      all keys.
+                    type: string
+                  operator:
+                    description: Operator represents a key's relationship to the value.
+                      Valid operators are Exists and Equal. Defaults to Equal. Exists
+                      is equivalent to wildcard for value, so that a pod can tolerate
+                      all taints of a particular category.
+                    type: string
+                  tolerationSeconds:
+                    description: TolerationSeconds represents the period of time the
+                      toleration (which must be of effect NoExecute, otherwise this
+                      field is ignored) tolerates the taint. By default, it is not
+                      set, which means tolerate the taint forever (do not evict).
+                      Zero and negative values will be treated as 0 (evict immediately)
+                      by the system.
+                    format: int64
+                    type: integer
+                  value:
+                    description: Value is the taint value the toleration matches to.
+                      If the operator is Exists, the value should be empty, otherwise
+                      just a regular string.
+                    type: string
+                type: object
+              type: array
+            version:
+              description: Version of Prometheus to be deployed.
+              type: string
+            volumes:
+              description: Volumes allows configuration of additional volumes on the
+                output StatefulSet definition. Volumes specified will be appended
+                to other volumes that are generated as a result of StorageSpec objects.
+              items:
+                description: Volume represents a named volume in a pod that may be
+                  accessed by any container in the pod.
+                properties:
+                  awsElasticBlockStore:
+                    description: |-
+                      Represents a Persistent Disk resource in AWS.
+
+                      An AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        type: string
+                      partition:
+                        description: 'The partition in the volume that you want to
+                          mount. If omitted, the default is to mount by volume name.
+                          Examples: For volume /dev/sda1, you specify the partition
+                          as "1". Similarly, the volume partition for /dev/sda is
+                          "0" (or you can leave the property empty).'
+                        format: int32
+                        type: integer
+                      readOnly:
+                        description: 'Specify "true" to force and set the ReadOnly
+                          property in VolumeMounts to "true". If omitted, the default
+                          is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        type: boolean
+                      volumeID:
+                        description: 'Unique ID of the persistent disk resource in
+                          AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  azureDisk:
+                    description: AzureDisk represents an Azure Data Disk mount on
+                      the host and bind mount to the pod.
+                    properties:
+                      cachingMode:
+                        description: 'Host Caching mode: None, Read Only, Read Write.'
+                        type: string
+                      diskName:
+                        description: The Name of the data disk in the blob storage
+                        type: string
+                      diskURI:
+                        description: The URI the data disk in the blob storage
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      kind:
+                        description: 'Expected values Shared: multiple blob disks
+                          per storage account  Dedicated: single blob disk per storage
+                          account  Managed: azure managed data disk (only in managed
+                          availability set). defaults to shared'
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                    required:
+                    - diskName
+                    - diskURI
+                    type: object
+                  azureFile:
+                    description: AzureFile represents an Azure File Service mount
+                      on the host and bind mount to the pod.
+                    properties:
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretName:
+                        description: the name of secret that contains Azure Storage
+                          Account Name and Key
+                        type: string
+                      shareName:
+                        description: Share Name
+                        type: string
+                    required:
+                    - secretName
+                    - shareName
+                    type: object
+                  cephfs:
+                    description: Represents a Ceph Filesystem mount that lasts the
+                      lifetime of a pod Cephfs volumes do not support ownership management
+                      or SELinux relabeling.
+                    properties:
+                      monitors:
+                        description: 'Required: Monitors is a collection of Ceph monitors
+                          More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                        items:
+                          type: string
+                        type: array
+                      path:
+                        description: 'Optional: Used as the mounted root, rather than
+                          the full Ceph tree, default is /'
+                        type: string
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts. More
+                          info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                        type: boolean
+                      secretFile:
+                        description: 'Optional: SecretFile is the path to key ring
+                          for User, default is /etc/ceph/user.secret More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                        type: string
+                      secretRef:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        type: object
+                      user:
+                        description: 'Optional: User is the rados user name, default
+                          is admin More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                        type: string
+                    required:
+                    - monitors
+                    type: object
+                  cinder:
+                    description: Represents a cinder volume resource in Openstack.
+                      A Cinder volume must exist before mounting to a container. The
+                      volume must also be in the same region as the kubelet. Cinder
+                      volumes support ownership management and SELinux relabeling.
+                    properties:
+                      fsType:
+                        description: 'Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Examples: "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md'
+                        type: string
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts. More
+                          info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md'
+                        type: boolean
+                      secretRef:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        type: object
+                      volumeID:
+                        description: 'volume id used to identify the volume in cinder
+                          More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md'
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  configMap:
+                    description: |-
+                      Adapts a ConfigMap into a volume.
+
+                      The contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: If unspecified, each key-value pair in the Data
+                          field of the referenced ConfigMap will be projected into
+                          the volume as a file whose name is the key and content is
+                          the value. If specified, the listed keys will be projected
+                          into the specified paths, and unlisted keys will not be
+                          present. If a key is specified which is not present in the
+                          ConfigMap, the volume setup will error unless it is marked
+                          optional. Paths must be relative and may not contain the
+                          '..' path or start with '..'.
+                        items:
+                          description: Maps a string key to a path within a volume.
+                          properties:
+                            key:
+                              description: The key to project.
+                              type: string
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              format: int32
+                              type: integer
+                            path:
+                              description: The relative path of the file to map the
+                                key to. May not be an absolute path. May not contain
+                                the path element '..'. May not start with the string
+                                '..'.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          type: object
+                        type: array
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      optional:
+                        description: Specify whether the ConfigMap or its keys must
+                          be defined
+                        type: boolean
+                    type: object
+                  csi:
+                    description: Represents a source location of a volume to mount,
+                      managed by an external CSI driver
+                    properties:
+                      driver:
+                        description: Driver is the name of the CSI driver that handles
+                          this volume. Consult with your admin for the correct name
+                          as registered in the cluster.
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Ex. "ext4", "xfs",
+                          "ntfs". If not provided, the empty value is passed to the
+                          associated CSI driver which will determine the default filesystem
+                          to apply.
+                        type: string
+                      nodePublishSecretRef:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        type: object
+                      readOnly:
+                        description: Specifies a read-only configuration for the volume.
+                          Defaults to false (read/write).
+                        type: boolean
+                      volumeAttributes:
+                        description: VolumeAttributes stores driver-specific properties
+                          that are passed to the CSI driver. Consult your driver's
+                          documentation for supported values.
+                        type: object
+                    required:
+                    - driver
+                    type: object
+                  downwardAPI:
+                    description: DownwardAPIVolumeSource represents a volume containing
+                      downward API info. Downward API volumes support ownership management
+                      and SELinux relabeling.
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: Items is a list of downward API volume file
+                        items:
+                          description: DownwardAPIVolumeFile represents information
+                            to create the file containing the pod field
+                          properties:
+                            fieldRef:
+                              description: ObjectFieldSelector selects an APIVersioned
+                                field of an object.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              format: int32
+                              type: integer
+                            path:
+                              description: 'Required: Path is  the relative path name
+                                of the file to be created. Must not be absolute or
+                                contain the ''..'' path. Must be utf-8 encoded. The
+                                first item of the relative path must not start with
+                                ''..'''
+                              type: string
+                            resourceFieldRef:
+                              description: ResourceFieldSelector represents container
+                                resources (cpu, memory) and their output format
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor: {}
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                          required:
+                          - path
+                          type: object
+                        type: array
+                    type: object
+                  emptyDir:
+                    description: Represents an empty directory for a pod. Empty directory
+                      volumes support ownership management and SELinux relabeling.
+                    properties:
+                      medium:
+                        description: 'What type of storage medium should back this
+                          directory. The default is "" which means to use the node''s
+                          default medium. Must be an empty string (default) or Memory.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                        type: string
+                      sizeLimit: {}
+                    type: object
+                  fc:
+                    description: Represents a Fibre Channel volume. Fibre Channel
+                      volumes can only be mounted as read/write once. Fibre Channel
+                      volumes support ownership management and SELinux relabeling.
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      lun:
+                        description: 'Optional: FC target lun number'
+                        format: int32
+                        type: integer
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts.'
+                        type: boolean
+                      targetWWNs:
+                        description: 'Optional: FC target worldwide names (WWNs)'
+                        items:
+                          type: string
+                        type: array
+                      wwids:
+                        description: 'Optional: FC volume world wide identifiers (wwids)
+                          Either wwids or combination of targetWWNs and lun must be
+                          set, but not both simultaneously.'
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  flexVolume:
+                    description: FlexVolume represents a generic volume resource that
+                      is provisioned/attached using an exec based plugin.
+                    properties:
+                      driver:
+                        description: Driver is the name of the driver to use for this
+                          volume.
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". The default filesystem depends on FlexVolume
+                          script.
+                        type: string
+                      options:
+                        description: 'Optional: Extra command options if any.'
+                        type: object
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts.'
+                        type: boolean
+                      secretRef:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        type: object
+                    required:
+                    - driver
+                    type: object
+                  flocker:
+                    description: Represents a Flocker volume mounted by the Flocker
+                      agent. One and only one of datasetName and datasetUUID should
+                      be set. Flocker volumes do not support ownership management
+                      or SELinux relabeling.
+                    properties:
+                      datasetName:
+                        description: Name of the dataset stored as metadata -> name
+                          on the dataset for Flocker should be considered as deprecated
+                        type: string
+                      datasetUUID:
+                        description: UUID of the dataset. This is unique identifier
+                          of a Flocker dataset
+                        type: string
+                    type: object
+                  gcePersistentDisk:
+                    description: |-
+                      Represents a Persistent Disk resource in Google Compute Engine.
+
+                      A GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: string
+                      partition:
+                        description: 'The partition in the volume that you want to
+                          mount. If omitted, the default is to mount by volume name.
+                          Examples: For volume /dev/sda1, you specify the partition
+                          as "1". Similarly, the volume partition for /dev/sda is
+                          "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        format: int32
+                        type: integer
+                      pdName:
+                        description: 'Unique name of the PD resource in GCE. Used
+                          to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: boolean
+                    required:
+                    - pdName
+                    type: object
+                  gitRepo:
+                    description: |-
+                      Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.
+
+                      DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.
+                    properties:
+                      directory:
+                        description: Target directory name. Must not contain or start
+                          with '..'.  If '.' is supplied, the volume directory will
+                          be the git repository.  Otherwise, if specified, the volume
+                          will contain the git repository in the subdirectory with
+                          the given name.
+                        type: string
+                      repository:
+                        description: Repository URL
+                        type: string
+                      revision:
+                        description: Commit hash for the specified revision.
+                        type: string
+                    required:
+                    - repository
+                    type: object
+                  glusterfs:
+                    description: Represents a Glusterfs mount that lasts the lifetime
+                      of a pod. Glusterfs volumes do not support ownership management
+                      or SELinux relabeling.
+                    properties:
+                      endpoints:
+                        description: 'EndpointsName is the endpoint name that details
+                          Glusterfs topology. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod'
+                        type: string
+                      path:
+                        description: 'Path is the Glusterfs volume path. More info:
+                          https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the Glusterfs volume
+                          to be mounted with read-only permissions. Defaults to false.
+                          More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod'
+                        type: boolean
+                    required:
+                    - endpoints
+                    - path
+                    type: object
+                  hostPath:
+                    description: Represents a host path mapped into a pod. Host path
+                      volumes do not support ownership management or SELinux relabeling.
+                    properties:
+                      path:
+                        description: 'Path of the directory on the host. If the path
+                          is a symlink, it will follow the link to the real path.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        type: string
+                      type:
+                        description: 'Type for HostPath Volume Defaults to "" More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        type: string
+                    required:
+                    - path
+                    type: object
+                  iscsi:
+                    description: Represents an ISCSI disk. ISCSI volumes can only
+                      be mounted as read/write once. ISCSI volumes support ownership
+                      management and SELinux relabeling.
+                    properties:
+                      chapAuthDiscovery:
+                        description: whether support iSCSI Discovery CHAP authentication
+                        type: boolean
+                      chapAuthSession:
+                        description: whether support iSCSI Session CHAP authentication
+                        type: boolean
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                        type: string
+                      initiatorName:
+                        description: Custom iSCSI Initiator Name. If initiatorName
+                          is specified with iscsiInterface simultaneously, new iSCSI
+                          interface <target portal>:<volume name> will be created
+                          for the connection.
+                        type: string
+                      iqn:
+                        description: Target iSCSI Qualified Name.
+                        type: string
+                      iscsiInterface:
+                        description: iSCSI Interface Name that uses an iSCSI transport.
+                          Defaults to 'default' (tcp).
+                        type: string
+                      lun:
+                        description: iSCSI Target Lun number.
+                        format: int32
+                        type: integer
+                      portals:
+                        description: iSCSI Target Portal List. The portal is either
+                          an IP or ip_addr:port if the port is other than default
+                          (typically TCP ports 860 and 3260).
+                        items:
+                          type: string
+                        type: array
+                      readOnly:
+                        description: ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false.
+                        type: boolean
+                      secretRef:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        type: object
+                      targetPortal:
+                        description: iSCSI Target Portal. The Portal is either an
+                          IP or ip_addr:port if the port is other than default (typically
+                          TCP ports 860 and 3260).
+                        type: string
+                    required:
+                    - targetPortal
+                    - iqn
+                    - lun
+                    type: object
+                  name:
+                    description: 'Volume''s name. Must be a DNS_LABEL and unique within
+                      the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  nfs:
+                    description: Represents an NFS mount that lasts the lifetime of
+                      a pod. NFS volumes do not support ownership management or SELinux
+                      relabeling.
+                    properties:
+                      path:
+                        description: 'Path that is exported by the NFS server. More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the NFS export to be
+                          mounted with read-only permissions. Defaults to false. More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: boolean
+                      server:
+                        description: 'Server is the hostname or IP address of the
+                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: string
+                    required:
+                    - server
+                    - path
+                    type: object
+                  persistentVolumeClaim:
+                    description: PersistentVolumeClaimVolumeSource references the
+                      user's PVC in the same namespace. This volume finds the bound
+                      PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource
+                      is, essentially, a wrapper around another type of volume that
+                      is owned by someone else (the system).
+                    properties:
+                      claimName:
+                        description: 'ClaimName is the name of a PersistentVolumeClaim
+                          in the same namespace as the pod using this volume. More
+                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        type: string
+                      readOnly:
+                        description: Will force the ReadOnly setting in VolumeMounts.
+                          Default false.
+                        type: boolean
+                    required:
+                    - claimName
+                    type: object
+                  photonPersistentDisk:
+                    description: Represents a Photon Controller persistent disk resource.
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      pdID:
+                        description: ID that identifies Photon Controller persistent
+                          disk
+                        type: string
+                    required:
+                    - pdID
+                    type: object
+                  portworxVolume:
+                    description: PortworxVolumeSource represents a Portworx volume
+                      resource.
+                    properties:
+                      fsType:
+                        description: FSType represents the filesystem type to mount
+                          Must be a filesystem type supported by the host operating
+                          system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                          if unspecified.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      volumeID:
+                        description: VolumeID uniquely identifies a Portworx volume
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  projected:
+                    description: Represents a projected volume source
+                    properties:
+                      defaultMode:
+                        description: Mode bits to use on created files by default.
+                          Must be a value between 0 and 0777. Directories within the
+                          path are not affected by this setting. This might be in
+                          conflict with other options that affect the file mode, like
+                          fsGroup, and the result can be other mode bits set.
+                        format: int32
+                        type: integer
+                      sources:
+                        description: list of volume projections
+                        items:
+                          description: Projection that may be projected along with
+                            other supported volume types
+                          properties:
+                            configMap:
+                              description: |-
+                                Adapts a ConfigMap into a projected volume.
+
+                                The contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.
+                              properties:
+                                items:
+                                  description: If unspecified, each key-value pair
+                                    in the Data field of the referenced ConfigMap
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the ConfigMap, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    keys must be defined
+                                  type: boolean
+                              type: object
+                            downwardAPI:
+                              description: Represents downward API info for projecting
+                                into a projected volume. Note that this is identical
+                                to a downwardAPI volume source without the default
+                                mode.
+                              properties:
+                                items:
+                                  description: Items is a list of DownwardAPIVolume
+                                    file
+                                  items:
+                                    description: DownwardAPIVolumeFile represents
+                                      information to create the file containing the
+                                      pod field
+                                    properties:
+                                      fieldRef:
+                                        description: ObjectFieldSelector selects an
+                                          APIVersioned field of an object.
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: 'Required: Path is  the relative
+                                          path name of the file to be created. Must
+                                          not be absolute or contain the ''..'' path.
+                                          Must be utf-8 encoded. The first item of
+                                          the relative path must not start with ''..'''
+                                        type: string
+                                      resourceFieldRef:
+                                        description: ResourceFieldSelector represents
+                                          container resources (cpu, memory) and their
+                                          output format
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor: {}
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                    required:
+                                    - path
+                                    type: object
+                                  type: array
+                              type: object
+                            secret:
+                              description: |-
+                                Adapts a secret into a projected volume.
+
+                                The contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.
+                              properties:
+                                items:
+                                  description: If unspecified, each key-value pair
+                                    in the Data field of the referenced Secret will
+                                    be projected into the volume as a file whose name
+                                    is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the Secret, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              type: object
+                            serviceAccountToken:
+                              description: ServiceAccountTokenProjection represents
+                                a projected service account token volume. This projection
+                                can be used to insert a service account token into
+                                the pods runtime filesystem for use against APIs (Kubernetes
+                                API Server or otherwise).
+                              properties:
+                                audience:
+                                  description: Audience is the intended audience of
+                                    the token. A recipient of a token must identify
+                                    itself with an identifier specified in the audience
+                                    of the token, and otherwise should reject the
+                                    token. The audience defaults to the identifier
+                                    of the apiserver.
+                                  type: string
+                                expirationSeconds:
+                                  description: ExpirationSeconds is the requested
+                                    duration of validity of the service account token.
+                                    As the token approaches expiration, the kubelet
+                                    volume plugin will proactively rotate the service
+                                    account token. The kubelet will start trying to
+                                    rotate the token if the token is older than 80
+                                    percent of its time to live or if the token is
+                                    older than 24 hours.Defaults to 1 hour and must
+                                    be at least 10 minutes.
+                                  format: int64
+                                  type: integer
+                                path:
+                                  description: Path is the path relative to the mount
+                                    point of the file to project the token into.
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                          type: object
+                        type: array
+                    required:
+                    - sources
+                    type: object
+                  quobyte:
+                    description: Represents a Quobyte mount that lasts the lifetime
+                      of a pod. Quobyte volumes do not support ownership management
+                      or SELinux relabeling.
+                    properties:
+                      group:
+                        description: Group to map volume access to Default is no group
+                        type: string
+                      readOnly:
+                        description: ReadOnly here will force the Quobyte volume to
+                          be mounted with read-only permissions. Defaults to false.
+                        type: boolean
+                      registry:
+                        description: Registry represents a single or multiple Quobyte
+                          Registry services specified as a string as host:port pair
+                          (multiple entries are separated with commas) which acts
+                          as the central registry for volumes
+                        type: string
+                      tenant:
+                        description: Tenant owning the given Quobyte volume in the
+                          Backend Used with dynamically provisioned Quobyte volumes,
+                          value is set by the plugin
+                        type: string
+                      user:
+                        description: User to map volume access to Defaults to serivceaccount
+                          user
+                        type: string
+                      volume:
+                        description: Volume is a string that references an already
+                          created Quobyte volume by name.
+                        type: string
+                    required:
+                    - registry
+                    - volume
+                    type: object
+                  rbd:
+                    description: Represents a Rados Block Device mount that lasts
+                      the lifetime of a pod. RBD volumes support ownership management
+                      and SELinux relabeling.
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                        type: string
+                      image:
+                        description: 'The rados image name. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      keyring:
+                        description: 'Keyring is the path to key ring for RBDUser.
+                          Default is /etc/ceph/keyring. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      monitors:
+                        description: 'A collection of Ceph monitors. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                        items:
+                          type: string
+                        type: array
+                      pool:
+                        description: 'The rados pool name. Default is rbd. More info:
+                          https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                        type: boolean
+                      secretRef:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        type: object
+                      user:
+                        description: 'The rados user name. Default is admin. More
+                          info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                    required:
+                    - monitors
+                    - image
+                    type: object
+                  scaleIO:
+                    description: ScaleIOVolumeSource represents a persistent ScaleIO
+                      volume
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Default is "xfs".
+                        type: string
+                      gateway:
+                        description: The host address of the ScaleIO API Gateway.
+                        type: string
+                      protectionDomain:
+                        description: The name of the ScaleIO Protection Domain for
+                          the configured storage.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretRef:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        type: object
+                      sslEnabled:
+                        description: Flag to enable/disable SSL communication with
+                          Gateway, default false
+                        type: boolean
+                      storageMode:
+                        description: Indicates whether the storage for a volume should
+                          be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                        type: string
+                      storagePool:
+                        description: The ScaleIO Storage Pool associated with the
+                          protection domain.
+                        type: string
+                      system:
+                        description: The name of the storage system as configured
+                          in ScaleIO.
+                        type: string
+                      volumeName:
+                        description: The name of a volume already created in the ScaleIO
+                          system that is associated with this volume source.
+                        type: string
+                    required:
+                    - gateway
+                    - system
+                    - secretRef
+                    type: object
+                  secret:
+                    description: |-
+                      Adapts a Secret into a volume.
+
+                      The contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        format: int32
+                        type: integer
+                      items:
+                        description: If unspecified, each key-value pair in the Data
+                          field of the referenced Secret will be projected into the
+                          volume as a file whose name is the key and content is the
+                          value. If specified, the listed keys will be projected into
+                          the specified paths, and unlisted keys will not be present.
+                          If a key is specified which is not present in the Secret,
+                          the volume setup will error unless it is marked optional.
+                          Paths must be relative and may not contain the '..' path
+                          or start with '..'.
+                        items:
+                          description: Maps a string key to a path within a volume.
+                          properties:
+                            key:
+                              description: The key to project.
+                              type: string
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              format: int32
+                              type: integer
+                            path:
+                              description: The relative path of the file to map the
+                                key to. May not be an absolute path. May not contain
+                                the path element '..'. May not start with the string
+                                '..'.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          type: object
+                        type: array
+                      optional:
+                        description: Specify whether the Secret or its keys must be
+                          defined
+                        type: boolean
+                      secretName:
+                        description: 'Name of the secret in the pod''s namespace to
+                          use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                        type: string
+                    type: object
+                  storageos:
+                    description: Represents a StorageOS persistent volume resource.
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretRef:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        type: object
+                      volumeName:
+                        description: VolumeName is the human-readable name of the
+                          StorageOS volume.  Volume names are only unique within a
+                          namespace.
+                        type: string
+                      volumeNamespace:
+                        description: VolumeNamespace specifies the scope of the volume
+                          within StorageOS.  If no namespace is specified then the
+                          Pod's namespace will be used.  This allows the Kubernetes
+                          name scoping to be mirrored within StorageOS for tighter
+                          integration. Set VolumeName to any name to override the
+                          default behaviour. Set to "default" if you are not using
+                          namespaces within StorageOS. Namespaces that do not pre-exist
+                          within StorageOS will be created.
+                        type: string
+                    type: object
+                  vsphereVolume:
+                    description: Represents a vSphere volume resource.
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      storagePolicyID:
+                        description: Storage Policy Based Management (SPBM) profile
+                          ID associated with the StoragePolicyName.
+                        type: string
+                      storagePolicyName:
+                        description: Storage Policy Based Management (SPBM) profile
+                          name.
+                        type: string
+                      volumePath:
+                        description: Path that identifies vSphere volume vmdk
+                        type: string
+                    required:
+                    - volumePath
+                    type: object
+                required:
+                - name
+                type: object
+              type: array
+            walCompression:
+              description: Enable compression of the write-ahead log using Snappy.
+                This flag is only available in versions of Prometheus >= 2.11.0.
+              type: boolean
+          type: object
+        status:
+          description: 'PrometheusStatus is the most recent observed status of the
+            Prometheus cluster. Read-only. Not included when requesting from the apiserver,
+            only from the Prometheus Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
+          properties:
+            availableReplicas:
+              description: Total number of available pods (ready for at least minReadySeconds)
+                targeted by this Prometheus deployment.
+              format: int32
+              type: integer
+            paused:
+              description: Represents whether any actions on the underlaying managed
+                objects are being performed. Only delete actions will be performed.
+              type: boolean
+            replicas:
+              description: Total number of non-terminated pods targeted by this Prometheus
+                deployment (their labels match the selector).
+              format: int32
+              type: integer
+            unavailableReplicas:
+              description: Total number of unavailable pods targeted by this Prometheus
+                deployment.
+              format: int32
+              type: integer
+            updatedReplicas:
+              description: Total number of non-terminated pods targeted by this Prometheus
+                deployment that have the desired version spec.
+              format: int32
+              type: integer
+          required:
+          - paused
+          - replicas
+          - updatedReplicas
+          - availableReplicas
+          - unavailableReplicas
+          type: object
+      type: object
+  version: v1
+{{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus-operator/crd-prometheusrules.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/crd-prometheusrules.yaml
@@ -1,0 +1,404 @@
+{{- if .Values.operator.enabled -}}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: prometheusrules.monitoring.coreos.com
+  labels: {{- include "prometheus-operator.operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: monitoring.coreos.com
+  names:
+    kind: PrometheusRule
+    plural: prometheusrules
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          description: ObjectMeta is metadata that all persisted resources must have,
+            which includes all objects users must create.
+          properties:
+            annotations:
+              description: 'Annotations is an unstructured key value map stored with
+                a resource that may be set by external tools to store and retrieve
+                arbitrary metadata. They are not queryable and should be preserved
+                when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+              type: object
+            clusterName:
+              description: The name of the cluster which the object belongs to. This
+                is used to distinguish resources with same name and namespace in different
+                clusters. This field is not set anywhere right now and apiserver is
+                going to ignore it if set in create or update request.
+              type: string
+            creationTimestamp:
+              description: Time is a wrapper around time.Time which supports correct
+                marshaling to YAML and JSON.  Wrappers are provided for many of the
+                factory methods that the time package offers.
+              format: date-time
+              type: string
+            deletionGracePeriodSeconds:
+              description: Number of seconds allowed for this object to gracefully
+                terminate before it will be removed from the system. Only set when
+                deletionTimestamp is also set. May only be shortened. Read-only.
+              format: int64
+              type: integer
+            deletionTimestamp:
+              description: Time is a wrapper around time.Time which supports correct
+                marshaling to YAML and JSON.  Wrappers are provided for many of the
+                factory methods that the time package offers.
+              format: date-time
+              type: string
+            finalizers:
+              description: Must be empty before the object is deleted from the registry.
+                Each entry is an identifier for the responsible component that will
+                remove the entry from the list. If the deletionTimestamp of the object
+                is non-nil, entries in this list can only be removed.
+              items:
+                type: string
+              type: array
+            generateName:
+              description: |-
+                GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
+                If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+
+                Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+              type: string
+            generation:
+              description: A sequence number representing a specific generation of
+                the desired state. Populated by the system. Read-only.
+              format: int64
+              type: integer
+            initializers:
+              description: Initializers tracks the progress of initialization.
+              properties:
+                pending:
+                  description: Pending is a list of initializers that must execute
+                    in order before this object is visible. When the last pending
+                    initializer is removed, and no failing result is set, the initializers
+                    struct will be set to nil and the object is considered as initialized
+                    and visible to all clients.
+                  items:
+                    description: Initializer is information about an initializer that
+                      has not yet completed.
+                    properties:
+                      name:
+                        description: name of the process that is responsible for initializing
+                          this object.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+                result:
+                  description: Status is a return value for calls that don't return
+                    other objects.
+                  properties:
+                    apiVersion:
+                      description: 'APIVersion defines the versioned schema of this
+                        representation of an object. Servers should convert recognized
+                        schemas to the latest internal value, and may reject unrecognized
+                        values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                      type: string
+                    code:
+                      description: Suggested HTTP return code for this status, 0 if
+                        not set.
+                      format: int32
+                      type: integer
+                    details:
+                      description: StatusDetails is a set of additional properties
+                        that MAY be set by the server to provide additional information
+                        about a response. The Reason field of a Status object defines
+                        what attributes will be set. Clients must ignore fields that
+                        do not match the defined type of each attribute, and should
+                        assume that any attribute may be empty, invalid, or under
+                        defined.
+                      properties:
+                        causes:
+                          description: The Causes array includes more details associated
+                            with the StatusReason failure. Not all StatusReasons may
+                            provide detailed causes.
+                          items:
+                            description: StatusCause provides more information about
+                              an api.Status failure, including cases when multiple
+                              errors are encountered.
+                            properties:
+                              field:
+                                description: |-
+                                  The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+
+                                  Examples:
+                                    "name" - the field "name" on the current resource
+                                    "items[0].name" - the field "name" on the first array entry in "items"
+                                type: string
+                              message:
+                                description: A human-readable description of the cause
+                                  of the error.  This field may be presented as-is
+                                  to a reader.
+                                type: string
+                              reason:
+                                description: A machine-readable description of the
+                                  cause of the error. If this value is empty there
+                                  is no information available.
+                                type: string
+                            type: object
+                          type: array
+                        group:
+                          description: The group attribute of the resource associated
+                            with the status StatusReason.
+                          type: string
+                        kind:
+                          description: 'The kind attribute of the resource associated
+                            with the status StatusReason. On some operations may differ
+                            from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: The name attribute of the resource associated
+                            with the status StatusReason (when there is a single name
+                            which can be described).
+                          type: string
+                        retryAfterSeconds:
+                          description: If specified, the time in seconds before the
+                            operation should be retried. Some errors may indicate
+                            the client must take an alternate action - for those errors
+                            this field may indicate how long to wait before taking
+                            the alternate action.
+                          format: int32
+                          type: integer
+                        uid:
+                          description: 'UID of the resource. (when there is a single
+                            resource which can be described). More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                          type: string
+                      type: object
+                    kind:
+                      description: 'Kind is a string value representing the REST resource
+                        this object represents. Servers may infer this from the endpoint
+                        the client submits requests to. Cannot be updated. In CamelCase.
+                        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                      type: string
+                    message:
+                      description: A human-readable description of the status of this
+                        operation.
+                      type: string
+                    metadata:
+                      description: ListMeta describes metadata that synthetic resources
+                        must have, including lists and various status objects. A resource
+                        may have only one of {ObjectMeta, ListMeta}.
+                      properties:
+                        continue:
+                          description: continue may be set if the user set a limit
+                            on the number of items returned, and indicates that the
+                            server has more data available. The value is opaque and
+                            may be used to issue another request to the endpoint that
+                            served this list to retrieve the next set of available
+                            objects. Continuing a consistent list may not be possible
+                            if the server configuration has changed or more than a
+                            few minutes have passed. The resourceVersion field returned
+                            when using this continue value will be identical to the
+                            value in the first response, unless you have received
+                            this token from an error message.
+                          type: string
+                        remainingItemCount:
+                          description: |-
+                            remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.
+
+                            This field is alpha and can be changed or removed without notice.
+                          format: int64
+                          type: integer
+                        resourceVersion:
+                          description: 'String that identifies the server''s internal
+                            version of this object that can be used by clients to
+                            determine when objects have changed. Value must be treated
+                            as opaque by clients and passed unmodified back to the
+                            server. Populated by the system. Read-only. More info:
+                            https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        selfLink:
+                          description: selfLink is a URL representing this object.
+                            Populated by the system. Read-only.
+                          type: string
+                      type: object
+                    reason:
+                      description: A machine-readable description of why this operation
+                        is in the "Failure" status. If this value is empty there is
+                        no information available. A Reason clarifies an HTTP status
+                        code but does not override it.
+                      type: string
+                    status:
+                      description: 'Status of the operation. One of: "Success" or
+                        "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                      type: string
+                  type: object
+              required:
+              - pending
+              type: object
+            labels:
+              description: 'Map of string keys and values that can be used to organize
+                and categorize (scope and select) objects. May match selectors of
+                replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+              type: object
+            managedFields:
+              description: |-
+                ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+
+                This field is alpha and can be changed or removed without notice.
+              items:
+                description: ManagedFieldsEntry is a workflow-id, a FieldSet and the
+                  group version of the resource that the fieldset applies to.
+                properties:
+                  apiVersion:
+                    description: APIVersion defines the version of this resource that
+                      this field set applies to. The format is "group/version" just
+                      like the top-level APIVersion field. It is necessary to track
+                      the version of a field set because it cannot be automatically
+                      converted.
+                    type: string
+                  fields:
+                    description: 'Fields stores a set of fields in a data structure
+                      like a Trie. To understand how this is used, see: https://github.com/kubernetes-sigs/structured-merge-diff'
+                    type: object
+                  manager:
+                    description: Manager is an identifier of the workflow managing
+                      these fields.
+                    type: string
+                  operation:
+                    description: Operation is the type of operation which lead to
+                      this ManagedFieldsEntry being created. The only valid values
+                      for this field are 'Apply' and 'Update'.
+                    type: string
+                  time:
+                    description: Time is a wrapper around time.Time which supports
+                      correct marshaling to YAML and JSON.  Wrappers are provided
+                      for many of the factory methods that the time package offers.
+                    format: date-time
+                    type: string
+                type: object
+              type: array
+            name:
+              description: 'Name must be unique within a namespace. Is required when
+                creating resources, although some resources may allow a client to
+                request the generation of an appropriate name automatically. Name
+                is primarily intended for creation idempotence and configuration definition.
+                Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+              type: string
+            namespace:
+              description: |-
+                Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
+                Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+              type: string
+            ownerReferences:
+              description: List of objects depended by this object. If ALL objects
+                in the list have been deleted, this object will be garbage collected.
+                If this object is managed by a controller, then an entry in this list
+                will point to this controller, with the controller field set to true.
+                There cannot be more than one managing controller.
+              items:
+                description: OwnerReference contains enough information to let you
+                  identify an owning object. An owning object must be in the same
+                  namespace as the dependent, or be cluster-scoped, so there is no
+                  namespace field.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  blockOwnerDeletion:
+                    description: If true, AND if the owner has the "foregroundDeletion"
+                      finalizer, then the owner cannot be deleted from the key-value
+                      store until this reference is removed. Defaults to false. To
+                      set this field, a user needs "delete" permission of the owner,
+                      otherwise 422 (Unprocessable Entity) will be returned.
+                    type: boolean
+                  controller:
+                    description: If true, this reference points to the managing controller.
+                    type: boolean
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                - uid
+                type: object
+              type: array
+            resourceVersion:
+              description: |-
+                An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
+                Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
+              type: string
+            selfLink:
+              description: SelfLink is a URL representing this object. Populated by
+                the system. Read-only.
+              type: string
+            uid:
+              description: |-
+                UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
+                Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+              type: string
+          type: object
+        spec:
+          description: PrometheusRuleSpec contains specification parameters for a
+            Rule.
+          properties:
+            groups:
+              description: Content of Prometheus rule file
+              items:
+                description: RuleGroup is a list of sequentially evaluated recording
+                  and alerting rules.
+                properties:
+                  interval:
+                    type: string
+                  name:
+                    type: string
+                  rules:
+                    items:
+                      description: Rule describes an alerting or recording rule.
+                      properties:
+                        alert:
+                          type: string
+                        annotations:
+                          type: object
+                        expr:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                        for:
+                          type: string
+                        labels:
+                          type: object
+                        record:
+                          type: string
+                      required:
+                      - expr
+                      type: object
+                    type: array
+                required:
+                - name
+                - rules
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1
+{{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus-operator/crd-servicemonitor.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/crd-servicemonitor.yaml
@@ -1,0 +1,308 @@
+{{- if .Values.operator.enabled -}}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: servicemonitors.monitoring.coreos.com
+  labels: {{- include "prometheus-operator.operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: monitoring.coreos.com
+  names:
+    kind: ServiceMonitor
+    plural: servicemonitors
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        spec:
+          description: ServiceMonitorSpec contains specification parameters for a
+            ServiceMonitor.
+          properties:
+            endpoints:
+              description: A list of endpoints allowed as part of this ServiceMonitor.
+              items:
+                description: Endpoint defines a scrapeable endpoint serving Prometheus
+                  metrics.
+                properties:
+                  basicAuth:
+                    description: 'BasicAuth allow an endpoint to authenticate over
+                      basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                    properties:
+                      password:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                      username:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                    type: object
+                  bearerTokenFile:
+                    description: File to read bearer token for scraping targets.
+                    type: string
+                  honorLabels:
+                    description: HonorLabels chooses the metric's labels on collisions
+                      with target labels.
+                    type: boolean
+                  interval:
+                    description: Interval at which metrics should be scraped
+                    type: string
+                  metricRelabelings:
+                    description: MetricRelabelConfigs to apply to samples before ingestion.
+                    items:
+                      description: 'RelabelConfig allows dynamic rewriting of the
+                        label set, being applied to samples before ingestion. It defines
+                        `<metric_relabel_configs>`-section of Prometheus configuration.
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                      properties:
+                        action:
+                          description: Action to perform based on regex matching.
+                            Default is 'replace'
+                          type: string
+                        modulus:
+                          description: Modulus to take of the hash of the source label
+                            values.
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched. defailt is '(.*)'
+                          type: string
+                        replacement:
+                          description: Replacement value against which a regex replace
+                            is performed if the regular expression matches. Regex
+                            capture groups are available. Default is '$1'
+                          type: string
+                        separator:
+                          description: Separator placed between concatenated source
+                            label values. default is ';'.
+                          type: string
+                        sourceLabels:
+                          description: The source labels select values from existing
+                            labels. Their content is concatenated using the configured
+                            separator and matched against the configured regular expression
+                            for the replace, keep, and drop actions.
+                          items:
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: Label to which the resulting value is written
+                            in a replace action. It is mandatory for replace actions.
+                            Regex capture groups are available.
+                          type: string
+                      type: object
+                    type: array
+                  params:
+                    description: Optional HTTP URL parameters
+                    type: object
+                  path:
+                    description: HTTP path to scrape for metrics.
+                    type: string
+                  port:
+                    description: Name of the service port this endpoint refers to.
+                      Mutually exclusive with targetPort.
+                    type: string
+                  proxyUrl:
+                    description: ProxyURL eg http://proxyserver:2195 Directs scrapes
+                      to proxy through this endpoint.
+                    type: string
+                  relabelings:
+                    description: 'RelabelConfigs to apply to samples before scraping.
+                      More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                    items:
+                      description: 'RelabelConfig allows dynamic rewriting of the
+                        label set, being applied to samples before ingestion. It defines
+                        `<metric_relabel_configs>`-section of Prometheus configuration.
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                      properties:
+                        action:
+                          description: Action to perform based on regex matching.
+                            Default is 'replace'
+                          type: string
+                        modulus:
+                          description: Modulus to take of the hash of the source label
+                            values.
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched. defailt is '(.*)'
+                          type: string
+                        replacement:
+                          description: Replacement value against which a regex replace
+                            is performed if the regular expression matches. Regex
+                            capture groups are available. Default is '$1'
+                          type: string
+                        separator:
+                          description: Separator placed between concatenated source
+                            label values. default is ';'.
+                          type: string
+                        sourceLabels:
+                          description: The source labels select values from existing
+                            labels. Their content is concatenated using the configured
+                            separator and matched against the configured regular expression
+                            for the replace, keep, and drop actions.
+                          items:
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: Label to which the resulting value is written
+                            in a replace action. It is mandatory for replace actions.
+                            Regex capture groups are available.
+                          type: string
+                      type: object
+                    type: array
+                  scheme:
+                    description: HTTP scheme to use for scraping.
+                    type: string
+                  scrapeTimeout:
+                    description: Timeout after which the scrape is ended
+                    type: string
+                  targetPort:
+                    anyOf:
+                    - type: string
+                    - type: integer
+                  tlsConfig:
+                    description: TLSConfig specifies TLS configuration parameters.
+                    properties:
+                      caFile:
+                        description: The CA cert to use for the targets.
+                        type: string
+                      certFile:
+                        description: The client cert file for the targets.
+                        type: string
+                      insecureSkipVerify:
+                        description: Disable target certificate validation.
+                        type: boolean
+                      keyFile:
+                        description: The client key file for the targets.
+                        type: string
+                      serverName:
+                        description: Used to verify the hostname for the targets.
+                        type: string
+                    type: object
+                type: object
+              type: array
+            jobLabel:
+              description: The label to use to retrieve the job name from.
+              type: string
+            namespaceSelector:
+              description: NamespaceSelector is a selector for selecting either all
+                namespaces or a list of namespaces.
+              properties:
+                any:
+                  description: Boolean describing whether all namespaces are selected
+                    in contrast to a list restricting them.
+                  type: boolean
+                matchNames:
+                  description: List of namespace names.
+                  items:
+                    type: string
+                  type: array
+              type: object
+            podTargetLabels:
+              description: PodTargetLabels transfers labels on the Kubernetes Pod
+                onto the target.
+              items:
+                type: string
+              type: array
+            sampleLimit:
+              description: SampleLimit defines per-scrape limit on number of scraped
+                samples that will be accepted.
+              format: int64
+              type: integer
+            selector:
+              description: A label selector is a label query over a set of resources.
+                The result of matchLabels and matchExpressions are ANDed. An empty
+                label selector matches all objects. A null label selector matches
+                no objects.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            targetLabels:
+              description: TargetLabels transfers labels on the Kubernetes Service
+                onto the target.
+              items:
+                type: string
+              type: array
+          required:
+          - endpoints
+          - selector
+          type: object
+      type: object
+  version: v1
+{{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus-operator/deployment.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/deployment.yaml
@@ -1,0 +1,93 @@
+{{- if .Values.operator.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "prometheus-operator.operator.fullname" . }}
+  labels: {{- include "prometheus-operator.operator.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {{- include "prometheus-operator.operator.matchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels: {{- include "prometheus-operator.operator.labels" . | nindent 8 }}
+      annotations:
+{{- if .Values.operator.podAnnotations }}
+{{ toYaml .Values.operator.podAnnotations | indent 8 }}
+{{- end }}
+    spec:
+      serviceAccountName: {{ template "prometheus-operator.operator.serviceAccountName" . }}
+      {{- if .Values.operator.schedulerName }}
+      schedulerName: {{ .Values.operator.schedulerName | quote }}
+      {{- end }}
+      {{- if .Values.operator.securityContext.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.operator.securityContext.runAsUser }}
+        fsGroup: {{ .Values.operator.securityContext.fsGroup }}
+        runAsNonRoot: {{ .Values.operator.securityContext.runAsNonRoot }}
+      {{- end }}
+      {{- if .Values.operator.nodeSelector }}
+      nodeSelector: {{- include "prometheus-operator.tplValue" (dict "value" .Values.operator.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.operator.tolerations }}
+      tolerations: {{- include "prometheus-operator.tplValue" (dict "value" .Values.operator.tolerations "context" $) | nindent 8 }}
+      {{- end }}
+      affinity:
+        {{- if .Values.operator.nodeAffinity }}
+        nodeAffinity: {{- include "prometheus-operator.tplValue" (dict "value" .Values.operator.nodeAffinity "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if eq .Values.operator.podAntiAffinity "hard" }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: "kubernetes.io/hostname"
+            labelSelector:
+              matchLabels: {{- include "prometheus-operator.operator.matchLabels" . | nindent 16 }}
+        {{- else if eq .Values.operator.podAntiAffinity "soft" }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels: {{- include "prometheus-operator.operator.matchLabels" . | nindent 18 }}
+        {{- end }}
+        {{- if .Values.operator.podAffinity }}
+        podAffinity: {{- include "prometheus-operator.tplValue" (dict "value" .Values.operator.podAffinity "context" $) | nindent 10 }}
+        {{- end }}
+      containers:
+      - name: {{ template "prometheus-operator.name" . }}
+        image: {{ template "prometheus-operator.image" . }}
+        imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
+        args:
+          {{- if .Values.operator.kubeletService.enabled }}
+          - --kubelet-service={{ .Values.operator.kubeletService.namespace }}/{{ template "prometheus-operator.fullname" . }}-kubelet
+          {{- end }}
+          {{- if .Values.operator.logFormat }}
+          - --log-format={{ .Values.operator.logFormat }}
+          {{- end }}
+          {{- if .Values.operator.logLevel }}
+          - --log-level={{ .Values.operator.logLevel }}
+          {{- end }}
+          - --logtostderr=true
+          - --localhost=127.0.0.1
+          - --config-reloader-image={{ template "prometheus-operator.configmapReload.image" . }}
+          - --prometheus-config-reloader={{ template "prometheus-operator.prometheusConfigReloader.image" . }}
+        ports:
+          - name: http
+            containerPort: 8080
+            protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: http
+{{ toYaml .Values.operator.livenessProbe | indent 10 }}
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: http
+{{ toYaml .Values.operator.readinessProbe | indent 10 }}
+        resources: {{- toYaml .Values.operator.resources | nindent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+{{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus-operator/psp-clusterrole.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/psp-clusterrole.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.operator.enabled .Values.rbac.create .Values.rbac.pspEnabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "prometheus-operator.operator.fullname" . }}-psp
+  labels: {{- include "prometheus-operator.operator.labels" . | nindent 4 }}
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs: ['use']
+  resourceNames:
+  - {{ template "prometheus-operator.operator.fullname" . }}
+{{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus-operator/psp-clusterrolebinding.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/psp-clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.operator.enabled .Values.rbac.create .Values.rbac.pspEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "prometheus-operator.operator.fullname" . }}-psp
+  labels: {{- include "prometheus-operator.operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "prometheus-operator.operator.fullname" . }}-psp
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "prometheus-operator.operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus-operator/psp.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/psp.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.operator.enabled .Values.rbac.create .Values.rbac.pspEnabled }}
+apiVersion: {{ template "podSecurityPolicy.apiVersion" . }}
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "prometheus-operator.operator.fullname" . }}
+  labels: {{- include "prometheus-operator.operator.labels" . | nindent 4 }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+  - ALL
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1001
+      max: 1001
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1001
+      max: 1001
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1001
+      max: 1001
+{{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus-operator/service.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/service.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.operator.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "prometheus-operator.operator.fullname" . }}
+  labels: {{- include "prometheus-operator.operator.labels" . | nindent 4 }}
+  {{- with .Values.operator.service.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.operator.service.type }}
+  {{- if and .Values.operator.service.loadBalancerIP (eq .Values.operator.service.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.operator.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.operator.service.type "LoadBalancer") .Values.operator.service.loadBalancerSourceRanges }}
+  {{- with .Values.operator.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+  {{- if and (eq .Values.operator.service.type "ClusterIP") .Values.operator.service.clusterIP }}
+  clusterIP: {{ .Values.operator.service.clusterIP }}
+  {{- end }}
+  ports:
+  - name: http
+    port: {{ .Values.operator.service.port }}
+    targetPort: http
+    {{- if and .Values.operator.service.nodePort (or (eq .Values.operator.service.type "NodePort") (eq .Values.operator.service.type "LoadBalancer")) }}
+    nodePort: {{ .Values.operator.service.nodePort }}
+    {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ template "prometheus-operator.name" . }}
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus-operator/serviceaccount.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if and .Values.operator.enabled .Values.operator.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "prometheus-operator.operator.serviceAccountName" . }}
+  labels: {{- include "prometheus-operator.operator.labels" . | nindent 4 }}
+{{- include "prometheus-operator.operator.imagePullSecrets" . }}
+{{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus-operator/servicemonitor.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/servicemonitor.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.operator.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "prometheus-operator.operator.fullname" . }}
+  labels: {{- include "prometheus-operator.operator.labels" . | nindent 4 }}
+spec:
+  endpoints:
+  - port: http
+    honorLabels: true
+    {{- if .Values.operator.serviceMonitor.interval }}
+    interval: {{ .Values.operator.serviceMonitor.interval }}
+    {{- end }}
+{{- if .Values.operator.serviceMonitor.metricRelabelings }}
+    metricRelabelings: {{- include "prometheus-operator.tplValue" ( dict "value" .Values.operator.serviceMonitor.metricRelabelings "context" $) | nindent 6 }}
+{{- end }}
+{{- if .Values.operator.serviceMonitor.relabelings }}
+    relabelings: {{- toYaml .Values.operator.serviceMonitor.relabelings | nindent 6 }}
+{{- end }}
+  selector:
+    matchLabels: {{- include "prometheus-operator.operator.matchLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus/clusterrole.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/clusterrole.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.prometheus.enabled .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "prometheus-operator.prometheus.fullname" . }}
+  labels: {{- include "prometheus-operator.prometheus.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes/metrics
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: [""]
+  resources:
+  - nodes
+  - nodes/proxy
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - extensions
+  - "networking.k8s.io"
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+{{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus/clusterrolebinding.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.prometheus.enabled .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "prometheus-operator.prometheus.fullname" . }}
+  labels: {{- include "prometheus-operator.prometheus.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "prometheus-operator.prometheus.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "prometheus-operator.prometheus.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus/ingress.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/ingress.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.prometheus.enabled .Values.prometheus.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "prometheus-operator.prometheus.fullname" . }}
+  labels: {{- include "prometheus-operator.prometheus.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.prometheus.ingress.certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- range $key, $value := .Values.prometheus.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+  {{- range .Values.prometheus.ingress.hosts }}
+  - host: {{ .name }}
+    http:
+      paths:
+      - path: {{ default "/" .path }}
+        backend:
+          serviceName: {{ template "prometheus-operator.prometheus.fullname" $ }}
+          servicePort: http
+  {{- end }}
+  {{- if .Values.prometheus.ingress.tls }}
+  tls:
+{{ toYaml .Values.prometheus.ingress.tls | indent 4 }}
+  {{- end }}
+{{- end -}}

--- a/bitnami/prometheus-operator/templates/prometheus/pdb.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.prometheus.enabled .Values.prometheus.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "prometheus-operator.prometheus.fullname" . }}
+  labels: {{- include "prometheus-operator.prometheus.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: prometheus
+      prometheus: {{ template "prometheus-operator.prometheus.fullname" . }}
+  {{- if .Values.prometheus.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.prometheus.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.prometheus.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.prometheus.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -1,0 +1,145 @@
+{{- if .Values.prometheus.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: {{ template "prometheus-operator.prometheus.fullname" . }}
+  labels: {{- include "prometheus-operator.prometheus.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.prometheus.replicaCount }}
+  serviceAccountName: {{ template "prometheus-operator.prometheus.serviceAccountName" . }}
+  {{- if .Values.prometheus.serviceMonitorSelector }}
+  serviceMonitorSelector: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.serviceMonitorSelector "context" $) | nindent 4 }}
+  {{- else }}
+  serviceMonitorSelector: {}
+  {{- end }}
+  alerting:
+    alertmanagers:
+    {{- if .Values.prometheus.externalLabels }}
+    {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.externalLabels "context" $) | indent 6 }}
+    {{- else }}
+    {{- if .Values.alertmanager.enabled }}
+      - namespace: {{ .Release.Namespace }}
+        name: {{ template "prometheus-operator.alertmanager.fullname" . }}
+        port: http
+        pathPrefix: "/"
+    {{- else }}
+      []
+    {{- end }}
+    {{- end }}
+  {{- if .Values.prometheus.image }}
+  baseImage: {{ template "prometheus-operator.prometheus.baseImage" . }}
+  version: {{ .Values.prometheus.image.tag }}
+  {{- end }}
+  {{- if .Values.prometheus.externalLabels }}
+  externalLabels: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.externalLabels "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.prometheus.prometheusExternalLabelNameClear }}
+  prometheusExternalLabelName: ""
+  {{- else if .Values.prometheus.prometheusExternalLabelName }}
+  prometheusExternalLabelName: "{{ .Values.prometheus.prometheusExternalLabelName }}"
+  {{- end }}
+  {{- if .Values.prometheus.replicaExternalLabelNameClear }}
+  replicaExternalLabelName: ""
+  {{- else if .Values.prometheus.replicaExternalLabelName }}
+  replicaExternalLabelName: "{{ .Values.prometheus.replicaExternalLabelName }}"
+  {{- end }}
+  {{- if and .Values.prometheus.ingress.enabled .Values.prometheus.ingress.hosts }}
+  externalUrl: {{ if .Values.prometheus.ingress.tls }}https{{else}}http{{ end }}://{{ (index .Values.prometheus.ingress.hosts 0).name }}/
+  {{- else }}
+  externalUrl: http://{{ template "prometheus-operator.prometheus.fullname" . }}.{{ .Release.Namespace }}:9090
+  {{- end }}
+  paused: {{ .Values.prometheus.paused }}
+  logLevel: {{ .Values.prometheus.logLevel }}
+  logFormat: {{ .Values.prometheus.logFormat }}
+  listenLocal: {{ .Values.prometheus.listenLocal }}
+  enableAdminAPI: {{ .Values.prometheus.enableAdminAPI }}
+  {{- if .Values.prometheus.scrapeInterval }}
+  scrapeInterval: {{ .Values.prometheus.scrapeInterval }}
+  {{- end }}
+  {{- if .Values.prometheus.evaluationInterval }}
+  evaluationInterval: {{ .Values.prometheus.evaluationInterval }}
+  {{- end }}
+  resources: {{- toYaml .Values.alertmanager.resources | nindent 4 }}
+  retention: {{ .Values.prometheus.retention }}
+  {{- if .Values.prometheus.retentionSize }}
+  retentionSize: {{ .Values.prometheus.retentionSize }}
+  {{- end }}
+  {{- if .Values.prometheus.walCompression }}
+  walCompression: {{ .Values.prometheus.walCompression }}
+  {{- end }}
+  routePrefix: "/"
+  {{- if .Values.prometheus.secrets }}
+  secrets: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.secrets "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.prometheus.configMaps }}
+  configMaps: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.configMaps "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.prometheus.serviceMonitorNamespaceSelector }}
+  serviceMonitorNamespaceSelector: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.serviceMonitorNamespaceSelector "context" $) | nindent 4 }}
+  {{- else }}
+  serviceMonitorNamespaceSelector: {}
+  {{- end }}
+  {{- if .Values.prometheus.remoteRead }}
+  remoteRead: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.remoteRead "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.prometheus.remoteWrite }}
+  remoteWrite: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.remoteWrite "context" $) | nindent 4 }}
+  {{- end }}
+{{- if .Values.prometheus.securityContext.enabled }}
+securityContext:
+  runAsUser: {{ .Values.prometheus.securityContext.runAsUser }}
+  fsGroup: {{ .Values.prometheus.securityContext.fsGroup }}
+{{- end }}
+  {{- if .Values.prometheus.ruleNamespaceSelector }}
+  ruleNamespaceSelector: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.ruleNamespaceSelector "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.prometheus.ruleSelector }}
+  ruleSelector: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.ruleSelector "context" $) | nindent 4 }}
+  {{- else }}
+  ruleSelector: {}
+  {{- end }}
+  {{- if .Values.prometheus.storageSpec }}
+  storage: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.storageSpec "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.prometheus.podMetadata }}
+  podMetadata: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.podMetadata "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.prometheus.querySpec }}
+  query: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.querySpec "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.prometheus.nodeSelector }}
+  nodeSelector: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.nodeSelector "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.prometheus.tolerations }}
+  tolerations: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.tolerations "context" $) | nindent 4 }}
+  {{- end }}
+  affinity:
+    {{- if .Values.prometheus.nodeAffinity }}
+    nodeAffinity: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.nodeAffinity "context" $) | nindent 6 }}
+    {{- end }}
+    {{- if eq .Values.prometheus.podAntiAffinity "hard" }}
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: "kubernetes.io/hostname"
+        labelSelector:
+          matchLabels: {{- include "prometheus-operator.prometheus.matchLabels" . | nindent 12 }}
+    {{- else if eq .Values.prometheus.podAntiAffinity "soft" }}
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          topologyKey: "kubernetes.io/hostname"
+          labelSelector:
+            matchLabels: {{- include "prometheus-operator.prometheus.matchLabels" . | nindent 14 }}
+    {{- end }}
+    {{- if .Values.prometheus.podAffinity }}
+    podAffinity: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.podAffinity "context" $) | nindent 6 }}
+    {{- end }}
+{{- include "prometheus-operator.prometheus.imagePullSecrets" . | indent 2 }}
+  {{- if .Values.prometheus.containers }}
+  containers: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.containers "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.prometheus.priorityClassName }}
+  priorityClassName: {{ .Values.prometheus.priorityClassName }}
+  {{- end }}
+{{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus/psp-clusterrole.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/psp-clusterrole.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.prometheus.enabled .Values.rbac.create .Values.rbac.pspEnabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "prometheus-operator.prometheus.fullname" . }}-psp
+  labels: {{- include "prometheus-operator.prometheus.labels" . | nindent 4 }}
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs: ['use']
+  resourceNames:
+  - {{ template "prometheus-operator.prometheus.fullname" . }}
+{{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus/psp-clusterrolebinding.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/psp-clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.prometheus.enabled .Values.rbac.create .Values.rbac.pspEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "prometheus-operator.prometheus.fullname" . }}-psp
+  labels: {{- include "prometheus-operator.prometheus.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "prometheus-operator.prometheus.fullname" . }}-psp
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "prometheus-operator.prometheus.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus/psp.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/psp.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.prometheus.enabled .Values.rbac.create .Values.rbac.pspEnabled }}
+apiVersion: {{ template "podSecurityPolicy.apiVersion" . }}
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "prometheus-operator.prometheus.fullname" . }}
+  labels: {{- include "prometheus-operator.prometheus.labels" . | nindent 4 }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+  - ALL
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1001
+      max: 1001
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1001
+      max: 1001
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1001
+      max: 1001
+{{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus/service.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/service.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.prometheus.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "prometheus-operator.prometheus.fullname" . }}
+  labels: {{- include "prometheus-operator.prometheus.labels" . | nindent 4 }}
+  {{- with .Values.prometheus.service.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.prometheus.service.type }}
+  {{- if and .Values.prometheus.service.loadBalancerIP (eq .Values.prometheus.service.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.prometheus.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.prometheus.service.type "LoadBalancer") .Values.prometheus.service.loadBalancerSourceRanges }}
+  {{- with .Values.prometheus.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+  {{- if and (eq .Values.prometheus.service.type "ClusterIP") .Values.prometheus.service.clusterIP }}
+  clusterIP: {{ .Values.prometheus.service.clusterIP }}
+  {{- end }}
+  ports:
+  - name: http
+    port: {{ .Values.prometheus.service.port }}
+    targetPort: 9090
+    {{- if and .Values.prometheus.service.nodePort (or (eq .Values.prometheus.service.type "NodePort") (eq .Values.prometheus.service.type "LoadBalancer")) }}
+    nodePort: {{ .Values.prometheus.service.nodePort }}
+    {{- end }}
+  selector:
+    app: prometheus
+    prometheus: {{ template "prometheus-operator.prometheus.fullname" . }}
+{{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus/serviceaccount.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if and .Values.prometheus.enabled .Values.prometheus.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "prometheus-operator.prometheus.serviceAccountName" . }}
+  labels: {{- include "prometheus-operator.prometheus.labels" . | nindent 4 }}
+{{- include "prometheus-operator.prometheus.imagePullSecrets" . }}
+{{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus/servicemonitor.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/servicemonitor.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.prometheus.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "prometheus-operator.prometheus.fullname" . }}
+  labels: {{- include "prometheus-operator.prometheus.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels: {{- include "prometheus-operator.prometheus.matchLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+  - port: http
+    {{- if .Values.prometheus.serviceMonitor.interval }}
+    interval: {{ .Values.prometheus.serviceMonitor.interval }}
+    {{- end }}
+    path: "/metrics"
+{{- if .Values.prometheus.serviceMonitor.metricRelabelings }}
+    metricRelabelings: {{- include "prometheus-operator.tplValue" ( dict "value" .Values.prometheus.serviceMonitor.metricRelabelings "context" $) | nindent 6 }}
+{{- end }}
+{{- if .Values.prometheus.serviceMonitor.relabelings }}
+    relabelings: {{- toYaml .Values.prometheus.serviceMonitor.relabelings | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/bitnami/prometheus-operator/values-production.yaml
+++ b/bitnami/prometheus-operator/values-production.yaml
@@ -42,7 +42,7 @@ operator:
   image:
     registry: docker.io
     repository: bitnami/prometheus-operator
-    tag: 0.33.0-debian-9-r0
+    tag: 0.34.0-debian-9-r3
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -197,7 +197,7 @@ operator:
     image:
       registry: docker.io
       repository: bitnami/configmap-reload
-      tag: 0.3.0-debian-9-r0
+      tag: 0.3.0-debian-9-r14
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -209,7 +209,7 @@ operator:
     image:
       registry: docker.io
       repository: bitnami/prometheus-operator
-      tag: 0.33.0-debian-9-r0
+      tag: 0.34.0-debian-9-r3
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -228,7 +228,7 @@ prometheus:
   image:
     registry: docker.io
     repository: bitnami/prometheus
-    tag: 2.13.0-debian-9-r10
+    tag: 2.13.1-debian-9-r14
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -524,7 +524,7 @@ alertmanager:
   image:
     registry: docker.io
     repository: bitnami/alertmanager
-    tag: 0.19.0-debian-9-r43
+    tag: 0.19.0-debian-9-r57
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/bitnami/prometheus-operator/values-production.yaml
+++ b/bitnami/prometheus-operator/values-production.yaml
@@ -1,0 +1,742 @@
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+## Current available global Docker image parameters: imageRegistry and imagePullSecrets
+##
+global:
+#   imageRegistry: myRegistryName
+#   imagePullSecrets:
+#     - myRegistryKeySecretName
+#   storageClass: myStorageClass
+
+  labels: {}
+    # foo: bar
+
+## String to partially override prometheus.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override prometheus.fullname template
+##
+# fullnameOverride:
+
+## Role Based Access
+## Ref: https://kubernetes.io/docs/admin/authorization/rbac/
+##
+rbac:
+  create: true
+
+  ## RBAC API version
+  ##
+  apiVersion: v1beta1
+
+  ## Podsecuritypolicy
+  ##
+  pspEnabled: true
+
+operator:
+  enabled: true
+
+  ## Bitnami Prometheus Operator image version
+  ## ref: https://hub.docker.com/r/bitnami/prometheus-operator/tags/
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/prometheus-operator
+    tag: 0.33.0-debian-9-r0
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+
+  ## Service account for Prometheus Operator to use.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  ##
+  serviceAccount:
+    ## Specifies whether a ServiceAccount should be created
+    ##
+    create: true
+    ## The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the prometheus-operator.operator.fullname template
+    # name:
+
+  ## Use an alternate scheduler, e.g. "stork".
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  # schedulerName:
+
+  ## SecurityContext configuration
+  ##
+  securityContext:
+    enabled: true
+    runAsUser: 1001
+    fsGroup: 1001
+
+  ## Prometheus Operator Service
+  ##
+  service:
+    ## Kubernetes service type and port number
+    ##
+    type: ClusterIP
+    port: 8080
+    # clusterIP: None
+
+    ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+    ##
+    # nodePort: 30080
+
+    ## Set the LoadBalancer service type to internal only.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    # loadBalancerIP:
+
+    ## Load Balancer sources
+    ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ##
+    # loadBalancerSourceRanges:
+    # - 10.10.10.0/24
+
+    ## Provide any additional annotations which may be required.
+    ##
+    annotations: {}
+
+  ## Create a servicemonitor for the operator
+  ##
+  serviceMonitor:
+    ## Scrape interval. If not set, the Prometheus default scrape interval is used.
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    interval: ""
+
+    ## Metric relabeling
+    ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+    ##
+    metricRelabelings: []
+
+    ## Relabel configs
+    ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+    ##
+    relabelings: []
+
+  ## Configure resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+
+  ## Pod annotations
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+
+  ## Node Affinity. The value is evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity
+  ##
+  nodeAffinity: {}
+
+  ## Pod AntiAffinity
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  podAntiAffinity: soft
+
+  ## Pod Affinity. The value is evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  podAffinity: {}
+
+  ## Node labels for pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Tolerations for pod assignment
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## Configure extra options for liveness and readiness probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+  ##
+  livenessProbe:
+    initialDelaySeconds: 120
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+
+  readinessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+
+  ## Log level for Prometheus Operator
+  ##
+  logLevel: error
+
+  ## Log format for Prometheus Operator
+  ##
+  logFormat: logfmt
+
+  ## If true, the operator will create and maintain a service for scraping kubelets
+  ##
+  kubeletService:
+    enabled: true
+    namespace: kube-system
+
+  ## Configmap-reload image to use for reloading configmaps
+  ##
+  configmapReload:
+    image:
+      registry: docker.io
+      repository: bitnami/configmap-reload
+      tag: 0.3.0-debian-9-r0
+      ## Optionally specify an array of imagePullSecrets.
+      ## Secrets must be manually created in the namespace.
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      ##
+      # pullSecrets:
+      #   - myRegistryKeySecretName
+
+  prometheusConfigReloader:
+    image:
+      registry: docker.io
+      repository: bitnami/prometheus-operator
+      tag: 0.33.0-debian-9-r0
+      ## Optionally specify an array of imagePullSecrets.
+      ## Secrets must be manually created in the namespace.
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      ##
+      # pullSecrets:
+      #   - myRegistryKeySecretName
+
+## Deploy a Prometheus instance
+##
+prometheus:
+  enabled: true
+
+  ## Bitnami Prometheus image version
+  ## ref: https://hub.docker.com/r/bitnami/prometheus-operator/tags/
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/prometheus
+    tag: 2.13.0-debian-9-r10
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+
+  ## Service account for Prometheus to use.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  ##
+  serviceAccount:
+    ## Specifies whether a ServiceAccount should be created
+    ##
+    create: true
+    ## The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the prometheus-operator.prometheus.fullname template
+    # name:
+
+  ## SecurityContext configuration
+  ##
+  securityContext:
+    enabled: true
+    runAsUser: 1001
+    fsGroup: 1001
+
+  ## Configure pod disruption budgets for Prometheus
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
+  ##
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    # maxUnavailable:
+
+  ## Prometheus Service
+  ##
+  service:
+    ## Kubernetes service type and port number
+    ##
+    type: ClusterIP
+    port: 9090
+    # clusterIP: None
+
+    ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+    ##
+    # nodePort: 30090
+
+    ## Set the LoadBalancer service type to internal only.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    # loadBalancerIP:
+
+    ## Load Balancer sources
+    ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ##
+    # loadBalancerSourceRanges:
+    # - 10.10.10.0/24
+
+    ## Provide any additional annotations which may be required.
+    ##
+    annotations: {}
+
+  serviceMonitor:
+    ## Scrape interval. If not set, the Prometheus default scrape interval is used.
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    interval: ""
+
+    ## Metric relabeling
+    ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+    ##
+    metricRelabelings: []
+
+    ## Relabel configs
+    ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+    ##
+    relabelings: []
+
+  ## Configure the ingress resource that allows you to access the
+  ## Alertmanager installation. Set up the URL
+  ## ref: http://kubernetes.io/docs/user-guide/ingress/
+  ##
+  ingress:
+    ## Set to true to enable ingress record generation
+    enabled: false
+
+    ## Set this to true in order to add the corresponding annotations for cert-manager
+    certManager: false
+
+    ## Ingress annotations done as key:value pairs
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+    ##
+    ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+    annotations: {}
+    #  kubernetes.io/ingress.class: nginx
+
+    ## The list of hostnames to be covered with this ingress record.
+    ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
+    hosts:
+    - name: prometheus.local
+      path: /
+
+    ## The tls configuration for the ingress
+    ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+    ## tls:
+    ## - hosts:
+    ##     - prometheus.local
+    ##   secretName: prometheus.local-tls
+
+  ## Configure resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+
+  ## Node Affinity. The value is evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity
+  ##
+  nodeAffinity: {}
+
+  ## Pod AntiAffinity
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  podAntiAffinity: soft
+
+  ## Pod Affinity. The value is evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  podAffinity: {}
+
+  ## Node labels for pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Tolerations for pod assignment
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## Interval between consecutive scrapes.
+  ##
+  scrapeInterval: ""
+
+  ## Interval between consecutive evaluations.
+  ##
+  evaluationInterval: ""
+
+  ## ListenLocal makes the Prometheus server listen on loopback, so that it does not bind against the Pod IP.
+  ##
+  listenLocal: false
+
+  ## Enable Prometheus adminitrative API
+  ## ref: https://prometheus.io/docs/prometheus/latest/querying/api/#tsdb-admin-apis
+  ##
+  enableAdminAPI: false
+
+  ## Alertmanagers to which alerts will be sent
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#alertmanagerendpoints
+  ##
+  alertingEndpoints: []
+
+  ## External labels to add to any time series or alerts when communicating with external systems
+  ##
+  externalLabels: {}
+
+  ## Name of the external label used to denote replica name
+  ##
+  replicaExternalLabelName: ""
+
+  ## If true, the Operator won't add the external label used to denote replica name
+  ##
+  replicaExternalLabelNameClear: false
+
+  ## Name of the external label used to denote Prometheus instance name
+  ##
+  prometheusExternalLabelName: ""
+
+  ## If true, the Operator won't add the external label used to denote Prometheus instance name
+  ##
+  prometheusExternalLabelNameClear: false
+
+  ## Secrets that should be mounted into the Prometheus Pods
+  ##
+  secrets: []
+
+  ## ConfigMaps that should be mounted into the Prometheus Pods
+  ##
+  configMaps: []
+
+  ## The query command line flags when starting Prometheus
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#queryspec
+  ##
+  querySpec: {}
+
+  ## Namespaces to be selected for PrometheusRules discovery
+  ## See https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#namespaceselector for usage
+  ##
+  ruleNamespaceSelector: {}
+
+  ## PrometheusRules to be selected for target discovery.
+  ## If {}, select all ServiceMonitors
+  ##
+  ruleSelector: {}
+
+  ## ServiceMonitors to be selected for target discovery.
+  ## If {}, select all ServiceMonitors
+  ##
+  serviceMonitorSelector: {}
+    # matchLabels:
+    #   foo: bar
+
+  ## Namespaces to be selected for ServiceMonitor discovery.
+  ## See https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#namespaceselector for usage
+  ##
+  serviceMonitorNamespaceSelector: {}
+
+  ## How long to retain metrics
+  ##
+  retention: 30d
+
+  ## Maximum size of metrics
+  ##
+  retentionSize: ""
+
+  ## Enable compression of the write-ahead log using Snappy.
+  ##
+  walCompression: false
+
+  ## If true, the Operator won't process any Prometheus configuration changes
+  ##
+  paused: false
+
+  ## Desired number of Prometheus nodes
+  ##
+  replicaCount: 3
+
+  ## Log level for Prometheus
+  ##
+  logLevel: error
+
+  ## Log format for Prometheus
+  ##
+  logFormat: logfmt
+
+  ## Standard object’s metadata
+  ## ref: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata
+  ##
+  podMetadata: {}
+  # labels:
+  #   app: prometheus
+  #   k8s-app: prometheus
+
+  ## The remote_read spec configuration for Prometheus.
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#remotereadspec
+  ##
+  remoteRead: []
+  # - url: http://remote1/read
+
+  ## The remote_write spec configuration for Prometheus.
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#remotewritespec
+  ##
+  remoteWrite: []
+  # - url: http://remote1/push
+
+  ## Prometheus StorageSpec for persistent data
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/storage.md
+  ##
+  storageSpec: {}
+
+  ## Priority class assigned to the Pods
+  ##
+  priorityClassName: ""
+
+  ## Containers allows injecting additional containers
+  ##
+  containers: []
+
+  ## Enable additional scrape configs that are managed externally to this chart
+  ##
+  additionalScrapeConfigsExternal: false
+
+## Configuration for alertmanager
+## ref: https://prometheus.io/docs/alerting/alertmanager/
+##
+alertmanager:
+  enabled: true
+
+  ## Bitnami Alertmanager image version
+  ## ref: https://hub.docker.com/r/bitnami/prometheus-operator/tags/
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/alertmanager
+    tag: 0.19.0-debian-9-r43
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+
+  ## Service account for Alertmanager to use.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  ##
+  serviceAccount:
+    ## Specifies whether a ServiceAccount should be created
+    ##
+    create: true
+    ## The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the prometheus-operator.alertmanager.fullname template
+    # name:
+
+  ## SecurityContext configuration
+  ##
+  securityContext:
+    enabled: true
+    runAsUser: 1001
+    fsGroup: 1001
+
+  ## Configure pod disruption budgets for Alertmanager
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
+  ##
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    # maxUnavailable:
+
+  ## Alertmanager Service
+  ##
+  service:
+    ## Kubernetes service type and port number
+    ##
+    type: ClusterIP
+    port: 9093
+    # clusterIP: None
+
+    ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+    ##
+    # nodePort: 30093
+
+    ## Set the LoadBalancer service type to internal only.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    # loadBalancerIP:
+
+    ## Load Balancer sources
+    ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ##
+    # loadBalancerSourceRanges:
+    # - 10.10.10.0/24
+
+    ## Provide any additional annotations which may be required.
+    ##
+    annotations: {}
+
+  ## If true, create a serviceMonitor for alertmanager
+  ##
+  serviceMonitor:
+    ## Scrape interval. If not set, the Prometheus default scrape interval is used.
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    interval: ""
+
+    ## Metric relabeling
+    ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+    ##
+    metricRelabelings: []
+
+    ## Relabel configs
+    ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+    ##
+    relabelings: []
+
+  ## Configure the ingress resource that allows you to access the
+  ## Alertmanager installation. Set up the URL
+  ## ref: http://kubernetes.io/docs/user-guide/ingress/
+  ##
+  ingress:
+    ## Set to true to enable ingress record generation
+    enabled: false
+
+    ## Set this to true in order to add the corresponding annotations for cert-manager
+    certManager: false
+
+    ## Ingress annotations done as key:value pairs
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+    ##
+    ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+    annotations: {}
+    #  kubernetes.io/ingress.class: nginx
+
+    ## The list of hostnames to be covered with this ingress record.
+    ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
+    hosts:
+    - name: alertmanager.local
+      path: /
+
+    ## The tls configuration for the ingress
+    ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+    ## tls:
+    ## - hosts:
+    ##     - alertmanager.local
+    ##   secretName: alertmanager.local-tls
+
+  ## Configure resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+
+  ## Node Affinity. The value is evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity
+  ##
+  nodeAffinity: {}
+
+  ## Pod AntiAffinity
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  podAntiAffinity: soft
+
+  ## Pod Affinity. The value is evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  podAffinity: {}
+
+  ## Node labels for pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Tolerations for pod assignment
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## Alertmanager configuration
+  ## ref: https://prometheus.io/docs/alerting/configuration/#configuration-file
+  ##
+  config:
+    global:
+      resolve_timeout: 5m
+    route:
+      group_by: ['job']
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 12h
+      receiver: 'null'
+      routes:
+      - match:
+          alertname: Watchdog
+        receiver: 'null'
+    receivers:
+    - name: 'null'
+
+  ## Desired number of Alertmanager nodes
+  ##
+  replicaCount: 3
+
+  ## Log level for Alertmanager
+  ##
+  logLevel: error
+
+  ## Log format for Alertmanager
+  ##
+  logFormat: logfmt
+
+  ## Standard object’s metadata. 
+  ## ref: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata
+  ##
+  podMetadata: {}
+
+  ## Secrets that should be mounted into the Alertmanager Pods
+  ##
+  secrets: []
+
+  ## ConfigMaps that should be mounted into the Alertmanager Pods
+  ##
+  configMaps: []
+
+  ## Metrics retention
+  ##
+  retention: 120h
+
+  ## Alertmanager StorageSpec for persistent data
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/storage.md
+  ##
+  storageSpec: {}
+
+  ## If true, the Operator won't process any Alertmanager configuration changes
+  ##
+  paused: false
+
+  ## ListenLocal makes the Alertmanager server listen on loopbac
+  ##
+  listenLocal: false
+
+  ## Containers allows injecting additional containers
+  ##
+  containers: []
+
+  ## Priority class assigned to the Pods
+  ##
+  priorityClassName: ""
+
+  ## AdditionalPeers allows injecting a set of additional Alertmanagers to peer with to form a highly available cluster.
+  ##
+  additionalPeers: []

--- a/bitnami/prometheus-operator/values.yaml
+++ b/bitnami/prometheus-operator/values.yaml
@@ -1,0 +1,742 @@
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+## Current available global Docker image parameters: imageRegistry and imagePullSecrets
+##
+global:
+#   imageRegistry: myRegistryName
+#   imagePullSecrets:
+#     - myRegistryKeySecretName
+#   storageClass: myStorageClass
+
+  labels: {}
+    # foo: bar
+
+## String to partially override prometheus.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override prometheus.fullname template
+##
+# fullnameOverride:
+
+## Role Based Access
+## Ref: https://kubernetes.io/docs/admin/authorization/rbac/
+##
+rbac:
+  create: true
+
+  ## RBAC API version
+  ##
+  apiVersion: v1beta1
+
+  ## Podsecuritypolicy
+  ##
+  pspEnabled: true
+
+operator:
+  enabled: true
+
+  ## Bitnami Prometheus Operator image version
+  ## ref: https://hub.docker.com/r/bitnami/prometheus-operator/tags/
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/prometheus-operator
+    tag: 0.33.0-debian-9-r0
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+
+  ## Service account for Prometheus Operator to use.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  ##
+  serviceAccount:
+    ## Specifies whether a ServiceAccount should be created
+    ##
+    create: true
+    ## The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the prometheus-operator.operator.fullname template
+    # name:
+
+  ## Use an alternate scheduler, e.g. "stork".
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  # schedulerName:
+
+  ## SecurityContext configuration
+  ##
+  securityContext:
+    enabled: true
+    runAsUser: 1001
+    fsGroup: 1001
+
+  ## Prometheus Operator Service
+  ##
+  service:
+    ## Kubernetes service type and port number
+    ##
+    type: ClusterIP
+    port: 8080
+    # clusterIP: None
+
+    ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+    ##
+    # nodePort: 30080
+
+    ## Set the LoadBalancer service type to internal only.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    # loadBalancerIP:
+
+    ## Load Balancer sources
+    ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ##
+    # loadBalancerSourceRanges:
+    # - 10.10.10.0/24
+
+    ## Provide any additional annotations which may be required.
+    ##
+    annotations: {}
+
+  ## Create a servicemonitor for the operator
+  ##
+  serviceMonitor:
+    ## Scrape interval. If not set, the Prometheus default scrape interval is used.
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    interval: ""
+
+    ## Metric relabeling
+    ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+    ##
+    metricRelabelings: []
+
+    ## Relabel configs
+    ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+    ##
+    relabelings: []
+
+  ## Configure resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+
+  ## Pod annotations
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+
+  ## Node Affinity. The value is evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity
+  ##
+  nodeAffinity: {}
+
+  ## Pod AntiAffinity
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  podAntiAffinity: soft
+
+  ## Pod Affinity. The value is evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  podAffinity: {}
+
+  ## Node labels for pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Tolerations for pod assignment
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## Configure extra options for liveness and readiness probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+  ##
+  livenessProbe:
+    initialDelaySeconds: 120
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+
+  readinessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+
+  ## Log level for Prometheus Operator
+  ##
+  logLevel: info
+
+  ## Log format for Prometheus Operator
+  ##
+  logFormat: logfmt
+
+  ## If true, the operator will create and maintain a service for scraping kubelets
+  ##
+  kubeletService:
+    enabled: true
+    namespace: kube-system
+
+  ## Configmap-reload image to use for reloading configmaps
+  ##
+  configmapReload:
+    image:
+      registry: docker.io
+      repository: bitnami/configmap-reload
+      tag: 0.3.0-debian-9-r0
+      ## Optionally specify an array of imagePullSecrets.
+      ## Secrets must be manually created in the namespace.
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      ##
+      # pullSecrets:
+      #   - myRegistryKeySecretName
+
+  prometheusConfigReloader:
+    image:
+      registry: docker.io
+      repository: bitnami/prometheus-operator
+      tag: 0.33.0-debian-9-r0
+      ## Optionally specify an array of imagePullSecrets.
+      ## Secrets must be manually created in the namespace.
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      ##
+      # pullSecrets:
+      #   - myRegistryKeySecretName
+
+## Deploy a Prometheus instance
+##
+prometheus:
+  enabled: true
+
+  ## Bitnami Prometheus image version
+  ## ref: https://hub.docker.com/r/bitnami/prometheus-operator/tags/
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/prometheus
+    tag: 2.13.0-debian-9-r10
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+
+  ## Service account for Prometheus to use.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  ##
+  serviceAccount:
+    ## Specifies whether a ServiceAccount should be created
+    ##
+    create: true
+    ## The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the prometheus-operator.prometheus.fullname template
+    # name:
+
+  ## SecurityContext configuration
+  ##
+  securityContext:
+    enabled: true
+    runAsUser: 1001
+    fsGroup: 1001
+
+  ## Configure pod disruption budgets for Prometheus
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
+  ##
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    # maxUnavailable:
+
+  ## Prometheus Service
+  ##
+  service:
+    ## Kubernetes service type and port number
+    ##
+    type: ClusterIP
+    port: 9090
+    # clusterIP: None
+
+    ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+    ##
+    # nodePort: 30090
+
+    ## Set the LoadBalancer service type to internal only.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    # loadBalancerIP:
+
+    ## Load Balancer sources
+    ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ##
+    # loadBalancerSourceRanges:
+    # - 10.10.10.0/24
+
+    ## Provide any additional annotations which may be required.
+    ##
+    annotations: {}
+
+  serviceMonitor:
+    ## Scrape interval. If not set, the Prometheus default scrape interval is used.
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    interval: ""
+
+    ## Metric relabeling
+    ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+    ##
+    metricRelabelings: []
+
+    ## Relabel configs
+    ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+    ##
+    relabelings: []
+
+  ## Configure the ingress resource that allows you to access the
+  ## Alertmanager installation. Set up the URL
+  ## ref: http://kubernetes.io/docs/user-guide/ingress/
+  ##
+  ingress:
+    ## Set to true to enable ingress record generation
+    enabled: false
+
+    ## Set this to true in order to add the corresponding annotations for cert-manager
+    certManager: false
+
+    ## Ingress annotations done as key:value pairs
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+    ##
+    ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+    annotations: {}
+    #  kubernetes.io/ingress.class: nginx
+
+    ## The list of hostnames to be covered with this ingress record.
+    ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
+    hosts:
+    - name: prometheus.local
+      path: /
+
+    ## The tls configuration for the ingress
+    ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+    ## tls:
+    ## - hosts:
+    ##     - prometheus.local
+    ##   secretName: prometheus.local-tls
+
+  ## Configure resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+
+  ## Node Affinity. The value is evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity
+  ##
+  nodeAffinity: {}
+
+  ## Pod AntiAffinity
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  podAntiAffinity: soft
+
+  ## Pod Affinity. The value is evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  podAffinity: {}
+
+  ## Node labels for pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Tolerations for pod assignment
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## Interval between consecutive scrapes.
+  ##
+  scrapeInterval: ""
+
+  ## Interval between consecutive evaluations.
+  ##
+  evaluationInterval: ""
+
+  ## ListenLocal makes the Prometheus server listen on loopback, so that it does not bind against the Pod IP.
+  ##
+  listenLocal: false
+
+  ## Enable Prometheus adminitrative API
+  ## ref: https://prometheus.io/docs/prometheus/latest/querying/api/#tsdb-admin-apis
+  ##
+  enableAdminAPI: false
+
+  ## Alertmanagers to which alerts will be sent
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#alertmanagerendpoints
+  ##
+  alertingEndpoints: []
+
+  ## External labels to add to any time series or alerts when communicating with external systems
+  ##
+  externalLabels: {}
+
+  ## Name of the external label used to denote replica name
+  ##
+  replicaExternalLabelName: ""
+
+  ## If true, the Operator won't add the external label used to denote replica name
+  ##
+  replicaExternalLabelNameClear: false
+
+  ## Name of the external label used to denote Prometheus instance name
+  ##
+  prometheusExternalLabelName: ""
+
+  ## If true, the Operator won't add the external label used to denote Prometheus instance name
+  ##
+  prometheusExternalLabelNameClear: false
+
+  ## Secrets that should be mounted into the Prometheus Pods
+  ##
+  secrets: []
+
+  ## ConfigMaps that should be mounted into the Prometheus Pods
+  ##
+  configMaps: []
+
+  ## The query command line flags when starting Prometheus
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#queryspec
+  ##
+  querySpec: {}
+
+  ## Namespaces to be selected for PrometheusRules discovery
+  ## See https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#namespaceselector for usage
+  ##
+  ruleNamespaceSelector: {}
+
+  ## PrometheusRules to be selected for target discovery.
+  ## If {}, select all ServiceMonitors
+  ##
+  ruleSelector: {}
+
+  ## ServiceMonitors to be selected for target discovery.
+  ## If {}, select all ServiceMonitors
+  ##
+  serviceMonitorSelector: {}
+    # matchLabels:
+    #   foo: bar
+
+  ## Namespaces to be selected for ServiceMonitor discovery.
+  ## See https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#namespaceselector for usage
+  ##
+  serviceMonitorNamespaceSelector: {}
+
+  ## How long to retain metrics
+  ##
+  retention: 10d
+
+  ## Maximum size of metrics
+  ##
+  retentionSize: ""
+
+  ## Enable compression of the write-ahead log using Snappy.
+  ##
+  walCompression: false
+
+  ## If true, the Operator won't process any Prometheus configuration changes
+  ##
+  paused: false
+
+  ## Desired number of Prometheus nodes
+  ##
+  replicaCount: 1
+
+  ## Log level for Prometheus
+  ##
+  logLevel: info
+
+  ## Log format for Prometheus
+  ##
+  logFormat: logfmt
+
+  ## Standard object’s metadata
+  ## ref: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata
+  ##
+  podMetadata: {}
+  # labels:
+  #   app: prometheus
+  #   k8s-app: prometheus
+
+  ## The remote_read spec configuration for Prometheus.
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#remotereadspec
+  ##
+  remoteRead: []
+  # - url: http://remote1/read
+
+  ## The remote_write spec configuration for Prometheus.
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#remotewritespec
+  ##
+  remoteWrite: []
+  # - url: http://remote1/push
+
+  ## Prometheus StorageSpec for persistent data
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/storage.md
+  ##
+  storageSpec: {}
+
+  ## Priority class assigned to the Pods
+  ##
+  priorityClassName: ""
+
+  ## Containers allows injecting additional containers
+  ##
+  containers: []
+
+  ## Enable additional scrape configs that are managed externally to this chart
+  ##
+  additionalScrapeConfigsExternal: false
+
+## Configuration for alertmanager
+## ref: https://prometheus.io/docs/alerting/alertmanager/
+##
+alertmanager:
+  enabled: true
+
+  ## Bitnami Alertmanager image version
+  ## ref: https://hub.docker.com/r/bitnami/prometheus-operator/tags/
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/alertmanager
+    tag: 0.19.0-debian-9-r43
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+
+  ## Service account for Alertmanager to use.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  ##
+  serviceAccount:
+    ## Specifies whether a ServiceAccount should be created
+    ##
+    create: true
+    ## The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the prometheus-operator.alertmanager.fullname template
+    # name:
+
+  ## SecurityContext configuration
+  ##
+  securityContext:
+    enabled: true
+    runAsUser: 1001
+    fsGroup: 1001
+
+  ## Configure pod disruption budgets for Alertmanager
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
+  ##
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    # maxUnavailable:
+
+  ## Alertmanager Service
+  ##
+  service:
+    ## Kubernetes service type and port number
+    ##
+    type: ClusterIP
+    port: 9093
+    # clusterIP: None
+
+    ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+    ##
+    # nodePort: 30093
+
+    ## Set the LoadBalancer service type to internal only.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    # loadBalancerIP:
+
+    ## Load Balancer sources
+    ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ##
+    # loadBalancerSourceRanges:
+    # - 10.10.10.0/24
+
+    ## Provide any additional annotations which may be required.
+    ##
+    annotations: {}
+
+  ## If true, create a serviceMonitor for alertmanager
+  ##
+  serviceMonitor:
+    ## Scrape interval. If not set, the Prometheus default scrape interval is used.
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    interval: ""
+
+    ## Metric relabeling
+    ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+    ##
+    metricRelabelings: []
+
+    ## Relabel configs
+    ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+    ##
+    relabelings: []
+
+  ## Configure the ingress resource that allows you to access the
+  ## Alertmanager installation. Set up the URL
+  ## ref: http://kubernetes.io/docs/user-guide/ingress/
+  ##
+  ingress:
+    ## Set to true to enable ingress record generation
+    enabled: false
+
+    ## Set this to true in order to add the corresponding annotations for cert-manager
+    certManager: false
+
+    ## Ingress annotations done as key:value pairs
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+    ##
+    ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+    annotations: {}
+    #  kubernetes.io/ingress.class: nginx
+
+    ## The list of hostnames to be covered with this ingress record.
+    ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
+    hosts:
+    - name: alertmanager.local
+      path: /
+
+    ## The tls configuration for the ingress
+    ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+    ## tls:
+    ## - hosts:
+    ##     - alertmanager.local
+    ##   secretName: alertmanager.local-tls
+
+  ## Configure resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+
+  ## Node Affinity. The value is evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity
+  ##
+  nodeAffinity: {}
+
+  ## Pod AntiAffinity
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  podAntiAffinity: soft
+
+  ## Pod Affinity. The value is evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  podAffinity: {}
+
+  ## Node labels for pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Tolerations for pod assignment
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## Alertmanager configuration
+  ## ref: https://prometheus.io/docs/alerting/configuration/#configuration-file
+  ##
+  config:
+    global:
+      resolve_timeout: 5m
+    route:
+      group_by: ['job']
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 12h
+      receiver: 'null'
+      routes:
+      - match:
+          alertname: Watchdog
+        receiver: 'null'
+    receivers:
+    - name: 'null'
+
+  ## Desired number of Alertmanager nodes
+  ##
+  replicaCount: 1
+
+  ## Log level for Alertmanager
+  ##
+  logLevel: info
+
+  ## Log format for Alertmanager
+  ##
+  logFormat: logfmt
+
+  ## Standard object’s metadata. 
+  ## ref: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata
+  ##
+  podMetadata: {}
+
+  ## Secrets that should be mounted into the Alertmanager Pods
+  ##
+  secrets: []
+
+  ## ConfigMaps that should be mounted into the Alertmanager Pods
+  ##
+  configMaps: []
+
+  ## Metrics retention
+  ##
+  retention: 120h
+
+  ## Alertmanager StorageSpec for persistent data
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/storage.md
+  ##
+  storageSpec: {}
+
+  ## If true, the Operator won't process any Alertmanager configuration changes
+  ##
+  paused: false
+
+  ## ListenLocal makes the Alertmanager server listen on loopbac
+  ##
+  listenLocal: false
+
+  ## Containers allows injecting additional containers
+  ##
+  containers: []
+
+  ## Priority class assigned to the Pods
+  ##
+  priorityClassName: ""
+
+  ## AdditionalPeers allows injecting a set of additional Alertmanagers to peer with to form a highly available cluster.
+  ##
+  additionalPeers: []

--- a/bitnami/prometheus-operator/values.yaml
+++ b/bitnami/prometheus-operator/values.yaml
@@ -42,7 +42,7 @@ operator:
   image:
     registry: docker.io
     repository: bitnami/prometheus-operator
-    tag: 0.33.0-debian-9-r0
+    tag: 0.34.0-debian-9-r3
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -197,7 +197,7 @@ operator:
     image:
       registry: docker.io
       repository: bitnami/configmap-reload
-      tag: 0.3.0-debian-9-r0
+      tag: 0.3.0-debian-9-r14
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -209,7 +209,7 @@ operator:
     image:
       registry: docker.io
       repository: bitnami/prometheus-operator
-      tag: 0.33.0-debian-9-r0
+      tag: 0.34.0-debian-9-r3
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -228,7 +228,7 @@ prometheus:
   image:
     registry: docker.io
     repository: bitnami/prometheus
-    tag: 2.13.0-debian-9-r10
+    tag: 2.13.1-debian-9-r14
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -524,7 +524,7 @@ alertmanager:
   image:
     registry: docker.io
     repository: bitnami/alertmanager
-    tag: 0.19.0-debian-9-r43
+    tag: 0.19.0-debian-9-r57
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION
**Description of the change**

New chart for deploying Prometheus Operator to the cluster

**Benefits**

Prometheus Operator provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files