### PR TITLE
[bitnami/memcached] Durable memcache. Fixes #1685

### DIFF
--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: memcached
-version: 4.0.1
+version: 4.1.0
 appVersion: 1.5.20
 description: Chart for Memcached
 keywords:

--- a/bitnami/memcached/README.md
+++ b/bitnami/memcached/README.md
@@ -59,6 +59,9 @@ The following tables lists the configurable parameters of the Memcached chart an
 | `nameOverride`                | String to partially override memcached.fullname template with a string (will prepend the release name) | `nil`                                                        |
 | `fullnameOverride`            | String to fully override memcached.fullname template with a string                                     | `nil`                                                        |
 | `clusterDomain`               | Kubernetes cluster domain                                                                              | `cluster.local`                                              |
+|`replicas`                     | Number of containers       | `1`                     |
+|`extraEnv`                     | Additional env vars to pass| `{}`                     |
+|`arguments`                    | Arguments to pass          | `["/run.sh"]`                     |
 | `memcachedUsername`           | Memcached admin user                                                                                   | `nil`                                                        |
 | `memcachedPassword`           | Memcached admin password                                                                               | `nil`                                                        |
 | `service.type`                | Kubernetes service type for Memcached                                                                  | `ClusterIP`                                                  |
@@ -69,6 +72,10 @@ The following tables lists the configurable parameters of the Memcached chart an
 | `service.annotations`         | Additional annotations for Memcached service                                                           | `{}`                                                         |
 | `resources.requests`          | CPU/Memory resource requests                                                                           | `{memory: "256Mi", cpu: "250m"}`                             |
 | `resources.limits`            | CPU/Memory resource limits                                                                             | `{}`                                                         |
+| `persistence.enabled`                | Enable persistence using PVC                                                                    | `true`                                                       |
+| `persistence.storageClass`           | PVC Storage Class for Jenkins volume                                                            | `nil` (uses alpha storage class annotation)                  |
+| `persistence.accessMode`             | PVC Access Mode for Jenkins volume                                                              | `ReadWriteOnce`                                              |
+| `persistence.size`                   | PVC Storage Request for Jenkins volume                                                          | `8Gi`                                                        |
 | `securityContext.enabled`     | Enable security context                                                                                | `true`                                                       |
 | `securityContext.fsGroup`     | Group ID for the container                                                                             | `1001`                                                       |
 | `securityContext.runAsUser`   | User ID for the container                                                                              | `1001`                                                       |
