### PR TITLE
[bitnami/magento][bitnami/kibana] Enable ES initContainer running sysctl by default

### DIFF
--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: kibana
+version: 2.0.0
 appVersion: 7.4.1
 description: Kibana is an open source, browser based analytics and search dashboard for Elasticsearch.
-version: 1.0.1
 keywords:
 - kibana
 - analitics

--- a/bitnami/kibana/README.md
+++ b/bitnami/kibana/README.md
@@ -144,7 +144,7 @@ The following tables lists the configurable parameters of the kibana chart and t
 | `metrics.enabled`                     | Start a side-car prometheus exporter                                                                                                                      | `false`                                                                                                 |
 | `metrics.service.annotations`         | Prometheus annotations for the Kibana service                                                                                                             | `{ prometheus.io/scrape: "true", prometheus.io/port: "80", prometheus.io/path: "_prometheus/metrics" }` |
 | `elasticsearch.enabled`               | Use bundled Elasticsearch                                                                                                                                 | `true`                                                                                                  |
-| `elasticsearch.sysctlImage.enabled`   | Use sysctl image for bundled Elasticsearch                                                                                                                | `false`                                                                                                 |
+| `elasticsearch.sysctlImage.enabled`   | Use sysctl image for bundled Elasticsearch                                                                                                                | `true`                                                                                                 |
 | `elasticsearch.master.replicas`       | Desired number of Elasticsearch master-eligible nodes                                                                                                     | `1`                                                                                                     |
 | `elasticsearch.coordinating.replicas` | Desired number of Elasticsearch coordinating-only nodes                                                                                                   | `1`                                                                                                     |
 | `elasticsearch.data.replicas`         | Desired number of Elasticsearch data nodes                                                                                                                | `1`                                                                                                     |
@@ -316,3 +316,16 @@ By default, the chart is configured to use Kubernetes Security Context to automa
 As an alternative, this chart supports using an initContainer to change the ownership of the volume before mounting it in the final destination.
 
 You can enable this initContainer by setting `volumePermissions.enabled` to `true`.
