### PR TITLE
[bitnami/{cassandra,consul,elasticsearch}] Run kubeval, yamllint and helm lint

### DIFF
--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cassandra
-version: 4.1.7
+version: 4.1.8
 appVersion: 3.11.5
 description: Apache Cassandra is a free and open-source distributed database management system designed to handle large amounts of data across many commodity servers, providing high availability with no single point of failure. Cassandra offers robust support for clusters spanning multiple datacenters, with asynchronous masterless replication allowing low latency operations for all clients.
 keywords:

--- a/bitnami/cassandra/templates/statefulset.yaml
+++ b/bitnami/cassandra/templates/statefulset.yaml
@@ -147,7 +147,7 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             exec:
-              command: [ "/bin/sh", "-c", "nodetool status" ]
+              command: ["/bin/sh", "-c", "nodetool status"]
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -157,7 +157,7 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             exec:
-              command: [ "/bin/sh", "-c", "nodetool status | grep -E \"^UN\\s+${POD_IP}\"" ]
+              command: ["/bin/sh", "-c", "nodetool status | grep -E \"^UN\\s+${POD_IP}\""]
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: consul
-version: 6.0.8
+version: 6.0.9
 appVersion: 1.6.1
 description: Highly available and distributed service discovery and key-value store designed with support for the modern data center to make distributed systems and configuration easy.
 home: https://www.consul.io/

--- a/bitnami/consul/values-production.yaml
+++ b/bitnami/consul/values-production.yaml
@@ -125,10 +125,10 @@ raftMultiplier: '1'
 
 ## Extra configuration that will be added to the default one.
 ##
-#localConfig: |-
-#  {
-#    "key": "value"
-#  }
+# localConfig: |-
+#   {
+#     "key": "value"
+#   }
 
 ## Number of HashiCorp Consul replicas to deploy
 ##

--- a/bitnami/consul/values.yaml
+++ b/bitnami/consul/values.yaml
@@ -125,10 +125,10 @@ raftMultiplier: '1'
 
 ## Extra configuration that will be added to the default one.
 ##
-#localConfig: |-
-#  {
-#    "key": "value"
-#  }
+# localConfig: |-
+#   {
+#     "key": "value"
+#   }
 
 ## Number of HashiCorp Consul replicas to deploy
 ##

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: elasticsearch
-version: 8.2.5
+version: 8.2.6
 appVersion: 7.4.2
 description: A highly scalable open-source full-text search and analytics engine
 keywords:

--- a/bitnami/elasticsearch/values-production.yaml
+++ b/bitnami/elasticsearch/values-production.yaml
@@ -567,15 +567,18 @@ curator:
       #   logformat: default
       #   blacklist: ['elasticsearch', 'urllib3']
 
-  resources: {}
+  ## Curator resources requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
     # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    # limits:
+    limits: {}
     #  cpu: 100m
     #  memory: 128Mi
-    # requests:
+    requests: {}
     #  cpu: 100m
     #  memory: 128Mi
 
@@ -593,40 +596,41 @@ curator:
   #     mountPath: /certs
   #     readOnly: true
 
-  # Add your own init container or uncomment and modify the given example.
+  ## Add your own init container or uncomment and modify the given example.
+  ##
   extraInitContainers: {}
-    ## Don't configure S3 repository till Elasticsearch is reachable.
-    ## Ensure that it is available at http://elasticsearch:9200
-    ##
-    # elasticsearch-s3-repository:
-    #   image: bitnami/minideb:latest
-    #   imagePullPolicy: "IfNotPresent"
-    #   command:
-    #   - "/bin/bash"
-    #   - "-c"
-    #   args:
-    #   - |
-    #     ES_HOST=elasticsearch
-    #     ES_PORT=9200
-    #     ES_REPOSITORY=backup
-    #     S3_REGION=us-east-1
-    #     S3_BUCKET=bucket
-    #     S3_BASE_PATH=backup
-    #     S3_COMPRESS=true
-    #     S3_STORAGE_CLASS=standard
-    #     install_packages curl && \
-    #     ( counter=0; while (( counter++ < 120 )); do curl -s http://${ES_HOST}:${ES_PORT} >/dev/null 2>&1 && break; echo "Waiting for elasticsearch $counter/120"; sleep 1; done ) && \
-    #     cat <<EOF | curl -sS -XPUT -H "Content-Type: application/json" -d @- http://${ES_HOST}:${ES_PORT}/_snapshot/${ES_REPOSITORY} \
-    #     {
-    #       "type": "s3",
-    #       "settings": {
-    #         "bucket": "${S3_BUCKET}",
-    #         "base_path": "${S3_BASE_PATH}",
-    #         "region": "${S3_REGION}",
-    #         "compress": "${S3_COMPRESS}",
-    #         "storage_class": "${S3_STORAGE_CLASS}"
-    #       }
-    #     }
+  ## Don't configure S3 repository till Elasticsearch is reachable.
+  ## Ensure that it is available at http://elasticsearch:9200
+  ##
+  # elasticsearch-s3-repository:
+  #   image: bitnami/minideb:latest
+  #   imagePullPolicy: "IfNotPresent"
+  #   command:
+  #   - "/bin/bash"
+  #   - "-c"
+  #   args:
+  #   - |
+  #     ES_HOST=elasticsearch
+  #     ES_PORT=9200
+  #     ES_REPOSITORY=backup
+  #     S3_REGION=us-east-1
+  #     S3_BUCKET=bucket
+  #     S3_BASE_PATH=backup
+  #     S3_COMPRESS=true
+  #     S3_STORAGE_CLASS=standard
+  #     install_packages curl && \
+  #     ( counter=0; while (( counter++ < 120 )); do curl -s http://${ES_HOST}:${ES_PORT} >/dev/null 2>&1 && break; echo "Waiting for elasticsearch $counter/120"; sleep 1; done ) && \
+  #     cat <<EOF | curl -sS -XPUT -H "Content-Type: application/json" -d @- http://${ES_HOST}:${ES_PORT}/_snapshot/${ES_REPOSITORY} \
+  #     {
+  #       "type": "s3",
+  #       "settings": {
+  #         "bucket": "${S3_BUCKET}",
+  #         "base_path": "${S3_BASE_PATH}",
+  #         "region": "${S3_REGION}",
+  #         "compress": "${S3_COMPRESS}",
+  #         "storage_class": "${S3_STORAGE_CLASS}"
+  #       }
+  #     }
 
 ## Elasticsearch Prometheus exporter configuration
 ## ref: https://hub.docker.com/r/bitnami/elasticsearch-exporter/tags/

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -567,15 +567,18 @@ curator:
       #   logformat: default
       #   blacklist: ['elasticsearch', 'urllib3']
 
