### PR TITLE
[bitnami/nginx] Warning in the README.md

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx
-version: 4.3.10
+version: 4.3.11
 appVersion: 1.16.1
 description: Chart for the nginx server
 keywords:

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -139,6 +139,8 @@ serverBlock: |-
   }
 ```
 
+> Warning: The above example is not compatible with enabling Prometheus metrics since it affects the `/status` endpoint.
+
 ## Upgrading
 
 ### To 1.0.0


### PR DESCRIPTION
**Description of the change**

This PR adds a warning for users that might follow the example to add a custom server block.

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/1530

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

