### PR TITLE
[bitnami/magento] bump major version

### DIFF
--- a/bitnami/magento/Chart.yaml
+++ b/bitnami/magento/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: magento
-version: 9.0.3
+version: 10.0.0
 appVersion: 2.3.3
 description: A feature-rich flexible e-commerce solution. It includes transaction options, multi-store functionality, loyalty programs, product categorization and shopper filtering, promotion rules, and more.
 keywords:

--- a/bitnami/magento/README.md
+++ b/bitnami/magento/README.md
@@ -221,6 +221,14 @@ You can disable the initContainer using the `elasticsearch.sysctlImage.enabled=f
 
 ## Upgrading
 
+### To 10.0.0
+
+Helm performs a lookup for the object based on its group (apps), version (v1), and kind (Deployment). Also known as its GroupVersionKind, or GVK. Changing the GVK is considered a compatibility breaker from Kubernetes' point of view, so you cannot "upgrade" those objects to the new GVK in-place. Earlier versions of Helm 3 did not perform the lookup correctly which has since been fixed to match the spec.
+
+In 4dfac075aacf74405e31ae5b27df4369e84eb0b0 the `apiVersion` of the deployment resources was updated to `apps/v1` in tune with the api's deprecated, resulting in compatibility breakage.
+
+This major version signifies this change.
+
 ### To 5.0.0
 
 Manual intervention is needed if configuring Elasticsearch 6 as Magento search engine is desired.

--- a/bitnami/magento/requirements.lock
+++ b/bitnami/magento/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.13.0
+  version: 7.0.1
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
-  version: 7.1.0
-digest: sha256:bc017dad5b9a712ea42edd2539f01cb21d3d5d8b3aa7797f7639ea2850adc905
-generated: 2019-11-06T07:16:16.012181847Z
+  version: 8.2.5
+digest: sha256:913775f6b0070a31ac74ad6304cc65ee19fd0950e55e2d81cbe03eca920cd7a1
+generated: "2019-11-15T14:16:56.71275685+05:30"

--- a/bitnami/magento/requirements.yaml
+++ b/bitnami/magento/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
   - name: mariadb
-    version: 6.x.x
+    version: 7.x.x
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: mariadb.enabled
   - name: elasticsearch
-    version: 7.x.x
+    version: 8.x.x
     repository: https://charts.bitnami.com/bitnami
     condition: elasticsearch.enabled

--- a/bitnami/magento/templates/_helpers.tpl
+++ b/bitnami/magento/templates/_helpers.tpl
@@ -233,3 +233,14 @@ but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else 
     {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "magento.deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/bitnami/magento/templates/deployment.yaml
+++ b/bitnami/magento/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if and (include "magento.host" .) (or .Values.mariadb.enabled .Values.externalDatabase.host) -}}
-apiVersion: apps/v1
+apiVersion: {{ template "magento.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "magento.fullname" . }}


### PR DESCRIPTION
**Description of the change**
Helm performs a lookup for the object based on its group (apps), version (v1), and kind (Deployment). Also known as its GroupVersionKind, or GVK. Changing the GVK is considered a compatibility breaker from Kubernetes' point of view, so you cannot "upgrade" those objects to the new GVK in-place. Earlier versions of Helm 3 did not perform the lookup correctly which has since been fixed to match the spec.

In 4dfac075aacf74405e31ae5b27df4369e84eb0b0 the `apiVersion` of the deployment resources was updated to `apps/v1` in tune with the api's deprecated, resulting in compatibility breakage.

This major version signifies this change.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files