### PR TITLE
[bitnami/metrics-server] Fix 'extraArgs' parameter

### DIFF
--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: metrics-server
-version: 4.0.1
+version: 4.0.2
 appVersion: 0.3.6
 description: Metrics Server is a cluster-wide aggregator of resource usage data. Metrics Server collects metrics from the Summary API, exposed by Kubelet on each node.
 keywords:

--- a/bitnami/metrics-server/ci/values-with-rbac.yaml
+++ b/bitnami/metrics-server/ci/values-with-rbac.yaml
@@ -6,3 +6,7 @@ rbac:
 
 serviceAccount:
   create: true
+
+extraArgs:
+  kubelet-insecure-tls: true
+  kubelet-preferred-address-types: InternalIP

--- a/bitnami/metrics-server/templates/deployment.yaml
+++ b/bitnami/metrics-server/templates/deployment.yaml
@@ -34,6 +34,6 @@ spec:
           command:
             - metrics-server
             - --secure-port={{ .Values.securePort }}
-            {{- if .Values.extraArgs }}
-            {{- toYaml .Values.extraArgs | nindent 12 }}
+            {{- range $key, $value := .Values.extraArgs }}
+            - --{{ $key }}={{ $value }}
             {{- end }}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

This PR fixes the 'extraArgs' parameter. https://github.com/bitnami/charts/pull/1646 broke it.

**Benefits**

User can add extra arguments

**Possible drawbacks**

None

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)