### PR TITLE
[bitnami/etcd] etcd auto-recover cluster

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: etcd
-version: 4.4.1
+version: 4.4.2
 appVersion: 3.4.3
 description: etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines
 keywords:

--- a/bitnami/etcd/templates/scripts-configmap.yaml
+++ b/bitnami/etcd/templates/scripts-configmap.yaml
@@ -163,8 +163,7 @@ data:
                 exit 1
             fi
 {{- else }}
-            echo "==> Disaster recovery is disabled, the cluster cannot be recovered!" 1>&3 2>&4
-            exit 1
+            echo "==> Disaster recovery is disabled, the cluster will try to recover on it's own..." 1>&3 2>&4
 {{- end }}
         elif should_add_new_member; then
             echo "==> Adding new member to existing cluster..." 1>&3 2>&4


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

This PR allows the etcd cluster to recover on it's own, so it can be recovered when nodes are temporarily down. More information can be found at https://github.com/bitnami/charts/issues/1513

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
