### PR TITLE
[bitnami/influxdb] Fix hard antiAffinity indentation

### DIFF
--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: influxdb
 sources:
   - https://github.com/bitnami/bitnami-docker-influxdb
-version: 0.2.2
+version: 0.2.3

--- a/bitnami/influxdb/templates/influxdb/standalone-dpl.yaml
+++ b/bitnami/influxdb/templates/influxdb/standalone-dpl.yaml
@@ -22,7 +22,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             - topologyKey: "kubernetes.io/hostname"
               labelSelector:
-                matchLabels: {{- include "influxdb.matchLabels" . | nindent 20 }}
+                matchLabels: {{- include "influxdb.matchLabels" . | nindent 18 }}
                   app.kubernetes.io/component: influxdb
         {{- else if eq .Values.influxdb.antiAffinity "soft" }}
         podAntiAffinity:

--- a/bitnami/influxdb/templates/influxdb/statefulset.yaml
+++ b/bitnami/influxdb/templates/influxdb/statefulset.yaml
@@ -28,7 +28,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             - topologyKey: "kubernetes.io/hostname"
               labelSelector:
-                matchLabels: {{- include "influxdb.matchLabels" . | nindent 20 }}
+                matchLabels: {{- include "influxdb.matchLabels" . | nindent 18 }}
                   app.kubernetes.io/component: influxdb
         {{- else if eq .Values.influxdb.antiAffinity "soft" }}
         podAntiAffinity:

--- a/bitnami/influxdb/templates/relay/deployment.yaml
+++ b/bitnami/influxdb/templates/relay/deployment.yaml
@@ -22,7 +22,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             - topologyKey: "kubernetes.io/hostname"
               labelSelector:
-                matchLabels: {{- include "influxdb.matchLabels" . | nindent 20 }}
+                matchLabels: {{- include "influxdb.matchLabels" . | nindent 18 }}
                   app.kubernetes.io/component: relay
         {{- else if eq .Values.relay.antiAffinity "soft" }}
         podAntiAffinity:


### PR DESCRIPTION
**Description of the change**
Fixes the indentation for hard anti affinity.

**Applicable issues**
  - fixes #1614

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
