### PR TITLE
[bitnami/prometheus-operator] Fix exporters.enabled

### DIFF
--- a/bitnami/prometheus-operator/Chart.yaml
+++ b/bitnami/prometheus-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.34.0
 description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 name: prometheus-operator
-version: 0.6.0
+version: 0.6.1
 keywords:
 - prometheus
 - alertmanager

--- a/bitnami/prometheus-operator/README.md
+++ b/bitnami/prometheus-operator/README.md
@@ -268,10 +268,10 @@ The following table lists the configurable parameters of the Prometheus Operator
 
 ### Exporters
 
-|             Parameter             |      Description       | Default |
-|-----------------------------------|------------------------|---------|
-| `exporters.enabled`               | Deploy exporters       | `true`  |
-| `exporters.node-exporter.enabled` | Deploy `node-exporter` | `true`  |
+|             Parameter             |      Description                                                                              | Default |
+|-----------------------------------|-----------------------------------------------------------------------------------------------|---------|
+| `exporters.enabled`               | Deploy exporters                                                                              | `false` |
+| `exporters.node-exporter.enabled` | Deploy [`node-exporter`](https://github.com/bitnami/charts/tree/master/bitnami/node-exporter) | `true`  |
 
 The above parameters map to the env variables defined in [bitnami/prometheus-operator](http://github.com/bitnami/bitnami-docker-prometheus-operator). For more information please refer to the [bitnami/prometheus-operator](http://github.com/bitnami/bitnami-docker-prometheus-operator) image documentation.
 
@@ -346,6 +346,13 @@ This chart includes a `values-production.yaml` file where you can find some para
 ```diff
 -   logLevel: info
 +   logLevel: error
+```
+
+- Enable exporters (node-exporter by default):
+
+```diff
+-   exporters.enabled: false
++   exporters.enabled: true
 ```
 
 ## Upgrading

--- a/bitnami/prometheus-operator/values-production.yaml
+++ b/bitnami/prometheus-operator/values-production.yaml
@@ -754,6 +754,7 @@ alertmanager:
 
 ## Exporters
 exporters:
+  enabled: true
   node-exporter:
     ## Enable node-exporter
     enabled: true

--- a/bitnami/prometheus-operator/values.yaml
+++ b/bitnami/prometheus-operator/values.yaml
@@ -754,6 +754,7 @@ alertmanager:
 
 ## Exporters
 exporters:
+  enabled: false
   node-exporter:
     ## Enable node-exporter
     enabled: true


### PR DESCRIPTION
**Description of the change**

Add `exporters.enabled` parameter to the _values*.yaml_ that is a necessary condition to install node-exporter:
https://github.com/bitnami/charts/blob/master/bitnami/prometheus-operator/requirements.yaml#L5

Parameter disabled in the _values.yaml_ to not modify the default behavior and enabled in the _values-production.yaml_.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files