### PR TITLE
[bitnami/fluentd] Fix aggregator extraEnv indentation

### DIFF
--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd
-version: 0.3.0
+version: 0.3.1
 appVersion: 1.7.4
 description: Fluentd is an open source data collector for unified logging layer
 keywords:

--- a/bitnami/fluentd/templates/aggregator-statefulset.yaml
+++ b/bitnami/fluentd/templates/aggregator-statefulset.yaml
@@ -38,7 +38,7 @@ spec:
         - name: FLUENTD_OPT
           value: {{ .Values.aggregator.extraArgs | quote }}
         {{- if .Values.aggregator.extraEnv }}
-        {{- toYaml .Values.aggregator.extraEnv | nindent 12 }}
+        {{- toYaml .Values.aggregator.extraEnv | nindent 8 }}
         {{- end }}
         ports:
         {{- if .Values.aggregator.port }}


### PR DESCRIPTION

**Description of the change**
Sets the correct indentation for the `aggregator.extraEnv` parameter.


**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
