### PR TITLE
[bitnami/postgresql-ha] New major version

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql-ha
-version: 0.4.0
+version: 1.0.0
 appVersion: 11.5.0
 description: Chart for PostgreSQL with HA architecture (using Replication Manager (repmgr) and Pgpool).
 keywords:

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -103,6 +103,7 @@ The following table lists the configurable parameters of the PostgreSQL HA chart
 | `postgresql.username`                          | PostgreSQL username                                                                                                                                                  | `postgres`                                                   |
 | `postgresql.password`                          | PostgreSQL password                                                                                                                                                  | `nil`                                                        |
 | `postgresql.database`                          | PostgreSQL database                                                                                                                                                  | `nil`                                                        |
+| `postgresql.upgradeRepmgrExtension`            | Upgrade repmgr extension in the database                                                                                                                             | `false`                                                      |
 | `postgresql.pgHbaTrustAll`                     | Configures PostgreSQL HBA to trust every user                                                                                                                        | `false`                                                      |
 | `postgresql.repmgrUsername`                    | PostgreSQL repmgr username                                                                                                                                           | `repmgr`                                                     |
 | `postgresql.repmgrPassword`                    | PostgreSQL repmgr password                                                                                                                                           | `nil`                                                        |
@@ -404,10 +405,34 @@ $ helm upgrade my-release bitnami/postgresql-ha \
 
 > Note: you need to substitute the placeholders _[POSTGRESQL_PASSWORD]_, and _[REPMGR_PASSWORD]_ with the values obtained from instructions in the installation notes.
 
+## 1.0.0
+
+A new major version of repmgr (5.0.0) was included. To upgrade to this major version, it's necessary to upgrade the repmgr extension installed on the database. To do so, follow the steps below:
+
+- Reduce your PostgreSQL setup to one replica (primary node) and upgrade to `1.0.0`, enabling the repmgr extension upgrade:
+
+```bash
+$ helm upgrade my-release --version 1.0.0 bitnami/postgresql-ha \
+    --set postgresql.password=[POSTGRESQL_PASSWORD] \
+    --set postgresql.repmgrPassword=[REPMGR_PASSWORD] \
+    --set postgresql.replicaCount=1 \
+    --set postgresql.upgradeRepmgrExtension=true
+```
+
+- Scale your PostgreSQL setup to the original number of replicas:
+
+```bash
+$ helm upgrade my-release --version 1.0.0 bitnami/postgresql-ha \
+    --set postgresql.password=[POSTGRESQL_PASSWORD] \
+    --set postgresql.repmgrPassword=[REPMGR_PASSWORD] \
+    --set postgresql.replicaCount=[NUMBER_OF_REPLICAS]
+```
+
+> Note: you need to substitute the placeholders _[POSTGRESQL_PASSWORD]_, and _[REPMGR_PASSWORD]_ with the values obtained from instructions in the installation notes.
+
 ## 0.4.0
 
-In this version, the chart will use PostgreSQL-Repmgr container images with the Postgis extension included.  The version used in Postgresql version 10, 11 and 12 is Postgis 2.5, and in Pôstgresql 9.6 is Postgis 2.3. 
-Postgis has been compiled with the following dependencies:
+In this version, the chart will use PostgreSQL-Repmgr container images with the Postgis extension included. The version used in Postgresql version 10, 11 and 12 is Postgis 2.5, and in Postgresql 9.6 is Postgis 2.3. Postgis has been compiled with the following dependencies:
 
  - protobuf
  - protobuf-c

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -78,6 +78,7 @@ The following table lists the configurable parameters of the PostgreSQL HA chart
 | **General**                                    |                                                                                                                                                                      |                                                              |
 | `nameOverride`                                 | String to partially override postgres-ha.fullname template with a string                                                                                             | `nil`                                                        |
 | `fullnameOverride`                             | String to fully override postgres-ha.fullname template with a string                                                                                                 | `nil`                                                        |
+| `clusterDomain`                                | Default Kubernetes cluster domain                                                                                                                                    | `cluster.local`                                              |
 | **PostgreSQL with Repmgr**                     |                                                                                                                                                                      |                                                              |
 | `postgresqlImage.registry`                     | Registry for PostgreSQL with Repmgr image                                                                                                                            | `docker.io`                                                  |
 | `postgresqlImage.repository`                   | Repository for PostgreSQL with Repmgr image                                                                                                                          | `bitnami/postgresql-repmgr`                                  |