+
+## Notable changes
+
+### 2.0.0
+
+This version enabled by default an initContainer that modify some kernel settings to meet the Elasticsearch requirements.
+
+Currently, Elasticsearch requires some changes in the kernel of the host machine to work as expected. If those values are not set in the underlying operating system, the ES containers fail to boot with ERROR messages. More information about these requirements can be found in the links below:
+
+- [File Descriptor requirements](https://www.elastic.co/guide/en/elasticsearch/reference/current/file-descriptors.html)
+- [Virtual memory requirements](https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html)
+
+You can disable the initContainer using the `elasticsearch.sysctlImage.enabled=false` parameter.

--- a/bitnami/kibana/requirements.lock
+++ b/bitnami/kibana/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
-  version: 6.3.10
-digest: sha256:7439a36bc3462641137a38d05119ffdaf1db949b5e918ea73913b707bcfaa642
-generated: 2019-10-03T16:44:18.923292966Z
+  version: 7.0.0
+digest: sha256:cf77e32c2c24eb28f1ca463ea8f829c44de25536a5d44a857cfa8d08e0b7000b
+generated: "2019-10-25T13:37:22.110373623Z"

--- a/bitnami/kibana/requirements.yaml
+++ b/bitnami/kibana/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: elasticsearch
-  version: 6.x.x
+  version: 7.x.x
   repository: https://charts.bitnami.com/bitnami
   condition: elasticsearch.enabled

--- a/bitnami/kibana/values-production.yaml
+++ b/bitnami/kibana/values-production.yaml
@@ -319,7 +319,7 @@ elasticsearch:
   enabled: false
   ## Enable sysctl image for the bundled Elasticsearch
   sysctlImage:
-    enabled: false
+    enabled: true
   ## Elasticsearch master-eligible node parameters
   master:
     replicas: 2

--- a/bitnami/kibana/values.yaml
+++ b/bitnami/kibana/values.yaml
@@ -319,7 +319,7 @@ elasticsearch:
   enabled: true
   ## Enable sysctl image for the bundled Elasticsearch
   sysctlImage:
-    enabled: false
+    enabled: true
   ## Elasticsearch master-eligible node parameters
   master:
     replicas: 1

--- a/bitnami/magento/Chart.yaml
+++ b/bitnami/magento/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: magento
-version: 8.3.8
+version: 9.0.0
 appVersion: 2.3.3
 description: A feature-rich flexible e-commerce solution. It includes transaction options, multi-store functionality, loyalty programs, product categorization and shopper filtering, promotion rules, and more.
 keywords:

--- a/bitnami/magento/README.md
+++ b/bitnami/magento/README.md
@@ -105,7 +105,7 @@ The following table lists the configurable parameters of the Magento chart and t
 | `elasticsearch.image.registry`          | Elasticsearch image registry                                                                         | `docker.io`                                                  |
 | `elasticsearch.image.repository`        | Elasticsearch image name                                                                             | `bitnami/elasticsearch`                                      |
 | `elasticsearch.image.tag`               | Elasticsearch image tag                                                                              | `{TAG_NAME}`                                                 |
-| `elasticsearch.sysctlImage.enabled`     | Enable kernel settings modifier image for Elasticsearch                                              | `false`                                                      |
+| `elasticsearch.sysctlImage.enabled`     | Enable kernel settings modifier image for Elasticsearch                                              | `true`                                                       |
 | `elasticsearch.master.replicas`         | Desired number of Elasticsearch master-eligible nodes                                                | `1`                                                          |
 | `elasticsearch.coordinating.replicas`   | Desired number of Elasticsearch coordinating-only nodes                                              | `1`                                                          |
 | `elasticsearch.data.replicas`           | Desired number of Elasticsearch data nodes                                                           | `1`                                                          |
@@ -205,6 +205,19 @@ This chart includes a `values-production.yaml` file where you can find some para
 The [Bitnami Magento](https://github.com/bitnami/bitnami-docker-magento) image stores the Magento data and configurations at the `/bitnami/magento` and `/bitnami/apache` paths of the container.
 
  Persistent Volume Claims are used to keep the data across deployments. There is a [known issue](https://github.com/kubernetes/kubernetes/issues/39178) in Kubernetes Clusters with EBS in different availability zones. Ensure your cluster is configured properly to create Volumes in the same availability zone where the nodes are running. Kuberentes 1.12 solved this issue with the [Volume Binding Mode](https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode).
+
+## Notable changes
+
+### 9.0.0
+
+This version enabled by default an initContainer that modify some kernel settings to meet the Elasticsearch requirements.
+
+Currently, Elasticsearch requires some changes in the kernel of the host machine to work as expected. If those values are not set in the underlying operating system, the ES containers fail to boot with ERROR messages. More information about these requirements can be found in the links below:
+
+- [File Descriptor requirements](https://www.elastic.co/guide/en/elasticsearch/reference/current/file-descriptors.html)
+- [Virtual memory requirements](https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html)
+
+You can disable the initContainer using the `elasticsearch.sysctlImage.enabled=false` parameter.
 
 ## Upgrading
 

--- a/bitnami/magento/requirements.lock
+++ b/bitnami/magento/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.11.0
+  version: 6.12.2
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
-  version: 6.3.10
-digest: sha256:9c303c5c0e4abac0c50690f6592fd4e997f320149b4b512c3ae92ea03de93d4f
-generated: 2019-10-08T23:41:16.964340128Z
+  version: 7.0.0
+digest: sha256:bc017dad5b9a712ea42edd2539f01cb21d3d5d8b3aa7797f7639ea2850adc905
+generated: "2019-10-25T13:37:47.054513202Z"

--- a/bitnami/magento/requirements.yaml
+++ b/bitnami/magento/requirements.yaml
@@ -4,6 +4,6 @@ dependencies:
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: mariadb.enabled
   - name: elasticsearch
-    version: 6.x.x
+    version: 7.x.x
     repository: https://charts.bitnami.com/bitnami
     condition: elasticsearch.enabled

--- a/bitnami/magento/values-production.yaml
+++ b/bitnami/magento/values-production.yaml
@@ -181,7 +181,7 @@ elasticsearch:
     tag: 6.8.3-debian-9-r32
   ## Enable to perform the sysctl operation
   sysctlImage:
-    enabled: false
+    enabled: true
   ## Elasticsearch master-eligible node parameters
   master:
     replicas: 1

--- a/bitnami/magento/values.yaml
+++ b/bitnami/magento/values.yaml
@@ -181,7 +181,7 @@ elasticsearch:
     tag: 6.8.3-debian-9-r32
   ## Enable to perform the sysctl operation
   sysctlImage:
-    enabled: false
+    enabled: true
   ## Elasticsearch master-eligible node parameters
   master:
     replicas: 1


### PR DESCRIPTION
**Description of the change**

This PR enables by default the Elasticsearch initContainer that modifies some kernel settings to meet the Elasticsearch requirements.

**Benefits**

`helm install` works out of the box

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
