### PR TITLE
[bitnami/mongodb-sharded] Use named port for ServiceMonitor

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb-sharded
-version: 0.1.1
+version: 0.1.2
 appVersion: 4.0.13
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications. Sharded topology.
 keywords:

--- a/bitnami/mongodb-sharded/templates/servicemonitor.yaml
+++ b/bitnami/mongodb-sharded/templates/servicemonitor.yaml
@@ -14,7 +14,7 @@ spec:
   selector:
     matchLabels: {{- include "mongodb-sharded.matchLabels" . | nindent 6 }}
   endpoints:
-    - port: 9216
+    - port: metrics
       {{- if .Values.metrics.serviceMonitor.interval }}
       interval: {{ .Values.metrics.serviceMonitor.interval }}
       {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Change port to use named reference in ServiceMonitor for mongodb-sharded template

**Benefits**

The latest CRD for prometheus-operator expects a string/name instead of a number.

**Possible drawbacks**

None

**Applicable issues**

**Additional information**
None

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
