### PR TITLE
[bitnami/influxdb] replicaCount is ignored on relay deployment

### DIFF
--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: influxdb
 sources:
   - https://github.com/bitnami/bitnami-docker-influxdb
-version: 0.2.3
+version: 0.2.4

--- a/bitnami/influxdb/templates/relay/deployment.yaml
+++ b/bitnami/influxdb/templates/relay/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels: {{- include "influxdb.labels" . | nindent 4 }}
     app.kubernetes.io/component: relay
 spec:
-  replicas: 1
+  replicas: {{ .Values.relay.replicaCount }}
   selector:
     matchLabels: {{- include "influxdb.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: relay


### PR DESCRIPTION
**Description of the change**

This PR ensures the `relay.replicaCount` parameter is used to set the number of replicas on relay deployment.

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/1700

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)