### PR TITLE
[bitnami/prometheus-operator] add node-exporter as a optional dependency

### DIFF
--- a/bitnami/prometheus-operator/Chart.yaml
+++ b/bitnami/prometheus-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.34.0
 description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 name: prometheus-operator
-version: 0.4.0
+version: 0.5.0
 keywords:
 - prometheus
 - alertmanager

--- a/bitnami/prometheus-operator/README.md
+++ b/bitnami/prometheus-operator/README.md
@@ -265,6 +265,13 @@ The following table lists the configurable parameters of the Prometheus Operator
 | `alertmanager.priorityClassName`                | Priority class assigned to the Pods                                                                                | ``                                                                                                                                                                                                                                                  |
 | `alertmanager.additionalPeers`                  | AdditionalPeers allows injecting a set of additional Alertmanagers to peer with to form a highly available cluster | `[]`                                                                                                                                                                                                                                                |
 
+### Exporters
+
+|             Parameter             |      Description       | Default |
+|-----------------------------------|------------------------|---------|
+| `exporters.enabled`               | Deploy exporters       | `true`  |
+| `exporters.node-exporter.enabled` | Deploy `node-exporter` | `true`  |
+
 The above parameters map to the env variables defined in [bitnami/prometheus-operator](http://github.com/bitnami/bitnami-docker-prometheus-operator). For more information please refer to the [bitnami/prometheus-operator](http://github.com/bitnami/bitnami-docker-prometheus-operator) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/bitnami/prometheus-operator/requirements.lock
+++ b/bitnami/prometheus-operator/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: node-exporter
+  repository: https://charts.bitnami.com/bitnami
+  version: 0.1.0
+digest: sha256:ed8eb97c5bf626e91d36ca8a98f59cacc240b25821e6c2fcfcce5daea768962d
+generated: "2019-11-28T20:00:58.626042613+05:30"

--- a/bitnami/prometheus-operator/requirements.yaml
+++ b/bitnami/prometheus-operator/requirements.yaml
@@ -1,0 +1,5 @@
+dependencies:
+  - name: node-exporter
+    repository: https://charts.bitnami.com/bitnami
+    version: 0.1.*
+    condition: exporters.enabled,exporters.node-exporter.enabled

--- a/bitnami/prometheus-operator/templates/NOTES.txt
+++ b/bitnami/prometheus-operator/templates/NOTES.txt
@@ -92,5 +92,5 @@ To access Alertmanager from outside the cluster execute the following commands:
 {{- end }}
 {{- end }}
 
-{{ include "prometheus-operator.validateValues" . }}
-{{ include "prometheus-operator.checkRollingTags" . }}
+{{- include "prometheus-operator.validateValues" . }}
+{{- include "prometheus-operator.checkRollingTags" . }}

--- a/bitnami/prometheus-operator/templates/prometheus-operator/service.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/service.yaml
@@ -27,8 +27,5 @@ spec:
     {{- if and .Values.operator.service.nodePort (or (eq .Values.operator.service.type "NodePort") (eq .Values.operator.service.type "LoadBalancer")) }}
     nodePort: {{ .Values.operator.service.nodePort }}
     {{- end }}
-  selector:
-    app.kubernetes.io/name: {{ template "prometheus-operator.name" . }}
-    app.kubernetes.io/component: operator
-    app.kubernetes.io/instance: {{ .Release.Name }}
+  selector: {{- include "prometheus-operator.operator.matchLabels" . | nindent 4 }}
 {{- end }}

--- a/bitnami/prometheus-operator/values-production.yaml
+++ b/bitnami/prometheus-operator/values-production.yaml
@@ -746,3 +746,23 @@ alertmanager:
   ## AdditionalPeers allows injecting a set of additional Alertmanagers to peer with to form a highly available cluster.
   ##
   additionalPeers: []
+
+## Exporters
+exporters:
+  node-exporter:
+    ## Enable node-exporter
+    enabled: true
+
+## Node Exporter deployment configuration
+node-exporter:
+  service:
+    labels:
+      jobLabel: node-exporter
+
+  serviceMonitor:
+    enabled: true
+    jobLabel: jobLabel
+
+  extraArgs:
+    collector.filesystem.ignored-mount-points: "^/(dev|proc|sys|var/lib/docker/.+)($|/)"
+    collector.filesystem.ignored-fs-types: "^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$"

--- a/bitnami/prometheus-operator/values.yaml
+++ b/bitnami/prometheus-operator/values.yaml
@@ -746,3 +746,23 @@ alertmanager:
   ## AdditionalPeers allows injecting a set of additional Alertmanagers to peer with to form a highly available cluster.
   ##
   additionalPeers: []
+
+## Exporters
+exporters:
+  node-exporter:
+    ## Enable node-exporter
+    enabled: true
+
+## Node Exporter deployment configuration
+node-exporter:
+  service:
+    labels:
+      jobLabel: node-exporter
+
+  serviceMonitor:
+    enabled: true
+    jobLabel: jobLabel
+
+  extraArgs:
+    collector.filesystem.ignored-mount-points: "^/(dev|proc|sys|var/lib/docker/.+)($|/)"
+    collector.filesystem.ignored-fs-types: "^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$"


### PR DESCRIPTION
**Description of the change**

Adds node-exporter as a optional dependency

**Additional Notes to Reviewer**

Depends on https://github.com/bitnami/charts/pull/1665

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files