### PR TITLE
[bitnami/mariadb-galera] specify `plugin_dir` parameter to configuration

### DIFF
--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb-galera
-version: 0.4.4
+version: 0.5.0
 appVersion: 10.3.18
 description: MariaDB Galera is a multi-master database cluster solution for synchronous replication and high availability.
 keywords:

--- a/bitnami/mariadb-galera/README.md
+++ b/bitnami/mariadb-galera/README.md
@@ -179,6 +179,18 @@ $ helm install --name my-release -f values.yaml bitnami/mariadb-galera
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
+## Passing extra command-line flags to mysqld startup
+
+While the chart allows you to specify the server configuration using the `.mariadbConfiguration` chart parameter, some options for the MariaDB server can only be specified via command line flags. For such cases, the chart exposes the `.extraFlags` parameter.
+
+For example, if you want to enable the PAM cleartext plugin, specify the command line parameter while deploying the chart like so:
+
+```bash
+$ helm install --name my-release \
+  --set extraFlags="--pam-use-cleartext-plugin=ON" \
+  bitnami/mariadb-galera
+```
+
 ## Configuration and installation details
 
 ### [Rolling VS Immutable tags](https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/)

--- a/bitnami/mariadb-galera/values-production.yaml
+++ b/bitnami/mariadb-galera/values-production.yaml
@@ -180,11 +180,13 @@ mariadbConfiguration: |-
   [client]
   port=3306
   socket=/opt/bitnami/mariadb/tmp/mysql.sock
+  plugin_dir=/opt/bitnami/mariadb/plugin
 
   [mysqld]
   default-storage-engine=InnoDB
   basedir=/opt/bitnami/mariadb
   datadir=/bitnami/mariadb/data
+  plugin_dir=/opt/bitnami/mariadb/plugin
   tmpdir=/opt/bitnami/mariadb/tmp
   socket=/opt/bitnami/mariadb/tmp/mysql.sock
   pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid

--- a/bitnami/mariadb-galera/values.yaml
+++ b/bitnami/mariadb-galera/values.yaml
@@ -180,11 +180,13 @@ mariadbConfiguration: |-
   [client]
   port=3306
   socket=/opt/bitnami/mariadb/tmp/mysql.sock
+  plugin_dir=/opt/bitnami/mariadb/plugin
 
   [mysqld]
   default-storage-engine=InnoDB
   basedir=/opt/bitnami/mariadb
   datadir=/bitnami/mariadb/data
+  plugin_dir=/opt/bitnami/mariadb/plugin
   tmpdir=/opt/bitnami/mariadb/tmp
   socket=/opt/bitnami/mariadb/tmp/mysql.sock
   pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid


### PR DESCRIPTION
Workaround for error message:

```
ERROR 1045 (28000): Plugin dialog could not be loaded: /opt/bitnami/mariadb//opt/bitnami/mariadb/plugin/dialog.so: cannot open shared object file: No such file or directory
```

It appears mariadb is looking for the plugins at the incorrect path under certain configurations, therefore are explicitly specifying the path in the configuration here

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
