### PR TITLE
[bitnami/kafka] Fixes error when using `externalZookeeper.servers` in a subchart

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 6.1.0
+version: 6.1.1
 appVersion: 2.3.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/values-production.yaml
+++ b/bitnami/kafka/values-production.yaml
@@ -453,4 +453,4 @@ externalZookeeper:
   ## This value is only used when zookeeper.enabled is set to false
 
   ## Server or list of external zookeeper servers to use.
-  # servers:
+  servers:

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -451,4 +451,4 @@ externalZookeeper:
   ## This value is only used when zookeeper.enabled is set to false
 
   ## Server or list of external zookeeper servers to use.
-  # servers:
+  servers:


### PR DESCRIPTION
**Description of the change**

While using Kafka chart as part of umbrella chart if `externalZookeeper.servers` is commented out it causes linting failure in Helm and error when upgrading charts if that value is specified.

**Reproduction steps**

1. Add Kafka chart as sub-chart
1. Set values `zookeeper.enabled: false` and `externalZookeeper.servers: some-value`
1. Run `helm dep build && helm lint .`

**Benefits**

<!-- What benefits will be realized by the code change? -->
Issue is resolved.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
None identified.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - Warning: Building values map for chart 'kafka'. Skipped value (map[]) for 'externalZookeeper', as it is not a table.

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
