### PR TITLE
[bitnami/kube-state-metrics] Fixed global labels injection

### DIFF
--- a/bitnami/kube-state-metrics/Chart.yaml
+++ b/bitnami/kube-state-metrics/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.8.0
 description: kube-state-metrics is a simple service that listens to the Kubernetes API server and generates metrics about the state of the objects.
 name: kube-state-metrics
-version: 0.1.0
+version: 0.1.1
 keywords:
   - prometheus
   - kube-state-metrics

--- a/bitnami/kube-state-metrics/templates/_helpers.tpl
+++ b/bitnami/kube-state-metrics/templates/_helpers.tpl
@@ -79,7 +79,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.global.labels }}
-{{- toYaml .Values.global.labels }}
+{{ toYaml .Values.global.labels }}
 {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
This `-` breaks global labels by concatenating the last normal label with the first global one

```yaml
# values.yaml
global:
  labels:
    metric-type: global

---
# Source: kube-state-metrics/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: release-name-kube-state-metrics
  labels:
    app.kubernetes.io/name: kube-state-metrics
    helm.sh/chart: kube-state-metrics-0.1.0
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "1.8.0"
    app.kubernetes.io/managed-by: Tillermetric-type: global # <-- HERE
```

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
  Don't know if its required, but I can change to `0.1.1` if it is.
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
