### PR TITLE
[bitnami/kibana] Update bundled ES to match versions

### DIFF
--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kibana
-version: 3.0.0
+version: 3.0.1
 appVersion: 7.4.2
 description: Kibana is an open source, browser based analytics and search dashboard for Elasticsearch.
 keywords:

--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kibana
 version: 3.0.1
-appVersion: 7.4.2
+appVersion: 7.5.0
 description: Kibana is an open source, browser based analytics and search dashboard for Elasticsearch.
 keywords:
 - kibana

--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kibana
-version: 3.0.1
+version: 4.0.0
 appVersion: 7.5.0
 description: Kibana is an open source, browser based analytics and search dashboard for Elasticsearch.
 keywords:

--- a/bitnami/kibana/requirements.lock
+++ b/bitnami/kibana/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
-  version: 8.2.5
-digest: sha256:97671ddccc4a7ec4739ec01b1ea42dd8424d62ed364bb34798971a95e81891bd
-generated: "2019-11-15T14:20:58.304199824+05:30"
+  version: 9.0.4
+digest: sha256:df707f375363ecc77b8dfd85bfa629e3aaf5cd2589088490c786a04a40d577c7
+generated: "2019-12-03T11:53:14.44223484Z"

--- a/bitnami/kibana/requirements.yaml
+++ b/bitnami/kibana/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: elasticsearch
-  version: 8.x.x
+  version: 9.x.x
   repository: https://charts.bitnami.com/bitnami
   condition: elasticsearch.enabled

--- a/bitnami/kibana/values-production.yaml
+++ b/bitnami/kibana/values-production.yaml
@@ -14,7 +14,7 @@ global: {}
 image:
   registry: docker.io
   repository: bitnami/kibana
-  tag: 7.4.2-debian-9-r3
+  tag: 7.5.0-debian-9-r0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/kibana/values.yaml
+++ b/bitnami/kibana/values.yaml
@@ -14,7 +14,7 @@ global: {}
 image:
   registry: docker.io
   repository: bitnami/kibana
-  tag: 7.4.2-debian-9-r3
+  tag: 7.5.0-debian-9-r0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
**Description of the change**

Use a new version of the ES dependency to match the same version and avoid this error releasing Kibana 7.5.0:

> This version of Kibana requires Elasticsearch v7.5.0 on all nodes. I found the following incompatible nodes in your cluster: v7.4.2

ElasticSearch 9.0.4 uses ES 7.5.0:
```yaml
apiVersion: v1
name: elasticsearch
version: 9.0.4
appVersion: 7.5.0
```

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
