### PR TITLE
[bitnami/metrics-server] Enable RBAC by default

### DIFF
--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: metrics-server
-version: 4.0.0
+version: 4.0.1
 appVersion: 0.3.6
 description: Metrics Server is a cluster-wide aggregator of resource usage data. Metrics Server collects metrics from the Summary API, exposed by Kubelet on each node.
 keywords:

--- a/bitnami/metrics-server/values.yaml
+++ b/bitnami/metrics-server/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/metrics-server
-  tag: 0.3.6-debian-9-r24
+  tag: 0.3.6-debian-9-r27
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/metrics-server/values.yaml
+++ b/bitnami/metrics-server/values.yaml
@@ -40,7 +40,7 @@ image:
 rbac:
   ## Specifies whether RBAC rules should be created
   ##
-  create: false
+  create: true
 
 ## Pods Service Account
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
@@ -48,7 +48,7 @@ rbac:
 serviceAccount:
   ## Specifies whether a ServiceAccount should be created
   ##
-  create: false
+  create: true
   ## The name of the ServiceAccount to use.
   ## If not set and create is true, a name is generated using the metrics-server.fullname template
   # name:


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

As part of [716d22d25d11d1253864bcb71cfc835bcc53732c](https://github.com/bitnami/charts/commit/716d22d25d11d1253864bcb71cfc835bcc53732c) we disabled RBAC by default by mistake. This PR fixes that.

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
