### PR TITLE
[bitnami/mongodb-sharded] Fix system log verbosity

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb-sharded
-version: 0.1.2
+version: 0.1.3
 appVersion: 4.0.13
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications. Sharded topology.
 keywords:

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
@@ -73,7 +73,7 @@ spec:
               value: "true"
             {{- end }}
             - name: MONGODB_SYSTEM_LOG_VERBOSITY
-              value: {{ .Values.mongodbSystemLogVerbosity | quote }}
+              value: {{ .Values.common.mongodbSystemLogVerbosity | quote }}
             - name: MONGODB_DISABLE_SYSTEM_LOG
               {{- if .Values.mongodbDisableSystemLog }}
               value: "yes"

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-deployment.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-deployment.yaml
@@ -89,7 +89,7 @@ spec:
             - name: MONGODB_CFG_REPLICA_SET_NAME
               value: {{ printf "%s-configsvr" ( include "mongodb-sharded.fullname" . ) }}
             - name: MONGODB_SYSTEM_LOG_VERBOSITY
-              value: {{ .Values.mongodbSystemLogVerbosity | quote }}
+              value: {{ .Values.common.mongodbSystemLogVerbosity | quote }}
             - name: MONGODB_DISABLE_SYSTEM_LOG
               {{- if .Values.mongodbDisableSystemLog }}
               value: "yes"

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -75,7 +75,7 @@ spec:
               value: "true"
             {{- end }}
             - name: MONGODB_SYSTEM_LOG_VERBOSITY
-              value: {{ $.Values.mongodbSystemLogVerbosity | quote }}
+              value: {{ $.Values.common.mongodbSystemLogVerbosity | quote }}
             - name: MONGODB_MAX_TIMEOUT
               value: {{ $.Values.common.mongodbMaxWaitTimeout | quote }}
             - name: MONGODB_DISABLE_SYSTEM_LOG


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

This PR fixes the setup of the environment variable **MONGODB_SYSTEM_LOG_VERBOSITY**.

**Benefits**

The log verbosity can be adapted.

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/1638

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