@@ -440,4 +441,3 @@ In this version, the chart will use PostgreSQL-Repmgr container images with the 
  - geos
  - proj
  - gdal
-

--- a/bitnami/postgresql-ha/templates/NOTES.txt
+++ b/bitnami/postgresql-ha/templates/NOTES.txt
@@ -1,8 +1,9 @@
+{{- $clusterDomain:= .Values.clusterDomain }}
 ** Please be patient while the chart is being deployed **
 
 PostgreSQL can be accessed through Pgpool via port {{ .Values.service.port }} on the following DNS name from within your cluster:
 
-    {{ include "postgresql-ha.pgpool" . }}.{{ .Release.Namespace }}.svc.cluster.local
+    {{ include "postgresql-ha.pgpool" . }}.{{ .Release.Namespace }}.svc.{{ $clusterDomain }}
 
 Pgpool acts as a load balancer for PostgreSQL and forward read/write connections to the primary node while read-only connections are forwarded to standby nodes.
 

--- a/bitnami/postgresql-ha/templates/_helpers.tpl
+++ b/bitnami/postgresql-ha/templates/_helpers.tpl
@@ -658,6 +658,7 @@ Compile all warnings into a single message, and call fail.
 */}}
 {{- define "postgresql-ha.validateValues" -}}
 {{- $messages := list -}}
+{{- $messages := append $messages (include "postgresql-ha.validateValues.releaseName" .) -}}
 {{- $messages := append $messages (include "postgresql-ha.validateValues.ldap" .) -}}
 {{- $messages := append $messages (include "postgresql-ha.validateValues.ldapPgHba" .) -}}
 {{- $messages := append $messages (include "postgresql-ha.validateValues.upgradeRepmgrExtension" .) -}}
@@ -666,6 +667,14 @@ Compile all warnings into a single message, and call fail.
 
 {{- if $message -}}
 {{-   printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Validate values of PostgreSQL HA - the release name cannot be longer that 18 characters */}}
+{{- define "postgresql-ha.validateValues.releaseName" -}}
+{{- if gt (len .Release.Name) 18 -}}
+postgresql-ha: releaseName
+    The release name '{{ .Release.Name }}' exceeds the limit: 18 characters. Please set a shorter one.
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/postgresql-ha/templates/_helpers.tpl
+++ b/bitnami/postgresql-ha/templates/_helpers.tpl
@@ -658,7 +658,7 @@ Compile all warnings into a single message, and call fail.
 */}}
 {{- define "postgresql-ha.validateValues" -}}
 {{- $messages := list -}}
-{{- $messages := append $messages (include "postgresql-ha.validateValues.releaseName" .) -}}
+{{- $messages := append $messages (include "postgresql-ha.validateValues.nodesHostnames" .) -}}
 {{- $messages := append $messages (include "postgresql-ha.validateValues.ldap" .) -}}
 {{- $messages := append $messages (include "postgresql-ha.validateValues.ldapPgHba" .) -}}
 {{- $messages := append $messages (include "postgresql-ha.validateValues.upgradeRepmgrExtension" .) -}}
@@ -670,11 +670,18 @@ Compile all warnings into a single message, and call fail.
 {{- end -}}
 {{- end -}}
 
-{{/* Validate values of PostgreSQL HA - the release name cannot be longer that 18 characters */}}
-{{- define "postgresql-ha.validateValues.releaseName" -}}
-{{- if gt (len .Release.Name) 18 -}}
-postgresql-ha: releaseName
-    The release name '{{ .Release.Name }}' exceeds the limit: 18 characters. Please set a shorter one.
+{{/* Validate values of PostgreSQL HA - PostgreSQL nodes hostnames cannot be longer than 128 characters */}}
+{{- define "postgresql-ha.validateValues.nodesHostnames" -}}
+{{- $postgresqlFullname := include "postgresql-ha.postgresql" . }}
+{{- $postgresqlHeadlessServiceName := printf "%s-headless" (include "postgresql-ha.postgresql" .) }}
+{{- $releaseNamespace := .Release.Namespace }}
+{{- $clusterDomain:= .Values.clusterDomain }}
+{{- $nodeHostname := printf "%s-00.%s.%s.svc.%s:1234" $postgresqlFullname $postgresqlHeadlessServiceName $releaseNamespace $clusterDomain }}
+{{- if gt (len $nodeHostname) 128 -}}
+postgresql-ha: Nodes hostnames
+    PostgreSQL nodes hostnames exceeds the characters limit for Pgpool: 128.
+    Consider using a shorter release name or namespace.
+    {{ $nodeHostname }}
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/postgresql-ha/templates/_helpers.tpl
+++ b/bitnami/postgresql-ha/templates/_helpers.tpl
@@ -681,7 +681,6 @@ Compile all warnings into a single message, and call fail.
 postgresql-ha: Nodes hostnames
     PostgreSQL nodes hostnames exceeds the characters limit for Pgpool: 128.
     Consider using a shorter release name or namespace.
