### PR TITLE
[bitnami/kafka] Lint chart

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,19 +1,19 @@
 apiVersion: v1
 name: kafka
-version: 7.0.0
+version: 7.0.1
 appVersion: 2.3.1
 description: Apache Kafka is a distributed streaming platform.
 keywords:
-- kafka
-- zookeeper
-- streaming
-- producer
-- consumer
+  - kafka
+  - zookeeper
+  - streaming
+  - producer
+  - consumer
 home: https://kafka.apache.org/
 sources:
-- https://github.com/bitnami/bitnami-docker-kafka
+  - https://github.com/bitnami/bitnami-docker-kafka
 maintainers:
-- name: Bitnami
-  email: containers@bitnami.com
+  - name: Bitnami
+    email: containers@bitnami.com
 engine: gotpl
 icon: https://bitnami.com/assets/stacks/kafka/img/kafka-stack-110x117.png

--- a/bitnami/kafka/requirements.lock
+++ b/bitnami/kafka/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
-- name: zookeeper
-  repository: https://charts.bitnami.com/bitnami
-  version: 5.0.7
+  - name: zookeeper
+    repository: https://charts.bitnami.com/bitnami
+    version: 5.0.7
 digest: sha256:2f3c43ce02e3966648b8c89be121fe39537f62ea1d161ad908f51ddc90e4243e
 generated: 2019-10-25T09:09:35.628793626Z

--- a/bitnami/kafka/requirements.yaml
+++ b/bitnami/kafka/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
-- name: zookeeper
-  version: 5.x.x
-  repository: https://charts.bitnami.com/bitnami
-  condition: zookeeper.enabled
+  - name: zookeeper
+    version: 5.x.x
+    repository: https://charts.bitnami.com/bitnami
+    condition: zookeeper.enabled

--- a/bitnami/kafka/templates/_helpers.tpl
+++ b/bitnami/kafka/templates/_helpers.tpl
@@ -32,6 +32,24 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Common labels
+*/}}
+{{- define "kafka.labels" -}}
+app.kubernetes.io/name: {{ include "kafka.name" . }}
+helm.sh/chart: {{ include "kafka.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Labels to use on deploy.spec.selector.matchLabels and svc.spec.selector
+*/}}
+{{- define "kafka.matchLabels" -}}
+app.kubernetes.io/name: {{ include "kafka.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
 Return the proper Kafka image name
 */}}
 {{- define "kafka.image" -}}

