### PR TITLE
[bitnami/harbor] bump major version

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: harbor
-version: 2.6.14
+version: 3.0.0
 appVersion: 1.9.1
 description: Harbor is an an open source trusted cloud native registry project that stores, signs, and scans content
 keywords:

--- a/bitnami/harbor/README.md
+++ b/bitnami/harbor/README.md
@@ -388,6 +388,14 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 
 ## Upgrade
 
+## 3.0.0
+
+Helm performs a lookup for the object based on its group (apps), version (v1), and kind (Deployment). Also known as its GroupVersionKind, or GVK. Changing the GVK is considered a compatibility breaker from Kubernetes' point of view, so you cannot "upgrade" those objects to the new GVK in-place. Earlier versions of Helm 3 did not perform the lookup correctly which has since been fixed to match the spec.
+
+In c085d396a0515be7217d65e92f4fbd474840908b the `apiVersion` of the deployment resources was updated to `apps/v1` in tune with the api's deprecated, resulting in compatibility breakage.
+
+This major version signifies this change.
+
 ## 2.0.0
 
 In this version, two major changes were performed:

--- a/bitnami/harbor/requirements.lock
+++ b/bitnami/harbor/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 6.5.3
+  version: 7.0.0
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 9.4.3
-digest: sha256:99c086e6c1e8c381e164fb75d158887bf9929a2babce2f2dd6778b71e3a7820f
-generated: 2019-10-29T09:56:40.58331808Z
+  version: 9.5.2
+digest: sha256:5fdd20635c94b258d24a4d774e33d66e0b44006191d37e68ca6ad3fdcadecb14
+generated: "2019-11-09T11:49:29.085223686+05:30"

--- a/bitnami/harbor/requirements.yaml
+++ b/bitnami/harbor/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  version: 6.x.x
+  version: 7.x.x
   repository: https://charts.bitnami.com/bitnami
   condition: postgresql.enabled
 - name: redis

--- a/bitnami/harbor/templates/_helpers.tpl
+++ b/bitnami/harbor/templates/_helpers.tpl
@@ -819,3 +819,14 @@ but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else 
     {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/bitnami/harbor/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/bitnami/harbor/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.chartmuseum.enabled }}
-apiVersion: apps/v1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: "{{ template "harbor.chartmuseum" . }}"

--- a/bitnami/harbor/templates/clair/clair-dpl.yaml
+++ b/bitnami/harbor/templates/clair/clair-dpl.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.clair.enabled }}
-apiVersion: apps/v1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: "{{ template "harbor.clair" . }}"

--- a/bitnami/harbor/templates/core/core-dpl.yaml
+++ b/bitnami/harbor/templates/core/core-dpl.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: "{{ template "harbor.core" . }}"

--- a/bitnami/harbor/templates/jobservice/jobservice-dpl.yaml
+++ b/bitnami/harbor/templates/jobservice/jobservice-dpl.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: "{{ template "harbor.jobservice" . }}"

--- a/bitnami/harbor/templates/nginx/deployment.yaml
+++ b/bitnami/harbor/templates/nginx/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if ne .Values.service.type "Ingress" }}
-apiVersion: apps/v1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: "{{ template "harbor.nginx" . }}"

--- a/bitnami/harbor/templates/portal/portal-dpl.yaml
+++ b/bitnami/harbor/templates/portal/portal-dpl.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: "{{ template "harbor.portal" . }}"

--- a/bitnami/harbor/templates/registry/registry-dpl.yaml
+++ b/bitnami/harbor/templates/registry/registry-dpl.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: "{{ template "harbor.registry" . }}"


### PR DESCRIPTION
**Description of the change**
Helm performs a lookup for the object based on its group (apps), version (v1), and kind (Deployment). Also known as its GroupVersionKind, or GVK. Changing the GVK is considered a compatibility breaker from Kubernetes' point of view, so you cannot "upgrade" those objects to the new GVK in-place. Earlier versions of Helm 3 did not perform the lookup correctly which has since been fixed to match the spec.

In c085d396a0515be7217d65e92f4fbd474840908b the `apiVersion` of the deployment resources was updated to `apps/v1` in tune with the api's deprecated, resulting in compatibility breakage.

This major version signifies this change.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.