### PR TITLE
[bitnami/es] Allow initContainer install procps package without install_packages script

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: elasticsearch
-version: 9.0.2
+version: 9.0.3
 appVersion: 7.4.2
 description: A highly scalable open-source full-text search and analytics engine
 keywords:

--- a/bitnami/elasticsearch/templates/configmap-initcontainer.yaml
+++ b/bitnami/elasticsearch/templates/configmap-initcontainer.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.sysctlImage.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "elasticsearch.fullname" . }}-initcontainer
+  labels: {{- include "elasticsearch.labels" . | nindent 4 }}
+data:
+  sysctl.sh: |-
+    #!/bin/bash
+    
+    set -o errexit
+    set -o pipefail
+    set -o nounset
+
+    if ! [ -x "$(command -v sysctl)" ]; then
+      echo 'sysctl not installed. Installing it...'
+      distro=$(awk -F= '/^ID=/{print $2}' /etc/os-release | tr -d '"')
+      case $distro in
+        ol | centos)
+          yum install -y procps
+          rm -rf /var/cache/yum;;
+        ubuntu | debian)
+          apt-get update -qq && apt-get install -y --no-install-recommends procps
+          rm -rf /var/lib/apt/lists /var/cache/apt/archives;;
+      esac
+    fi
+    sysctl -w vm.max_map_count=262144 && sysctl -w fs.file-max=65536
+{{- end }}

--- a/bitnami/elasticsearch/templates/coordinating-deploy.yaml
+++ b/bitnami/elasticsearch/templates/coordinating-deploy.yaml
@@ -38,24 +38,13 @@ spec:
           image: {{ include "elasticsearch.sysctl.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           command:
-            - /bin/bash
-            - -ec
-            - |
-              if ! [ -x "$(command -v sysctl)" ]; then
-                echo 'sysctl not installed. Installing it...'
-                distro=$(awk -F= '/^ID=/{print $2}' /etc/os-release | tr -d '"')
-                case $distro in
-                  ol | centos)
-                    yum install -y procps
-                    rm -rf /var/cache/yum;;
-                  ubuntu | debian)
-                    apt-get update -qq && apt-get install -y --no-install-recommends procps
-                    rm -rf /var/lib/apt/lists /var/cache/apt/archives;;
-                esac
-              fi
-              sysctl -w vm.max_map_count=262144 && sysctl -w fs.file-max=65536
+            - /scripts/sysctl.sh
           securityContext:
             privileged: true
+          volumeMounts:
+            - name: initcontainer-script
+              mountPath: /scripts/sysctl.sh
+              subPath: sysctl.sh
       {{- end }}
       containers:
         - name: elasticsearch
@@ -124,6 +113,12 @@ spec:
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
       volumes:
+        {{- if .Values.sysctlImage.enabled }}
+        - name: initcontainer-script
+          configMap:
+            name: {{ include "elasticsearch.fullname" . }}-initcontainer
+            defaultMode: 0755
+        {{- end }}
         {{- if .Values.config }}
         - name: config
           configMap:

--- a/bitnami/elasticsearch/templates/coordinating-deploy.yaml
+++ b/bitnami/elasticsearch/templates/coordinating-deploy.yaml
@@ -41,7 +41,18 @@ spec:
             - /bin/bash
             - -ec
             - |
-              install_packages procps
+              if ! [ -x "$(command -v sysctl)" ]; then
+                echo 'sysctl not installed. Installing it...'
+                distro=$(awk -F= '/^ID=/{print $2}' /etc/os-release | tr -d '"')
+                case $distro in
+                  ol | centos)
+                    yum install -y procps
+                    rm -rf /var/cache/yum;;
+                  ubuntu | debian)
+                    apt-get update -qq && apt-get install -y --no-install-recommends procps
+                    rm -rf /var/lib/apt/lists /var/cache/apt/archives;;
+                esac
+              fi
               sysctl -w vm.max_map_count=262144 && sysctl -w fs.file-max=65536
           securityContext:
             privileged: true

