### PR TITLE
README.md PoC

### DIFF
--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd
-version: 0.1.1
+version: 0.1.2
 appVersion: 1.7.3
 description: Fluentd is an open source data collector for unified logging layer
 keywords:

--- a/bitnami/fluentd/README.md
+++ b/bitnami/fluentd/README.md
@@ -44,7 +44,7 @@ $ helm delete my-release
 
 The command removes all the Kubernetes components associated with the chart and deletes the release. Use the option `--purge` to delete all history too.
 
-## Configuration
+## Parameters
 
 The following tables lists the configurable parameters of the kibana chart and their default values.
 
@@ -140,6 +140,32 @@ $ helm install --name my-release -f values.yaml bitnami/fluentd
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
+## Configuration and installation details
+
+### Production configuration and horizontal scaling
+
+This chart includes a `values-production.yaml` file where you can find some parameters oriented to production configuration in comparison to the regular `values.yaml`. You can use this file instead of the default one.
+
+- Number of aggregator nodes:
+```diff
+- aggregator.replicaCount: 1
++ aggregator.replicaCount: 2
+```
+
+- Enable prometheus to access fluentd metrics endpoint:
+```diff
+- metrics.enabled: false
++ metrics.enabled: true
+```
+
+To horizontally scale this chart once it has been deployed you can upgrade the deployment using a new value for the `aggregator.replicaCount` parameter.
+
+### [Rolling VS Immutable tags](https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/)
+
+It is strongly recommended to use immutable tags in a production environment. This ensures your deployment does not change automatically if the same tag is updated with a different image.
+
+Bitnami will release a new chart updating its containers if a new version of the main container, significant changes, or critical vulnerabilities exist.
+
 ### Forwarding the logs to another service
 
 By default, the aggregators in this chart will send the processed logs to the standard output. However, a common practice is to send them to another service, like Elasticsearch, instead. This can be achieved with this Helm Chart by mounting your own configuration files. For example:
@@ -234,39 +260,3 @@ $ helm install bitnami/fluentd \
     --set aggregator.extraEnv[1].name=ELASTICSEARCH_PORT \
     --set aggregator.extraEnv[1].value=your-port-here \
 ```
-
-### Production configuration and horizontal scaling
-
-This chart includes a `values-production.yaml` file where you can find some parameters oriented to production configuration in comparison to the regular `values.yaml`.
-
-```console
-$ helm install --name my-release -f ./values-production.yaml bitnami/fluentd
-```
-
-- Number of aggregator nodes:
-```diff
-- statefulset.replicaCount: 1
-+ statefulset.replicaCount: 2
-```
-
-- Enable prometheus to access fluentd metrics endpoint:
-```diff
-- metrics.enabled: false
-+ metrics.enabled: true
-```
-
-To horizontally scale this chart once it has been deployed:
-
-```console
-$ helm upgrade my-release bitnami/fluentd \
-  -f ./values-production.yaml \
-  --set statefulset.replicaCount=3
-```
-
-> **Note**: Scaling the statefulset with `kubectl scale ...` command is discouraged. Use `helm upgrade ...` for horizontal scaling to ensure the forwarders configuration is refreshed and aware of the new pods.
-
-### [Rolling VS Immutable tags](https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/)
-
-It is strongly recommended to use immutable tags in a production environment. This ensures your deployment does not change automatically if the same tag is updated with a different image.
-
-Bitnami will release a new chart updating its containers if a new version of the main container, significant changes, or critical vulnerabilities exist.

--- a/bitnami/fluentd/README.md
+++ b/bitnami/fluentd/README.md
@@ -142,6 +142,12 @@ $ helm install --name my-release -f values.yaml bitnami/fluentd
 
 ## Configuration and installation details
 
+### [Rolling VS Immutable tags](https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/)
+
+It is strongly recommended to use immutable tags in a production environment. This ensures your deployment does not change automatically if the same tag is updated with a different image.
+
+Bitnami will release a new chart updating its containers if a new version of the main container, significant changes, or critical vulnerabilities exist.
+
 ### Production configuration and horizontal scaling
 
 This chart includes a `values-production.yaml` file where you can find some parameters oriented to production configuration in comparison to the regular `values.yaml`. You can use this file instead of the default one.
@@ -158,13 +164,7 @@ This chart includes a `values-production.yaml` file where you can find some para
 + metrics.enabled: true
 ```
 
-To horizontally scale this chart once it has been deployed you can upgrade the deployment using a new value for the `aggregator.replicaCount` parameter.
-
-### [Rolling VS Immutable tags](https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/)
-
-It is strongly recommended to use immutable tags in a production environment. This ensures your deployment does not change automatically if the same tag is updated with a different image.
-
-Bitnami will release a new chart updating its containers if a new version of the main container, significant changes, or critical vulnerabilities exist.
+To horizontally scale this chart once it has been deployed, you can upgrade the deployment using a new value for the `aggregator.replicaCount` parameter.
 
 ### Forwarding the logs to another service
 
@@ -244,19 +244,12 @@ data:
     </match>
 ```
 
-Create the `ConfigMap` resource:
+As an example, using the above configmap, you should specify the required parameters when upgrading or installing the chart:
 
 ```console
-$ kubectl create -f configmap.yaml
-```
-
-And then deploy the Fluentd chart with your configuration file and your Elasticsearch host and port:
-
-```console
-$ helm install bitnami/fluentd \
-    --set aggregator.configMap=elasticsearch-output \
-    --set aggregator.extraEnv[0].name=ELASTICSEARCH_HOST \
-    --set aggregator.extraEnv[0].value=your-ip-here \
-    --set aggregator.extraEnv[1].name=ELASTICSEARCH_PORT \
-    --set aggregator.extraEnv[1].value=your-port-here \
+aggregator.configMap=elasticsearch-output
+aggregator.extraEnv[0].name=ELASTICSEARCH_HOST
+aggregator.extraEnv[0].value=your-ip-here
+aggregator.extraEnv[1].name=ELASTICSEARCH_PORT
+aggregator.extraEnv[1].value=your-port-here
 ```


### PR DESCRIPTION
- There are two common sections across charts ("Rolling VS Immutable tags" and "Production configuration and horizontal scaling"). The first one is present in all the charts, while the second one is present when the chart contains a `values-production.yaml`. As both sections are very usual, I placed just after the table.
- After those common sections, there are other sections specific per chart.
- Avoid CLI commands when possible
```
.
├── Parameters
│  └── (Table)
└── Configuration and installation details
   ├── Rolling VS Immutable tags
   ├── Production configuration and horizontal scaling
   └── Forwarding the logs to another service
```