### PR TITLE
[bitnami/kafka] Fix port in serviceMonitor

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 6.1.6
+version: 6.1.7
 appVersion: 2.3.1
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/templates/servicemonitor.yaml
+++ b/bitnami/kafka/templates/servicemonitor.yaml
@@ -23,7 +23,7 @@ spec:
       app.kubernetes.io/component: kafka
   endpoints:
   {{- if .Values.metrics.kafka.enabled }}
-  - port: {{ .Values.metrics.kafka.exporterPort }}
+  - port: {{ .Values.metrics.kafka.port }}
     {{- if .Values.metrics.serviceMonitor.interval }}
     interval: {{ .Values.metrics.serviceMonitor.interval }}
     {{- end }}


### PR DESCRIPTION
**Description of the change**

Fix the following error:
```
Failed to install app kafka. Error: release kafka failed: ServiceMonitor.monitoring.coreos.com "kafka" is invalid: []: validation failure list: spec.endpoints.port in body must be of type string: "null" spec.endpoints.port in body must be of type string: "integer"
```
Because the port is defined as `port` and not `exporterPort` in the [_values.yaml_](https://github.com/bitnami/charts/blob/master/bitnami/kafka/values.yaml#L356).

Previous result of `helm template`:
```yaml
# Source: kafka/templates/servicemonitor.yaml

apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
...
  endpoints:
  - port:
  - port: 5556
  namespaceSelector:
    matchNames:
    - default
```

Current result:
```yaml
# Source: kafka/templates/servicemonitor.yaml

apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
...
  endpoints:
  - port: 9308
  - port: 5556
  namespaceSelector:
    matchNames:
    - default
```

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files