### PR TITLE
[bitnami/apache] add path to http probes

### DIFF
--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: apache
-version: 7.2.15
+version: 7.3.0
 appVersion: 2.4.41
 description: Chart for Apache HTTP Server
 keywords:

--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: apache
-version: 7.2.14
+version: 7.2.15
 appVersion: 2.4.41
 description: Chart for Apache HTTP Server
 keywords:

--- a/bitnami/apache/README.md
+++ b/bitnami/apache/README.md
@@ -75,6 +75,10 @@ The following tables lists the configurable parameters of the Apache chart and t
 | `cloneHtdocsFromGit.branch`      | Branch inside the git repository                        | `nil`                                                        |
 | `cloneHtdocsFromGit.interval`    | Interval for sidecar container pull from the repository | `60`                                                         |
 | `podAnnotations`                 | Pod annotations                                         | `{}`                                                         |
+| `livenessProbe.enabled`          | Enable liveness probe                                   | `true`                                                       |
+| `livenessProbe.path`             | Path to access on the HTTP server                       | `/`                                                          |
+| `readinessProbe.enabled`         | Enable readiness probe                                  | `true`                                                       |
+| `readinessProbe.path`            | Path to access on the HTTP server                       | `/`                                                          |    
 | `ingress.enabled`                | Enable ingress controller resource                      | `false`                                                      |
 | `ingress.hostname`               | Default host for the ingress resource                   | `example.local`                                              |
 | `ingress.certManager`            | Add annotations for cert-manager                        | `false`                                                      |

--- a/bitnami/apache/templates/deployment.yaml
+++ b/bitnami/apache/templates/deployment.yaml
@@ -79,8 +79,8 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /
-              port: http
+              path: {{ .Values.livenessProbe.path }}
+              port: {{ .Values.livenessProbe.port }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -90,8 +90,8 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /
-              port: http
+              path: {{ .Values.readinessProbe.path }}
+              port: {{ .Values.readinessProbe.port }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/bitnami/apache/templates/deployment.yaml
+++ b/bitnami/apache/templates/deployment.yaml
@@ -80,7 +80,7 @@ spec:
           livenessProbe:
             httpGet:
               path: {{ .Values.livenessProbe.path }}
-              port: {{ .Values.livenessProbe.port }}
+              port: http
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -91,7 +91,7 @@ spec:
           readinessProbe:
             httpGet:
               path: {{ .Values.readinessProbe.path }}
-              port: {{ .Values.readinessProbe.port }}
+              port: http
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -121,6 +121,8 @@ resources:
 ##
 livenessProbe:
   enabled: true
+  path: "/"
+  port: http
   initialDelaySeconds: 180
   periodSeconds: 20
   timeoutSeconds: 5
@@ -128,6 +130,8 @@ livenessProbe:
   successThreshold: 1
 readinessProbe:
   enabled: true
+  path: "/"
+  port: http
   initialDelaySeconds: 30
   periodSeconds: 10
   timeoutSeconds: 5


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

I have added the option to allow the pod health checks(liveness and readiness probes) be pointed at other paths and ports different from the defaults, "/" and "http".

**Benefits**

This allows the pod to point to a specific path and port on apache weather it is an html file, other web app or in our case "/server-status" the built-in apache health check.

**Possible drawbacks**

if the path and port are changed from default and arent configured properly in the apache vhost, config or web-app it could cause an error.

**Applicable issues**

N/A

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
