### PR TITLE
[bitnami/influxdb] Fix timeouts on readiness/liveness probes

### DIFF
--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.7.8
+appVersion: 1.7.9
 description: InfluxDB is an open source time-series database designed to handle large write and read loads in real-time.
 engine: gotpl
 home: https://www.influxdata.com/products/influxdb-overview/

--- a/bitnami/influxdb/templates/influxdb/standalone-dpl.yaml
+++ b/bitnami/influxdb/templates/influxdb/standalone-dpl.yaml
@@ -148,6 +148,7 @@ spec:
               containerPort: 8088
               protocol: TCP
           {{- if .Values.influxdb.livenessProbe.enabled }}
+          {{- $livenessTimeout := sub (int .Values.influxdb.livenessProbe.timeoutSeconds) 1 }}
           livenessProbe:
             exec:
               command:
@@ -157,7 +158,7 @@ spec:
                   if [[ -f "${INFLUXDB_ADMIN_USER_PASSWORD_FILE:-}" ]]; then
                       export INFLUXDB_ADMIN_USER_PASSWORD="$(< "${INFLUXDB_ADMIN_USER_PASSWORD_FILE}")"
                   fi
-                  {{ if .Values.authEnabled }}INFLUX_USERNAME="$INFLUXDB_ADMIN_USER" INFLUX_PASSWORD="$INFLUXDB_ADMIN_USER_PASSWORD"{{ end }} influx -host 127.0.0.1 -port 8086 -execute "SHOW DATABASES"
+                  {{ if .Values.authEnabled }}INFLUX_USERNAME="$INFLUXDB_ADMIN_USER" INFLUX_PASSWORD="$INFLUXDB_ADMIN_USER_PASSWORD"{{ end }} timeout {{ $livenessTimeout }}s influx -host 127.0.0.1 -port 8086 -execute "SHOW DATABASES"
             initialDelaySeconds: {{ .Values.influxdb.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.influxdb.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.influxdb.livenessProbe.timeoutSeconds }}
@@ -165,6 +166,7 @@ spec:
             failureThreshold: {{ .Values.influxdb.livenessProbe.failureThreshold }}
           {{- end }}
           {{- if .Values.influxdb.readinessProbe.enabled }}
+          {{- $readinessTimeout := sub (int .Values.influxdb.readinessProbe.timeoutSeconds) 1 }}
           readinessProbe:
             exec:
               command:
@@ -174,7 +176,7 @@ spec:
                   if [[ -f "${INFLUXDB_ADMIN_USER_PASSWORD_FILE:-}" ]]; then
                       export INFLUXDB_ADMIN_USER_PASSWORD="$(< "${INFLUXDB_ADMIN_USER_PASSWORD_FILE}")"
                   fi
-                  {{ if .Values.authEnabled }}INFLUX_USERNAME="$INFLUXDB_ADMIN_USER" INFLUX_PASSWORD="$INFLUXDB_ADMIN_USER_PASSWORD"{{ end }} influx -host 127.0.0.1 -port 8086 -execute "SHOW DATABASES"
+                  {{ if .Values.authEnabled }}INFLUX_USERNAME="$INFLUXDB_ADMIN_USER" INFLUX_PASSWORD="$INFLUXDB_ADMIN_USER_PASSWORD"{{ end }} timeout {{ $readinessTimeout }}s influx -host 127.0.0.1 -port 8086 -execute "SHOW DATABASES"
             initialDelaySeconds: {{ .Values.influxdb.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.influxdb.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.influxdb.readinessProbe.timeoutSeconds }}

--- a/bitnami/influxdb/templates/influxdb/statefulset.yaml
+++ b/bitnami/influxdb/templates/influxdb/statefulset.yaml
@@ -154,6 +154,7 @@ spec:
               containerPort: 8088
               protocol: TCP
           {{- if .Values.influxdb.livenessProbe.enabled }}
+          {{- $livenessTimeout := sub (int .Values.influxdb.livenessProbe.timeoutSeconds) 1 }}
           livenessProbe:
             exec:
               command:
@@ -163,7 +164,7 @@ spec:
                   if [[ -f "${INFLUXDB_ADMIN_USER_PASSWORD_FILE:-}" ]]; then
                       export INFLUXDB_ADMIN_USER_PASSWORD="$(< "${INFLUXDB_ADMIN_USER_PASSWORD_FILE}")"
                   fi
