### PR TITLE
[bitnami/apache] Fix typo in values.schema.json

### DIFF
--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: apache
-version: 7.2.13
+version: 7.2.14
 appVersion: 2.4.41
 description: Chart for Apache HTTP Server
 keywords:

--- a/bitnami/apache/values.schema.json
+++ b/bitnami/apache/values.schema.json
@@ -11,7 +11,7 @@
           "type": "boolean",
           "form": true,
           "title": "Use a custom hostname",
-          "description": "Enable the ingress resource that allows you to access the WordPress installation."
+          "description": "Enable the ingress resource that allows you to access the Apache installation."
         },
         "certManager": {
           "type": "boolean",


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

This PR fixes a typo in the **values.schema.json** for Apache

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)