### PR TITLE
[bitnami/elasticsearch] Enable initContainer running sysctl by default

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: elasticsearch
-version: 6.3.15
+version: 7.0.0
 appVersion: 7.4.1
 description: A highly scalable open-source full-text search and analytics engine
 keywords:

--- a/bitnami/elasticsearch/templates/NOTES.txt
+++ b/bitnami/elasticsearch/templates/NOTES.txt
@@ -38,6 +38,23 @@
       helm upgrade {{ .Release.Name }} bitnami/elasticsearch \
         --set sysctlImage.enabled=true
 
+{{- else if .Values.sysctlImage.enabled }}
+
+-------------------------------------------------------------------------------
+ WARNING
+
+    Elasticsearch requires some changes in the kernel of the host machine to
+    work as expected. If those values are not set in the underlying operating
+    system, the ES containers fail to boot with ERROR messages.
+
+    More information about these requirements can be found in the links below:
+
+      https://www.elastic.co/guide/en/elasticsearch/reference/current/file-descriptors.html
+      https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html
+
+    This chart uses a privileged initContainer to change those settings in the Kernel
+    by running: sysctl -w vm.max_map_count=262144 && sysctl -w fs.file-max=65536
+
 {{- end }}
 
 ** Please be patient while the chart is being deployed **

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -30,7 +30,7 @@ image:
 ## Image that performs the sysctl operation
 ##
 sysctlImage:
-  enabled: false
+  enabled: true
   registry: docker.io
   repository: bitnami/minideb
   tag: stretch


### PR DESCRIPTION
**Description of the change**

This PR enables by default the initContainer that modifies some kernel settings to meet the Elasticsearch requirements.

`values-production.yaml` doesn't include this change.

**Benefits**

`helm install` works out of the box

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