--- a/bitnami/elasticsearch/templates/data-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/data-statefulset.yaml
@@ -48,24 +48,13 @@ spec:
           image: {{ include "elasticsearch.sysctl.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           command:
-            - /bin/bash
-            - -ec
-            - |
-              if ! [ -x "$(command -v sysctl)" ]; then
-                echo 'sysctl not installed. Installing it...'
-                distro=$(awk -F= '/^ID=/{print $2}' /etc/os-release | tr -d '"')
-                case $distro in
-                  ol | centos)
-                    yum install -y procps
-                    rm -rf /var/cache/yum;;
-                  ubuntu | debian)
-                    apt-get update -qq && apt-get install -y --no-install-recommends procps
-                    rm -rf /var/lib/apt/lists /var/cache/apt/archives;;
-                esac
-              fi
-              sysctl -w vm.max_map_count=262144 && sysctl -w fs.file-max=65536
+            - /scripts/sysctl.sh
           securityContext:
             privileged: true
+          volumeMounts:
+            - name: initcontainer-script
+              mountPath: /scripts/sysctl.sh
+              subPath: sysctl.sh
         {{- end }}
         {{- if and .Values.volumePermissions.enabled .Values.data.persistence.enabled }}
         - name: volume-permissions
@@ -151,6 +140,12 @@ spec:
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
       volumes:
+        {{- if .Values.sysctlImage.enabled }}
+        - name: initcontainer-script
+          configMap:
+            name: {{ include "elasticsearch.fullname" . }}-initcontainer
+            defaultMode: 0755
+        {{- end }}
         {{- if .Values.config }}
         - name: "config"
           configMap:

--- a/bitnami/elasticsearch/templates/data-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/data-statefulset.yaml
@@ -42,7 +42,7 @@ spec:
       {{- end }}
       {{- if or .Values.sysctlImage.enabled (and .Values.volumePermissions.enabled .Values.data.persistence.enabled) }}
       initContainers:
-      {{- if .Values.sysctlImage.enabled }}
+        {{- if .Values.sysctlImage.enabled }}
         ## Image that performs the sysctl operation to modify Kernel settings (needed sometimes to avoid boot errors)
         - name: sysctl
           image: {{ include "elasticsearch.sysctl.image" . }}
@@ -51,7 +51,18 @@ spec:
             - /bin/bash
             - -ec
             - |
-              install_packages procps
+              if ! [ -x "$(command -v sysctl)" ]; then
+                echo 'sysctl not installed. Installing it...'
+                distro=$(awk -F= '/^ID=/{print $2}' /etc/os-release | tr -d '"')
+                case $distro in
+                  ol | centos)
+                    yum install -y procps
+                    rm -rf /var/cache/yum;;
+                  ubuntu | debian)
+                    apt-get update -qq && apt-get install -y --no-install-recommends procps
+                    rm -rf /var/lib/apt/lists /var/cache/apt/archives;;
+                esac
+              fi
               sysctl -w vm.max_map_count=262144 && sysctl -w fs.file-max=65536
           securityContext:
             privileged: true

--- a/bitnami/elasticsearch/templates/ingest-deploy.yaml
+++ b/bitnami/elasticsearch/templates/ingest-deploy.yaml
@@ -39,24 +39,13 @@ spec:
           image: {{ include "elasticsearch.sysctl.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           command:
-            - /bin/bash
-            - -ec
-            - |
-              if ! [ -x "$(command -v sysctl)" ]; then
-                echo 'sysctl not installed. Installing it...'
-                distro=$(awk -F= '/^ID=/{print $2}' /etc/os-release | tr -d '"')
-                case $distro in
-                  ol | centos)
-                    yum install -y procps
-                    rm -rf /var/cache/yum;;
-                  ubuntu | debian)
-                    apt-get update -qq && apt-get install -y --no-install-recommends procps
-                    rm -rf /var/lib/apt/lists /var/cache/apt/archives;;
-                esac
-              fi
-              sysctl -w vm.max_map_count=262144 && sysctl -w fs.file-max=65536
+            - /scripts/sysctl.sh
           securityContext:
             privileged: true
+          volumeMounts:
+            - name: initcontainer-script
+              mountPath: /scripts/sysctl.sh
+              subPath: sysctl.sh
       {{- end }}
       containers:
         - name: elasticsearch
@@ -125,6 +114,12 @@ spec:
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
       volumes:
