### PR TITLE
[bitnami/kafka] Use port name instead of the value

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 6.1.7
+version: 6.1.8
 appVersion: 2.3.1
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/templates/kafka-exporter.yaml
+++ b/bitnami/kafka/templates/kafka-exporter.yaml
@@ -34,7 +34,8 @@ spec:
           - --kafka.server={{ template "kafka.fullname" . }}:{{ .Values.service.port }}
           - --web.listen-address=:{{ .Values.metrics.kafka.port }}
         ports:
-          - containerPort: {{ .Values.metrics.kafka.port }}
+        - name: kafka-port
+          containerPort: {{ .Values.metrics.kafka.port }}
         resources:
 {{ toYaml .Values.metrics.kafka.resources | indent 10 }}
 {{- end }}

--- a/bitnami/kafka/templates/kafka-exporter.yaml
+++ b/bitnami/kafka/templates/kafka-exporter.yaml
@@ -34,8 +34,8 @@ spec:
           - --kafka.server={{ template "kafka.fullname" . }}:{{ .Values.service.port }}
           - --web.listen-address=:{{ .Values.metrics.kafka.port }}
         ports:
-        - name: kafka-port
-          containerPort: {{ .Values.metrics.kafka.port }}
+          - name: kafka-port
+            containerPort: {{ .Values.metrics.kafka.port }}
         resources:
 {{ toYaml .Values.metrics.kafka.resources | indent 10 }}
 {{- end }}

--- a/bitnami/kafka/templates/servicemonitor.yaml
+++ b/bitnami/kafka/templates/servicemonitor.yaml
@@ -23,22 +23,22 @@ spec:
       app.kubernetes.io/component: kafka
   endpoints:
   {{- if .Values.metrics.kafka.enabled }}
-  - port: kafka-port
-    {{- if .Values.metrics.serviceMonitor.interval }}
-    interval: {{ .Values.metrics.serviceMonitor.interval }}
-    {{- end }}
-    {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
-    scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
-    {{- end }}
+    - port: kafka-port
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
   {{- end }}
   {{- if .Values.metrics.jmx.enabled }}
-  - port: jmx-port
-    {{- if .Values.metrics.serviceMonitor.interval }}
-    interval: {{ .Values.metrics.serviceMonitor.interval }}
-    {{- end }}
-    {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
-    scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
-    {{- end }}
+    - port: jmx-port
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
   {{- end }}
   namespaceSelector:
     matchNames:

--- a/bitnami/kafka/templates/servicemonitor.yaml
+++ b/bitnami/kafka/templates/servicemonitor.yaml
@@ -23,7 +23,7 @@ spec:
       app.kubernetes.io/component: kafka
   endpoints:
   {{- if .Values.metrics.kafka.enabled }}
-  - port: {{ .Values.metrics.kafka.port }}
+  - port: kafka-port
     {{- if .Values.metrics.serviceMonitor.interval }}
     interval: {{ .Values.metrics.serviceMonitor.interval }}
     {{- end }}
@@ -32,7 +32,7 @@ spec:
     {{- end }}
   {{- end }}
   {{- if .Values.metrics.jmx.enabled }}
-  - port: {{ .Values.metrics.jmx.exporterPort }}
+  - port: jmx-port
     {{- if .Values.metrics.serviceMonitor.interval }}
     interval: {{ .Values.metrics.serviceMonitor.interval }}
     {{- end }}

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -287,7 +287,8 @@ spec:
         - {{ .Values.metrics.jmx.exporterPort | quote }}
         - /etc/jmx-kafka/jmx-kafka-prometheus.yml
         ports:
-        - containerPort: {{ .Values.metrics.jmx.exporterPort }}
+        - name: jmx-port
+          containerPort: {{ .Values.metrics.jmx.exporterPort }}
         resources:
 {{ toYaml .Values.metrics.jmx.resources | indent 10 }}
         volumeMounts:

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -287,8 +287,8 @@ spec:
         - {{ .Values.metrics.jmx.exporterPort | quote }}
         - /etc/jmx-kafka/jmx-kafka-prometheus.yml
         ports:
-        - name: jmx-port
-          containerPort: {{ .Values.metrics.jmx.exporterPort }}
+          - name: jmx-port
+            containerPort: {{ .Values.metrics.jmx.exporterPort }}
         resources:
 {{ toYaml .Values.metrics.jmx.resources | indent 10 }}
         volumeMounts:


### PR DESCRIPTION
As a continuation of https://github.com/bitnami/charts/pull/1582

It is not possible to use the port value; instead of that, we should use the port name:
```
spec.endpoints.port in body must be of type string instead of "integer"
```