### PR TITLE
[bitnami/nginx] Ability to add labels for ingress

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx
-version: 4.3.12
+version: 4.3.13
 appVersion: 1.16.1
 description: Chart for the nginx server
 keywords:

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -83,8 +83,9 @@ The following tables lists the configurable parameters of the NGINX Open Source 
 | `service.loadBalancerIP`         | LoadBalancer service IP address                  | `""`                                                         |
 | `service.annotations`            | Service annotations                              | `{}`                                                         |
 | `ingress.enabled`                | Enable ingress controller resource               | `false`                                                      |
-| `ingress.certManager`            | Add annotations for cert-manager                 | `false`                                                      |
-| `ingress.annotations`            | Ingress annotations                              | `[]`                                                         |
+| `ingress.certManager`            | Add annotations for cert-manager                 | `false`
+| `ingress.selectors`              | Ingress selectors for labelSelector option       | `[]`     
+| `ingress.annotations`            | Ingress annotations                              | `[]`                                 
 | `ingress.hosts[0].name`          | Hostname to your NGINX installation              | `nginx.local`                                                |
 | `ingress.hosts[0].path`          | Path within the url structure                    | `/`                                                          |
 | `ingress.tls[0].hosts[0]`        | TLS hosts                                        | `nginx.local`                                                |

--- a/bitnami/nginx/templates/ingress.yaml
+++ b/bitnami/nginx/templates/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  {{- range $key, $value := .Values.ingress.labels }}
+  {{- range $key, $value := .Values.ingress.selectors }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
   annotations:

--- a/bitnami/nginx/templates/ingress.yaml
+++ b/bitnami/nginx/templates/ingress.yaml
@@ -8,6 +8,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- range $key, $value := .Values.ingress.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
   annotations:
     {{- if .Values.ingress.certManager }}
     kubernetes.io/tls-acme: "true"

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -70,6 +70,10 @@ ingress:
   ## Set this to true in order to add the corresponding annotations for cert-manager
   certManager: false
 
+  # Ingress lables. If you need to add specific lablel for labelSelector option
+  selectors:
+  #  traffic-type: external
+
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
   ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md


### PR DESCRIPTION
I use traefik as ingress controller. Traefik uses service labels for labelSelector. I want to have the ability to have additional labels for nginx's ingress