-  resources: {}
+  ## Curator resources requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
     # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    # limits:
+    limits: {}
     #  cpu: 100m
     #  memory: 128Mi
-    # requests:
+    requests: {}
     #  cpu: 100m
     #  memory: 128Mi
 
@@ -593,40 +596,41 @@ curator:
   #     mountPath: /certs
   #     readOnly: true
 
-  # Add your own init container or uncomment and modify the given example.
+  ## Add your own init container or uncomment and modify the given example.
+  ##
   extraInitContainers: {}
-    ## Don't configure S3 repository till Elasticsearch is reachable.
-    ## Ensure that it is available at http://elasticsearch:9200
-    ##
-    # elasticsearch-s3-repository:
-    #   image: bitnami/minideb:latest
-    #   imagePullPolicy: "IfNotPresent"
-    #   command:
-    #   - "/bin/bash"
-    #   - "-c"
-    #   args:
-    #   - |
-    #     ES_HOST=elasticsearch
-    #     ES_PORT=9200
-    #     ES_REPOSITORY=backup
-    #     S3_REGION=us-east-1
-    #     S3_BUCKET=bucket
-    #     S3_BASE_PATH=backup
-    #     S3_COMPRESS=true
-    #     S3_STORAGE_CLASS=standard
-    #     install_packages curl && \
-    #     ( counter=0; while (( counter++ < 120 )); do curl -s http://${ES_HOST}:${ES_PORT} >/dev/null 2>&1 && break; echo "Waiting for elasticsearch $counter/120"; sleep 1; done ) && \
-    #     cat <<EOF | curl -sS -XPUT -H "Content-Type: application/json" -d @- http://${ES_HOST}:${ES_PORT}/_snapshot/${ES_REPOSITORY} \
-    #     {
-    #       "type": "s3",
-    #       "settings": {
-    #         "bucket": "${S3_BUCKET}",
-    #         "base_path": "${S3_BASE_PATH}",
-    #         "region": "${S3_REGION}",
-    #         "compress": "${S3_COMPRESS}",
-    #         "storage_class": "${S3_STORAGE_CLASS}"
-    #       }
-    #     }
+  ## Don't configure S3 repository till Elasticsearch is reachable.
+  ## Ensure that it is available at http://elasticsearch:9200
+  ##
+  # elasticsearch-s3-repository:
+  #   image: bitnami/minideb:latest
+  #   imagePullPolicy: "IfNotPresent"
+  #   command:
+  #   - "/bin/bash"
+  #   - "-c"
+  #   args:
+  #   - |
+  #     ES_HOST=elasticsearch
+  #     ES_PORT=9200
+  #     ES_REPOSITORY=backup
+  #     S3_REGION=us-east-1
+  #     S3_BUCKET=bucket
+  #     S3_BASE_PATH=backup
+  #     S3_COMPRESS=true
+  #     S3_STORAGE_CLASS=standard
+  #     install_packages curl && \
+  #     ( counter=0; while (( counter++ < 120 )); do curl -s http://${ES_HOST}:${ES_PORT} >/dev/null 2>&1 && break; echo "Waiting for elasticsearch $counter/120"; sleep 1; done ) && \
+  #     cat <<EOF | curl -sS -XPUT -H "Content-Type: application/json" -d @- http://${ES_HOST}:${ES_PORT}/_snapshot/${ES_REPOSITORY} \
+  #     {
+  #       "type": "s3",
+  #       "settings": {
+  #         "bucket": "${S3_BUCKET}",
+  #         "base_path": "${S3_BASE_PATH}",
+  #         "region": "${S3_REGION}",
+  #         "compress": "${S3_COMPRESS}",
+  #         "storage_class": "${S3_STORAGE_CLASS}"
+  #       }
+  #     }
 
 ## Elasticsearch Prometheus exporter configuration
 ## ref: https://hub.docker.com/r/bitnami/elasticsearch-exporter/tags/


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

Run linters suggested at https://github.com/bitnami/charts/pull/1452 to Cassandra, Consul and Elasticsearch chart.

**Possible drawbacks**

None

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