@@ -123,6 +130,13 @@ This chart includes a `values-production.yaml` file where you can find some para
 - metrics.enabled: false
 + metrics.enabled: true
 ```
+
+## Persistence
+
+The [Bitnami Memcached](https://github.com/bitnami/bitnami-docker-memcached) image stores the cache-state at the `/cache-state` path of the container if enabled.
+
+Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
+See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
 
 ## Notable changes
 

--- a/bitnami/memcached/templates/NOTES.txt
+++ b/bitnami/memcached/templates/NOTES.txt
@@ -17,3 +17,5 @@ To access the Memcached Prometheus metrics from outside the cluster execute the 
     curl http://127.0.0.1:{{ .Values.metrics.service.port }}/metrics
 
 {{- end }}
+
+{{- include "memcached.validateValues" . }}

--- a/bitnami/memcached/templates/NOTES.txt
+++ b/bitnami/memcached/templates/NOTES.txt
@@ -1,7 +1,13 @@
 
 ** Please be patient while the chart is being deployed **
 
+{{- if eq .Values.architecture "standalone" }}
 Memcached can be accessed on port 11211 on the following DNS name from within your cluster: {{ template "memcached.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
+{{- else if eq .Values.architecture "high-availability" }}
+Memcached endpoints are exposed on the headless service named: {{ template "memcached.fullname" . }}.
+Please see https://github.com/memcached/memcached/wiki/ConfiguringClient to understand the Memcached model and need for client-based consistent hashing.
+You might also want to consider more advanced routing/replication approaches with mcrouter: https://github.com/facebook/mcrouter/wiki/Replicated-pools-setup
+{{- end }}
 
 {{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
 

--- a/bitnami/memcached/templates/_helpers.tpl
+++ b/bitnami/memcached/templates/_helpers.tpl
@@ -129,6 +129,42 @@ imagePullSecrets:
 {{- end -}}
 {{- end -}}
 
+
+{{/*
+Return the proper Storage Class
+*/}}
+{{- define "memcached.storageClass" -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
+*/}}
+{{- if .Values.global -}}
+    {{- if .Values.global.storageClass -}}
+        {{- if (eq "-" .Values.global.storageClass) -}}
+            {{- printf "storageClassName: \"\"" -}}
+        {{- else }}
+            {{- printf "storageClassName: %s" .Values.global.storageClass -}}
+        {{- end -}}
+    {{- else -}}
+        {{- if .Values.persistence.storageClass -}}
+              {{- if (eq "-" .Values.persistence.storageClass) -}}
+                  {{- printf "storageClassName: \"\"" -}}
+              {{- else }}
+                  {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
+              {{- end -}}
+        {{- end -}}
+    {{- end -}}
+{{- else -}}
+    {{- if .Values.persistence.storageClass -}}
+        {{- if (eq "-" .Values.persistence.storageClass) -}}
+            {{- printf "storageClassName: \"\"" -}}
+        {{- else }}
+            {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Renders a value that contains template.
 Usage:

--- a/bitnami/memcached/templates/_helpers.tpl
+++ b/bitnami/memcached/templates/_helpers.tpl
@@ -189,7 +189,7 @@ memcached: architecture
 {{- end -}}
 {{- end -}}
 
-{{/* Validate values of InfluxDB - number of replicas */}}
+{{/* Validate values of Memcached - number of replicas */}}
 {{- define "memcached.validateValues.replicaCount" -}}
 {{- $replicaCount := int .Values.replicaCount }}
 {{- if and (eq .Values.architecture "standalone") (gt $replicaCount 1) -}}

--- a/bitnami/memcached/templates/deployment.yaml
+++ b/bitnami/memcached/templates/deployment.yaml
@@ -40,7 +40,8 @@ spec:
         - name: memcached
           image: {{ template "memcached.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-          command: {{- toYaml .Values.command | nindent 12 }}
+          args:
+          {{ toYaml .Values.arguments | nindent 12 }}
           env:
             - name: MEMCACHED_USERNAME
               value: {{ default "" .Values.memcachedUsername | quote }}

--- a/bitnami/memcached/templates/deployment.yaml
+++ b/bitnami/memcached/templates/deployment.yaml
@@ -68,6 +68,9 @@ spec:
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           {{- if .Values.securityContext.enabled }}
           securityContext:
             readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
@@ -95,4 +98,7 @@ spec:
           resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
           {{- end }}
         {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
 {{- end }}

--- a/bitnami/memcached/templates/deployment.yaml
+++ b/bitnami/memcached/templates/deployment.yaml
@@ -40,8 +40,7 @@ spec:
         - name: memcached
           image: {{ template "memcached.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-          args:
-          {{ toYaml .Values.arguments | nindent 12 }}
+          args: {{- toYaml .Values.arguments | nindent 12 }}
           env:
             - name: MEMCACHED_USERNAME
               value: {{ default "" .Values.memcachedUsername | quote }}

--- a/bitnami/memcached/templates/deployment.yaml
+++ b/bitnami/memcached/templates/deployment.yaml
@@ -68,6 +68,10 @@ spec:
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
+          {{- if .Values.securityContext.enabled }}
+          securityContext:
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+          {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
           image: {{ template "memcached.metrics.image" . }}

--- a/bitnami/memcached/templates/deployment.yaml
+++ b/bitnami/memcached/templates/deployment.yaml
@@ -40,8 +40,7 @@ spec:
         - name: memcached
           image: {{ template "memcached.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-          command:
-{{ toYaml .Values.command | indent 12 }}
+          command: {{- toYaml .Values.command | nindent 12 }}
           env:
             - name: MEMCACHED_USERNAME
               value: {{ default "" .Values.memcachedUsername | quote }}

--- a/bitnami/memcached/templates/deployment.yaml
+++ b/bitnami/memcached/templates/deployment.yaml
@@ -49,7 +49,9 @@ spec:
                 secretKeyRef:
                   name: {{ template "memcached.fullname" . }}
                   key: memcached-password
+            {{- if .Values.extraEnv }}
             {{- toYaml .Values.extraEnv | nindent 12 }}
+            {{- end }}
           ports:
             - name: memcache
               containerPort: 11211

--- a/bitnami/memcached/templates/deployment.yaml
+++ b/bitnami/memcached/templates/deployment.yaml
@@ -49,6 +49,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "memcached.fullname" . }}
                   key: memcached-password
+            {{- toYaml .Values.extraEnv | nindent 12 }}
           ports:
             - name: memcache
               containerPort: 11211

--- a/bitnami/memcached/templates/service.yaml
+++ b/bitnami/memcached/templates/service.yaml
@@ -8,6 +8,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if eq .Values.architecture "high-availability" }}
+  clusterIP: None
+  {{- end }}
   {{- if and (not (empty .Values.service.loadBalancerIP)) (eq .Values.service.type "LoadBalancer") }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}

--- a/bitnami/memcached/templates/statefulset.yaml
+++ b/bitnami/memcached/templates/statefulset.yaml
@@ -84,7 +84,7 @@ spec:
           {{- end }}
           {{- if .Values.persistence.enabled }}
           volumeMounts:
-            - name: pv-data
+            - name: data
               mountPath: /cache-state
           {{- end }}
         {{- if .Values.metrics.enabled }}
@@ -113,13 +113,21 @@ spec:
 {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
-        name: pv-data
+        name: data
+      {{- with .Values.persistence.annotations }}
+        annotations:
+        {{- range $key, $value := . }}
+          {{ $key }}: {{ $value }}
+        {{- end }}
+      {{- end }}
       spec:
         accessModes:
-          - ReadWriteOnce
-        storageClassName: {{ .Values.persistence.storageClassName }}
+        {{- range .Values.persistence.accessModes }}
+          - {{ . | quote }}
+        {{- end }}
         resources:
           requests:
-            storage: {{ .Values.persistence.requests.storage }}
+            storage: {{ .Values.persistence.size | quote }}
+        {{ include "memcached.storageClass" . | nindent 8 }}
 {{- end }}
 {{- end }}

--- a/bitnami/memcached/templates/statefulset.yaml
+++ b/bitnami/memcached/templates/statefulset.yaml
@@ -59,7 +59,9 @@ spec:
                 secretKeyRef:
                   name: {{ template "memcached.fullname" . }}
                   key: memcached-password
+            {{- if .Values.extraEnv }}
             {{- toYaml .Values.extraEnv | nindent 12 }}
+            {{- end }}
           ports:
             - name: memcache
               containerPort: 11211

--- a/bitnami/memcached/templates/statefulset.yaml
+++ b/bitnami/memcached/templates/statefulset.yaml
@@ -39,10 +39,18 @@ spec:
       {{- end }}
       containers:
         - name: memcached
+          {{- if .Values.persistence.enabled }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "/usr/bin/pkill -10 memcached ; sleep 60s"]
+          {{- end }}
           image: {{ template "memcached.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           command:
 {{ toYaml .Values.command | indent 12 }}
+          args:
+{{ toYaml .Values.arguments | indent 12 }}
 {{- if .Values.persistence.enabled }}
             - -e/cache-state/memory_file
 {{- end }}

--- a/bitnami/memcached/templates/statefulset.yaml
+++ b/bitnami/memcached/templates/statefulset.yaml
@@ -47,8 +47,7 @@ spec:
           {{- end }}
           image: {{ template "memcached.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-          command:
-{{ toYaml .Values.command | indent 12 }}
+          command: {{- toYaml .Values.command | nindent 12 }}
           args:
 {{ toYaml .Values.arguments | indent 12 }}
 {{- if .Values.persistence.enabled }}

--- a/bitnami/memcached/templates/statefulset.yaml
+++ b/bitnami/memcached/templates/statefulset.yaml
@@ -59,6 +59,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "memcached.fullname" . }}
                   key: memcached-password
+            {{- toYaml .Values.extraEnv | nindent 12 }}
           ports:
             - name: memcache
               containerPort: 11211

--- a/bitnami/memcached/templates/statefulset.yaml
+++ b/bitnami/memcached/templates/statefulset.yaml
@@ -8,6 +8,7 @@ spec:
   selector:
     matchLabels: {{- include "memcached.matchLabels" . | nindent 6 }}
   replicas: {{ .Values.replicaCount }}
+  serviceName: {{ template "memcached.fullname" . }}-headless
   template:
     metadata:
       labels: {{- include "memcached.labels" . | nindent 8 }}

--- a/bitnami/memcached/templates/statefulset.yaml
+++ b/bitnami/memcached/templates/statefulset.yaml
@@ -47,8 +47,7 @@ spec:
           {{- end }}
           image: {{ template "memcached.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-          args:
-          {{ toYaml .Values.arguments | nindent 12 }}
+          args: {{- toYaml .Values.arguments | nindent 12 }}
           {{- if .Values.persistence.enabled }}
             - -e/cache-state/memory_file
           {{- end }}

--- a/bitnami/memcached/templates/statefulset.yaml
+++ b/bitnami/memcached/templates/statefulset.yaml
@@ -44,7 +44,7 @@ spec:
           command:
 {{ toYaml .Values.command | indent 12 }}
 {{- if .Values.persistence.enabled }}
-            - -e /cache-state/memory_file
+            - -e/cache-state/memory_file
 {{- end }}
           env:
             - name: MEMCACHED_USERNAME

--- a/bitnami/memcached/templates/statefulset.yaml
+++ b/bitnami/memcached/templates/statefulset.yaml
@@ -72,6 +72,10 @@ spec:
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
+          {{- if .Values.securityContext.enabled }}
+          securityContext:
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+          {{- end }}
           {{- if .Values.persistence.enabled }}
           volumeMounts:
             - name: pv-data

--- a/bitnami/memcached/templates/statefulset.yaml
+++ b/bitnami/memcached/templates/statefulset.yaml
@@ -71,6 +71,11 @@ spec:
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
+          {{- if .Values.persistence.enabled }}
+          volumeMounts:
+            - name: pv-data
+              mountPath: /cache-state
+          {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
           image: {{ template "memcached.metrics.image" . }}
@@ -93,9 +98,6 @@ spec:
           {{- if .Values.metrics.resources }}
           resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
           {{- end }}
-          volumeMounts:
-            - name: pv-data
-              mountPath: /cache-state
         {{- end }}
 {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:

--- a/bitnami/memcached/templates/statefulset.yaml
+++ b/bitnami/memcached/templates/statefulset.yaml
@@ -1,6 +1,6 @@
-{{- if eq .Values.architecture "standalone" }}
+{{- if eq .Values.architecture "high-availability" }}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ template "memcached.fullname" . }}
   labels: {{- include "memcached.labels" . | nindent 4 }}
@@ -42,6 +42,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           command:
 {{ toYaml .Values.command | indent 12 }}
+{{- if .Values.persistence.enabled }}
+            - -e /cache-state/memory_file
+{{- end }}
           env:
             - name: MEMCACHED_USERNAME
               value: {{ default "" .Values.memcachedUsername | quote }}
@@ -90,5 +93,20 @@ spec:
           {{- if .Values.metrics.resources }}
           resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
           {{- end }}
+          volumeMounts:
+            - name: pv-data
+              mountPath: /cache-state
         {{- end }}
+{{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: pv-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: {{ .Values.persistence.storageClassName }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.requests.storage }}
+{{- end }}
 {{- end }}

--- a/bitnami/memcached/templates/statefulset.yaml
+++ b/bitnami/memcached/templates/statefulset.yaml
@@ -8,7 +8,7 @@ spec:
   selector:
     matchLabels: {{- include "memcached.matchLabels" . | nindent 6 }}
   replicas: {{ .Values.replicaCount }}
-  serviceName: {{ template "memcached.fullname" . }}-headless
+  serviceName: {{ template "memcached.fullname" . }}
   template:
     metadata:
       labels: {{- include "memcached.labels" . | nindent 8 }}

--- a/bitnami/memcached/templates/statefulset.yaml
+++ b/bitnami/memcached/templates/statefulset.yaml
@@ -86,6 +86,8 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /cache-state
+            - name: tmp
+              mountPath: /tmp
           {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
@@ -110,6 +112,9 @@ spec:
           resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
           {{- end }}
         {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
 {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/bitnami/memcached/templates/statefulset.yaml
+++ b/bitnami/memcached/templates/statefulset.yaml
@@ -47,12 +47,11 @@ spec:
           {{- end }}
           image: {{ template "memcached.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-          command: {{- toYaml .Values.command | nindent 12 }}
           args:
-{{ toYaml .Values.arguments | indent 12 }}
-{{- if .Values.persistence.enabled }}
+          {{ toYaml .Values.arguments | nindent 12 }}
+          {{- if .Values.persistence.enabled }}
             - -e/cache-state/memory_file
-{{- end }}
+          {{- end }}
           env:
             - name: MEMCACHED_USERNAME
               value: {{ default "" .Values.memcachedUsername | quote }}

--- a/bitnami/memcached/values-production.yaml
+++ b/bitnami/memcached/values-production.yaml
@@ -98,7 +98,7 @@ securityContext:
   enabled: true
   fsGroup: 1001
   runAsUser: 1001
-  readOnlyRootFilesystem: true
+  readOnlyRootFilesystem: false
 
 ## Pod annotations
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/

--- a/bitnami/memcached/values-production.yaml
+++ b/bitnami/memcached/values-production.yaml
@@ -123,10 +123,26 @@ tolerations: {}
 ## Persistence - used for dumping and restoring states between recreations
 ## Ref: https://github.com/memcached/memcached/wiki/WarmRestart
 persistence:
-  enabled: false
-  storageClassName: ""
-  # requests:
-  #   storage: 5Gi
+  enabled: true
+  ## Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##  set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##  GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  ## Persistent Volume Claim annotations
+  ##
+  annotations: {}
+  ## Persistent Volume Access Mode
+  ##
+  accessModes:
+    - ReadWriteOnce
+  ## Persistent Volume size
+  ##
+  size: 8Gi
+
 
 ## Args for running memcached
 ## Ref: https://github.com/memcached/memcached/wiki/ConfiguringServer

--- a/bitnami/memcached/values-production.yaml
+++ b/bitnami/memcached/values-production.yaml
@@ -132,7 +132,7 @@ persistence:
 command:
   - memcached
   # - -m <maxMemoryLimit>
-  # - -i <maxItemSize>
+  # - -I <maxItemSize>
   # - -vv
 
 ## Prometheus Exporter / Metrics

--- a/bitnami/memcached/values-production.yaml
+++ b/bitnami/memcached/values-production.yaml
@@ -26,6 +26,10 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+## Extra environment vars to pass.
+## ref: https://github.com/bitnami/bitnami-docker-memcached#configuration
+extraEnv: []
+
 ## String to partially override memcached.fullname template (will maintain the release name)
 ##
 # nameOverride:

--- a/bitnami/memcached/values-production.yaml
+++ b/bitnami/memcached/values-production.yaml
@@ -130,8 +130,7 @@ persistence:
 
 ## Args for running memcached
 ## Ref: https://github.com/memcached/memcached/wiki/ConfiguringServer
-command:
-  - memcached
+arguments:
   # - -m <maxMemoryLimit>
   # - -I <maxItemSize>
   # - -vv

--- a/bitnami/memcached/values-production.yaml
+++ b/bitnami/memcached/values-production.yaml
@@ -147,6 +147,7 @@ persistence:
 ## Args for running memcached
 ## Ref: https://github.com/memcached/memcached/wiki/ConfiguringServer
 arguments:
+  - /run.sh
   # - -m <maxMemoryLimit>
   # - -I <maxItemSize>
   # - -vv

--- a/bitnami/memcached/values-production.yaml
+++ b/bitnami/memcached/values-production.yaml
@@ -102,7 +102,7 @@ securityContext:
   enabled: true
   fsGroup: 1001
   runAsUser: 1001
-  readOnlyRootFilesystem: false
+  readOnlyRootFilesystem: true
 
 ## Pod annotations
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/

--- a/bitnami/memcached/values-production.yaml
+++ b/bitnami/memcached/values-production.yaml
@@ -123,7 +123,7 @@ tolerations: {}
 ## Ref: https://github.com/memcached/memcached/wiki/WarmRestart
 persistence:
   enabled: false
-  # storageClassName: ""
+  storageClassName: ""
   # requests:
   #   storage: 5Gi
 

--- a/bitnami/memcached/values-production.yaml
+++ b/bitnami/memcached/values-production.yaml
@@ -30,12 +30,19 @@ image:
 ##
 # nameOverride:
 
+## Number of containers to run
+replicaCount: 2
+
 ## String to fully override memcached.fullname template
 ##
 # fullnameOverride:
 
 # Cluster domain
 clusterDomain: cluster.local
+
+## Memcahed architecture. Allowed values: standalone or high-availability
+##
+architecture: standalone
 
 ## Memcached admin user
 ## ref: https://github.com/bitnami/bitnami-docker-memcached#creating-the-memcached-admin-user
@@ -111,6 +118,22 @@ nodeSelector: {}
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
 tolerations: {}
+
+## Persistence - used for dumping and restoring states between recreations
+## Ref: https://github.com/memcached/memcached/wiki/WarmRestart
+persistence:
+  enabled: false
+  # storageClassName: ""
+  # requests:
+  #   storage: 5Gi
+
+## Args for running memcached
+## Ref: https://github.com/memcached/memcached/wiki/ConfiguringServer
+command:
+  - memcached
+  # - -m <maxMemoryLimit>
+  # - -i <maxItemSize>
+  # - -vv
 
 ## Prometheus Exporter / Metrics
 ##

--- a/bitnami/memcached/values-production.yaml
+++ b/bitnami/memcached/values-production.yaml
@@ -98,6 +98,7 @@ securityContext:
   enabled: true
   fsGroup: 1001
   runAsUser: 1001
+  readOnlyRootFilesystem: true
 
 ## Pod annotations
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -98,7 +98,7 @@ securityContext:
   enabled: true
   fsGroup: 1001
   runAsUser: 1001
-  readOnlyRootFilesystem: true
+  readOnlyRootFilesystem: false
 
 ## Pod annotations
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -146,6 +146,7 @@ persistence:
 ## Args for running memcached
 ## Ref: https://github.com/memcached/memcached/wiki/ConfiguringServer
 arguments:
+  - /run.sh
   # - -m <maxMemoryLimit>
   # - -I <maxItemSize>
   # - -vv

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -26,6 +26,10 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+## Extra environment vars to pass.
+## ref: https://github.com/bitnami/bitnami-docker-memcached#configuration
+extraEnv: []
+
 ## String to partially override memcached.fullname template (will maintain the release name)
 ##
 # nameOverride:

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -30,12 +30,19 @@ image:
 ##
 # nameOverride:
 
+## Number of containers to run
+replicaCount: 1
+
 ## String to fully override memcached.fullname template
 ##
 # fullnameOverride:
 
 # Cluster domain
 clusterDomain: cluster.local
+
+## Memcahed architecture. Allowed values: standalone or high-availability
+##
+architecture: standalone
 
 ## Memcached admin user
 ## ref: https://github.com/bitnami/bitnami-docker-memcached#creating-the-memcached-admin-user
@@ -111,6 +118,23 @@ nodeSelector: {}
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
 tolerations: {}
+
+## Persistence - used for dumping and restoring states between recreations
+## Ref: https://github.com/memcached/memcached/wiki/WarmRestart
+persistence:
+  enabled: false
+  # storageClassName: ""
+  # requests:
+  #   storage: 5Gi
+
+## Args for running memcached
+## Ref: https://github.com/memcached/memcached/wiki/ConfiguringServer
+command:
+  - memcached
+  # - -m <maxMemoryLimit>
+  # - -i <maxItemSize>
+  # - -vv
+
 
 ## Prometheus Exporter / Metrics
 ##

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -132,7 +132,7 @@ persistence:
 command:
   - memcached
   # - -m <maxMemoryLimit>
-  # - -i <maxItemSize>
+  # - -I <maxItemSize>
   # - -vv
 
 

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -130,8 +130,7 @@ persistence:
 
 ## Args for running memcached
 ## Ref: https://github.com/memcached/memcached/wiki/ConfiguringServer
-command:
-  - memcached
+arguments:
   # - -m <maxMemoryLimit>
   # - -I <maxItemSize>
   # - -vv

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -123,10 +123,25 @@ tolerations: {}
 ## Persistence - used for dumping and restoring states between recreations
 ## Ref: https://github.com/memcached/memcached/wiki/WarmRestart
 persistence:
-  enabled: false
-  storageClassName: ""
-  # requests:
-  #   storage: 5Gi
+  enabled: true
+  ## Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##  set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##  GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  ## Persistent Volume Claim annotations
+  ##
+  annotations: {}
+  ## Persistent Volume Access Mode
+  ##
+  accessModes:
+    - ReadWriteOnce
+  ## Persistent Volume size
+  ##
+  size: 8Gi
 
 ## Args for running memcached
 ## Ref: https://github.com/memcached/memcached/wiki/ConfiguringServer

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -102,7 +102,7 @@ securityContext:
   enabled: true
   fsGroup: 1001
   runAsUser: 1001
-  readOnlyRootFilesystem: false
+  readOnlyRootFilesystem: true
 
 ## Pod annotations
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -123,7 +123,7 @@ tolerations: {}
 ## Ref: https://github.com/memcached/memcached/wiki/WarmRestart
 persistence:
   enabled: false
-  # storageClassName: ""
+  storageClassName: ""
   # requests:
   #   storage: 5Gi
 

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -98,6 +98,7 @@ securityContext:
   enabled: true
   fsGroup: 1001
   runAsUser: 1001
+  readOnlyRootFilesystem: true
 
 ## Pod annotations
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/


### PR DESCRIPTION
Signed-off-by: David J. M. Karlsen <david@davidkarlsen.com>

WorkInProgress - please provide feedback.


**Description of the change**
Provides HA by using PVC to store memory state on.

**Benefits**

Cache survives pod-recreation/upgrades.

**Possible drawbacks**

Added complexity and state - however the default is to run a single deployment as before depending on the `architecture` parameter.

**Applicable issues**

  - fixes #1685

**Additional information**

I'd like to add readonlyRootFilesystem too

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bitnami/charts/1710)
<!-- Reviewable:end -->
