### PR TITLE
[bitnami/kafka]Add SSL Support for Kafka with Listeners, Service & Container port set

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 6.1.5
+version: 6.1.6
 appVersion: 2.3.1
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -105,6 +105,8 @@ spec:
         - name: KAFKA_CFG_LISTENERS
           {{- if .Values.listeners }}
           value: {{ .Values.listeners }}
+          {{- else if and .Values.auth.ssl .Values.auth.enabled }}
+          value: "SASL_SSL://:$(KAFKA_PORT_NUMBER),SSL://:9093"
           {{- else if .Values.auth.enabled }}
           value: "SASL_SSL://:$(KAFKA_PORT_NUMBER)"
           {{- else }}
@@ -113,6 +115,8 @@ spec:
         - name: KAFKA_CFG_ADVERTISED_LISTENERS
           {{- if .Values.advertisedListeners }}
           value: {{ .Values.advertisedListeners }}
+          {{- else if and .Values.auth.ssl .Values.auth.enabled }}
+          value: 'SASL_SSL://$(MY_POD_NAME).{{ template "kafka.fullname" . }}-headless.{{.Release.Namespace}}.svc.{{ .Values.clusterDomain }}:$(KAFKA_PORT_NUMBER),SSL://$(MY_POD_NAME).{{ template "kafka.fullname" . }}-headless.{{.Release.Namespace}}.svc.{{ .Values.clusterDomain }}:9093'
           {{- else if .Values.auth.enabled  }}
           value: 'SASL_SSL://$(MY_POD_NAME).{{ template "kafka.fullname" . }}-headless.{{.Release.Namespace}}.svc.{{ .Values.clusterDomain }}:$(KAFKA_PORT_NUMBER)'
           {{- else }}
@@ -229,6 +233,10 @@ spec:
         ports:
         - name: kafka
           containerPort: {{ .Values.service.port }}
+        {{- if .Values.auth.ssl }}
+        - name: kafka-ssl
+          containerPort: 9093
+        {{- end }}
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           tcpSocket:

--- a/bitnami/kafka/templates/svc-headless.yaml
+++ b/bitnami/kafka/templates/svc-headless.yaml
@@ -15,6 +15,11 @@ spec:
   - name: kafka
     port: {{ .Values.service.port }}
     targetPort: kafka
+  {{- if .Values.auth.ssl }}
+  - name: kafka-ssl
+    port: 9093
+    targetPort: kafka-ssl
+  {{- end }}
   selector:
     app.kubernetes.io/name: {{ template "kafka.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/bitnami/kafka/templates/svc.yaml
+++ b/bitnami/kafka/templates/svc.yaml
@@ -26,6 +26,11 @@ spec:
     nodePort: {{ .Values.service.nodePort }}
     {{- end }}
     targetPort: kafka
+  {{- if .Values.auth.ssl }}
+  - name: kafka-ssl
+    port: 9093
+    targetPort: kafka-ssl
+  {{- end }}
   selector:
     app.kubernetes.io/name: {{ template "kafka.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/bitnami/kafka/values-production.yaml
+++ b/bitnami/kafka/values-production.yaml
@@ -205,7 +205,9 @@ sslEndpointIdentificationAlgorithm: https
 auth:
   ## Switch to enable the kafka authentication.
   enabled: true
-
+  ##Enable SSL to be used with brokers and consumers
+  #ssl: true
+  
   ## Name of the existing secret containing credentials for brokerUser, interBrokerUser and zookeeperUser.
   #existingSecret:
 


### PR DESCRIPTION

**Add SSL Support for Kafka with Listeners & Container port set**

Set the Container Port, Service Port and Listeners for Kafka SSL on Port 9093

**Benefits**

Kafka will work with SSL listener on Port 9093. We had to manually configure this after generating the manifests using helm template command

**Possible drawbacks**


**Applicable issues**

  - fixes #1279

**Additional information**



**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [x ] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
