### PR TITLE
[bitnami/kibana] bump major version

### DIFF
--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kibana
-version: 2.0.6
+version: 3.0.0
 appVersion: 7.4.2
 description: Kibana is an open source, browser based analytics and search dashboard for Elasticsearch.
 keywords:

--- a/bitnami/kibana/README.md
+++ b/bitnami/kibana/README.md
@@ -324,6 +324,16 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 
 ## Notable changes
 
+### 3.0.0
+
+[bitnami/kibana] bump major version
+
+Helm performs a lookup for the object based on its group (apps), version (v1), and kind (Deployment). Also known as its GroupVersionKind, or GVK. Changing the GVK is considered a compatibility breaker from Kubernetes' point of view, so you cannot "upgrade" those objects to the new GVK in-place. Earlier versions of Helm 3 did not perform the lookup correctly which has since been fixed to match the spec.
+
+In 4dfac075aacf74405e31ae5b27df4369e84eb0b0 the `apiVersion` of the deployment resources was updated to `apps/v1` in tune with the api's deprecated, resulting in compatibility breakage.
+
+This major version signifies this change.
+
 ### 2.0.0
 
 This version enabled by default an initContainer that modify some kernel settings to meet the Elasticsearch requirements.

--- a/bitnami/kibana/requirements.lock
+++ b/bitnami/kibana/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
-  version: 7.1.0
-digest: sha256:cf77e32c2c24eb28f1ca463ea8f829c44de25536a5d44a857cfa8d08e0b7000b
-generated: 2019-10-30T17:59:20.535567548Z
+  version: 8.2.5
+digest: sha256:97671ddccc4a7ec4739ec01b1ea42dd8424d62ed364bb34798971a95e81891bd
+generated: "2019-11-15T14:20:58.304199824+05:30"

--- a/bitnami/kibana/requirements.yaml
+++ b/bitnami/kibana/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: elasticsearch
-  version: 7.x.x
+  version: 8.x.x
   repository: https://charts.bitnami.com/bitnami
   condition: elasticsearch.enabled

--- a/bitnami/kibana/templates/_helpers.tpl
+++ b/bitnami/kibana/templates/_helpers.tpl
@@ -298,3 +298,14 @@ kibana: missing-extra-volume-mounts
     the extraVolumeMounts value
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "kibana.deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/bitnami/kibana/templates/deployment.yaml
+++ b/bitnami/kibana/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion: {{ template "kibana.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ include "kibana.fullname" . }}


### PR DESCRIPTION
**Description of the change**
Helm performs a lookup for the object based on its group (apps), version (v1), and kind (Deployment). Also known as its GroupVersionKind, or GVK. Changing the GVK is considered a compatibility breaker from Kubernetes' point of view, so you cannot "upgrade" those objects to the new GVK in-place. Earlier versions of Helm 3 did not perform the lookup correctly which has since been fixed to match the spec.

In 4dfac075aacf74405e31ae5b27df4369e84eb0b0 the `apiVersion` of the deployment resources was updated to `apps/v1` in tune with the api's deprecated, resulting in compatibility breakage.

This major version signifies this change.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files