### PR TITLE
[bitnami/*] Remove reference to Cassandra on non-cassandra charts

### DIFF
--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: consul
-version: 6.0.10
+version: 6.0.11
 appVersion: 1.6.2
 description: Highly available and distributed service discovery and key-value store designed with support for the modern data center to make distributed systems and configuration easy.
 home: https://www.consul.io/

--- a/bitnami/consul/values-production.yaml
+++ b/bitnami/consul/values-production.yaml
@@ -150,9 +150,6 @@ securityContext:
 
 ## HashiCorp Consul container's resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-## Minimum memory for development is 4GB and 2 CPU cores
-## Minimum memory for production is 8GB and 4 CPU cores
-## ref: http://docs.datastax.com/en/archived/cassandra/2.0/cassandra/architecture/architecturePlanningHardware_c.html
 ##
 resources:
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/bitnami/consul/values.yaml
+++ b/bitnami/consul/values.yaml
@@ -150,9 +150,6 @@ securityContext:
 
 ## HashiCorp Consul container's resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-## Minimum memory for development is 4GB and 2 CPU cores
-## Minimum memory for production is 8GB and 4 CPU cores
-## ref: http://docs.datastax.com/en/archived/cassandra/2.0/cassandra/architecture/architecturePlanningHardware_c.html
 ##
 resources:
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: etcd
-version: 4.4.4
+version: 4.4.5
 appVersion: 3.4.3
 description: etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines
 keywords:

--- a/bitnami/etcd/values-production.yaml
+++ b/bitnami/etcd/values-production.yaml
@@ -217,9 +217,6 @@ persistence:
 
 ## Etcd containers' resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-## Minimum memory for development is 4GB and 2 CPU cores
-## Minimum memory for production is 8GB and 4 CPU cores
-## ref: http://docs.datastax.com/en/archived/cassandra/2.0/cassandra/architecture/architecturePlanningHardware_c.html
 ##
 resources:
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/bitnami/etcd/values.yaml
+++ b/bitnami/etcd/values.yaml
@@ -217,9 +217,6 @@ persistence:
 
 ## Etcd containers' resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-## Minimum memory for development is 4GB and 2 CPU cores
-## Minimum memory for production is 8GB and 4 CPU cores
-## ref: http://docs.datastax.com/en/archived/cassandra/2.0/cassandra/architecture/architecturePlanningHardware_c.html
 ##
 resources:
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd
-version: 0.4.1
+version: 0.4.2
 appVersion: 1.7.4
 description: Fluentd is an open source data collector for unified logging layer
 keywords:

--- a/bitnami/fluentd/values-production.yaml
+++ b/bitnami/fluentd/values-production.yaml
@@ -171,9 +171,6 @@ forwarder:
 
   ## Forwarder containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-  ## Minimum memory for development is 4GB and 2 CPU cores
-  ## Minimum memory for production is 8GB and 4 CPU cores
-  ## ref: http://docs.datastax.com/en/archived/cassandra/2.0/cassandra/architecture/architecturePlanningHardware_c.html
   ##
   resources:
     # We usually recommend not to specify default resources and to leave this as a conscious
@@ -332,9 +329,6 @@ aggregator:
 
   ## Aggregator containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-  ## Minimum memory for development is 4GB and 2 CPU cores
-  ## Minimum memory for production is 8GB and 4 CPU cores
-  ## ref: http://docs.datastax.com/en/archived/cassandra/2.0/cassandra/architecture/architecturePlanningHardware_c.html
   ##
   resources:
     # We usually recommend not to specify default resources and to leave this as a conscious

--- a/bitnami/fluentd/values.yaml
+++ b/bitnami/fluentd/values.yaml
@@ -171,9 +171,6 @@ forwarder:
 
   ## Forwarder containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-  ## Minimum memory for development is 4GB and 2 CPU cores
-  ## Minimum memory for production is 8GB and 4 CPU cores
-  ## ref: http://docs.datastax.com/en/archived/cassandra/2.0/cassandra/architecture/architecturePlanningHardware_c.html
   ##
   resources:
     # We usually recommend not to specify default resources and to leave this as a conscious
@@ -332,9 +329,6 @@ aggregator:
 
   ## Aggregator containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-  ## Minimum memory for development is 4GB and 2 CPU cores
-  ## Minimum memory for production is 8GB and 4 CPU cores
-  ## ref: http://docs.datastax.com/en/archived/cassandra/2.0/cassandra/architecture/architecturePlanningHardware_c.html
   ##
   resources:
     # We usually recommend not to specify default resources and to leave this as a conscious

--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 1.1.5
+version: 1.1.6
 appVersion: 6.5.0
 description: Grafana is an open source, feature rich metrics dashboard and graph editor for Graphite, Elasticsearch, OpenTSDB, Prometheus and InfluxDB.
 keywords:

--- a/bitnami/grafana/values-production.yaml
+++ b/bitnami/grafana/values-production.yaml
@@ -256,9 +256,6 @@ securityContext:
 
 ## Grafana containers' resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-## Minimum memory for development is 4GB and 2 CPU cores
-## Minimum memory for production is 8GB and 4 CPU cores
-## ref: http://docs.datastax.com/en/archived/cassandra/2.0/cassandra/architecture/architecturePlanningHardware_c.html
 ##
 resources:
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/bitnami/grafana/values.yaml
+++ b/bitnami/grafana/values.yaml
@@ -256,9 +256,6 @@ securityContext:
 
 ## Grafana containers' resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-## Minimum memory for development is 4GB and 2 CPU cores
-## Minimum memory for production is 8GB and 4 CPU cores
-## ref: http://docs.datastax.com/en/archived/cassandra/2.0/cassandra/architecture/architecturePlanningHardware_c.html
 ##
 resources:
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/bitnami/mxnet/Chart.yaml
+++ b/bitnami/mxnet/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mxnet
-version: 1.4.0
+version: 1.4.1
 appVersion: 1.5.1
 description: A flexible and efficient library for deep learning
 keywords:

--- a/bitnami/mxnet/templates/scheduler-deployment.yaml
+++ b/bitnami/mxnet/templates/scheduler-deployment.yaml
@@ -16,13 +16,13 @@ spec:
     spec:
 {{- include "mxnet.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.affinity }}
-      affinity: {{- include "cassandra.tplValue" (dict "value" .Values.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "mxnet.tplValue" (dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.nodeSelector }}
-      nodeSelector: {{- include "cassandra.tplValue" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      nodeSelector: {{- include "mxnet.tplValue" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.tolerations }}
-      tolerations: {{- include "cassandra.tplValue" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
+      tolerations: {{- include "mxnet.tplValue" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:

--- a/bitnami/mxnet/templates/server-statefulset.yml
+++ b/bitnami/mxnet/templates/server-statefulset.yml
@@ -19,13 +19,13 @@ spec:
     spec:
 {{- include "mxnet.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.affinity }}
-      affinity: {{- include "cassandra.tplValue" (dict "value" .Values.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "mxnet.tplValue" (dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.nodeSelector }}
-      nodeSelector: {{- include "cassandra.tplValue" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      nodeSelector: {{- include "mxnet.tplValue" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.tolerations }}
-      tolerations: {{- include "cassandra.tplValue" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
+      tolerations: {{- include "mxnet.tplValue" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:

--- a/bitnami/mxnet/templates/standalone-deployment.yaml
+++ b/bitnami/mxnet/templates/standalone-deployment.yaml
@@ -17,13 +17,13 @@ spec:
     spec:
 {{- include "mxnet.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.affinity }}
-      affinity: {{- include "cassandra.tplValue" (dict "value" .Values.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "mxnet.tplValue" (dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.nodeSelector }}
-      nodeSelector: {{- include "cassandra.tplValue" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      nodeSelector: {{- include "mxnet.tplValue" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.tolerations }}
-      tolerations: {{- include "cassandra.tplValue" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
+      tolerations: {{- include "mxnet.tplValue" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:

--- a/bitnami/mxnet/templates/worker-statefulset.yml
+++ b/bitnami/mxnet/templates/worker-statefulset.yml
@@ -19,13 +19,13 @@ spec:
     spec:
 {{- include "mxnet.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.affinity }}
-      affinity: {{- include "cassandra.tplValue" (dict "value" .Values.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "mxnet.tplValue" (dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.nodeSelector }}
-      nodeSelector: {{- include "cassandra.tplValue" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      nodeSelector: {{- include "mxnet.tplValue" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.tolerations }}
-      tolerations: {{- include "cassandra.tplValue" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
+      tolerations: {{- include "mxnet.tplValue" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

Remove references to Cassandra on other charts (due to copy-paste)

**Possible drawbacks**

None


**Checklist*

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files