### PR TITLE
[bitnami/cassandra] Fix networkpolicy

### DIFF
--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cassandra
-version: 4.1.10
+version: 4.1.11
 appVersion: 3.11.5
 description: Apache Cassandra is a free and open-source distributed database management system designed to handle large amounts of data across many commodity servers, providing high availability with no single point of failure. Cassandra offers robust support for clusters spanning multiple datacenters, with asynchronous masterless replication allowing low latency operations for all clients.
 keywords:

--- a/bitnami/cassandra/templates/networkpolicy.yaml
+++ b/bitnami/cassandra/templates/networkpolicy.yaml
@@ -13,8 +13,8 @@ spec:
     - ports:
         - port: {{ .Values.service.port }}
         - port: {{ .Values.service.thriftPort }}
-      {{- if not .Values.networkPolicy.allowExternal }}
       from:
+      {{- if not .Values.networkPolicy.allowExternal }}
         - podSelector:
             matchLabels:
               {{ include "cassandra.fullname" . }}-client: "true"


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

This PR fixes the networkpolicy manifest for Cassandra.

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/1705

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
