### PR TITLE
[bitnami/kibana] Remove ES as a dependency

### DIFF
--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kibana
-version: 4.0.0
+version: 5.0.0
 appVersion: 7.5.0
 description: Kibana is an open source, browser based analytics and search dashboard for Elasticsearch.
 keywords:

--- a/bitnami/kibana/README.md
+++ b/bitnami/kibana/README.md
@@ -6,12 +6,7 @@
 
 ```console
 $ helm repo add bitnami https://charts.bitnami.com/bitnami
-
-# Option 1: With an existing Elasticsearch instance
-$ helm install bitnami/kibana --set elasticsearch.external.hosts[0]=<Hostname of your ES instance> --set elasticsearch.external.port=<port of your ES instance>
-
-# Option 2: With a bundled Elasticsearch instance
-$ helm install bitnami/kibana --set elasticsearch.enabled=true
+$ helm install bitnami/kibana --set elasticsearch.hosts[0]=<Hostname of your ES instance> --set elasticsearch.port=<port of your ES instance>
 ```
 
 ## Introduction
@@ -29,24 +24,15 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 
 ## Installing the Chart
 
-This chart requires a Elasticsearch instance to work. The chart offers two options:
-
-- Use an already existing Elasticsearch instance.
-- Deploy a new Elasticsearch instance together with Kibana. This is the default option when deploying the chart.
+This chart requires a Elasticsearch instance to work. You can use an already existing Elasticsearch instance.
 
  To install the chart with the release name `my-release`:
 
 ```console
 $ helm repo add bitnami https://charts.bitnami.com/bitnami
-
-# Option 1: With an existing Elasticsearch instance
 $ helm install bitnami/kibana --name my-release \
-  --set elasticsearch.external.hosts[0]=<Hostname of your ES instance> \
-  --set elasticsearch.external.port=<port of your ES instance>
-
-# Option 2: With a bundled Elasticsearch instance
-$ helm install bitnami/kibana --name my-release \
-  --set elasticsearch.enabled=true
+  --set elasticsearch.hosts[0]=<Hostname of your ES instance> \
+  --set elasticsearch.port=<port of your ES instance>
 ```
 
 These commands deploy kibana on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
@@ -148,13 +134,8 @@ The following tables lists the configurable parameters of the kibana chart and t
 | `metrics.serviceMonitor.interval`      | Interval at which metrics should be scraped.                                                                                                              | `nil` (Prometheus Operator default value)                                                               |             |
 | `metrics.serviceMonitor.scrapeTimeout` | Timeout after which the scrape is ended                                                                                                                   | `nil` (Prometheus Operator default value)                                                               |             |
 | `metrics.serviceMonitor.selector`      | Prometheus instance selector labels                                                                                                                       | `nil`                                                                                                   |             |
-| `elasticsearch.enabled`                | Use bundled Elasticsearch                                                                                                                                 | `true`                                                                                                  |             |
-| `elasticsearch.sysctlImage.enabled`    | Use sysctl image for bundled Elasticsearch                                                                                                                | `true`                                                                                                  |             |
-| `elasticsearch.master.replicas`        | Desired number of Elasticsearch master-eligible nodes                                                                                                     | `1`                                                                                                     |             |
-| `elasticsearch.coordinating.replicas`  | Desired number of Elasticsearch coordinating-only nodes                                                                                                   | `1`                                                                                                     |             |
-| `elasticsearch.data.replicas`          | Desired number of Elasticsearch data nodes                                                                                                                | `1`                                                                                                     |             |
-| `elasticsearch.external.hosts`         | Array containing the hostnames for the already existing Elasticsearch instances                                                                           | `nil`                                                                                                   |             |
-| `elasticsearch.external.port`          | Port for the accessing external Elasticsearch instances                                                                                                   | `nil`                                                                                                   |             |
+| `elasticsearch.hosts`                  | Array containing the hostnames for the already existing Elasticsearch instances                                                                           | `nil`                                                                                                   |             |
+| `elasticsearch.port`                   | Port for the accessing external Elasticsearch instances                                                                                                   | `nil`                                                                                                   |             |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -184,24 +165,6 @@ Bitnami will release a new chart updating its containers if a new version of the
 ### Production configuration
 
 This chart includes a `values-production.yaml` file where you can find some parameters oriented to production configuration in comparison to the regular `values.yaml`. You can use this file instead of the default one.
-
-- Disable bundled Elasticsearch
-
-```diff
-- elasticsearch.enabled: true
-+ elasticsearch.enabled: false
-```
-
-- Increase the number of default Elasticsearch nodes (if manually enabled)
-
-```diff
-- elasticsearch.master.replicas: 1
-+ elasticsearch.master.replicas: 2
-- elasticsearch.coordinating.replicas: 1
-+ elasticsearch.coordinating.replicas: 2
-- elasticsearch.data.replicas: 1
-+ elasticsearch.data.replicas: 2
-```
 
 - Enable metrics scraping
 
