### PR TITLE
[bitnami/spark] Fix headless service selector

### DIFF
--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 1.0.11
+version: 1.0.12
 appVersion: 2.4.4
 description: Spark is a fast and general-purpose cluster computing system.
 name: spark

--- a/bitnami/spark/templates/headless-svc.yaml
+++ b/bitnami/spark/templates/headless-svc.yaml
@@ -12,4 +12,4 @@ spec:
   clusterIP: None
   selector:
     app.kubernetes.io/name: {{ include "spark.name" . }}
-    release: "{{ .Release.Name }}"
+    app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
**Description of the change**

The headless service has an incorrect selector preventing DNS resolution to the driver pod. 

**Benefits**

Make a Spark cluster deployed by the chart functional. 

**Possible drawbacks**

N/A

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #1626 

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
