### PR TITLE
[bitnami/mongodb-sharded] Set persistence settings separate in data nodes and config servers

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb-sharded
-version: 0.1.4
+version: 1.0.0
 appVersion: 4.0.13
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications. Sharded topology.
 keywords:

--- a/bitnami/mongodb-sharded/README.md
+++ b/bitnami/mongodb-sharded/README.md
@@ -109,13 +109,6 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `securityContext.fsGroup`            | Group ID for the container                                                                                                                                | `1001`                                                   |
 | `securityContext.runAsUser`          | User ID for the container                                                                                                                                 | `1001`                                                   |
 | `securityContext.runAsNonRoot`       | Run containers as non-root users                                                                                                                          | `true`                                                   |
-| `persistence.enabled`                | Use a PVC to persist data                                                                                                                                 | `true`                                                   |
-| `persistence.mountPath`              | Path to mount the volume at                                                                                                                               | `/bitnami/mongodb`                                       |
-| `persistence.subPath`                | Subdirectory of the volume to mount at                                                                                                                    | `""`                                                     |
-| `persistence.storageClass`           | Storage class of backing PVC                                                                                                                              | `nil` (uses alpha storage class annotation)              |
-| `persistence.accessModes`            | Use volume as ReadOnly or ReadWrite                                                                                                                       | `[ReadWriteOnce]`                                        |
-| `persistence.size`                   | Size of data volume                                                                                                                                       | `8Gi`                                                    |
-| `persistence.annotations`            | Persistent Volume annotations                                                                                                                             | `{}`                                                     |
 | `livenessProbe.enabled`              | Enable/disable the Liveness probe                                                                                                                         | `true`                                                   |
 | `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                                                                                                                  | `30`                                                     |
 | `livenessProbe.periodSeconds`        | How often to perform the probe                                                                                                                            | `10`                                                     |
@@ -133,28 +126,35 @@ The following table lists the configurable parameters of the MongoDB chart and t
 
 ### Config Server configuration
 
-| Parameter                      | Description                                                                                     | Default         |
-|--------------------------------|-------------------------------------------------------------------------------------------------|-----------------|
-| `configsvr.replicas`           | Number of nodes in the replica set (the first node will be primary)                             | `1`             |
-| `configsvr.podAnnotations`     | Annotations to be added to the deployment or statefulsets                                       | `{}`            |
-| `configsvr.podLabels`          | Annotations to be added to the deployment or statefulsets                                       | `{}`            |
-| `configsvr.resources`          | Pod resources                                                                                   | `{}`            |
-| `configsvr.priorityClassName`  | Pod priority class name                                                                         | ``              |
-| `configsvr.nodeSelector`       | Node labels for pod assignment (evaluated as a template)                                        | `{}`            |
-| `configsvr.affinity`           | Affinity for pod assignment (evaluated as a template)                                           | `{}`            |
-| `configsvr.tolerations`        | Toleration labels for pod assignment (evaluated as a template)                                  | `{}`            |
-| `configsvr.updateStrategy`     | Statefulsets update strategy policy (evaluated as a template)                                   | `RollingUpdate` |
-| `configsvr.schedulerName`      | Name of the k8s scheduler (other than default)                                                  | `nil`           |
-| `configsvr.sidecars`           | Attach additional containers (evaluated as a template)                                          | `nil`           |
-| `configsvr.initContainers`     | Add additional init containers (evaluated as a template)                                        | `nil`           |
-| `configsvr.config`             | MongoDB configuration                                                                           | `nil`           |
-| `configsvr.configCM`           | ConfigMap name with MongoDB configuration (cannot be used with configsvr.config)                | `nil`           |
-| `configsvr.mongodbExtraFlags`  | MongoDB additional command line flags                                                           | `[]`            |
-| `configsvr.extraEnvVars`       | Array containing extra env vars (evaluated as a template)                                       | `nil`           |
-| `configsvr.extraEnvVarsCM`     | ConfigMap containing extra env vars (evaluated as a template)                                   | `nil`           |
-| `configsvr.extraEnvVarsSecret` | Secret containing extra env vars (evaluated as a template)                                      | `nil`           |
-| `configsvr.extraVolumes`       | Array of extra volumes (evaluated as template). Requires setting `common.extraVolumeMounts`     | `nil`           |
-| `configsvr.extraVolumeMounts`  | Array of extra volume mounts (evaluated as template). Normally used with `common.extraVolumes`. | `nil`           |
+| Parameter                            | Description                                                                                     | Default                                     |
+|--------------------------------------|-------------------------------------------------------------------------------------------------|---------------------------------------------|
+| `configsvr.replicas`                 | Number of nodes in the replica set (the first node will be primary)                             | `1`                                         |
+| `configsvr.podAnnotations`           | Annotations to be added to the deployment or statefulsets                                       | `{}`                                        |
+| `configsvr.podLabels`                | Annotations to be added to the deployment or statefulsets                                       | `{}`                                        |
+| `configsvr.resources`                | Pod resources                                                                                   | `{}`                                        |
+| `configsvr.priorityClassName`        | Pod priority class name                                                                         | ``                                          |
+| `configsvr.nodeSelector`             | Node labels for pod assignment (evaluated as a template)                                        | `{}`                                        |
+| `configsvr.affinity`                 | Affinity for pod assignment (evaluated as a template)                                           | `{}`                                        |
+| `configsvr.tolerations`              | Toleration labels for pod assignment (evaluated as a template)                                  | `{}`                                        |
+| `configsvr.updateStrategy`           | Statefulsets update strategy policy (evaluated as a template)                                   | `RollingUpdate`                             |
+| `configsvr.schedulerName`            | Name of the k8s scheduler (other than default)                                                  | `nil`                                       |
+| `configsvr.sidecars`                 | Attach additional containers (evaluated as a template)                                          | `nil`                                       |
+| `configsvr.initContainers`           | Add additional init containers (evaluated as a template)                                        | `nil`                                       |
+| `configsvr.config`                   | MongoDB configuration                                                                           | `nil`                                       |
+| `configsvr.configCM`                 | ConfigMap name with MongoDB configuration (cannot be used with configsvr.config)                | `nil`                                       |
+| `configsvr.mongodbExtraFlags`        | MongoDB additional command line flags                                                           | `[]`                                        |
+| `configsvr.extraEnvVars`             | Array containing extra env vars (evaluated as a template)                                       | `nil`                                       |
+| `configsvr.extraEnvVarsCM`           | ConfigMap containing extra env vars (evaluated as a template)                                   | `nil`                                       |
+| `configsvr.extraEnvVarsSecret`       | Secret containing extra env vars (evaluated as a template)                                      | `nil`                                       |
+| `configsvr.extraVolumes`             | Array of extra volumes (evaluated as template). Requires setting `common.extraVolumeMounts`     | `nil`                                       |
+| `configsvr.extraVolumeMounts`        | Array of extra volume mounts (evaluated as template). Normally used with `common.extraVolumes`. | `nil`                                       |
+| `configsvr.persistence.enabled`      | Use a PVC to persist data                                                                       | `true`                                      |
+| `configsvr.persistence.mountPath`    | Path to mount the volume at                                                                     | `/bitnami/mongodb`                          |
+| `configsvr.persistence.subPath`      | Subdirectory of the volume to mount at                                                          | `""`                                        |
+| `configsvr.persistence.storageClass` | Storage class of backing PVC                                                                    | `nil` (uses alpha storage class annotation) |
+| `configsvr.persistence.accessModes`  | Use volume as ReadOnly or ReadWrite                                                             | `[ReadWriteOnce]`                           |
+| `configsvr.persistence.size`         | Size of data volume                                                                             | `8Gi`                                       |
+| `configsvr.persistence.annotations`  | Persistent Volume annotations                                                                   | `{}`                                        |
 
 ### Mongos configuration
 
@@ -183,28 +183,35 @@ The following table lists the configurable parameters of the MongoDB chart and t
 
 ### Shard configuration: Data nodes
 
-| Parameter                              | Description                                                                                     | Default         |
-|----------------------------------------|-------------------------------------------------------------------------------------------------|-----------------|
-| `shardsvr.dataNode.replicas`           | Number of nodes in each shard replica set (the first node will be primary)                      | `1`             |
-| `shardsvr.dataNode.podAnnotations`     | Annotations to be added to the deployment or statefulsets                                       | `{}`            |
-| `shardsvr.dataNode.podLabels`          | Annotations to be added to the deployment or statefulsets                                       | `{}`            |
-| `shardsvr.dataNode.resources`          | Pod resources                                                                                   | `{}`            |
-| `shardsvr.dataNode.priorityClassName`  | Pod priority class name                                                                         | ``              |
-| `shardsvr.dataNode.nodeSelector`       | Node labels for pod assignment (evaluated as a template)                                        | `{}`            |
-| `shardsvr.dataNode.affinity`           | Affinity for pod assignment (evaluated as a template)                                           | `{}`            |
-| `shardsvr.dataNode.tolerations`        | Toleration labels for pod assignment (evaluated as a template)                                  | `{}`            |
-| `shardsvr.dataNode.updateStrategy`     | Statefulsets update strategy policy (evaluated as a template)                                   | `RollingUpdate` |
-| `shardsvr.dataNode.schedulerName`      | Name of the k8s scheduler (other than default)                                                  | `nil`           |
-| `shardsvr.dataNode.sidecars`           | Attach additional containers (evaluated as a template)                                          | `nil`           |
-| `shardsvr.dataNode.initContainers`     | Add additional init containers (evaluated as a template)                                        | `nil`           |
-| `shardsvr.dataNode.config`             | MongoDB configuration                                                                           | `nil`           |
-| `shardsvr.dataNode.configCM`           | ConfigMap name with MongoDB configuration (cannot be used with shardsvr.dataNode.config)        | `nil`           |
-| `shardsvr.dataNode.mongodbExtraFlags`  | MongoDB additional command line flags                                                           | `[]`            |
-| `shardsvr.dataNode.extraEnvVars`       | Array containing extra env vars (evaluated as a template)                                       | `nil`           |
-| `shardsvr.dataNode.extraEnvVarsCM`     | ConfigMap containing extra env vars (evaluated as a template)                                   | `nil`           |
-| `shardsvr.dataNode.extraEnvVarsSecret` | Secret containing extra env vars (evaluated as a template)                                      | `nil`           |
-| `shardsvr.dataNode.extraVolumes`       | Array of extra volumes (evaluated as template). Requires setting `common.extraVolumeMounts`     | `nil`           |
-| `shardsvr.dataNode.extraVolumeMounts`  | Array of extra volume mounts (evaluated as template). Normally used with `common.extraVolumes`. | `nil`           |
+| Parameter                              | Description                                                                                     | Default                                     |
+|----------------------------------------|-------------------------------------------------------------------------------------------------|---------------------------------------------|
+| `shardsvr.dataNode.replicas`           | Number of nodes in each shard replica set (the first node will be primary)                      | `1`                                         |
+| `shardsvr.dataNode.podAnnotations`     | Annotations to be added to the deployment or statefulsets                                       | `{}`                                        |
+| `shardsvr.dataNode.podLabels`          | Annotations to be added to the deployment or statefulsets                                       | `{}`                                        |
+| `shardsvr.dataNode.resources`          | Pod resources                                                                                   | `{}`                                        |
+| `shardsvr.dataNode.priorityClassName`  | Pod priority class name                                                                         | ``                                          |
+| `shardsvr.dataNode.nodeSelector`       | Node labels for pod assignment (evaluated as a template)                                        | `{}`                                        |
+| `shardsvr.dataNode.affinity`           | Affinity for pod assignment (evaluated as a template)                                           | `{}`                                        |
+| `shardsvr.dataNode.tolerations`        | Toleration labels for pod assignment (evaluated as a template)                                  | `{}`                                        |
+| `shardsvr.dataNode.updateStrategy`     | Statefulsets update strategy policy (evaluated as a template)                                   | `RollingUpdate`                             |
+| `shardsvr.dataNode.schedulerName`      | Name of the k8s scheduler (other than default)                                                  | `nil`                                       |
+| `shardsvr.dataNode.sidecars`           | Attach additional containers (evaluated as a template)                                          | `nil`                                       |
+| `shardsvr.dataNode.initContainers`     | Add additional init containers (evaluated as a template)                                        | `nil`                                       |
+| `shardsvr.dataNode.config`             | MongoDB configuration                                                                           | `nil`                                       |
+| `shardsvr.dataNode.configCM`           | ConfigMap name with MongoDB configuration (cannot be used with shardsvr.dataNode.config)        | `nil`                                       |
+| `shardsvr.dataNode.mongodbExtraFlags`  | MongoDB additional command line flags                                                           | `[]`                                        |
+| `shardsvr.dataNode.extraEnvVars`       | Array containing extra env vars (evaluated as a template)                                       | `nil`                                       |
+| `shardsvr.dataNode.extraEnvVarsCM`     | ConfigMap containing extra env vars (evaluated as a template)                                   | `nil`                                       |
+| `shardsvr.dataNode.extraEnvVarsSecret` | Secret containing extra env vars (evaluated as a template)                                      | `nil`                                       |
+| `shardsvr.dataNode.extraVolumes`       | Array of extra volumes (evaluated as template). Requires setting `common.extraVolumeMounts`     | `nil`                                       |
+| `shardsvr.dataNode.extraVolumeMounts`  | Array of extra volume mounts (evaluated as template). Normally used with `common.extraVolumes`. | `nil`                                       |
+| `shardsvr.persistence.enabled`         | Use a PVC to persist data                                                                       | `true`                                      |
+| `shardsvr.persistence.mountPath`       | Path to mount the volume at                                                                     | `/bitnami/mongodb`                          |
+| `shardsvr.persistence.subPath`         | Subdirectory of the volume to mount at                                                          | `""`                                        |
+| `shardsvr.persistence.storageClass`    | Storage class of backing PVC                                                                    | `nil` (uses alpha storage class annotation) |
+| `shardsvr.persistence.accessModes`     | Use volume as ReadOnly or ReadWrite                                                             | `[ReadWriteOnce]`                           |
+| `shardsvr.persistence.size`            | Size of data volume                                                                             | `8Gi`                                       |
+| `shardsvr.persistence.annotations`     | Persistent Volume annotations                                                                   | `{}`                                        |
 
 ### Shard configuration: Arbiters
 

--- a/bitnami/mongodb-sharded/templates/_helpers.tpl
+++ b/bitnami/mongodb-sharded/templates/_helpers.tpl
@@ -305,7 +305,7 @@ mongodb: configSvrNodeConflictingConfig
 {{/*
 Return  the proper Storage Class
 */}}
-{{- define "mongodb-sharded.storageClass" -}}
+{{- define "mongodb-sharded.shardsvr.storageClass" -}}
 {{/*
 Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
 but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
@@ -318,20 +318,55 @@ but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else 
             {{- printf "storageClassName: %s" .Values.global.storageClass -}}
         {{- end -}}
     {{- else -}}
-        {{- if .Values.persistence.storageClass -}}
-              {{- if (eq "-" .Values.persistence.storageClass) -}}
+        {{- if .Values.shardsvr.persistence.storageClass -}}
+              {{- if (eq "-" .Values.shardsvr.persistence.storageClass) -}}
                   {{- printf "storageClassName: \"\"" -}}
               {{- else }}
-                  {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
+                  {{- printf "storageClassName: %s" .Values.shardsvr.persistence.storageClass -}}
               {{- end -}}
         {{- end -}}
     {{- end -}}
 {{- else -}}
-    {{- if .Values.persistence.storageClass -}}
-        {{- if (eq "-" .Values.persistence.storageClass) -}}
+    {{- if .Values.shardsvr.persistence.storageClass -}}
+        {{- if (eq "-" .Values.shardsvr.persistence.storageClass) -}}
             {{- printf "storageClassName: \"\"" -}}
         {{- else }}
-            {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
+            {{- printf "storageClassName: %s" .Values.shardsvr.persistence.storageClass -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return  the proper Storage Class
+*/}}
+{{- define "mongodb-sharded.configsvr.storageClass" -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
+*/}}
+{{- if .Values.global -}}
+    {{- if .Values.global.storageClass -}}
+        {{- if (eq "-" .Values.global.storageClass) -}}
+            {{- printf "storageClassName: \"\"" -}}
+        {{- else }}
+            {{- printf "storageClassName: %s" .Values.global.storageClass -}}
+        {{- end -}}
+    {{- else -}}
+        {{- if .Values.configsvr.persistence.storageClass -}}
+              {{- if (eq "-" .Values.configsvr.persistence.storageClass) -}}
+                  {{- printf "storageClassName: \"\"" -}}
+              {{- else }}
+                  {{- printf "storageClassName: %s" .Values.configsvr.persistence.storageClass -}}
+              {{- end -}}
+        {{- end -}}
+    {{- end -}}
+{{- else -}}
+    {{- if .Values.configsvr.persistence.storageClass -}}
+        {{- if (eq "-" .Values.configsvr.persistence.storageClass) -}}
+            {{- printf "storageClassName: \"\"" -}}
+        {{- else }}
+            {{- printf "storageClassName: %s" .Values.configsvr.persistence.storageClass -}}
         {{- end -}}
     {{- end -}}
 {{- end -}}

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
@@ -43,17 +43,17 @@ spec:
       {{- end }}
       {{- include "mongodb-sharded.imagePullSecrets" . | nindent 6 }}
       initContainers:
-        {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
+        {{- if and .Values.volumePermissions.enabled .Values.configsvr.persistence.enabled }}
         - name: volume-permissions
           image: {{ include "mongodb-sharded.volumePermissions.image" . }}
           imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
-          command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}", "{{ .Values.persistence.mountPath }}"]
+          command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}", "{{ .Values.configsvr.persistence.mountPath }}"]
           securityContext:
             runAsUser: 0
           resources: {{ toYaml .Values.volumePermissions.resources | nindent 12 }}
           volumeMounts:
             - name: datadir
-              mountPath: {{ .Values.persistence.mountPath }}
+              mountPath: {{ .Values.configsvr.persistence.mountPath }}
         {{- end }}
       containers:
         - name: mongodb
@@ -186,7 +186,7 @@ spec:
             - name: replicaset-entrypoint-configmap
               mountPath: /entrypoint
             - name: datadir
-              mountPath: {{ .Values.persistence.mountPath }}
+              mountPath: {{ .Values.configsvr.persistence.mountPath }}
             {{- if or .Values.configsvr.config .Values.configsvr.configCM }}
             - name: config
               mountPath: /bitnami/mongodb/conf/
@@ -303,23 +303,23 @@ spec:
         {{- if .Values.configsvr.extraVolumes }}
           {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.configsvr.extraVolumes "context" $ ) | nindent 8 }}
         {{- end }}
-  {{- if .Values.persistence.enabled }}
+  {{- if .Values.configsvr.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: datadir
         annotations:
-        {{- range $key, $value := .Values.persistence.annotations }}
+        {{- range $key, $value := .Values.configsvr.persistence.annotations }}
           {{ $key }}: "{{ $value }}"
         {{- end }}
       spec:
         accessModes:
-        {{- range .Values.persistence.accessModes }}
+        {{- range .Values.configsvr.persistence.accessModes }}
           - {{ . | quote }}
         {{- end }}
         resources:
           requests:
-            storage: {{ .Values.persistence.size | quote }}
-        {{ include "mongodb-sharded.storageClass" . }}
+            storage: {{ .Values.configsvr.persistence.size | quote }}
+        {{ include "mongodb-sharded.configsvr.storageClass" . }}
   {{- else }}
         - name: datadir
           emptyDir: {}

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -45,17 +45,17 @@ spec:
       {{- end }}
       {{- include "mongodb-sharded.imagePullSecrets" $ | nindent 6 }}
       initContainers:
-        {{- if and $.Values.volumePermissions.enabled $.Values.persistence.enabled }}
+        {{- if and $.Values.volumePermissions.enabled $.Values.shardsvr.persistence.enabled }}
         - name: volume-permissions
           image: {{ include "mongodb-sharded.volumePermissions.image" $ }}
           imagePullPolicy: {{ $.Values.volumePermissions.image.pullPolicy | quote }}
-          command: ["chown", "-R", "{{ $.Values.securityContext.runAsUser }}:{{ $.Values.securityContext.fsGroup }}", "{{ $.Values.persistence.mountPath }}"]
+          command: ["chown", "-R", "{{ $.Values.securityContext.runAsUser }}:{{ $.Values.securityContext.fsGroup }}", "{{ $.Values.shardsvr.persistence.mountPath }}"]
           securityContext:
             runAsUser: 0
           resources: {{ toYaml $.Values.volumePermissions.resources | nindent 12 }}
           volumeMounts:
             - name: datadir
-              mountPath: {{ $.Values.persistence.mountPath }}
+              mountPath: {{ $.Values.shardsvr.persistence.mountPath }}
         {{- end }}
       containers:
         - name: mongodb
@@ -165,7 +165,7 @@ spec:
             - name: replicaset-entrypoint-configmap
               mountPath: /entrypoint
             - name: datadir
-              mountPath: {{ $.Values.persistence.mountPath }}
+              mountPath: {{ $.Values.shardsvr.persistence.mountPath }}
             {{- if or $.Values.shardsvr.dataNode.config $.Values.shardsvr.dataNode.configCM }}
             - name: config
               mountPath: /bitnami/mongodb/conf/
@@ -282,23 +282,23 @@ spec:
         {{- if $.Values.shardsvr.dataNode.extraVolumes }}
           {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.dataNode.extraVolumes "context" $ ) | nindent 8 }}
         {{- end }}
-  {{- if $.Values.persistence.enabled }}
+  {{- if $.Values.shardsvr.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: datadir
         annotations:
-        {{- range $key, $value := $.Values.persistence.annotations }}
+        {{- range $key, $value := $.Values.shardsvr.persistence.annotations }}
           {{ $key }}: "{{ $value }}"
         {{- end }}
       spec:
         accessModes:
-        {{- range $.Values.persistence.accessModes }}
+        {{- range $.Values.shardsvr.persistence.accessModes }}
           - {{ . | quote }}
         {{- end }}
         resources:
           requests:
-            storage: {{ $.Values.persistence.size | quote }}
-        {{- include "mongodb-sharded.storageClass" $ | nindent 8}}
+            storage: {{ $.Values.shardsvr.persistence.size | quote }}
+        {{- include "mongodb-sharded.shardsvr.storageClass" $ | nindent 8}}
   {{- else }}
         - name: datadir
           emptyDir: {}

--- a/bitnami/mongodb-sharded/values-production.yaml
+++ b/bitnami/mongodb-sharded/values-production.yaml
@@ -287,6 +287,38 @@ shardsvr:
     ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
     ##
     schedulerName:
+  ## Enable persistence using Persistent Volume Claims
+  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  ##
+  persistence:
+    enabled: true
+    ## The path the volume will be mounted at, useful when using different
+    ## MongoDB images.
+    ##
+    mountPath: /bitnami/mongodb
+
+    ## The subdirectory of the volume to mount to, useful in dev environments
+    ## and one PV for multiple services.
+    ##
+    subPath: ""
+
+    ## mongodb data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    accessModes:
+      - ReadWriteOnce
+    ## PersistentVolumeClaim size
+    ##
+    size: 8Gi
+    ## Additional volume annotations
+    ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+    ##
+    annotations: {}
 
 ## Config Server replica set properties
 ## ref: https://docs.mongodb.com/manual/core/sharded-cluster-config-servers/
@@ -385,6 +417,38 @@ configsvr:
   ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
   ##
   schedulerName:
+  ## Enable persistence using Persistent Volume Claims
+  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  ##
+  persistence:
+    enabled: true
+    ## The path the volume will be mounted at, useful when using different
+    ## MongoDB images.
+    ##
+    mountPath: /bitnami/mongodb
+
+    ## The subdirectory of the volume to mount to, useful in dev environments
+    ## and one PV for multiple services.
+    ##
+    subPath: ""
+
+    ## mongodb data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    accessModes:
+      - ReadWriteOnce
+    ## PersistentVolumeClaim size
+    ##
+    size: 8Gi
+    ## Additional volume annotations
+    ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+    ##
+    annotations: {}
 
 ## Mongos properties
 ## ref: https://docs.mongodb.com/manual/reference/program/mongos/#bin.mongos
@@ -640,39 +704,6 @@ service:
   ## Extra ports to expose (normally used with the `sidecar` value)
   ##
   extraPorts:
-
-## Enable persistence using Persistent Volume Claims
-## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-##
-persistence:
-  enabled: true
-  ## The path the volume will be mounted at, useful when using different
-  ## MongoDB images.
-  ##
-  mountPath: /bitnami/mongodb
-
-  ## The subdirectory of the volume to mount to, useful in dev environments
-  ## and one PV for multiple services.
-  ##
-  subPath: ""
-
-  ## mongodb data Persistent Volume Storage Class
-  ## If defined, storageClassName: <storageClass>
-  ## If set to "-", storageClassName: "", which disables dynamic provisioning
-  ## If undefined (the default) or set to null, no storageClassName spec is
-  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-  ##   GKE, AWS & OpenStack)
-  ##
-  # storageClass: "-"
-  accessModes:
-    - ReadWriteOnce
-  ## PersistentVolumeClaim size
-  ##
-  size: 8Gi
-  ## Additional volume annotations
-  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-  ##
-  annotations: {}
 
 ## Configure extra options for liveness and readiness probes
 ## This applies to all the MongoDB in the sharded cluster

--- a/bitnami/mongodb-sharded/values.yaml
+++ b/bitnami/mongodb-sharded/values.yaml
@@ -287,6 +287,38 @@ shardsvr:
     ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
     ##
     schedulerName:
+  ## Enable persistence using Persistent Volume Claims
+  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  ##
+  persistence:
+    enabled: true
+    ## The path the volume will be mounted at, useful when using different
+    ## MongoDB images.
+    ##
+    mountPath: /bitnami/mongodb
+
+    ## The subdirectory of the volume to mount to, useful in dev environments
+    ## and one PV for multiple services.
+    ##
+    subPath: ""
+
+    ## mongodb data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    accessModes:
+      - ReadWriteOnce
+    ## PersistentVolumeClaim size
+    ##
+    size: 8Gi
+    ## Additional volume annotations
+    ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+    ##
+    annotations: {}
 
 ## Config Server replica set properties
 ## ref: https://docs.mongodb.com/manual/core/sharded-cluster-config-servers/
@@ -385,6 +417,38 @@ configsvr:
   ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
   ##
   schedulerName:
+  ## Enable persistence using Persistent Volume Claims
+  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  ##
+  persistence:
+    enabled: true
+    ## The path the volume will be mounted at, useful when using different
+    ## MongoDB images.
+    ##
+    mountPath: /bitnami/mongodb
+
+    ## The subdirectory of the volume to mount to, useful in dev environments
+    ## and one PV for multiple services.
+    ##
+    subPath: ""
+
+    ## mongodb data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    accessModes:
+      - ReadWriteOnce
+    ## PersistentVolumeClaim size
+    ##
+    size: 8Gi
+    ## Additional volume annotations
+    ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+    ##
+    annotations: {}
 
 ## Mongos properties
 ## ref: https://docs.mongodb.com/manual/reference/program/mongos/#bin.mongos
@@ -642,40 +706,6 @@ service:
   ## Extra ports to expose (normally used with the `sidecar` value)
   ##
   extraPorts: []
-
-## Enable persistence using Persistent Volume Claims
-## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-##
-persistence:
-  enabled: true
-  ## The path the volume will be mounted at, useful when using different
-  ## MongoDB images.
-  ##
-  mountPath: /bitnami/mongodb
-
-  ## The subdirectory of the volume to mount to, useful in dev environments
-  ## and one PV for multiple services.
-  ##
-  subPath: ""
-
-  ## mongodb data Persistent Volume Storage Class
-  ## If defined, storageClassName: <storageClass>
-  ## If set to "-", storageClassName: "", which disables dynamic provisioning
-  ## If undefined (the default) or set to null, no storageClassName spec is
-  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-  ##   GKE, AWS & OpenStack)
-  ##
-  # storageClass: "-"
-  accessModes:
-    - ReadWriteOnce
-  ## PersistentVolumeClaim size
-  ##
-  size: 8Gi
-  ## Additional volume annotations
-  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-  ##
-  annotations: {}
-
 
 ## Configure extra options for liveness and readiness probes
 ## This applies to all the MongoDB in the sharded cluster


### PR DESCRIPTION
Signed-off-by: Javier J. Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This change allows to specify different persistence settings in data nodes and config servers. For example, having 500 GB PVCs in data shards and 20 GB PVCs in config servers.

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