-    {{ $nodeHostname }}
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
@@ -51,13 +51,14 @@ spec:
       {{- $postgresqlFullname := include "postgresql-ha.postgresql" . }}
       {{- $postgresqlHeadlessServiceName := printf "%s-headless" (include "postgresql-ha.postgresql" .) }}
       {{- $releaseName := .Release.Namespace }}
+      {{- $clusterDomain:= .Values.clusterDomain }}
       initContainers:
       - name: wait-for-backend-nodes
         image: {{ include "postgresql-ha.volumePermissionsImage" . }}
         imagePullPolicy: {{ .Values.volumePermissionsImage.pullPolicy | quote }}
         env:
         - name: PGPOOL_BACKEND_NODES
-          value: {{range $e, $i := until $postgresqlReplicaCount }}{{ $i }}:{{ $postgresqlFullname }}-{{ $i }}.{{ $postgresqlHeadlessServiceName }}.{{ $releaseName }}.svc.cluster.local:5432,{{ end }}
+          value: {{range $e, $i := until $postgresqlReplicaCount }}{{ $i }}:{{ $postgresqlFullname }}-{{ $i }}.{{ $postgresqlHeadlessServiceName }}.{{ $releaseName }}.svc.{{ $clusterDomain }}:5432,{{ end }}
         command:
           - /bin/bash
           - -c
@@ -106,7 +107,7 @@ spec:
         - name: BITNAMI_DEBUG
           value: {{ ternary "true" "false" .Values.pgpoolImage.debug | quote }}
         - name: PGPOOL_BACKEND_NODES
-          value: {{range $e, $i := until $postgresqlReplicaCount }}{{ $i }}:{{ $postgresqlFullname }}-{{ $i }}.{{ $postgresqlHeadlessServiceName }}.{{ $releaseName }}.svc.cluster.local:5432,{{ end }}
+          value: {{range $e, $i := until $postgresqlReplicaCount }}{{ $i }}:{{ $postgresqlFullname }}-{{ $i }}.{{ $postgresqlHeadlessServiceName }}.{{ $releaseName }}.svc.{{ $clusterDomain }}:5432,{{ end }}
         - name: PGPOOL_SR_CHECK_USER
           value: {{ (include "postgresql-ha.postgresqlRepmgrUsername" .) | quote }}
         {{- if .Values.postgresql.usePasswordFile }}

--- a/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
@@ -46,6 +46,54 @@ spec:
       securityContext:
         fsGroup: {{ .Values.pgpool.securityContext.fsGroup }}
       {{- end }}
