### PR TITLE
[bitnami/jenkins] Add JSON Schema

### DIFF
--- a/bitnami/jenkins/Chart.yaml
+++ b/bitnami/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: jenkins
-version: 4.0.4
+version: 4.1.0
 appVersion: 2.190.3
 description: The leading open source automation server
 keywords:

--- a/bitnami/jenkins/README.md
+++ b/bitnami/jenkins/README.md
@@ -70,7 +70,7 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 | `persistence.storageClass`           | PVC Storage Class for Jenkins volume                                                                 | `nil` (uses alpha storage class annotation)                  |
 | `persistence.accessMode`             | PVC Access Mode for Jenkins volume                                                                   | `ReadWriteOnce`                                              |
 | `persistence.size`                   | PVC Storage Request for Jenkins volume                                                               | `8Gi`                                                        |
-| `resources`                          | CPU/Memory resource requests/limits                                                                  | `{}`                                                         |
+| `resources`                          | CPU/Memory resource requests/limits                                                                  | `requests: { cpu: "300m", memory: "512Mi" }`                 |
 | `livenessProbe.enabled`              | Turn on and off liveness probe                                                                       | `true`                                                       |
 | `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                                                             | `180`                                                        |
 | `livenessProbe.periodSeconds`        | How often to perform the probe                                                                       | `10`                                                         |
@@ -112,7 +112,7 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 | `metrics.image.pullPolicy`           | Image pull policy                                                                                    | `IfNotPresent`                                               |
 | `metrics.image.pullSecrets`          | Specify docker-registry secret names as an array                                                     | `[]` (does not add image pull secrets to deployed pods)      |
 | `metrics.podAnnotations`             | Additional annotations for Metrics exporter pod                                                      | `{prometheus.io/scrape: "true", prometheus.io/port: "9118"}` |
-| `metrics.resources`                  | Exporter resource requests/limit                                                                     | Memory: `256Mi`, CPU: `100m`                                 |
+| `metrics.resources`                  | Exporter resource requests/limit                                                                     | `requests: { cpu: "256m", memory: "100Mi" }`                 |
 
 The above parameters map to the env variables defined in [bitnami/jenkins](http://github.com/bitnami/bitnami-docker-jenkins). For more information please refer to the [bitnami/jenkins](http://github.com/bitnami/bitnami-docker-jenkins) image documentation.
 

--- a/bitnami/jenkins/values.schema.json
+++ b/bitnami/jenkins/values.schema.json
@@ -80,16 +80,6 @@
           "title": "Use a custom hostname",
           "description": "Enable the ingress resource that allows you to access the Jenkins installation."
         },
-        "certManager": {
-          "type": "boolean",
-          "form": true,
-          "title": "Enable TLS annotations via cert-manager",
-          "description": "Set this to true in order to add the corresponding annotations for cert-manager",
-          "hidden": {
-            "condition": false,
-            "value": "ingress.enabled"
-          }
-        },
         "hostname": {
           "type": "string",
           "form": true,

--- a/bitnami/jenkins/values.schema.json
+++ b/bitnami/jenkins/values.schema.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "jenkinsUser": {
+      "type": "string",
+      "title": "Username",
+      "form": true
+    },
+    "jenkinsPassword": {
+      "type": "string",
+      "title": "Password",
+      "form": true,
+      "description": "Defaults to a random 10-character alphanumeric string if not set"
+    },
+    "persistence": {
+      "type": "object",
+      "title": "Persistence",
+      "form": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "form": true,
+          "title": "Enable persistence",
+          "description": "Enable persistence using Persistent Volume Claims"
+        },
+        "size": {
+          "type": "string",
+          "title": "Persistent Volume Size",
+          "form": true,
+          "render": "slider",
+          "sliderMin": 1,
+          "sliderMax": 100,
+          "sliderUnit": "Gi",
+          "hidden": {
+            "condition": false,
+            "value": "persistence.enabled"
+          }
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "title": "Required Resources",
+      "form": true,
+      "properties": {
+        "requests": {
+          "type": "object",
+          "properties": {
+            "memory": {
+              "type": "string",
+              "form": true,
+              "render": "slider",
+              "title": "Memory Request",
+              "sliderMin": 10,
+              "sliderMax": 2048,
+              "sliderUnit": "Mi"
+            },
+            "cpu": {
+              "type": "string",
+              "form": true,
+              "render": "slider",
+              "title": "CPU Request",
+              "sliderMin": 10,
+              "sliderMax": 2000,
+              "sliderUnit": "m"
+            }
+          }
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "form": true,
+      "title": "Ingress details",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "form": true,
+          "title": "Use a custom hostname",
+          "description": "Enable the ingress resource that allows you to access the Jenkins installation."
+        },
+        "certManager": {
+          "type": "boolean",
+          "form": true,
+          "title": "Enable TLS annotations via cert-manager",
+          "description": "Set this to true in order to add the corresponding annotations for cert-manager",
+          "hidden": {
+            "condition": false,
+            "value": "ingress.enabled"
+          }
+        },
+        "hostname": {
+          "type": "string",
+          "form": true,
+          "title": "Hostname",
+          "hidden": {
+            "condition": false,
+            "value": "ingress.enabled"
+          }
+        }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "form": true,
+      "title": "Prometheus metrics details",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Create Prometheus metrics exporter",
+          "description": "Create a side-car container to expose Prometheus metrics",
+          "form": true
+        }
+      }
+    }
+  }
+}

--- a/bitnami/jenkins/values.yaml
+++ b/bitnami/jenkins/values.yaml
@@ -87,9 +87,9 @@ resources:
   limits: {}
   #   cpu: 500m
   #   memory: 1Gi
-  requests: {}
-  #   cpu: 300m
-  #   memory: 512Mi
+  requests:
+    cpu: 300m
+    memory: 512Mi
 
 ## Pod annotations
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

This PR includes a basic JSON schema for the Jenkins chart. It doesn't cover all the possible values of the chart but just the ones that, in my opinion, are more likely to be modified.

This is valid for Helm 3 to validate some values and, at the same time, for Kubeapps to render a simple form so the chart containing it is easier to configure and deploy. See https://github.com/kubeapps/kubeapps/blob/master/docs/developer/basic-form-support.md for more information.

This is an example of the file rendered by Kubeapps:

![Screenshot 2019-11-28 at 16 01 43](https://user-images.githubusercontent.com/6740773/69816419-9f46cb80-11f8-11ea-8543-1aa838b10731.png)


**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)