### PR TITLE
[bitnami/prometheus-operator] add kube-state-metrics as a optional dependency

### DIFF
--- a/bitnami/prometheus-operator/Chart.yaml
+++ b/bitnami/prometheus-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.34.0
 description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 name: prometheus-operator
-version: 0.6.0
+version: 0.7.0
 keywords:
 - prometheus
 - alertmanager

--- a/bitnami/prometheus-operator/README.md
+++ b/bitnami/prometheus-operator/README.md
@@ -268,10 +268,11 @@ The following table lists the configurable parameters of the Prometheus Operator
 
 ### Exporters
 
-|             Parameter             |      Description       | Default |
-|-----------------------------------|------------------------|---------|
-| `exporters.enabled`               | Deploy exporters       | `true`  |
-| `exporters.node-exporter.enabled` | Deploy `node-exporter` | `true`  |
+|               Parameter                |         Description         | Default |
+|----------------------------------------|-----------------------------|---------|
+| `exporters.enabled`                    | Deploy exporters            | `true`  |
+| `exporters.node-exporter.enabled`      | Deploy `node-exporter`      | `true`  |
+| `exporters.kube-state-metrics.enabled` | Deploy `kube-state-metrics` | `true`  |
 
 The above parameters map to the env variables defined in [bitnami/prometheus-operator](http://github.com/bitnami/bitnami-docker-prometheus-operator). For more information please refer to the [bitnami/prometheus-operator](http://github.com/bitnami/bitnami-docker-prometheus-operator) image documentation.
 

--- a/bitnami/prometheus-operator/requirements.lock
+++ b/bitnami/prometheus-operator/requirements.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: node-exporter
   repository: https://charts.bitnami.com/bitnami
   version: 0.1.0
-digest: sha256:ed8eb97c5bf626e91d36ca8a98f59cacc240b25821e6c2fcfcce5daea768962d
-generated: "2019-11-28T20:00:58.626042613+05:30"
+- name: kube-state-metrics
+  repository: https://charts.bitnami.com/bitnami
+  version: 0.1.0
+digest: sha256:5f0976e482fe22c14a81d278db6c28a999fedbb3f8d87167bac814d3dd892cc3
+generated: "2019-12-05T15:41:14.038031115+05:30"

--- a/bitnami/prometheus-operator/requirements.yaml
+++ b/bitnami/prometheus-operator/requirements.yaml
@@ -3,3 +3,8 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     version: 0.1.*
     condition: exporters.enabled,exporters.node-exporter.enabled
+
+  - name: kube-state-metrics
+    repository: https://charts.bitnami.com/bitnami
+    version: 0.1.*
+    condition: exporters.enabled,exporters.kube-state-metrics.enabled

--- a/bitnami/prometheus-operator/values-production.yaml
+++ b/bitnami/prometheus-operator/values-production.yaml
@@ -758,6 +758,10 @@ exporters:
     ## Enable node-exporter
     enabled: true
 
+  kube-state-metrics:
+    ## Enable kube-state-metrics
+    enabled: true
+
 ## Node Exporter deployment configuration
 node-exporter:
   service:
@@ -771,3 +775,8 @@ node-exporter:
   extraArgs:
     collector.filesystem.ignored-mount-points: "^/(dev|proc|sys|var/lib/docker/.+)($|/)"
     collector.filesystem.ignored-fs-types: "^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$"
+
+kube-state-metrics:
+  replicaCount: 2
+  serviceMonitor:
+    enabled: true

--- a/bitnami/prometheus-operator/values.yaml
+++ b/bitnami/prometheus-operator/values.yaml
@@ -758,6 +758,10 @@ exporters:
     ## Enable node-exporter
     enabled: true
 
+  kube-state-metrics:
+    ## Enable kube-state-metrics
+    enabled: true
+
 ## Node Exporter deployment configuration
 node-exporter:
   service:
@@ -771,3 +775,7 @@ node-exporter:
   extraArgs:
     collector.filesystem.ignored-mount-points: "^/(dev|proc|sys|var/lib/docker/.+)($|/)"
     collector.filesystem.ignored-fs-types: "^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$"
+
+kube-state-metrics:
+  serviceMonitor:
+    enabled: true


### PR DESCRIPTION
**Description of the change**

Adds kube-state-metrics chart as an external dependency

**Additional information**

Depends on https://github.com/bitnami/charts/pull/1690

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files