+      # Auxiliar vars to populate environment variables
+      {{- $postgresqlReplicaCount := int .Values.postgresql.replicaCount }}
+      {{- $postgresqlFullname := include "postgresql-ha.postgresql" . }}
+      {{- $postgresqlHeadlessServiceName := printf "%s-headless" (include "postgresql-ha.postgresql" .) }}
+      {{- $releaseName := .Release.Namespace }}
+      initContainers:
+      - name: wait-for-backend-nodes
+        image: {{ include "postgresql-ha.volumePermissionsImage" . }}
+        imagePullPolicy: {{ .Values.volumePermissionsImage.pullPolicy | quote }}
+        env:
+        - name: PGPOOL_BACKEND_NODES
+          value: {{range $e, $i := until $postgresqlReplicaCount }}{{ $i }}:{{ $postgresqlFullname }}-{{ $i }}.{{ $postgresqlHeadlessServiceName }}.{{ $releaseName }}.svc.cluster.local:5432,{{ end }}
+        command:
+          - /bin/bash
+          - -c
+          - |
+            dns_lookup() {
+                local host="${1:?host is missing}"
+                getent ahosts "$host" | awk '/STREAM/ {print $1 }'
+            }
+            is_hostname_resolved() {
+                local -r host="${1:?missing value}"
+                if [[ -n "$(dns_lookup "$host")" ]]; then
+                    true
+                else
+                    false
+                fi
+            }
+            read -r -a nodes <<< "$(tr ',;' ' ' <<< "${PGPOOL_BACKEND_NODES}")"
+            declare -i node_counter=0
+            for node in "${nodes[@]}"; do
+                read -r -a fields <<< "$(tr ':' ' ' <<< "${node}")"
+                host="${fields[1]:?field host is needed}"
+                for ((i = 1 ; i <= 10 ; i+=1 )); do
+                    is_hostname_resolved "$host" && node_counter+=1 && break
+                    sleep 5
+                done
+            done
+            if [[ $node_counter -ne ${#nodes[@]} ]]; then
+                echo "Not enough active backend nodes!"
+                exit 1
+            fi
+            echo "Every backend node is active!"
+            exit 0
+        {{- if .Values.pgpool.securityContext.enabled }}
+        securityContext:
+          runAsUser: {{ .Values.pgpool.securityContext.runAsUser }}
+        {{- end }}
       containers:
       - name: pgpool
         image: {{ include "postgresql-ha.pgpoolImage" . }}
@@ -54,11 +102,6 @@ spec:
         securityContext:
           runAsUser: {{ .Values.pgpool.securityContext.runAsUser }}
         {{- end }}
-        # Auxiliar vars to populate environment variables
-        {{- $postgresqlReplicaCount := int .Values.postgresql.replicaCount }}
-        {{- $postgresqlFullname := include "postgresql-ha.postgresql" . }}
-        {{- $postgresqlHeadlessServiceName := printf "%s-headless" (include "postgresql-ha.postgresql" .) }}
-        {{- $releaseName := .Release.Namespace }}
         env:
         - name: BITNAMI_DEBUG
           value: {{ ternary "true" "false" .Values.pgpoolImage.debug | quote }}

--- a/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
@@ -50,7 +50,7 @@ spec:
       {{- $postgresqlReplicaCount := int .Values.postgresql.replicaCount }}
       {{- $postgresqlFullname := include "postgresql-ha.postgresql" . }}
       {{- $postgresqlHeadlessServiceName := printf "%s-headless" (include "postgresql-ha.postgresql" .) }}
-      {{- $releaseName := .Release.Namespace }}
+      {{- $releaseNamespace := .Release.Namespace }}
       {{- $clusterDomain:= .Values.clusterDomain }}
       initContainers:
       - name: wait-for-backend-nodes
@@ -58,7 +58,7 @@ spec:
         imagePullPolicy: {{ .Values.volumePermissionsImage.pullPolicy | quote }}
         env:
         - name: PGPOOL_BACKEND_NODES
-          value: {{range $e, $i := until $postgresqlReplicaCount }}{{ $i }}:{{ $postgresqlFullname }}-{{ $i }}.{{ $postgresqlHeadlessServiceName }}.{{ $releaseName }}.svc.{{ $clusterDomain }}:5432,{{ end }}
+          value: {{range $e, $i := until $postgresqlReplicaCount }}{{ $i }}:{{ $postgresqlFullname }}-{{ $i }}.{{ $postgresqlHeadlessServiceName }}.{{ $releaseNamespace }}.svc.{{ $clusterDomain }}:5432,{{ end }}
         command:
           - /bin/bash
           - -c
@@ -107,7 +107,7 @@ spec:
         - name: BITNAMI_DEBUG
           value: {{ ternary "true" "false" .Values.pgpoolImage.debug | quote }}
         - name: PGPOOL_BACKEND_NODES
-          value: {{range $e, $i := until $postgresqlReplicaCount }}{{ $i }}:{{ $postgresqlFullname }}-{{ $i }}.{{ $postgresqlHeadlessServiceName }}.{{ $releaseName }}.svc.{{ $clusterDomain }}:5432,{{ end }}
+          value: {{range $e, $i := until $postgresqlReplicaCount }}{{ $i }}:{{ $postgresqlFullname }}-{{ $i }}.{{ $postgresqlHeadlessServiceName }}.{{ $releaseNamespace }}.svc.{{ $clusterDomain }}:5432,{{ end }}
         - name: PGPOOL_SR_CHECK_USER
           value: {{ (include "postgresql-ha.postgresqlRepmgrUsername" .) | quote }}
         {{- if .Values.postgresql.usePasswordFile }}

--- a/bitnami/postgresql-ha/templates/pgpool/ingress.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/ingress.yaml
@@ -3,7 +3,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ include "postgresql-ha.fullname" }}
+  name: {{ include "postgresql-ha.fullname" . }}
   labels: {{ include "postgresql-ha.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.ingress.certManager }}

--- a/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
@@ -113,6 +113,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: REPMGR_UPGRADE_EXTENSION
+          value: {{ ternary "yes" "no" .Values.postgresql.upgradeRepmgrExtension | quote }}
         - name: REPMGR_PGHBA_TRUST_ALL
           value: {{ ternary "yes" "no" .Values.postgresql.pgHbaTrustAll | quote }}
         - name: REPMGR_MOUNTED_CONF_DIR

--- a/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
@@ -84,6 +84,7 @@ spec:
         {{- $postgresqlFullname := include "postgresql-ha.postgresql" . }}
         {{- $postgresqlHeadlessServiceName := printf "%s-headless" (include "postgresql-ha.postgresql" .) }}
         {{- $releaseName := .Release.Namespace }}
+        {{- $clusterDomain:= .Values.clusterDomain }}
         env:
         - name: BITNAMI_DEBUG
           value: {{ ternary "true" "false" .Values.postgresqlImage.debug | quote }}
@@ -120,13 +121,13 @@ spec:
         - name: REPMGR_MOUNTED_CONF_DIR
           value: "/bitnami/repmgr/conf"
         - name: REPMGR_PARTNER_NODES
-          value: {{range $e, $i := until $postgresqlReplicaCount }}{{ $postgresqlFullname }}-{{ $i }}.{{ $postgresqlHeadlessServiceName }}.{{ $releaseName }}.svc.cluster.local,{{ end }}
+          value: {{range $e, $i := until $postgresqlReplicaCount }}{{ $postgresqlFullname }}-{{ $i }}.{{ $postgresqlHeadlessServiceName }}.{{ $releaseName }}.svc.{{ $clusterDomain }},{{ end }}
         - name: REPMGR_PRIMARY_HOST
-          value: {{ printf "%s-0.%s.%s.svc.cluster.local" $postgresqlFullname $postgresqlHeadlessServiceName .Release.Namespace | quote }}
+          value: {{ printf "%s-0.%s.%s.svc.%s" $postgresqlFullname $postgresqlHeadlessServiceName .Release.Namespace $clusterDomain | quote }}
         - name: REPMGR_NODE_NAME
           value: "$(MY_POD_NAME)"
         - name: REPMGR_NODE_NETWORK_NAME
-          value: "$(MY_POD_NAME).{{ $postgresqlHeadlessServiceName }}.{{ .Release.Namespace }}.svc.cluster.local"
+          value: "$(MY_POD_NAME).{{ $postgresqlHeadlessServiceName }}.{{ .Release.Namespace }}.svc.{{ $clusterDomain }}"
         - name: REPMGR_LOG_LEVEL
           value: {{ .Values.postgresql.repmgrLogLevel | quote }}
         - name: REPMGR_CONNECT_TIMEOUT

--- a/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
@@ -83,7 +83,7 @@ spec:
         {{- $postgresqlReplicaCount := int .Values.postgresql.replicaCount }}
         {{- $postgresqlFullname := include "postgresql-ha.postgresql" . }}
         {{- $postgresqlHeadlessServiceName := printf "%s-headless" (include "postgresql-ha.postgresql" .) }}
-        {{- $releaseName := .Release.Namespace }}
+        {{- $releaseNamespace := .Release.Namespace }}
         {{- $clusterDomain:= .Values.clusterDomain }}
         env:
         - name: BITNAMI_DEBUG
@@ -121,7 +121,7 @@ spec:
         - name: REPMGR_MOUNTED_CONF_DIR
           value: "/bitnami/repmgr/conf"
         - name: REPMGR_PARTNER_NODES
-          value: {{range $e, $i := until $postgresqlReplicaCount }}{{ $postgresqlFullname }}-{{ $i }}.{{ $postgresqlHeadlessServiceName }}.{{ $releaseName }}.svc.{{ $clusterDomain }},{{ end }}
+          value: {{range $e, $i := until $postgresqlReplicaCount }}{{ $postgresqlFullname }}-{{ $i }}.{{ $postgresqlHeadlessServiceName }}.{{ $releaseNamespace }}.svc.{{ $clusterDomain }},{{ end }}
         - name: REPMGR_PRIMARY_HOST
           value: {{ printf "%s-0.%s.%s.svc.%s" $postgresqlFullname $postgresqlHeadlessServiceName .Release.Namespace $clusterDomain | quote }}
         - name: REPMGR_NODE_NAME

--- a/bitnami/postgresql-ha/values-production.yaml
+++ b/bitnami/postgresql-ha/values-production.yaml
@@ -193,6 +193,10 @@ postgresql:
   # password:
   # database:
 
+  ## Upgrade repmgr extension in the database
+  ##
+  upgradeRepmgrExtension: false
+
   ##
   pgHbaTrustAll: false
 

--- a/bitnami/postgresql-ha/values-production.yaml
+++ b/bitnami/postgresql-ha/values-production.yaml
@@ -29,7 +29,7 @@
 postgresqlImage:
   registry: docker.io
   repository: bitnami/postgresql-repmgr
-  tag: 11.5.0-debian-9-r23
+  tag: 11.5.0-debian-9-r24
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -90,7 +90,7 @@ volumePermissionsImage:
 metricsImage:
   registry: docker.io
   repository: bitnami/postgres-exporter
-  tag: 0.7.0-debian-9-r3
+  tag: 0.7.0-debian-9-r7
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##

--- a/bitnami/postgresql-ha/values-production.yaml
+++ b/bitnami/postgresql-ha/values-production.yaml
@@ -114,6 +114,10 @@ metricsImage:
 ##
 # fullnameOverride:
 
+## Kubernetes Cluster Domain
+##
+clusterDomain: cluster.local
+
 ## PostgreSQL parameters
 ##
 postgresql:

--- a/bitnami/postgresql-ha/values-production.yaml
+++ b/bitnami/postgresql-ha/values-production.yaml
@@ -51,7 +51,7 @@ postgresqlImage:
 pgpoolImage:
   registry: docker.io
   repository: bitnami/pgpool
-  tag: 4.1.0-debian-9-r2
+  tag: 4.1.0-debian-9-r5
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##

--- a/bitnami/postgresql-ha/values.yaml
+++ b/bitnami/postgresql-ha/values.yaml
@@ -188,6 +188,10 @@ postgresql:
   # password:
   # database:
 
+  ## Upgrade repmgr extension in the database
+  ##
+  upgradeRepmgrExtension: false
+
   ## Configures pg_hba.conf to trust every user
   ##
   pgHbaTrustAll: false

--- a/bitnami/postgresql-ha/values.yaml
+++ b/bitnami/postgresql-ha/values.yaml
@@ -29,7 +29,7 @@
 postgresqlImage:
   registry: docker.io
   repository: bitnami/postgresql-repmgr
-  tag: 11.5.0-debian-9-r23
+  tag: 11.5.0-debian-9-r24
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -90,7 +90,7 @@ volumePermissionsImage:
 metricsImage:
   registry: docker.io
   repository: bitnami/postgres-exporter
-  tag: 0.7.0-debian-9-r3
+  tag: 0.7.0-debian-9-r7
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##

--- a/bitnami/postgresql-ha/values.yaml
+++ b/bitnami/postgresql-ha/values.yaml
@@ -114,6 +114,10 @@ metricsImage:
 ##
 # fullnameOverride:
 
+## Kubernetes Cluster Domain
+##
+clusterDomain: cluster.local
+
 ## PostgreSQL parameters
 ##
 postgresql:

--- a/bitnami/postgresql-ha/values.yaml
+++ b/bitnami/postgresql-ha/values.yaml
@@ -51,7 +51,7 @@ postgresqlImage:
 pgpoolImage:
   registry: docker.io
   repository: bitnami/pgpool
-  tag: 4.1.0-debian-9-r2
+  tag: 4.1.0-debian-9-r5
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

This PR bumps the major version of PostgreSQL HA since **repmgr** was upgraded to `5.0.0`.

Instructions to upgrade from chart version `0.4.0` to `1.0.0` are provided in the README.md

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
