### PR TITLE
s/Container/Kubernetes/

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This repository contains:
 
 ### Setup a Kubernetes Cluster
 
-The quickest way to setup a Kubernetes cluster is with [Azure Kubernetes Service](https://azure.microsoft.com/en-us/services/kubernetes-service/), [AWS Elastic Container Service](https://aws.amazon.com/eks/) or [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/) using their respective quick-start guides. For setting up Kubernetes on other cloud platforms or bare-metal servers refer to the Kubernetes [getting started guide](http://kubernetes.io/docs/getting-started-guides/).
+The quickest way to setup a Kubernetes cluster is with [Azure Kubernetes Service](https://azure.microsoft.com/en-us/services/kubernetes-service/), [AWS Elastic Kubernetes Service](https://aws.amazon.com/eks/) or [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/) using their respective quick-start guides. For setting up Kubernetes on other cloud platforms or bare-metal servers refer to the Kubernetes [getting started guide](http://kubernetes.io/docs/getting-started-guides/).
 
 ### Install Helm
 


### PR DESCRIPTION
just a tiny doc update

tired: ECS (Elastic Container Service)
wired: EKS (Elastic Kubernetes Service)

also, your users are going to have a heckuva time trying to get k8s running on ECS
