### PR TITLE
[bitnami/prometheus-operator]: Fixed wrong indent of securityContext

### DIFF
--- a/bitnami/prometheus-operator/Chart.yaml
+++ b/bitnami/prometheus-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.34.0
 description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 name: prometheus-operator
-version: 0.7.1
+version: 0.7.2
 keywords:
 - prometheus
 - alertmanager

--- a/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -85,11 +85,11 @@ spec:
   {{- if .Values.prometheus.remoteWrite }}
   remoteWrite: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.remoteWrite "context" $) | nindent 4 }}
   {{- end }}
-{{- if .Values.prometheus.securityContext.enabled }}
-securityContext:
-  runAsUser: {{ .Values.prometheus.securityContext.runAsUser }}
-  fsGroup: {{ .Values.prometheus.securityContext.fsGroup }}
-{{- end }}
+  {{- if .Values.prometheus.securityContext.enabled }}
+  securityContext:
+    runAsUser: {{ .Values.prometheus.securityContext.runAsUser }}
+    fsGroup: {{ .Values.prometheus.securityContext.fsGroup }}
+  {{- end }}
   {{- if .Values.prometheus.ruleNamespaceSelector }}
   ruleNamespaceSelector: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.ruleNamespaceSelector "context" $) | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
Signed-off-by: Christian Kotzbauer <christian.kotzbauer@gmail.com>

**Description of the change**
Fixed wrong indention of the `securityContext` block of the `Prometheus` CRD.

**Benefits**
Prometheus is provisioned correctly and works as expected.

**Possible drawbacks**

**Applicable issues**
Related: https://github.com/coreos/prometheus-operator/issues/2828#issuecomment-562598893

**Additional information**
Tested successfully in my own cluster.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
