### PR TITLE
[bitnami/cassandra] Fix indentation for cassandra statefulset pod annotations

### DIFF
--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cassandra
-version: 4.1.8
+version: 4.1.9
 appVersion: 3.11.5
 description: Apache Cassandra is a free and open-source distributed database management system designed to handle large amounts of data across many commodity servers, providing high availability with no single point of failure. Cassandra offers robust support for clusters spanning multiple datacenters, with asynchronous masterless replication allowing low latency operations for all clients.
 keywords:

--- a/bitnami/cassandra/templates/statefulset.yaml
+++ b/bitnami/cassandra/templates/statefulset.yaml
@@ -25,10 +25,10 @@ spec:
       {{- if or .Values.podAnnotations (and .Values.metrics.enabled .Values.metrics.podAnnotations) }}
       annotations:
         {{- if .Values.podAnnotations }}
-        {{- toYaml .Values.podAnnotations | indent 8 }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
         {{- if .Values.metrics.podAnnotations }}
-        {{- toYaml .Values.metrics.podAnnotations | indent 8 }}
+        {{- toYaml .Values.metrics.podAnnotations | nindent 8 }}
         {{- end }}
       {{- end }}
     spec:


### PR DESCRIPTION
When the cassandra chart is built with the metrics.enabled=true flag, the template is rendered like so:

        heritage: Tiller
      annotations:        prometheus.io/port: "8080"
        prometheus.io/scrape: "true"

which is not valid.yaml. This PR fixes the indentation for this.  