### PR TITLE
[bitnami/influxdb] Increase default values for timeoutSeconds/periodSeconds on probes

### DIFF
--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: influxdb
 sources:
   - https://github.com/bitnami/bitnami-docker-influxdb
-version: 0.2.4
+version: 0.2.5

--- a/bitnami/influxdb/values-production.yaml
+++ b/bitnami/influxdb/values-production.yaml
@@ -194,15 +194,15 @@ influxdb:
   livenessProbe:
     enabled: true
     initialDelaySeconds: 30
-    periodSeconds: 10
-    timeoutSeconds: 15
+    periodSeconds: 45
+    timeoutSeconds: 30
     successThreshold: 1
     failureThreshold: 6
   readinessProbe:
     enabled: true
     initialDelaySeconds: 5
-    periodSeconds: 10
-    timeoutSeconds: 15
+    periodSeconds: 45
+    timeoutSeconds: 30
     successThreshold: 1
     failureThreshold: 6
 

--- a/bitnami/influxdb/values.yaml
+++ b/bitnami/influxdb/values.yaml
@@ -194,15 +194,15 @@ influxdb:
   livenessProbe:
     enabled: true
     initialDelaySeconds: 30
-    periodSeconds: 10
-    timeoutSeconds: 15
+    periodSeconds: 45
+    timeoutSeconds: 30
     successThreshold: 1
     failureThreshold: 6
   readinessProbe:
     enabled: true
     initialDelaySeconds: 5
-    periodSeconds: 10
-    timeoutSeconds: 15
+    periodSeconds: 45
+    timeoutSeconds: 30
     successThreshold: 1
     failureThreshold: 6
 


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

Some users reported issues with the current default values for readiness/liveness probes. They're very tight and the pods get restarted for no apparent reason. Some users reported more than 100 restarts on a single day.

This PR increases them based on @antegulin's researches: no restarts on 24 hours after increasing them to:

```yaml
timeoutSeconds: 30
periodSeconds: 45
```

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/1681

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files