### PR TITLE
[bitnami/etcd] Fix issue with restarting pods on single-node clusters

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: etcd
-version: 4.4.0
+version: 4.4.1
 appVersion: 3.4.3
 description: etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines
 keywords:

--- a/bitnami/etcd/templates/scripts-configmap.yaml
+++ b/bitnami/etcd/templates/scripts-configmap.yaml
@@ -26,7 +26,7 @@ data:
     set -o errexit
     set -o pipefail
     set -o nounset
-    
+
     # Debug section
     exec 3>&1
     exec 4>&2
@@ -142,7 +142,9 @@ data:
 {{- end }}
     else
         echo "==> Detected data from previous deployments..." 1>&3 2>&4
-        if is_disastrous_failure; then
+        if [[ {{ $replicaCount }} -eq 1 ]]; then
+            echo "==> Single node cluster detected!!" 1>&3 2>&4
+        elif is_disastrous_failure; then
             echo "==> Cluster not responding!!" 1>&3 2>&4
 {{- if .Values.disasterRecovery.enabled }}
             if [[ -f "/snapshots/db" ]]; then
@@ -188,7 +190,7 @@ data:
     set -o errexit
     set -o pipefail
     set -o nounset
-    
+
     # Debug section
     exec 3>&1
     exec 4>&2
@@ -215,7 +217,7 @@ data:
     set -o errexit
     set -o pipefail
     set -o nounset
-    
+
     # Debug section
     exec 3>&1
     exec 4>&2
@@ -230,7 +232,7 @@ data:
 
     # Constants
     AUTH_OPTIONS="{{ $etcdAuthOptions }}"
-    
+
     echo "==> [DEBUG] Probing etcd cluster"
     echo "==> [DEBUG] Probe command: \"etcdctl $AUTH_OPTIONS endpoint health\""
     etcdctl $AUTH_OPTIONS endpoint health
@@ -241,7 +243,7 @@ data:
     set -o errexit
     set -o pipefail
     set -o nounset
-    
+
     # Debug section
     exec 3>&1
     exec 4>&2


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

This PR ensures the setup logic doesn't initializes the recovery process on single-node clusters.

**Benefits**

Etcd works properly when deploying with a single node.

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/1513

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