--- a/bitnami/kafka/templates/configmap.yaml
+++ b/bitnami/kafka/templates/configmap.yaml
@@ -3,11 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "kafka.fullname" . }}-configuration
-  labels:
-    app.kubernetes.io/name: {{ template "kafka.name" . }}
-    helm.sh/chart: {{ template "kafka.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "kafka.labels" . | nindent 4 }}
 data:
   server.properties: |-
 {{ .Values.config | indent 4 }}

--- a/bitnami/kafka/templates/jmx-configmap.yaml
+++ b/bitnami/kafka/templates/jmx-configmap.yaml
@@ -21,47 +21,47 @@ data:
     whitelistObjectNames: ["{{ join "\",\"" .Values.metrics.jmx.whitelistObjectNames }}"]
     {{ end }}
     rules:
-    - pattern: kafka.controller<type=(ControllerChannelManager), name=(QueueSize), broker-id=(\d+)><>(Value)
-      name: kafka_controller_$1_$2_$4
-      labels:
-        broker_id: "$3"
-    - pattern: kafka.controller<type=(ControllerChannelManager), name=(TotalQueueSize)><>(Value)
-      name: kafka_controller_$1_$2_$3
-    - pattern: kafka.controller<type=(KafkaController), name=(.+)><>(Value)
-      name: kafka_controller_$1_$2_$3
-    - pattern: kafka.controller<type=(ControllerStats), name=(.+)><>(Count)
-      name: kafka_controller_$1_$2_$3
-    - pattern: kafka.server<type=(ReplicaFetcherManager), name=(.+), clientId=(.+)><>(Value)
-      name: kafka_server_$1_$2_$4
-      labels:
-        client_id: "$3"
-    - pattern : kafka.network<type=(Processor), name=(IdlePercent), networkProcessor=(.+)><>(Value)
-      name: kafka_network_$1_$2_$4
-      labels:
-        network_processor: $3
-    - pattern : kafka.network<type=(RequestMetrics), name=(RequestsPerSec), request=(.+)><>(Count)
-      name: kafka_network_$1_$2_$4
-      labels:
-        request: $3
-    - pattern: kafka.server<type=(.+), name=(.+), topic=(.+)><>(Count|OneMinuteRate)
-      name: kafka_server_$1_$2_$4
-      labels:
-        topic: $3
-    - pattern: kafka.server<type=(DelayedOperationPurgatory), name=(.+), delayedOperation=(.+)><>(Value)
-      name: kafka_server_$1_$2_$3_$4
-    - pattern: kafka.server<type=(.+), name=(.+)><>(Count|Value|OneMinuteRate)
-      name: kafka_server_$1_total_$2_$3
-    - pattern: kafka.server<type=(.+)><>(queue-size)
-      name: kafka_server_$1_$2
-    - pattern: java.lang<type=(.+), name=(.+)><(.+)>(\w+)
-      name: java_lang_$1_$4_$3_$2
-    - pattern: java.lang<type=(.+), name=(.+)><>(\w+)
-      name: java_lang_$1_$3_$2
-    - pattern : java.lang<type=(.*)>
-    - pattern: kafka.log<type=(.+), name=(.+), topic=(.+), partition=(.+)><>Value
-      name: kafka_log_$1_$2
-      labels:
-        topic: $3
-        partition: $4
+      - pattern: kafka.controller<type=(ControllerChannelManager), name=(QueueSize), broker-id=(\d+)><>(Value)
+        name: kafka_controller_$1_$2_$4
+        labels:
+          broker_id: "$3"
+      - pattern: kafka.controller<type=(ControllerChannelManager), name=(TotalQueueSize)><>(Value)
+        name: kafka_controller_$1_$2_$3
+      - pattern: kafka.controller<type=(KafkaController), name=(.+)><>(Value)
+        name: kafka_controller_$1_$2_$3
+      - pattern: kafka.controller<type=(ControllerStats), name=(.+)><>(Count)
+        name: kafka_controller_$1_$2_$3
+      - pattern: kafka.server<type=(ReplicaFetcherManager), name=(.+), clientId=(.+)><>(Value)
+        name: kafka_server_$1_$2_$4
+        labels:
+          client_id: "$3"
+      - pattern : kafka.network<type=(Processor), name=(IdlePercent), networkProcessor=(.+)><>(Value)
+        name: kafka_network_$1_$2_$4
+        labels:
+          network_processor: $3
+      - pattern : kafka.network<type=(RequestMetrics), name=(RequestsPerSec), request=(.+)><>(Count)
+        name: kafka_network_$1_$2_$4
+        labels:
+          request: $3
+      - pattern: kafka.server<type=(.+), name=(.+), topic=(.+)><>(Count|OneMinuteRate)
+        name: kafka_server_$1_$2_$4
+        labels:
+          topic: $3
+      - pattern: kafka.server<type=(DelayedOperationPurgatory), name=(.+), delayedOperation=(.+)><>(Value)
+        name: kafka_server_$1_$2_$3_$4
+      - pattern: kafka.server<type=(.+), name=(.+)><>(Count|Value|OneMinuteRate)
+        name: kafka_server_$1_total_$2_$3
+      - pattern: kafka.server<type=(.+)><>(queue-size)
+        name: kafka_server_$1_$2
+      - pattern: java.lang<type=(.+), name=(.+)><(.+)>(\w+)
+        name: java_lang_$1_$4_$3_$2
+      - pattern: java.lang<type=(.+), name=(.+)><>(\w+)
+        name: java_lang_$1_$3_$2
+      - pattern : java.lang<type=(.*)>
+      - pattern: kafka.log<type=(.+), name=(.+), topic=(.+), partition=(.+)><>Value
+        name: kafka_log_$1_$2
+        labels:
+          topic: $3
+          partition: $4
 {{- end }}
 {{- end -}}

--- a/bitnami/kafka/templates/kafka-exporter.yaml
+++ b/bitnami/kafka/templates/kafka-exporter.yaml
@@ -3,26 +3,16 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kafka.fullname" . }}-exporter
-  labels:
-    app.kubernetes.io/name: {{ template "kafka.name" . }}
-    helm.sh/chart: {{ template "kafka.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics
 spec:
   replicas: 1
   selector:
-    matchLabels:
-      app.kubernetes.io/name: {{ template "kafka.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+    matchLabels: {{- include "kafka.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: metrics
   template:
     metadata:
-      labels:
-        app.kubernetes.io/name: {{ template "kafka.name" . }}
-        helm.sh/chart: {{ template "kafka.chart" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
+      labels: {{- include "kafka.labels" . | nindent 8 }}
         app.kubernetes.io/component: metrics
     spec:
 {{- include "kafka.imagePullSecrets" . | indent 6 }}

--- a/bitnami/kafka/templates/kafka-jmx-metrics-svc.yaml
+++ b/bitnami/kafka/templates/kafka-jmx-metrics-svc.yaml
@@ -3,11 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kafka.fullname" . }}-jmx-metrics
-  labels:
-    app.kubernetes.io/name: {{ template "kafka.name" . }}
-    helm.sh/chart: {{ template "kafka.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
   annotations: {{ include "kafka.tplValue" ( dict "value" .Values.metrics.jmx.service.annotations "context" $) | nindent 4 }}
 spec:
@@ -27,8 +23,6 @@ spec:
       {{- else if eq .Values.metrics.jmx.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
-  selector:
-    app.kubernetes.io/name: {{ template "kafka.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+  selector: {{- include "kafka.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
 {{- end }}

--- a/bitnami/kafka/templates/kafka-metrics-svc.yaml
+++ b/bitnami/kafka/templates/kafka-metrics-svc.yaml
@@ -3,11 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kafka.fullname" . }}-metrics
-  labels:
-    app.kubernetes.io/name: {{ template "kafka.name" . }}
-    helm.sh/chart: {{ template "kafka.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics
   annotations: {{ include "kafka.tplValue" ( dict "value" .Values.metrics.kafka.service.annotations "context" $) | nindent 4 }}
 spec:
@@ -27,8 +23,6 @@ spec:
       {{- else if eq .Values.metrics.kafka.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
-  selector:
-    app.kubernetes.io/name: {{ template "kafka.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+  selector: {{- include "kafka.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: metrics
 {{- end }}

--- a/bitnami/kafka/templates/poddisruptionbudget.yaml
+++ b/bitnami/kafka/templates/poddisruptionbudget.yaml
@@ -4,17 +4,11 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "kafka.fullname" . }}
-  labels:
-    app.kubernetes.io/name: {{ template "kafka.name" . }}
-    helm.sh/chart: {{ template "kafka.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
 spec:
   selector:
-    matchLabels:
-      app.kubernetes.io/name: {{ template "kafka.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+    matchLabels: {{- include "kafka.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: kafka
 {{ toYaml .Values.podDisruptionBudget | indent 2 }}
 {{- end }}

--- a/bitnami/kafka/templates/secrets.yaml
+++ b/bitnami/kafka/templates/secrets.yaml
@@ -3,11 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "kafka.fullname" . }}
-  labels:
-    app.kubernetes.io/name: {{ template "kafka.name" . }}
-    helm.sh/chart: {{ template "kafka.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "kafka.labels" . | nindent 4 }}
 type: Opaque
 data:
   {{- if .Values.auth.brokerPassword }}

--- a/bitnami/kafka/templates/servicemonitor-jmx-metrics.yaml
+++ b/bitnami/kafka/templates/servicemonitor-jmx-metrics.yaml
@@ -6,20 +6,14 @@ metadata:
   {{- if .Values.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.metrics.serviceMonitor.namespace }}
   {{- end }}
-  labels:
-    app.kubernetes.io/name: {{ template "kafka.name" . }}
-    helm.sh/chart: {{ template "kafka.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
     {{- range $key, $value := .Values.metrics.serviceMonitor.selector }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
   selector:
-    matchLabels:
-      app.kubernetes.io/name: {{ template "kafka.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+    matchLabels: {{- include "kafka.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: kafka
   endpoints:
     - port: metrics

--- a/bitnami/kafka/templates/servicemonitor-metrics.yaml
+++ b/bitnami/kafka/templates/servicemonitor-metrics.yaml
@@ -6,20 +6,14 @@ metadata:
   {{- if .Values.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.metrics.serviceMonitor.namespace }}
   {{- end }}
-  labels:
-    app.kubernetes.io/name: {{ template "kafka.name" . }}
-    helm.sh/chart: {{ template "kafka.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics
     {{- range $key, $value := .Values.metrics.serviceMonitor.selector }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
   selector:
-    matchLabels:
-      app.kubernetes.io/name: {{ template "kafka.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+    matchLabels: {{- include "kafka.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: metrics
   endpoints:
     - port: metrics

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -1,18 +1,12 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: "{{ template "kafka.fullname" . }}"
-  labels:
-    app.kubernetes.io/name: {{ template "kafka.name" . }}
-    helm.sh/chart: {{ template "kafka.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  name: {{ include "kafka.fullname" . }}
+  labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
 spec:
   selector:
-    matchLabels:
-      app.kubernetes.io/name: {{ template "kafka.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+    matchLabels: {{- include "kafka.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: kafka
   serviceName: {{ template "kafka.fullname" . }}-headless
   podManagementPolicy: "Parallel"
@@ -27,13 +21,7 @@ spec:
     {{- end }}
   template:
     metadata:
-      annotations:
-      name: "{{ template "kafka.fullname" . }}"
-      labels:
-        app.kubernetes.io/name: {{ template "kafka.name" . }}
-        helm.sh/chart: {{ template "kafka.chart" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
+      labels: {{- include "kafka.labels" . | nindent 8 }}
         app.kubernetes.io/component: kafka
     spec:
 {{- include "kafka.imagePullSecrets" . | indent 6 }}
@@ -42,285 +30,267 @@ spec:
         fsGroup: {{ .Values.securityContext.fsGroup }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- end }}
-      {{- if .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-      {{- end }}
-      {{- if .Values.tolerations }}
-      tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
-      {{- end }}
-      {{- if .Values.affinity }}
-      affinity:
-{{ toYaml .Values.affinity | indent 8 }}
-      {{- end }}
+      nodeSelector: {{- include "kafka.tplValue" ( dict "value" .Values.nodeSelector "context" $ ) | nindent 8 }}
+      tolerations: {{- include "kafka.tplValue" ( dict "value" .Values.tolerations "context" $ ) | nindent 8 }}
+      affinity: {{- include "kafka.tplValue" ( dict "value" .Values.affinity "context" $ ) | nindent 8 }}
       {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
       initContainers:
-      - name: volume-permissions
-        image: "{{ template "kafka.volumePermissions.image" . }}"
-        imagePullPolicy: {{ default "" .Values.volumePermissions.image.pullPolicy | quote }}
-        command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}", "/bitnami/kafka"]
-        securityContext:
-          runAsUser: 0
-        resources: {{ toYaml .Values.volumePermissions.resources | nindent 10 }}
-        volumeMounts:
-        - name: data
-          mountPath: "/bitnami/kafka"
+        - name: volume-permissions
+          image: {{ include "kafka.volumePermissions.image" . }}
+          imagePullPolicy: {{ default "" .Values.volumePermissions.image.pullPolicy | quote }}
+          command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}", "/bitnami/kafka"]
+          securityContext:
+            runAsUser: 0
+          {{- if .Values.volumePermissions.resources }}
+          resources: {{ toYaml .Values.volumePermissions.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: "/bitnami/kafka"
       {{- end }}
       containers:
-      - name: kafka
-        image: "{{ template "kafka.image" . }}"
-        imagePullPolicy: "{{ .Values.image.pullPolicy }}"
-        resources:
-{{ toYaml .Values.resources | indent 10 }}
-        env:
-        {{- if .Values.image.debug }}
-        - name: BASH_DEBUG
-          value: "1"
-        - name: NAMI_DEBUG
-          value: "1"
-        - name: NAMI_LOG_LEVEL
-          value: "trace8"
-        {{- end }}
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: KAFKA_CFG_ZOOKEEPER_CONNECT
-          {{- if .Values.zookeeper.enabled }}
-          value: {{ template "kafka.zookeeper.fullname" . }}
-          {{- else }}
-          value: {{ .Values.externalZookeeper.servers | quote }}
-          {{- end }}
-        - name: KAFKA_PORT_NUMBER
-          value: {{ .Values.service.port | quote }}
-        - name: KAFKA_CFG_LISTENERS
-          {{- if .Values.listeners }}
-          value: {{ .Values.listeners }}
-          {{- else if and .Values.auth.ssl .Values.auth.enabled }}
-          value: "SASL_SSL://:$(KAFKA_PORT_NUMBER),SSL://:9093"
-          {{- else if .Values.auth.enabled }}
-          value: "SASL_SSL://:$(KAFKA_PORT_NUMBER)"
-          {{- else }}
-          value: "PLAINTEXT://:$(KAFKA_PORT_NUMBER)"
-          {{- end }}
-        - name: KAFKA_CFG_ADVERTISED_LISTENERS
-          {{- if .Values.advertisedListeners }}
-          value: {{ .Values.advertisedListeners }}
-          {{- else if and .Values.auth.ssl .Values.auth.enabled }}
-          value: 'SASL_SSL://$(MY_POD_NAME).{{ template "kafka.fullname" . }}-headless.{{.Release.Namespace}}.svc.{{ .Values.clusterDomain }}:$(KAFKA_PORT_NUMBER),SSL://$(MY_POD_NAME).{{ template "kafka.fullname" . }}-headless.{{.Release.Namespace}}.svc.{{ .Values.clusterDomain }}:9093'
-          {{- else if .Values.auth.enabled  }}
-          value: 'SASL_SSL://$(MY_POD_NAME).{{ template "kafka.fullname" . }}-headless.{{.Release.Namespace}}.svc.{{ .Values.clusterDomain }}:$(KAFKA_PORT_NUMBER)'
-          {{- else }}
-          value: 'PLAINTEXT://$(MY_POD_NAME).{{ template "kafka.fullname" . }}-headless.{{.Release.Namespace}}.svc.{{ .Values.clusterDomain }}:$(KAFKA_PORT_NUMBER)'
-          {{- end }}
-        {{- if .Values.listenerSecurityProtocolMap }}
-        - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
-          value: {{ .Values.listenerSecurityProtocolMap }}
-        {{- end }}
-        {{- if .Values.interBrokerListenerName }}
-        - name: KAFKA_INTER_BROKER_LISTENER_NAME
-          value: {{ .Values.interBrokerListenerName }}
-        {{- end }}
-        {{- if .Values.metrics.jmx.enabled }}
-        - name: JMX_PORT
-          value: {{ .Values.metrics.jmx.jmxPort | quote }}
-        {{- end }}
-        {{- if .Values.auth.enabled }}
-        - name: KAFKA_OPTS
-          value: "-Djava.security.auth.login.config=/opt/bitnami/kafka/conf/kafka_jaas.conf"
-        - name: KAFKA_BROKER_USER
-          value: {{ .Values.auth.brokerUser | quote }}
-        - name: KAFKA_BROKER_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ if .Values.auth.existingSecret }}{{ .Values.auth.existingSecret }}{{ else }}{{ template "kafka.fullname" . }}{{ end }}
-              key: kafka-broker-password
-        - name: KAFKA_INTER_BROKER_USER
-          value: {{ .Values.auth.interBrokerUser | quote }}
-        - name: KAFKA_INTER_BROKER_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ if .Values.auth.existingSecret }}{{ .Values.auth.existingSecret }}{{ else }}{{ template "kafka.fullname" . }}{{ end }}
-              key: kafka-inter-broker-password
-        {{- if .Values.auth.zookeeperUser }}
-        - name: KAFKA_ZOOKEEPER_USER
-          value: {{ .Values.auth.zookeeperUser | quote }}
-        {{- end }}
-        {{- if .Values.auth.zookeeperPassword }}
-        - name: KAFKA_ZOOKEEPER_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ if .Values.auth.existingSecret }}{{ .Values.auth.existingSecret }}{{ else }}{{ template "kafka.fullname" . }}{{ end }}
-              key: kafka-zookeeper-password
-        {{- end }}
-        {{- end }}
-        {{- if .Values.auth.certificatesPassword }}
-        - name: KAFKA_CERTIFICATE_PASSWORD
-          value: {{ .Values.auth.certificatesPassword | quote }}
-        {{- end }}
-        - name: ALLOW_PLAINTEXT_LISTENER
-          {{- if .Values.auth.enabled }}
-          value: "no"
-          {{- else if .Values.allowPlaintextListener }}
-          value: "yes"
-          {{- else }}
-          value: "no"
-          {{- end }}
-        - name: KAFKA_CFG_BROKER_ID
-          value: {{ .Values.brokerId | quote }}
-        - name: KAFKA_CFG_DELETE_TOPIC_ENABLE
-          value: {{ .Values.deleteTopicEnable | quote }}
-        - name: KAFKA_HEAP_OPTS
-          value: {{ .Values.heapOpts | quote }}
-        - name: KAFKA_CFG_LOG_FLUSH_INTERVAL_MESSAGES
-          value: {{ .Values.logFlushIntervalMessages | quote }}
-        - name: KAFKA_CFG_LOG_FLUSH_INTERVAL_MS
-          value: {{ .Values.logFlushIntervalMs | quote }}
-        - name: KAFKA_CFG_LOG_RETENTION_BYTES
-          value: {{ .Values.logRetentionBytes | replace "_" "" | quote }}
-        - name: KAFKA_CFG_LOG_RETENTION_CHECK_INTERVALS_MS
-          value: {{ .Values.logRetentionCheckIntervalMs | quote }}
-        - name: KAFKA_CFG_LOG_RETENTION_HOURS
-          value: {{ .Values.logRetentionHours | quote }}
-        {{- if .Values.logMessageFormatVersion }}
-        - name: KAFKA_CFG_LOG_MESSAGE_FORMAT_VERSION
-          value: {{ .Values.logMessageFormatVersion | quote }}
-        {{- end }}
-        - name: KAFKA_CFG_MESSAGE_MAX_BYTES
-          value: {{ .Values.maxMessageBytes | replace "_" "" | quote }}
-        - name: KAFKA_CFG_LOG_SEGMENT_BYTES
-          value: {{ .Values.logSegmentBytes | replace "_" "" | quote }}
-        - name: KAFKA_CFG_LOG_DIRS
-          value: {{ .Values.logsDirs }}
-        - name: KAFKA_CFG_DEFAULT_REPLICATION_FACTOR
-          value: {{ .Values.defaultReplicationFactor | quote }}
-        - name: KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR
-          value: {{ .Values.offsetsTopicReplicationFactor | quote }}
-        - name: KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
-          value: {{ .Values.transactionStateLogReplicationFactor | quote }}
-        - name: KAFKA_CFG_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM
-          value: {{ .Values.sslEndpointIdentificationAlgorithm | quote }}
-        - name: KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR
-          value: {{ .Values.transactionStateLogMinIsr | quote }}
-        - name: KAFKA_CFG_NUM_IO_THREADS
-          value: {{ .Values.numIoThreads | quote }}
-        - name: KAFKA_CFG_NUM_NETWORK_THREADS
-          value: {{ .Values.numNetworkThreads | quote }}
-        - name: KAFKA_CFG_NUM_PARTITIONS
-          value: {{ .Values.numPartitions | quote }}
-        - name: KAFKA_CFG_NUM_RECOVERY_THREADS_PER_DATA_DIR
-          value: {{ .Values.numRecoveryThreadsPerDataDir | quote }}
-        - name: KAFKA_CFG_SOCKET_RECEIVE_BUFFER_BYTES
-          value: {{ .Values.socketReceiveBufferBytes | quote }}
-        - name: KAFKA_CFG_SOCKET_REQUEST_MAX_BYTES
-          value: {{ .Values.socketRequestMaxBytes | replace "_" "" | quote }}
-        - name: KAFKA_CFG_SOCKET_SEND_BUFFER_BYTES
-          value: {{ .Values.socketSendBufferBytes | quote }}
-        - name: KAFKA_CFG_ZOOKEEPER_CONNECTION_TIMEOUT_MS
-          value: {{ .Values.zookeeperConnectionTimeoutMs | quote }}
-        {{- if .Values.extraEnvVars }}
-          {{ toYaml .Values.extraEnvVars | nindent 8 }}
-        {{- end }}
-        ports:
         - name: kafka
-          containerPort: {{ .Values.service.port }}
-        {{- if .Values.auth.ssl }}
-        - name: kafka-ssl
-          containerPort: 9093
-        {{- end }}
-        {{- if .Values.livenessProbe.enabled }}
-        livenessProbe:
-          tcpSocket:
-            port: kafka
-          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.livenessProbe.successThreshold }}
-          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
-        {{- end }}
-        {{- if .Values.readinessProbe.enabled }}
-        readinessProbe:
-          tcpSocket:
-            port: kafka
-          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.readinessProbe.successThreshold }}
-          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
-        {{- end }}
-        volumeMounts:
-        {{- if .Values.persistence.enabled }}
-        - name: data
-          mountPath: /bitnami/kafka
-        {{- end }}
-        {{- if .Values.config }}
-        - name: kafka-config
-          mountPath: /opt/bitnami/kafka/conf/server.properties
-          subPath: server.properties
-        {{- end }}
-        {{- if .Values.auth.enabled }}
-        - name: kafka-certificates
-          mountPath: /opt/bitnami/kafka/conf/certs/
-          readOnly: true
-        {{- end }}
-      {{ if .Values.metrics.jmx.enabled }}
-      - name: jmx-exporter
-        image: "{{ template "kafka.metrics.jmx.image" . }}"
-        imagePullPolicy: "{{ .Values.metrics.jmx.image.pullPolicy }}"
-        command:
-        - java
-        - -XX:+UnlockExperimentalVMOptions
-        - -XX:+UseCGroupMemoryLimitForHeap
-        - -XX:MaxRAMFraction=1
-        - -XshowSettings:vm
-        - -jar
-        - jmx_prometheus_httpserver.jar
-        - {{ .Values.metrics.jmx.exporterPort | quote }}
-        - /etc/jmx-kafka/jmx-kafka-prometheus.yml
-        ports:
-          - name: metrics
-            containerPort: {{ .Values.metrics.jmx.exporterPort }}
-        {{- if .Values.metrics.jmx.resources }}
-        resources: {{ toYaml .Values.metrics.jmx.resources | nindent 10 }}
-        {{- end }}
-        volumeMounts:
-        - name: jmx-config
-          mountPath: /etc/jmx-kafka
-      {{ end }}
-      volumes:
-      {{ if .Values.metrics.jmx.enabled }}
-      - name: jmx-config
-        configMap:
-          {{- if .Values.metrics.jmx.configMap.overrideName }}
-          name: {{ .Values.metrics.jmx.configMap.overrideName }}
-          {{- else }}
-          name: {{ template "kafka.fullname" . }}-jmx-configuration
+          image: {{ include "kafka.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          {{- if .Values.resources }}
+          resources: {{ toYaml .Values.resources | nindent 12 }}
           {{- end }}
-      {{ end }}
-      {{ if .Values.config }}
-      - name: kafka-config
-        configMap:
-          name: {{ template "kafka.fullname" . }}-configuration
-      {{ end }}
-      {{ if .Values.auth.enabled }}
-      - name: kafka-certificates
-        secret:
-          secretName: {{ required "A secret containinig the Kafka JKS certificates is required when authentication in enabled" .Values.auth.certificatesSecret }}
-          defaultMode: 256
-      {{ end }}
+          env:
+            - name: BITNAMI_DEBUG
+              value: {{ ternary "true" "false" .Values.image.debug | quote }}
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KAFKA_CFG_ZOOKEEPER_CONNECT
+              {{- if .Values.zookeeper.enabled }}
+              value: {{ template "kafka.zookeeper.fullname" . }}
+              {{- else }}
+              value: {{ .Values.externalZookeeper.servers | quote }}
+              {{- end }}
+            - name: KAFKA_PORT_NUMBER
+              value: {{ .Values.service.port | quote }}
+            - name: KAFKA_CFG_LISTENERS
+              {{- if .Values.listeners }}
+              value: {{ .Values.listeners }}
+              {{- else if and .Values.auth.ssl .Values.auth.enabled }}
+              value: "SASL_SSL://:$(KAFKA_PORT_NUMBER),SSL://:9093"
+              {{- else if .Values.auth.enabled }}
+              value: "SASL_SSL://:$(KAFKA_PORT_NUMBER)"
+              {{- else }}
+              value: "PLAINTEXT://:$(KAFKA_PORT_NUMBER)"
+              {{- end }}
+            - name: KAFKA_CFG_ADVERTISED_LISTENERS
+              {{- if .Values.advertisedListeners }}
+              value: {{ .Values.advertisedListeners }}
+              {{- else if and .Values.auth.ssl .Values.auth.enabled }}
+              value: 'SASL_SSL://$(MY_POD_NAME).{{ template "kafka.fullname" . }}-headless.{{.Release.Namespace}}.svc.{{ .Values.clusterDomain }}:$(KAFKA_PORT_NUMBER),SSL://$(MY_POD_NAME).{{ template "kafka.fullname" . }}-headless.{{.Release.Namespace}}.svc.{{ .Values.clusterDomain }}:9093'
+              {{- else if .Values.auth.enabled  }}
+              value: 'SASL_SSL://$(MY_POD_NAME).{{ template "kafka.fullname" . }}-headless.{{.Release.Namespace}}.svc.{{ .Values.clusterDomain }}:$(KAFKA_PORT_NUMBER)'
+              {{- else }}
+              value: 'PLAINTEXT://$(MY_POD_NAME).{{ template "kafka.fullname" . }}-headless.{{.Release.Namespace}}.svc.{{ .Values.clusterDomain }}:$(KAFKA_PORT_NUMBER)'
+              {{- end }}
+            {{- if .Values.listenerSecurityProtocolMap }}
+            - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+              value: {{ .Values.listenerSecurityProtocolMap }}
+            {{- end }}
+            {{- if .Values.interBrokerListenerName }}
+            - name: KAFKA_INTER_BROKER_LISTENER_NAME
+              value: {{ .Values.interBrokerListenerName }}
+            {{- end }}
+            {{- if .Values.metrics.jmx.enabled }}
+            - name: JMX_PORT
+              value: {{ .Values.metrics.jmx.jmxPort | quote }}
+            {{- end }}
+            {{- if .Values.auth.enabled }}
+            - name: KAFKA_OPTS
+              value: "-Djava.security.auth.login.config=/opt/bitnami/kafka/conf/kafka_jaas.conf"
+            - name: KAFKA_BROKER_USER
+              value: {{ .Values.auth.brokerUser | quote }}
+            - name: KAFKA_BROKER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if .Values.auth.existingSecret }}{{ .Values.auth.existingSecret }}{{ else }}{{ template "kafka.fullname" . }}{{ end }}
+                  key: kafka-broker-password
+            - name: KAFKA_INTER_BROKER_USER
+              value: {{ .Values.auth.interBrokerUser | quote }}
+            - name: KAFKA_INTER_BROKER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if .Values.auth.existingSecret }}{{ .Values.auth.existingSecret }}{{ else }}{{ template "kafka.fullname" . }}{{ end }}
+                  key: kafka-inter-broker-password
+            {{- if .Values.auth.zookeeperUser }}
+            - name: KAFKA_ZOOKEEPER_USER
+              value: {{ .Values.auth.zookeeperUser | quote }}
+            {{- end }}
+            {{- if .Values.auth.zookeeperPassword }}
+            - name: KAFKA_ZOOKEEPER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if .Values.auth.existingSecret }}{{ .Values.auth.existingSecret }}{{ else }}{{ template "kafka.fullname" . }}{{ end }}
+                  key: kafka-zookeeper-password
+            {{- end }}
+            {{- end }}
+            {{- if .Values.auth.certificatesPassword }}
+            - name: KAFKA_CERTIFICATE_PASSWORD
+              value: {{ .Values.auth.certificatesPassword | quote }}
+            {{- end }}
+            - name: ALLOW_PLAINTEXT_LISTENER
+              value: {{ ternary "yes" "no" (or .Values.auth.enabled .Values.allowPlaintextListener) | quote }}
+            - name: KAFKA_CFG_BROKER_ID
+              value: {{ .Values.brokerId | quote }}
+            - name: KAFKA_CFG_DELETE_TOPIC_ENABLE
+              value: {{ .Values.deleteTopicEnable | quote }}
+            - name: KAFKA_HEAP_OPTS
+              value: {{ .Values.heapOpts | quote }}
+            - name: KAFKA_CFG_LOG_FLUSH_INTERVAL_MESSAGES
+              value: {{ .Values.logFlushIntervalMessages | quote }}
+            - name: KAFKA_CFG_LOG_FLUSH_INTERVAL_MS
+              value: {{ .Values.logFlushIntervalMs | quote }}
+            - name: KAFKA_CFG_LOG_RETENTION_BYTES
+              value: {{ .Values.logRetentionBytes | replace "_" "" | quote }}
+            - name: KAFKA_CFG_LOG_RETENTION_CHECK_INTERVALS_MS
+              value: {{ .Values.logRetentionCheckIntervalMs | quote }}
+            - name: KAFKA_CFG_LOG_RETENTION_HOURS
+              value: {{ .Values.logRetentionHours | quote }}
+            {{- if .Values.logMessageFormatVersion }}
+            - name: KAFKA_CFG_LOG_MESSAGE_FORMAT_VERSION
+              value: {{ .Values.logMessageFormatVersion | quote }}
+            {{- end }}
+            - name: KAFKA_CFG_MESSAGE_MAX_BYTES
+              value: {{ .Values.maxMessageBytes | replace "_" "" | quote }}
+            - name: KAFKA_CFG_LOG_SEGMENT_BYTES
+              value: {{ .Values.logSegmentBytes | replace "_" "" | quote }}
+            - name: KAFKA_CFG_LOG_DIRS
+              value: {{ .Values.logsDirs }}
+            - name: KAFKA_CFG_DEFAULT_REPLICATION_FACTOR
+              value: {{ .Values.defaultReplicationFactor | quote }}
+            - name: KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR
+              value: {{ .Values.offsetsTopicReplicationFactor | quote }}
+            - name: KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
+              value: {{ .Values.transactionStateLogReplicationFactor | quote }}
+            - name: KAFKA_CFG_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM
+              value: {{ .Values.sslEndpointIdentificationAlgorithm | quote }}
+            - name: KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR
+              value: {{ .Values.transactionStateLogMinIsr | quote }}
+            - name: KAFKA_CFG_NUM_IO_THREADS
+              value: {{ .Values.numIoThreads | quote }}
+            - name: KAFKA_CFG_NUM_NETWORK_THREADS
+              value: {{ .Values.numNetworkThreads | quote }}
+            - name: KAFKA_CFG_NUM_PARTITIONS
+              value: {{ .Values.numPartitions | quote }}
+            - name: KAFKA_CFG_NUM_RECOVERY_THREADS_PER_DATA_DIR
+              value: {{ .Values.numRecoveryThreadsPerDataDir | quote }}
+            - name: KAFKA_CFG_SOCKET_RECEIVE_BUFFER_BYTES
+              value: {{ .Values.socketReceiveBufferBytes | quote }}
+            - name: KAFKA_CFG_SOCKET_REQUEST_MAX_BYTES
+              value: {{ .Values.socketRequestMaxBytes | replace "_" "" | quote }}
+            - name: KAFKA_CFG_SOCKET_SEND_BUFFER_BYTES
+              value: {{ .Values.socketSendBufferBytes | quote }}
+            - name: KAFKA_CFG_ZOOKEEPER_CONNECTION_TIMEOUT_MS
+              value: {{ .Values.zookeeperConnectionTimeoutMs | quote }}
+            {{- if .Values.extraEnvVars }}
+            {{ include "kafka.tplValue" ( dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: kafka
+              containerPort: {{ .Values.service.port }}
+            {{- if .Values.auth.ssl }}
+            - name: kafka-ssl
+              containerPort: 9093
+            {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            tcpSocket:
+              port: kafka
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            tcpSocket:
+              port: kafka
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          volumeMounts:
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: /bitnami/kafka
+            {{- end }}
+            {{- if .Values.config }}
+            - name: kafka-config
+              mountPath: /opt/bitnami/kafka/conf/server.properties
+              subPath: server.properties
+            {{- end }}
+            {{- if .Values.auth.enabled }}
+            - name: kafka-certificates
+              mountPath: /opt/bitnami/kafka/conf/certs/
+              readOnly: true
+            {{- end }}
+        {{ if .Values.metrics.jmx.enabled }}
+        - name: jmx-exporter
+          image: "{{ template "kafka.metrics.jmx.image" . }}"
+          imagePullPolicy: "{{ .Values.metrics.jmx.image.pullPolicy }}"
+          command:
+            - java
+            - -XX:+UnlockExperimentalVMOptions
+            - -XX:+UseCGroupMemoryLimitForHeap
+            - -XX:MaxRAMFraction=1
+            - -XshowSettings:vm
+            - -jar
+            - jmx_prometheus_httpserver.jar
+            - {{ .Values.metrics.jmx.exporterPort | quote }}
+            - /etc/jmx-kafka/jmx-kafka-prometheus.yml
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.metrics.jmx.exporterPort }}
+          {{- if .Values.metrics.jmx.resources }}
+          resources: {{ toYaml .Values.metrics.jmx.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: jmx-config
+              mountPath: /etc/jmx-kafka
+        {{ end }}
+      volumes:
+        {{ if .Values.metrics.jmx.enabled }}
+        - name: jmx-config
+          configMap:
+            {{- if .Values.metrics.jmx.configMap.overrideName }}
+            name: {{ .Values.metrics.jmx.configMap.overrideName }}
+            {{- else }}
+            name: {{ template "kafka.fullname" . }}-jmx-configuration
+            {{- end }}
+        {{ end }}
+        {{ if .Values.config }}
+        - name: kafka-config
+          configMap:
+            name: {{ template "kafka.fullname" . }}-configuration
+        {{ end }}
+        {{ if .Values.auth.enabled }}
+        - name: kafka-certificates
+          secret:
+            secretName: {{ required "A secret containinig the Kafka JKS certificates is required when authentication in enabled" .Values.auth.certificatesSecret }}
+            defaultMode: 256
+        {{ end }}
 {{- if not .Values.persistence.enabled }}
-      - name: data
-        emptyDir: {}
+        - name: data
+          emptyDir: {}
 {{- else if .Values.persistence.existingClaim }}
-      - name: data
-        persistentVolumeClaim:
+        - name: data
+          persistentVolumeClaim:
 {{- with .Values.persistence.existingClaim }}
-          claimName: {{ tpl . $ }}
+            claimName: {{ tpl . $ }}
 {{- end }}
 {{- else }}
   volumeClaimTemplates:
@@ -340,5 +310,5 @@ spec:
         resources:
           requests:
             storage: {{ .Values.persistence.size | quote }}
-        {{ include "kafka.storageClass" . }}
+        {{ include "kafka.storageClass" . | nindent 8 }}
 {{- end }}

--- a/bitnami/kafka/templates/svc-headless.yaml
+++ b/bitnami/kafka/templates/svc-headless.yaml
@@ -2,25 +2,19 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kafka.fullname" . }}-headless
-  labels:
-    app.kubernetes.io/name: {{ template "kafka.name" . }}
-    helm.sh/chart: {{ template "kafka.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
 spec:
   type: ClusterIP
   clusterIP: None
   ports:
-  - name: kafka
-    port: {{ .Values.service.port }}
-    targetPort: kafka
-  {{- if .Values.auth.ssl }}
-  - name: kafka-ssl
-    port: 9093
-    targetPort: kafka-ssl
-  {{- end }}
-  selector:
-    app.kubernetes.io/name: {{ template "kafka.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    - name: kafka
+      port: {{ .Values.service.port }}
+      targetPort: kafka
+    {{- if .Values.auth.ssl }}
+    - name: kafka-ssl
+      port: 9093
+      targetPort: kafka-ssl
+    {{- end }}
+  selector: {{- include "kafka.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: kafka

--- a/bitnami/kafka/templates/svc.yaml
+++ b/bitnami/kafka/templates/svc.yaml
@@ -2,11 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kafka.fullname" . }}
-  labels:
-    app.kubernetes.io/name: {{ template "kafka.name" . }}
-    helm.sh/chart: {{ template "kafka.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
   annotations: {{ include "kafka.tplValue" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
 spec:
@@ -17,18 +13,16 @@ spec:
   {{- end }}
   {{- end }}
   ports:
-  - name: kafka
-    port: {{ .Values.service.port }}
-    {{- if and .Values.service.nodePort (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) }}
-    nodePort: {{ .Values.service.nodePort }}
+    - name: kafka
+      port: {{ .Values.service.port }}
+      {{- if and .Values.service.nodePort (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
+      targetPort: kafka
+    {{- if .Values.auth.ssl }}
+    - name: kafka-ssl
+      port: 9093
+      targetPort: kafka-ssl
     {{- end }}
-    targetPort: kafka
-  {{- if .Values.auth.ssl }}
-  - name: kafka-ssl
-    port: 9093
-    targetPort: kafka-ssl
-  {{- end }}
-  selector:
-    app.kubernetes.io/name: {{ template "kafka.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+  selector: {{- include "kafka.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: kafka

--- a/bitnami/kafka/values-production.yaml
+++ b/bitnami/kafka/values-production.yaml
@@ -337,6 +337,9 @@ metrics:
   kafka:
     enabled: true
 
+    ## Bitnami Kafka exporter image
+    ## ref: https://hub.docker.com/r/bitnami/kafka-exporter/tags/
+    ##
     image:
       registry: docker.io
       repository: bitnami/kafka-exporter
@@ -355,14 +358,20 @@ metrics:
     ## Port kafka-exporter exposes for Prometheus to scrape metrics
     port: 9308
 
-    ## Resource limits
-    resources: {}
-#      limits:
-#        cpu: 200m
-#        memory: 1Gi
-#      requests:
-#        cpu: 100m
-#        memory: 100Mi
+    ## Prometheus Kafka Exporter' resource requests and limits
+    ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+    ##
+    resources:
+      # We usually recommend not to specify default resources and to leave this as a conscious
+      # choice for the user. This also increases chances charts run on environments with little
+      # resources, such as Minikube. If you do want to specify resources, uncomment the following
+      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+      limits: {}
+      #   cpu: 100m
+      #   memory: 128Mi
+      requests: {}
+      #   cpu: 100m
+      #   memory: 128Mi
 
     service:
       ## Kafka Exporter Service type
@@ -391,9 +400,13 @@ metrics:
         prometheus.io/path: "/metrics"
 
   ## Prometheus JMX Exporter: exposes the majority of Kafkas metrics
+  ##
   jmx:
     enabled: true
 
+    ## Bitnami JMX exporter image
+    ## ref: https://hub.docker.com/r/bitnami/jmx-exporter/tags/
+    ##
     image:
       registry: docker.io
       repository: bitnami/jmx-exporter
@@ -407,18 +420,27 @@ metrics:
       #   - myRegistryKeySecretName
 
     ## Interval at which Prometheus scrapes metrics, note: only used by Prometheus Operator
+    ##
     interval: 10s
 
     ## Port jmx-exporter exposes Prometheus format metrics to scrape
+    ##
     exporterPort: 5556
 
-    resources: {}
-      # limits:
-      #   cpu: 200m
-      #   memory: 1Gi
-      # requests:
+    ## Prometheus JMX Exporter' resource requests and limits
+    ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+    ##
+    resources:
+      # We usually recommend not to specify default resources and to leave this as a conscious
+      # choice for the user. This also increases chances charts run on environments with little
+      # resources, such as Minikube. If you do want to specify resources, uncomment the following
+      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+      limits: {}
       #   cpu: 100m
-      #   memory: 100Mi
+      #   memory: 128Mi
+      requests: {}
+      #   cpu: 100m
+      #   memory: 128Mi
 
     service:
       ## JMX Exporter Service type
@@ -453,12 +475,15 @@ metrics:
     ## there are still more stats to clean up and expose, others will never get exposed.  They keep lots of duplicates
     ## that can be derived easily.  The configMap in this chart cleans up the metrics it exposes to be in a Prometheus
     ## format, eg topic, broker are labels and not part of metric name. Improvements are gladly accepted and encouraged.
+    ##
     configMap:
       ## Allows disabling the default configmap, note a configMap is needed
+      ##
       enabled: true
       ## Allows setting values to generate confimap
       ## To allow all metrics through (warning its crazy excessive) comment out below `overrideConfig` and set
       ## `whitelistObjectNames: []`
+      ##
       overrideConfig: {}
         # jmxUrl: service:jmx:rmi:///jndi/rmi://127.0.0.1:5555/jmxrmi
         # lowercaseOutputName: true
@@ -468,19 +493,22 @@ metrics:
         # - pattern: ".*"
       ## If you would like to supply your own ConfigMap for JMX metrics, supply the name of that
       ## ConfigMap as an `overrideName` here.
+      ##
       overrideName: ""
     ## Port the jmx metrics are exposed in native jmx format, not in Prometheus format
+    ##
     jmxPort: 5555
     ## JMX Whitelist Objects, can be set to control which JMX metrics are exposed.  Only whitelisted
     ## values will be exposed via JMX Exporter.  They must also be exposed via Rules.  To expose all metrics
     ## (warning its crazy excessive and they aren't formatted in a prometheus style) (1) `whitelistObjectNames: []`
     ## (2) commented out above `overrideConfig`.
+    ##
     whitelistObjectNames:  # []
-    - kafka.controller:*
-    - kafka.server:*
-    - java.lang:*
-    - kafka.network:*
-    - kafka.log:*
+      - kafka.controller:*
+      - kafka.server:*
+      - java.lang:*
+      - kafka.network:*
+      - kafka.log:*
 
   # Enable this if you're using https://github.com/coreos/prometheus-operator
   serviceMonitor:

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -337,6 +337,9 @@ metrics:
   kafka:
     enabled: false
 
+    ## Bitnami Kafka exporter image
+    ## ref: https://hub.docker.com/r/bitnami/kafka-exporter/tags/
+    ##
     image:
       registry: docker.io
       repository: bitnami/kafka-exporter
@@ -355,14 +358,20 @@ metrics:
     ## Port kafka-exporter exposes for Prometheus to scrape metrics
     port: 9308
 
-    ## Resource limits
-    resources: {}
-#      limits:
-#        cpu: 200m
-#        memory: 1Gi
-#      requests:
-#        cpu: 100m
-#        memory: 100Mi
+    ## Prometheus Kafka Exporter' resource requests and limits
+    ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+    ##
+    resources:
+      # We usually recommend not to specify default resources and to leave this as a conscious
+      # choice for the user. This also increases chances charts run on environments with little
+      # resources, such as Minikube. If you do want to specify resources, uncomment the following
+      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+      limits: {}
+      #   cpu: 100m
+      #   memory: 128Mi
+      requests: {}
+      #   cpu: 100m
+      #   memory: 128Mi
 
     service:
       ## Kafka Exporter Service type
@@ -391,9 +400,13 @@ metrics:
         prometheus.io/path: "/metrics"
 
   ## Prometheus JMX Exporter: exposes the majority of Kafkas metrics
+  ##
   jmx:
     enabled: false
 
+    ## Bitnami JMX exporter image
+    ## ref: https://hub.docker.com/r/bitnami/jmx-exporter/tags/
+    ##
     image:
       registry: docker.io
       repository: bitnami/jmx-exporter
@@ -407,18 +420,27 @@ metrics:
       #   - myRegistryKeySecretName
 
     ## Interval at which Prometheus scrapes metrics, note: only used by Prometheus Operator
+    ##
     interval: 10s
 
     ## Port jmx-exporter exposes Prometheus format metrics to scrape
+    ##
     exporterPort: 5556
 
-    resources: {}
-      # limits:
-      #   cpu: 200m
-      #   memory: 1Gi
-      # requests:
+    ## Prometheus JMX Exporter' resource requests and limits
+    ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+    ##
+    resources:
+      # We usually recommend not to specify default resources and to leave this as a conscious
+      # choice for the user. This also increases chances charts run on environments with little
+      # resources, such as Minikube. If you do want to specify resources, uncomment the following
+      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+      limits: {}
       #   cpu: 100m
-      #   memory: 100Mi
+      #   memory: 128Mi
+      requests: {}
+      #   cpu: 100m
+      #   memory: 128Mi
 
     service:
       ## JMX Exporter Service type
@@ -453,12 +475,15 @@ metrics:
     ## there are still more stats to clean up and expose, others will never get exposed.  They keep lots of duplicates
     ## that can be derived easily.  The configMap in this chart cleans up the metrics it exposes to be in a Prometheus
     ## format, eg topic, broker are labels and not part of metric name. Improvements are gladly accepted and encouraged.
+    ##
     configMap:
       ## Allows disabling the default configmap, note a configMap is needed
+      ##
       enabled: true
       ## Allows setting values to generate confimap
       ## To allow all metrics through (warning its crazy excessive) comment out below `overrideConfig` and set
       ## `whitelistObjectNames: []`
+      ##
       overrideConfig: {}
         # jmxUrl: service:jmx:rmi:///jndi/rmi://127.0.0.1:5555/jmxrmi
         # lowercaseOutputName: true
@@ -468,19 +493,22 @@ metrics:
         # - pattern: ".*"
       ## If you would like to supply your own ConfigMap for JMX metrics, supply the name of that
       ## ConfigMap as an `overrideName` here.
+      ##
       overrideName: ""
     ## Port the jmx metrics are exposed in native jmx format, not in Prometheus format
+    ##
     jmxPort: 5555
     ## JMX Whitelist Objects, can be set to control which JMX metrics are exposed.  Only whitelisted
     ## values will be exposed via JMX Exporter.  They must also be exposed via Rules.  To expose all metrics
     ## (warning its crazy excessive and they aren't formatted in a prometheus style) (1) `whitelistObjectNames: []`
     ## (2) commented out above `overrideConfig`.
+    ##
     whitelistObjectNames:  # []
-    - kafka.controller:*
-    - kafka.server:*
-    - java.lang:*
-    - kafka.network:*
-    - kafka.log:*
+      - kafka.controller:*
+      - kafka.server:*
+      - java.lang:*
+      - kafka.network:*
+      - kafka.log:*
 
   # Enable this if you're using https://github.com/coreos/prometheus-operator
   serviceMonitor:


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

This PR lints the Kafka Helm chart and include some of the Helm best practices.

**Benefits**

More readable manifests

**Possible drawbacks**

None

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

