### PR TITLE
[bitnami/nginx] Add JSON Schema to NGINX chart

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx
-version: 5.0.0
+version: 5.1.0
 appVersion: 1.16.1
 description: Chart for the nginx server
 keywords:

--- a/bitnami/nginx/values.schema.json
+++ b/bitnami/nginx/values.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "ingress": {
+      "type": "object",
+      "form": true,
+      "title": "Ingress details",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "form": true,
+          "title": "Use a custom hostname",
+          "description": "Enable the ingress resource that allows you to access the NGINX installation."
+        },
+        "certManager": {
+          "type": "boolean",
+          "form": true,
+          "title": "Enable TLS annotations via cert-manager",
+          "description": "Set this to true in order to add the corresponding annotations for cert-manager",
+          "hidden": {
+            "condition": false,
+            "value": "ingress.enabled"
+          }
+        },
+        "hostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "hidden": {
+            "condition": false,
+            "value": "ingress.enabled"
+          }
+        }
+      }
+    },
+    "replicaCount": {
+      "type": "integer",
+      "form": true,
+      "title": "Number of replicas",
+      "description": "Number of replicas to deploy"
+    },
+    "serverBlock": {
+      "type": "string",
+      "form": true,
+      "title": "Custom server block",
+      "description": "Custom server block to be added to NGINX configuration"
+    },
+    "metrics": {
+      "type": "object",
+      "form": true,
+      "title": "Prometheus metrics details",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Create Prometheus metrics exporter",
+          "description": "Create a side-car container to expose Prometheus metrics",
+          "form": true
+        },
+        "serviceMonitor": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Create Prometheus Operator ServiceMonitor",
+              "description": "Create a ServiceMonitor to track metrics using Prometheus Operator",
+              "form": true,
+              "hidden": {
+                "condition": false,
+                "value": "metrics.enabled"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/bitnami/nginx/values.schema.json
+++ b/bitnami/nginx/values.schema.json
@@ -13,16 +13,6 @@
           "title": "Use a custom hostname",
           "description": "Enable the ingress resource that allows you to access the NGINX installation."
         },
-        "certManager": {
-          "type": "boolean",
-          "form": true,
-          "title": "Enable TLS annotations via cert-manager",
-          "description": "Set this to true in order to add the corresponding annotations for cert-manager",
-          "hidden": {
-            "condition": false,
-            "value": "ingress.enabled"
-          }
-        },
         "hostname": {
           "type": "string",
           "form": true,


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

This PR includes a basic JSON schema for the NGINX chart. It doesn't cover all the possible values of the chart but just the ones that, in my opinion, are more likely to be modified.

This is valid for Helm 3 to validate some values and, at the same time, for Kubeapps to render a simple form so the chart containing it is easier to configure and deploy. See https://github.com/kubeapps/kubeapps/blob/master/docs/developer/basic-form-support.md for more information.

This is an example of the file rendered by Kubeapps:

![Screenshot 2019-11-28 at 15 42 55](https://user-images.githubusercontent.com/6740773/69815033-c3ed7400-11f5-11ea-9d5a-c04725ba9786.png)

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)