@@ -251,9 +214,8 @@ Alternatively, you can use a ConfigMap or a Secret with the environment variable
 For advanced operations, the Bitnami Kibana charts allows using custom init scripts that will be mounted in `/docker-entrypoint.init-db`. You can use a ConfigMap or a Secret (in case of sensitive data) for mounting these extra scripts. Then use the `initScriptsCM` and `initScriptsSecret` values.
 
 ```console
-elasticsearch.enabled=false
-elasticsearch.external.hosts[0]=elasticsearch-host
-elasticsearch.external.port=9200
+elasticsearch.hosts[0]=elasticsearch-host
+elasticsearch.port=9200
 initScriptsCM=special-scripts
 initScriptsSecret=special-scripts-sensitive
 ```
@@ -263,9 +225,8 @@ initScriptsSecret=special-scripts-sensitive
 The Bitnami Kibana chart allows you to install a set of plugins at deployment time using the `plugins` value:
 
 ```console
-elasticsearch.enabled=false
-elasticsearch.external.hosts[0]=elasticsearch-host
-elasticsearch.external.port=9200
+elasticsearch.hosts[0]=elasticsearch-host
+elasticsearch.port=9200
 plugins[0]=https://github.com/fbaligand/kibana-enhanced-table/releases/download/v1.5.0/enhanced-table-1.5.0_7.3.2.zip
 ```
 
@@ -324,13 +285,15 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 
 ## Notable changes
 
-### 3.0.0
+### 4.0.0
 
-[bitnami/kibana] bump major version
+This version does not include Elasticsearch as a bundled dependency. From now on, you should specify an external Elasticsearch instance using the `elasticsearch.hosts[]` and `elasticsearch.port` [parameters](#parameters).
+
+### 3.0.0
 
 Helm performs a lookup for the object based on its group (apps), version (v1), and kind (Deployment). Also known as its GroupVersionKind, or GVK. Changing the GVK is considered a compatibility breaker from Kubernetes' point of view, so you cannot "upgrade" those objects to the new GVK in-place. Earlier versions of Helm 3 did not perform the lookup correctly which has since been fixed to match the spec.
 
-In 4dfac075aacf74405e31ae5b27df4369e84eb0b0 the `apiVersion` of the deployment resources was updated to `apps/v1` in tune with the api's deprecated, resulting in compatibility breakage.
+In [4dfac075aacf74405e31ae5b27df4369e84eb0b0](https://github.com/bitnami/charts/commit/4dfac075aacf74405e31ae5b27df4369e84eb0b0) the `apiVersion` of the deployment resources was updated to `apps/v1` in tune with the api's deprecated, resulting in compatibility breakage.
 
 This major version signifies this change.
 

--- a/bitnami/kibana/requirements.lock
+++ b/bitnami/kibana/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: elasticsearch
-  repository: https://charts.bitnami.com/bitnami
-  version: 9.0.4
-digest: sha256:df707f375363ecc77b8dfd85bfa629e3aaf5cd2589088490c786a04a40d577c7
-generated: "2019-12-03T11:53:14.44223484Z"

--- a/bitnami/kibana/requirements.yaml
+++ b/bitnami/kibana/requirements.yaml
@@ -1,5 +1,0 @@
-dependencies:
-- name: elasticsearch
-  version: 9.x.x
-  repository: https://charts.bitnami.com/bitnami
-  condition: elasticsearch.enabled

--- a/bitnami/kibana/templates/NOTES.txt
+++ b/bitnami/kibana/templates/NOTES.txt
@@ -1,5 +1,16 @@
-** Please be patient while the chart is being deployed **
+{{- if or (not .Values.elasticsearch.hosts) (not .Values.elasticsearch.port) -}}
+######################################################################################################
+### ERROR: You did not provide the Elasticsearch external host or port in your 'helm install' call ###
+######################################################################################################
 
+Complete your Kibana deployment by running:
+
+  helm upgrade {{ .Release.Name }} bitnami/kibana \
+    --set elasticsearch.hosts[0]=YOUR_ES_HOST,elasticsearch.port=YOUR_ES_PORT
+
+Replacing "YOUR_ES_HOST" and "YOUR_ES_PORT" placeholders by the proper values of your Elasticsearch deployment.
+
+{{- else -}}
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
@@ -41,3 +52,4 @@ WARNING: For Prometheus metrics to work, make sure that the kibana-prometheus-ex
 {{- end }}
 
 {{ include "kibana.validateValues" . }}
+{{- end }}

--- a/bitnami/kibana/templates/_helpers.tpl
+++ b/bitnami/kibana/templates/_helpers.tpl
@@ -82,7 +82,8 @@ Set Elasticsearch URL.
 {{- define "kibana.elasticsearch.url" -}}
 {{- if .Values.elasticsearch.hosts -}}
 {{- $totalHosts := len .Values.elasticsearch.hosts -}}
-{{- range $i, $host := .Values.elasticsearch.hosts -}}
+{{- range $i, $hostTemplate := .Values.elasticsearch.hosts -}}
+{{- $host := tpl $hostTemplate $ }}
 {{- printf "http://%s:%s" $host (include "kibana.elasticsearch.port" $) -}}
 {{- if (lt ( add1 $i ) $totalHosts ) }}{{- printf "," -}}{{- end }}
 {{- end -}}

--- a/bitnami/kibana/templates/_helpers.tpl
+++ b/bitnami/kibana/templates/_helpers.tpl
@@ -25,19 +25,6 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
-Create a default fully qualified elasticsearch name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-*/}}
-{{- define "kibana.elasticsearch.fullname" -}}
-{{- if .Values.elasticsearch.fullnameOverride -}}
-{{- .Values.elasticsearch.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default "elasticsearch" .Values.elasticsearch.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "kibana.imagePullSecrets" -}}
@@ -89,17 +76,16 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Set Elasticsearch URL.
+*/}}
 {{- define "kibana.elasticsearch.url" -}}
