### PR TITLE
[bitnami/postgresql] Fix error when running init-container

### DIFF
--- a/upstreamed/postgresql/Chart.yaml
+++ b/upstreamed/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 6.5.4
+version: 6.5.5
 appVersion: 11.5.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/upstreamed/postgresql/templates/statefulset.yaml
+++ b/upstreamed/postgresql/templates/statefulset.yaml
@@ -79,7 +79,7 @@ spec:
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
           command:
-            - sh
+            - /bin/sh
             - -c
             - |
               mkdir -p {{ .Values.persistence.mountPath }}/data


### PR DESCRIPTION
**Description of the change**

When I use another image like `postgres:11.5` I always get the following error:
```
Error: failed to create containerd task: OCI runtime create failed: container_linux.go:337: starting container process caused "exec: \"sh\": executable file not found in $PATH": unknown
```

Using the full path to `sh` (`/bin/sh`) fixes that problem.

**Benefits**

People can use other images without get the above error.

**Possible drawbacks**

No.

**Applicable issues**

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
