### PR TITLE
[bitnami/prometheus-operator] Remove `helm.sh/hook-delete-policy` on crds

### DIFF
--- a/bitnami/prometheus-operator/Chart.yaml
+++ b/bitnami/prometheus-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.33.0
 description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 name: prometheus-operator
-version: 0.2.0
+version: 0.2.1
 keywords:
 - prometheus
 - alertmanager

--- a/bitnami/prometheus-operator/templates/prometheus-operator/crd-alertmanager.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/crd-alertmanager.yaml
@@ -6,7 +6,6 @@ metadata:
   labels: {{- include "prometheus-operator.operator.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": crd-install
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   group: monitoring.coreos.com
   names:

--- a/bitnami/prometheus-operator/templates/prometheus-operator/crd-podmonitor.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/crd-podmonitor.yaml
@@ -6,7 +6,6 @@ metadata:
   labels: {{- include "prometheus-operator.operator.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": crd-install
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   group: monitoring.coreos.com
   names:

--- a/bitnami/prometheus-operator/templates/prometheus-operator/crd-prometheus.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/crd-prometheus.yaml
@@ -6,7 +6,6 @@ metadata:
   labels: {{- include "prometheus-operator.operator.labels" . | nindent 4}}
   annotations:
     "helm.sh/hook": crd-install
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   group: monitoring.coreos.com
   names:

--- a/bitnami/prometheus-operator/templates/prometheus-operator/crd-prometheusrules.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/crd-prometheusrules.yaml
@@ -6,7 +6,6 @@ metadata:
   labels: {{- include "prometheus-operator.operator.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": crd-install
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   group: monitoring.coreos.com
   names:

--- a/bitnami/prometheus-operator/templates/prometheus-operator/crd-servicemonitor.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/crd-servicemonitor.yaml
@@ -6,7 +6,6 @@ metadata:
   labels: {{- include "prometheus-operator.operator.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": crd-install
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   group: monitoring.coreos.com
   names:


### PR DESCRIPTION
The `"helm.sh/hook-delete-policy": "before-hook-creation"` annotation results in existing crds being deleted while the chart is being deployed leading to the error:

```
the server could not find the requested resource (post alertmanagers.monitoring.coreos.com)
```