### PR TITLE
[bitnami/elasticsearch] configure `minimum_master_nodes` to avoid split brain

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: elasticsearch
-version: 8.1.2
+version: 8.2.0
 appVersion: 7.4.2
 description: A highly scalable open-source full-text search and analytics engine
 keywords:

--- a/bitnami/elasticsearch/templates/master-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/master-statefulset.yaml
@@ -85,6 +85,8 @@ spec:
           {{- $elasticsearchMasterFullname := include "elasticsearch.master.fullname" . }}
           {{- $replicas := int .Values.master.replicas }}
           value: {{range $i, $e := until $replicas }}{{ $elasticsearchMasterFullname }}-{{ $e }} {{ end }}
+        - name: ELASTICSEARCH_MINIMUM_MASTER_NODES
+          value: {{ add (div .Values.master.replicas 2) 1 | quote }}
         {{- if .Values.plugins }}
         - name: ELASTICSEARCH_PLUGINS
           value: {{ .Values.plugins | quote }}


### PR DESCRIPTION
**Description of the change**
ref: https://www.elastic.co/guide/en/elasticsearch/reference/6.4/modules-node.html#split-brain

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.