+        {{- if .Values.sysctlImage.enabled }}
+        - name: initcontainer-script
+          configMap:
+            name: {{ include "elasticsearch.fullname" . }}-initcontainer
+            defaultMode: 0755
+        {{- end }}
         {{- if .Values.config }}
         - name: config
           configMap:

--- a/bitnami/elasticsearch/templates/ingest-deploy.yaml
+++ b/bitnami/elasticsearch/templates/ingest-deploy.yaml
@@ -42,7 +42,18 @@ spec:
             - /bin/bash
             - -ec
             - |
-              install_packages procps
+              if ! [ -x "$(command -v sysctl)" ]; then
+                echo 'sysctl not installed. Installing it...'
+                distro=$(awk -F= '/^ID=/{print $2}' /etc/os-release | tr -d '"')
+                case $distro in
+                  ol | centos)
+                    yum install -y procps
+                    rm -rf /var/cache/yum;;
+                  ubuntu | debian)
+                    apt-get update -qq && apt-get install -y --no-install-recommends procps
+                    rm -rf /var/lib/apt/lists /var/cache/apt/archives;;
+                esac
+              fi
               sysctl -w vm.max_map_count=262144 && sysctl -w fs.file-max=65536
           securityContext:
             privileged: true

--- a/bitnami/elasticsearch/templates/master-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/master-statefulset.yaml
@@ -43,7 +43,18 @@ spec:
             - /bin/bash
             - -ec
             - |
-              install_packages procps
+              if ! [ -x "$(command -v sysctl)" ]; then
+                echo 'sysctl not installed. Installing it...'
+                distro=$(awk -F= '/^ID=/{print $2}' /etc/os-release | tr -d '"')
+                case $distro in
+                  ol | centos)
+                    yum install -y procps
+                    rm -rf /var/cache/yum;;
+                  ubuntu | debian)
+                    apt-get update -qq && apt-get install -y --no-install-recommends procps
+                    rm -rf /var/lib/apt/lists /var/cache/apt/archives;;
+                esac
+              fi
               sysctl -w vm.max_map_count=262144 && sysctl -w fs.file-max=65536
           securityContext:
             privileged: true

--- a/bitnami/elasticsearch/templates/master-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/master-statefulset.yaml
@@ -40,24 +40,13 @@ spec:
           image: {{ include "elasticsearch.sysctl.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           command:
-            - /bin/bash
-            - -ec
-            - |
-              if ! [ -x "$(command -v sysctl)" ]; then
-                echo 'sysctl not installed. Installing it...'
-                distro=$(awk -F= '/^ID=/{print $2}' /etc/os-release | tr -d '"')
-                case $distro in
-                  ol | centos)
-                    yum install -y procps
-                    rm -rf /var/cache/yum;;
-                  ubuntu | debian)
-                    apt-get update -qq && apt-get install -y --no-install-recommends procps
-                    rm -rf /var/lib/apt/lists /var/cache/apt/archives;;
-                esac
-              fi
-              sysctl -w vm.max_map_count=262144 && sysctl -w fs.file-max=65536
+            - /scripts/sysctl.sh
           securityContext:
             privileged: true
+          volumeMounts:
+            - name: initcontainer-script
+              mountPath: /scripts/sysctl.sh
+              subPath: sysctl.sh
         {{- end }}
         {{- if and .Values.volumePermissions.enabled .Values.master.persistence.enabled }}
         - name: volume-permissions
@@ -149,6 +138,12 @@ spec:
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
       volumes:
+        {{- if .Values.sysctlImage.enabled }}
+        - name: initcontainer-script
+          configMap:
+            name: {{ include "elasticsearch.fullname" . }}-initcontainer
+            defaultMode: 0755
+        {{- end }}
         {{- if .Values.config }}
         - name: config
           configMap:


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

**Description of the change**

The default image for the initContainer that perform some modifications in the kernel setting is `bitnami/minideb`, this image doesn't have `sysctl` command installed by default, so we are installing `procps` package using `install_package` script.

As we allow users to modify the base image for this container we can't ensure that this new image contains the `install_packages` script so:
- First, we check if `sysctl` is already in the image. If it is installed, we don't install anything
- If it is not installed, we install `procps` but using the distro native package manager instead of `install_packages`

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files