-{{- if not .Values.elasticsearch.enabled -}}
-{{- if .Values.elasticsearch.external.hosts -}}
-{{- $totalHosts := len .Values.elasticsearch.external.hosts -}}
-{{- range $i, $host := .Values.elasticsearch.external.hosts -}}
+{{- if .Values.elasticsearch.hosts -}}
+{{- $totalHosts := len .Values.elasticsearch.hosts -}}
+{{- range $i, $host := .Values.elasticsearch.hosts -}}
 {{- printf "http://%s:%s" $host (include "kibana.elasticsearch.port" $) -}}
 {{- if (lt ( add1 $i ) $totalHosts ) }}{{- printf "," -}}{{- end }}
 {{- end -}}
-{{- end -}}
-{{- else -}}
-{{- printf "http://%s:%s" (printf "%s-coordinating-only" (include "kibana.elasticsearch.fullname" .)) (include "kibana.elasticsearch.port" .) -}}
 {{- end -}}
 {{- end -}}
 
@@ -107,15 +93,11 @@ Create chart name and version as used by the chart label.
 Set Elasticsearch Port.
 */}}
 {{- define "kibana.elasticsearch.port" -}}
-{{- if .Values.elasticsearch.enabled -}}
-{{- .Values.elasticsearch.coordinating.service.port -}}
-{{- else -}}
-{{- .Values.elasticsearch.external.port -}}
-{{- end -}}
+{{- .Values.elasticsearch.port -}}
 {{- end -}}
 
 {{/*
-Set Elasticsearch Port.
+Set Elasticsearch PVC.
 */}}
 {{- define "kibana.pvc" -}}
 {{- .Values.persistence.existingClaim | default (include "kibana.fullname" .) -}}
@@ -234,8 +216,6 @@ Compile all warnings into a single message, and call fail.
 {{- define "kibana.validateValues" -}}
 {{- $messages := list -}}
 {{- $messages := append $messages (include "kibana.validateValues.noElastic" .) -}}
-{{- $messages := append $messages (include "kibana.validateValues.elasticConflict" .) -}}
-{{- $messages := append $messages (include "kibana.validateValues.externalESSettings" .) -}}
 {{- $messages := append $messages (include "kibana.validateValues.configConflict" .) -}}
 {{- $messages := append $messages (include "kibana.validateValues.extraVolumes" .) -}}
 {{- $messages := without $messages "" -}}
@@ -246,38 +226,20 @@ Compile all warnings into a single message, and call fail.
 {{- end -}}
 {{- end -}}
 
-
-{{/* Validate values of Kibana - must provide a ElasticSearch */}}
+{{/* Validate values of Kibana - must provide an ElasticSearch */}}
 {{- define "kibana.validateValues.noElastic" -}}
-{{- if and (not .Values.elasticsearch.enabled) (not .Values.elasticsearch.external.hosts) (not .Values.elasticsearch.external.port) -}}
+{{- if and (not .Values.elasticsearch.hosts) (not .Values.elasticsearch.port) -}}
 kibana: no-elasticsearch