-                  {{ if .Values.authEnabled }}INFLUX_USERNAME="$INFLUXDB_ADMIN_USER" INFLUX_PASSWORD="$INFLUXDB_ADMIN_USER_PASSWORD"{{ end }} influx -host 127.0.0.1 -port 8086 -execute "SHOW DATABASES"
+                  {{ if .Values.authEnabled }}INFLUX_USERNAME="$INFLUXDB_ADMIN_USER" INFLUX_PASSWORD="$INFLUXDB_ADMIN_USER_PASSWORD"{{ end }} timeout {{ $livenessTimeout }}s influx -host 127.0.0.1 -port 8086 -execute "SHOW DATABASES"
             initialDelaySeconds: {{ .Values.influxdb.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.influxdb.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.influxdb.livenessProbe.timeoutSeconds }}
@@ -171,6 +172,7 @@ spec:
             failureThreshold: {{ .Values.influxdb.livenessProbe.failureThreshold }}
           {{- end }}
           {{- if .Values.influxdb.readinessProbe.enabled }}
+          {{- $readinessTimeout := sub (int .Values.influxdb.readinessProbe.timeoutSeconds) 1 }}
           readinessProbe:
             exec:
               command:
@@ -180,7 +182,7 @@ spec:
                   if [[ -f "${INFLUXDB_ADMIN_USER_PASSWORD_FILE:-}" ]]; then
                       export INFLUXDB_ADMIN_USER_PASSWORD="$(< "${INFLUXDB_ADMIN_USER_PASSWORD_FILE}")"
                   fi
-                  {{ if .Values.authEnabled }}INFLUX_USERNAME="$INFLUXDB_ADMIN_USER" INFLUX_PASSWORD="$INFLUXDB_ADMIN_USER_PASSWORD"{{ end }} influx -host 127.0.0.1 -port 8086 -execute "SHOW DATABASES"
+                  {{ if .Values.authEnabled }}INFLUX_USERNAME="$INFLUXDB_ADMIN_USER" INFLUX_PASSWORD="$INFLUXDB_ADMIN_USER_PASSWORD"{{ end }} timeout {{ $readinessTimeout }}s influx -host 127.0.0.1 -port 8086 -execute "SHOW DATABASES"
             initialDelaySeconds: {{ .Values.influxdb.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.influxdb.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.influxdb.readinessProbe.timeoutSeconds }}

--- a/bitnami/influxdb/values-production.yaml
+++ b/bitnami/influxdb/values-production.yaml
@@ -18,7 +18,7 @@
 image:
   registry: docker.io
   repository: bitnami/influxdb
-  tag: 1.7.8-debian-9-r17
+  tag: 1.7.9-debian-9-r0
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##

--- a/bitnami/influxdb/values-production.yaml
+++ b/bitnami/influxdb/values-production.yaml
@@ -195,14 +195,14 @@ influxdb:
     enabled: true
     initialDelaySeconds: 30
     periodSeconds: 10
-    timeoutSeconds: 5
+    timeoutSeconds: 15
     successThreshold: 1
     failureThreshold: 6
   readinessProbe:
     enabled: true
     initialDelaySeconds: 5
     periodSeconds: 10
-    timeoutSeconds: 5
+    timeoutSeconds: 15
     successThreshold: 1
     failureThreshold: 6
 

--- a/bitnami/influxdb/values.yaml
+++ b/bitnami/influxdb/values.yaml
@@ -18,7 +18,7 @@
 image:
   registry: docker.io
   repository: bitnami/influxdb
-  tag: 1.7.8-debian-9-r17
+  tag: 1.7.9-debian-9-r0
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##

--- a/bitnami/influxdb/values.yaml
+++ b/bitnami/influxdb/values.yaml
@@ -195,14 +195,14 @@ influxdb:
     enabled: true
     initialDelaySeconds: 30
     periodSeconds: 10
-    timeoutSeconds: 5
+    timeoutSeconds: 15
     successThreshold: 1
     failureThreshold: 6
   readinessProbe:
     enabled: true
     initialDelaySeconds: 5
     periodSeconds: 10
-    timeoutSeconds: 5
+    timeoutSeconds: 15
     successThreshold: 1
     failureThreshold: 6
 


### PR DESCRIPTION
**Description of the change**

This PR fixes an issue with timeout on readiness/liveness probes by ensuring the command is finished before the timeout is reached.

**Benefits**

Pods reaching the right state

**Possible drawbacks**

None

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
