### PR TITLE
[bitnami/etcd] redirect output to new_member_envs

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: etcd
-version: 4.4.3
+version: 4.4.4
 appVersion: 3.4.3
 description: etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines
 keywords:

--- a/bitnami/etcd/templates/scripts-configmap.yaml
+++ b/bitnami/etcd/templates/scripts-configmap.yaml
@@ -163,7 +163,7 @@ data:
 {{- end }}
         elif should_add_new_member; then
             echo "==> Adding new member to existing cluster..." 1>&3 2>&4
-            etcdctl $AUTH_OPTIONS member add "$HOSTNAME" --peer-urls="{{ $etcdPeerProtocol }}://${HOSTNAME}.{{ $etcdHeadlessServiceName }}.{{ .Release.Namespace }}.svc.{{ $clusterDomain }}:{{ $peerPort }}" | grep "^ETCD_" > "$ETCD_DATA_DIR/new_member_envs" 1>&3 2>&4
+            etcdctl $AUTH_OPTIONS member add "$HOSTNAME" --peer-urls="{{ $etcdPeerProtocol }}://${HOSTNAME}.{{ $etcdHeadlessServiceName }}.{{ .Release.Namespace }}.svc.{{ $clusterDomain }}:{{ $peerPort }}" | grep "^ETCD_" > "$ETCD_DATA_DIR/new_member_envs"
             sed -ie 's/^/export /' "$ETCD_DATA_DIR/new_member_envs"
             echo "==> Loading env vars of existing cluster..." 1>&3 2>&4
             source "$ETCD_DATA_DIR/new_member_envs" 1>&3 2>&4


### PR DESCRIPTION
Saving the env vars to file combined with stdout/stderr redirection does not seem to work. The `new_member_envs` stays empty and `ETCD_INITIAL_CLUSTER_STATE` is always `NEW` triggering the wrong path in the setup script.

fixes #1640