-    You did not specify an external Elasticsearch instance nor enabled the bundled
-    one. Please set either elasticsearch.enabled=true or set elasticsearch.external.hosts and elasticsearch.external.port
-{{- end -}}
-{{- end -}}
-
-{{/* Validate values of Kibana - conflict with ElasticSearch */}}
-{{- define "kibana.validateValues.elasticConflict" -}}
-{{- if and (.Values.elasticsearch.enabled) (.Values.elasticsearch.external.hosts) -}}
-kibana: conflict-elasticsearch
-    You specified both the external Elasticsearch instance and the bundled one.
-    Please only set either elasticsearch.enabled=true or elasticsearch.external.hosts
-{{- end -}}
-{{- end -}}
-
-{{/* Validate values of Kibana - Missing external ES Setting */}}
-{{- define "kibana.validateValues.externalESSettings" -}}
-{{- if (not .Values.elasticsearch.enabled) }}
-{{- if and (not .Values.elasticsearch.external.hosts) .Values.elasticsearch.external.port }}
+    You did not specify an external Elasticsearch instance.
+    Please set elasticsearch.hosts and elasticsearch.port
+{{- else if and (not .Values.elasticsearch.hosts) .Values.elasticsearch.port }}
 kibana: missing-es-settings-host
     You specified the external Elasticsearch port but not the host. Please
-    set elasticsearch.external.hosts
-{{- end -}}
-{{- if and .Values.elasticsearch.external.hosts (not .Values.elasticsearch.external.port) }}
+    set elasticsearch.hosts
+{{- else if and .Values.elasticsearch.hosts (not .Values.elasticsearch.port) }}
 kibana: missing-es-settings-port
     You specified the external Elasticsearch hosts but not the port. Please
-    set elasticsearch.external.port
-{{- end -}}
+    set elasticsearch.port
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/kibana/templates/configmap.yml
+++ b/bitnami/kibana/templates/configmap.yml
@@ -1,4 +1,4 @@
-{{- if not .Values.configurationCM }}
+{{- if and (not .Values.configurationCM) (and .Values.elasticsearch.hosts .Values.elasticsearch.port) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/bitnami/kibana/templates/deployment.yaml
+++ b/bitnami/kibana/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.elasticsearch.hosts .Values.elasticsearch.port -}}
 apiVersion: {{ template "kibana.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
@@ -184,3 +185,4 @@ spec:
       tolerations:
       {{- tpl (toYaml .Values.tolerations) $ | nindent 6 }}
       {{- end }}
+{{- end }}

--- a/bitnami/kibana/values-production.yaml
+++ b/bitnami/kibana/values-production.yaml
@@ -339,23 +339,7 @@ metrics:
 ## Properties for Elasticsearch
 ##
 elasticsearch:
-  ## Enable bundled Elasticsearch
-  enabled: false
-  ## Enable sysctl image for the bundled Elasticsearch
-  sysctlImage:
-    enabled: true
-  ## Elasticsearch master-eligible node parameters
-  master:
-    replicas: 2
-  ## Elasticsearch coordinating-only node parameters
-  coordinating:
-    replicas: 2
-  ## Elasticsearch data node parameters
-  data:
-    replicas: 2
-  ## Properties when enabled is false
-  external:
-    hosts:
-    # - elasticsearch-1
-    # - elasticsearch-2
-    port:
+  hosts:
+  # - elasticsearch-1
+  # - elasticsearch-2
+  port:

--- a/bitnami/kibana/values.yaml
+++ b/bitnami/kibana/values.yaml
@@ -339,23 +339,7 @@ metrics:
 ## Properties for Elasticsearch
 ##
 elasticsearch:
-  ## Enable bundled Elasticsearch
-  enabled: true
-  ## Enable sysctl image for the bundled Elasticsearch
-  sysctlImage:
-    enabled: true
-  ## Elasticsearch master-eligible node parameters
-  master:
-    replicas: 1
-  ## Elasticsearch coordinating-only node parameters
-  coordinating:
-    replicas: 1
-  ## Elasticsearch data node parameters
-  data:
-    replicas: 1
-  ## Properties when enabled is false
-  external:
-    hosts:
-    # - elasticsearch-1
-    # - elasticsearch-2
-    port:
+  hosts:
+  # - elasticsearch-1
+  # - elasticsearch-2
+  port:


### PR DESCRIPTION
Reviewed and accepted in https://github.com/bitnami/charts/pull/1567

**Description of the change**

Remove Elasticsearch as dependency bundled in Kibana. From now on, Kibana will be included as a dependency in the ES chart.

**Additional information**

⚠️ Please, review it but not merge the PR because we need to review what happens with marketplaces where `helm install` should work by default. In this case, as it is shown in the README, you need to use the already running ES host and port.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files