### PR TITLE
[bitnami/kafka] Specify LOG_MESSAGE_FORMAT_VERSION env-var if not empty

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 6.1.0
+version: 6.1.1
 appVersion: 2.3.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -187,8 +187,10 @@ spec:
           value: {{ .Values.logRetentionCheckIntervalMs | quote }}
         - name: KAFKA_CFG_LOG_RETENTION_HOURS
           value: {{ .Values.logRetentionHours | quote }}
+        {{- if .Values.logMessageFormatVersion }}
         - name: KAFKA_CFG_LOG_MESSAGE_FORMAT_VERSION
           value: {{ .Values.logMessageFormatVersion | quote }}
+        {{- end }}
         - name: KAFKA_CFG_MESSAGE_MAX_BYTES
           value: {{ .Values.maxMessageBytes | replace "_" "" | quote }}
         - name: KAFKA_CFG_LOG_SEGMENT_BYTES


### PR DESCRIPTION
**Description of the change**

It would be good to define the `KAFKA_CFG_LOG_MESSAGE_FORMAT_VERSION` env-var only if not empty. Related to: https://github.com/bitnami/bitnami-docker-kafka/issues/72

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files