### PR TITLE
[bitnami/elasticsearch] Add Kibana as an ES dependency

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: elasticsearch
-version: 9.1.0
+version: 10.0.0
 appVersion: 7.5.0
 description: A highly scalable open-source full-text search and analytics engine
 keywords:

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: elasticsearch
-version: 9.0.4
+version: 9.1.0
 appVersion: 7.5.0
 description: A highly scalable open-source full-text search and analytics engine
 keywords:

--- a/bitnami/elasticsearch/README.md
+++ b/bitnami/elasticsearch/README.md
@@ -458,7 +458,7 @@ You can disable the initContainer using the `sysctlImage.enabled=false` paramete
 
 ### Enable bundled Kibana
 
-This Elasticsearch chart contains Kibana as subchart, you can enable it just setting the `kibana.enabled=true` parameter.
+This Elasticsearch chart contains Kibana as subchart, you can enable it just setting the `kibana.enabled=true` parameter. It is enabled by default using the `values-production.yaml` file.
 If you want to modify the `nameOverride` parameter in the Elasticsearch chart, you also need to set the same value for the `kibana.nameOverride` in order to use the same value in both charts.
 
 ## Persistence

--- a/bitnami/elasticsearch/README.md
+++ b/bitnami/elasticsearch/README.md
@@ -249,7 +249,7 @@ The following table lists the configurable parameters of the Elasticsearch chart
 
 | `kibana.enabled`               | Use bundled Kibana                                                                  | `false`                                                                                 |
 | `kibana.elasticsearch.hosts`   | Array containing hostnames for the ES instances. Used to generate the URL           | `{{ include "elasticsearch.coordinating.fullname" . }}` Coordinating service (fullname) |
-| `kibana.elasticsearch.port`    | Port to connect Kibana and ES instance. Used to generate the UR                     | `9200`                                                                                  |
+| `kibana.elasticsearch.port`    | Port to connect Kibana and ES instance. Used to generate the URL                    | `9200`                                                                                  |
 | `kibana.nameOverride`          | String to partially override elasticsearch.fullname template in the kibana subchart | `elasticsearch`                                                                         |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/bitnami/elasticsearch/README.md
+++ b/bitnami/elasticsearch/README.md
@@ -57,6 +57,7 @@ The following table lists the configurable parameters of the Elasticsearch chart
 | `global.imageRegistry`                            | Global Docker image registry                                                                                                                              | `nil`                                                        |
 | `global.imagePullSecrets`                         | Global Docker registry secret names as an array                                                                                                           | `[]` (does not add image pull secrets to deployed pods)      |
 | `global.storageClass`                             | Global storage class for dynamic provisioning                                                                                                             | `nil`                                                        |
+| `global.coordinating.name`                        | Coordinating-only node pod name at global level to be used also in the Kibana subchart                                                                    | `coordinating-only`                                          |
 | `image.registry`                                  | Elasticsearch image registry                                                                                                                              | `docker.io`                                                  |
 | `image.repository`                                | Elasticsearch image repository                                                                                                                            | `bitnami/elasticsearch`                                      |
 | `image.tag`                                       | Elasticsearch image tag                                                                                                                                   | `{TAG_NAME}`                                                 |
@@ -103,7 +104,6 @@ The following table lists the configurable parameters of the Elasticsearch chart
 | `master.readinessProbe.failureThreshold`          | Minimum consecutive failures for the probe to be considered failed after having succeeded                                                                 | `5`                                                          |
 | `clusterDomain`                                   | Kubernetes cluster domain                                                                                                                                 | `cluster.local`                                              |
 | `discovery.name`                                  | Discover node pod name                                                                                                                                    | `discovery`                                                  |
-| `coordinating.name`                               | Coordinating-only node pod name                                                                                                                           | `coordinating-only`                                          |
 | `coordinating.replicas`                           | Desired number of Elasticsearch coordinating-only nodes                                                                                                   | `2`                                                          |
 | `coordinating.heapSize`                           | Coordinating-only node heap size                                                                                                                          | `128m`                                                       |
 | `coordinating.antiAffinity`                       | Coordinating-only node pod anti-affinity policy                                                                                                           | `soft`                                                       |
@@ -244,7 +244,13 @@ The following table lists the configurable parameters of the Elasticsearch chart
 | `volumePermissions.image.tag`                     | Init container volume-permissions image tag                                                                                                               | `stretch`                                                    |
 | `volumePermissions.image.pullPolicy`              | Init container volume-permissions image pull policy                                                                                                       | `Always`                                                     |
 | `volumePermissions.resources`                     | Init container resource requests/limit                                                                                                                    | `nil`                                                        |
-| `kibana.enabled`                                  | Use bundled Kibana                                                                                                                                        | `false`                                                      |
+
+### Kibana Parameters
+
+| `kibana.enabled`               | Use bundled Kibana                                                                  | `false`                                                                                 |
+| `kibana.elasticsearch.hosts`   | Array containing hostnames for the ES instances. Used to generate the URL           | `{{ include "elasticsearch.coordinating.fullname" . }}` Coordinating service (fullname) |
+| `kibana.elasticsearch.port`    | Port to connect Kibana and ES instance. Used to generate the UR                     | `9200`                                                                                  |
+| `kibana.nameOverride`          | String to partially override elasticsearch.fullname template in the kibana subchart | `elasticsearch`                                                                         |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -450,6 +456,11 @@ Currently, Elasticsearch requires some changes in the kernel of the host machine
 This chart uses a **privileged** initContainer to change those settings in the Kernel by running: `sysctl -w vm.max_map_count=262144 && sysctl -w fs.file-max=65536`.
 You can disable the initContainer using the `sysctlImage.enabled=false` parameter.
 
+### Enable bundled Kibana
+
+This Elasticsearch chart contains Kibana as subchart, you can enable it just setting the `kibana.enabled=true` parameter.
+If you want to modify the `nameOverride` parameter in the Elasticsearch chart, you also need to set the same value for the `kibana.nameOverride` in order to use the same value in both charts.
+
 ## Persistence
 
 The [Bitnami Elasticsearch](https://github.com/bitnami/bitnami-docker-elasticsearch) image stores the Elasticsearch data at the `/bitnami/elasticsearch/data` path of the container.
@@ -466,6 +477,10 @@ As an alternative, this chart supports using an initContainer to change the owne
 You can enable this initContainer by setting `volumePermissions.enabled` to `true`.
 
 ## Notable changes
+
+### 10.0.0
+
+In this version, Kibana was added as dependant chart. More info about how to enable and work with this bundled Kibana in the ["Enable bundled Kibana"](#enable-bundled-kibana) section.
 
 ### 9.0.0
 

--- a/bitnami/elasticsearch/README.md
+++ b/bitnami/elasticsearch/README.md
@@ -244,6 +244,7 @@ The following table lists the configurable parameters of the Elasticsearch chart
 | `volumePermissions.image.tag`                     | Init container volume-permissions image tag                                                                                                               | `stretch`                                                    |
 | `volumePermissions.image.pullPolicy`              | Init container volume-permissions image pull policy                                                                                                       | `Always`                                                     |
 | `volumePermissions.resources`                     | Init container resource requests/limit                                                                                                                    | `nil`                                                        |
+| `kibana.enabled`                                  | Use bundled Kibana                                                                                                                                        | `false`                                                      |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -431,6 +432,12 @@ This chart includes a `values-production.yaml` file where you can find some para
 ```diff
 - metrics.enabled: false
 + metrics.enabled: true
+```
+
+- Enable bundled Kibana:
+```diff
+- kibana.enabled: false
++ kibana.enabled: true
 ```
 
 ### Default kernel settings

--- a/bitnami/elasticsearch/requirements.lock
+++ b/bitnami/elasticsearch/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: kibana
+  repository: https://charts.bitnami.com/bitnami
+  version: 5.0.0
+digest: sha256:25180f145e2b144df74901fa1825cedd396faa2d5d1881a45b28d61a9e000bde
+generated: "2019-12-12T18:42:40.963383539Z"

--- a/bitnami/elasticsearch/requirements.yaml
+++ b/bitnami/elasticsearch/requirements.yaml
@@ -1,0 +1,5 @@
+dependencies:
+- name: kibana
+  version: 4.x.x
+  repository: https://charts.bitnami.com/bitnami
+  condition: kibana.enabled

--- a/bitnami/elasticsearch/requirements.yaml
+++ b/bitnami/elasticsearch/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: kibana
-  version: 4.x.x
+  version: 5.x.x
   repository: https://charts.bitnami.com/bitnami
   condition: kibana.enabled

--- a/bitnami/elasticsearch/requirements.yaml
+++ b/bitnami/elasticsearch/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
-- name: kibana
-  version: 5.x.x
-  repository: https://charts.bitnami.com/bitnami
-  condition: kibana.enabled
+  - name: kibana
+    version: 5.x.x
+    repository: https://charts.bitnami.com/bitnami
+    condition: kibana.enabled

--- a/bitnami/elasticsearch/templates/_helpers.tpl
+++ b/bitnami/elasticsearch/templates/_helpers.tpl
@@ -127,7 +127,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "elasticsearch.coordinating.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s-%s" .Release.Name $name .Values.coordinating.name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.global.coordinating.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/elasticsearch/values-production.yaml
+++ b/bitnami/elasticsearch/values-production.yaml
@@ -2,11 +2,15 @@
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value
 ## Current available global Docker image parameters: imageRegistry and imagePullSecrets
 ##
-# global:
+global:
 #   imageRegistry: myRegistryName
 #   imagePullSecrets:
 #     - myRegistryKeySecretName
 #   storageClass: myStorageClass
+  ## Coordinating name to be used in the Kibana subchart (service name)
+  ##
+  coordinating:
+    name: coordinating-only
 
 ## Bitnami Elasticsearch image version
 ## ref: https://hub.docker.com/r/bitnami/elasticsearch/tags/
@@ -238,7 +242,6 @@ master:
 ## Elasticsearch coordinating-only node parameters
 ##
 coordinating:
-  name: coordinating-only
   ## Number of coordinating-only node(s) replicas to deploy
   ##
   replicas: 2
@@ -735,3 +738,10 @@ metrics:
 ##
 kibana:
   enabled: false
+  elasticsearch:
+    hosts:
+    - '{{ include "elasticsearch.coordinating.fullname" . }}'
+    port: 9200
+  ## String to partially override elasticsearch.fullname template in the kibana subchart
+  ##
+  nameOverride: elasticsearch

--- a/bitnami/elasticsearch/values-production.yaml
+++ b/bitnami/elasticsearch/values-production.yaml
@@ -730,3 +730,8 @@ metrics:
     ##
     # selector:
     #   prometheus: my-prometheus
+
+## Enable bundled Kibana
+##
+kibana:
+  enabled: false

--- a/bitnami/elasticsearch/values-production.yaml
+++ b/bitnami/elasticsearch/values-production.yaml
@@ -737,7 +737,7 @@ metrics:
 ## Enable bundled Kibana
 ##
 kibana:
-  enabled: false
+  enabled: true
   elasticsearch:
     hosts:
     - '{{ include "elasticsearch.coordinating.fullname" . }}'

--- a/bitnami/elasticsearch/values-production.yaml
+++ b/bitnami/elasticsearch/values-production.yaml
@@ -3,10 +3,10 @@
 ## Current available global Docker image parameters: imageRegistry and imagePullSecrets
 ##
 global:
-#   imageRegistry: myRegistryName
-#   imagePullSecrets:
-#     - myRegistryKeySecretName
-#   storageClass: myStorageClass
+  # imageRegistry: myRegistryName
+  # imagePullSecrets:
+  #   - myRegistryKeySecretName
+  # storageClass: myStorageClass
   ## Coordinating name to be used in the Kibana subchart (service name)
   ##
   coordinating:
@@ -740,7 +740,7 @@ kibana:
   enabled: true
   elasticsearch:
     hosts:
-    - '{{ include "elasticsearch.coordinating.fullname" . }}'
+      - '{{ include "elasticsearch.coordinating.fullname" . }}'
     port: 9200
   ## String to partially override elasticsearch.fullname template in the kibana subchart
   ##

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -2,11 +2,15 @@
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value
 ## Current available global Docker image parameters: imageRegistry and imagePullSecrets
 ##
-# global:
+global:
 #   imageRegistry: myRegistryName
 #   imagePullSecrets:
 #     - myRegistryKeySecretName
 #   storageClass: myStorageClass
+  ## Coordinating name to be used in the Kibana subchart (service name)
+  ##
+  coordinating:
+    name: coordinating-only
 
 ## Bitnami Elasticsearch image version
 ## ref: https://hub.docker.com/r/bitnami/elasticsearch/tags/
@@ -238,7 +242,6 @@ master:
 ## Elasticsearch coordinating-only node parameters
 ##
 coordinating:
-  name: coordinating-only
   ## Number of coordinating-only node(s) replicas to deploy
   ##
   replicas: 2
@@ -737,5 +740,8 @@ kibana:
   enabled: false
   elasticsearch:
     hosts:
-    - {{ include "influxdb.fullname" . }}
+    - '{{ include "elasticsearch.coordinating.fullname" . }}'
     port: 9200
+  ## String to partially override elasticsearch.fullname template in the kibana subchart
+  ##
+  nameOverride: elasticsearch

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -3,10 +3,10 @@
 ## Current available global Docker image parameters: imageRegistry and imagePullSecrets
 ##
 global:
-#   imageRegistry: myRegistryName
-#   imagePullSecrets:
-#     - myRegistryKeySecretName
-#   storageClass: myStorageClass
+  # imageRegistry: myRegistryName
+  # imagePullSecrets:
+  #   - myRegistryKeySecretName
+  # storageClass: myStorageClass
   ## Coordinating name to be used in the Kibana subchart (service name)
   ##
   coordinating:
@@ -740,7 +740,7 @@ kibana:
   enabled: false
   elasticsearch:
     hosts:
-    - '{{ include "elasticsearch.coordinating.fullname" . }}'
+      - '{{ include "elasticsearch.coordinating.fullname" . }}'
     port: 9200
   ## String to partially override elasticsearch.fullname template in the kibana subchart
   ##

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -730,3 +730,8 @@ metrics:
     ##
     # selector:
     #   prometheus: my-prometheus
+
+## Enable bundled Kibana
+##
+kibana:
+  enabled: false

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -735,3 +735,7 @@ metrics:
 ##
 kibana:
   enabled: false
+  elasticsearch:
+    hosts:
+    - {{ include "influxdb.fullname" . }}
+    port: 9200


### PR DESCRIPTION
**Description of the change**

Add Kibana as an ES dependency.
Required changes in Kibana: https://github.com/bitnami/charts/pull/1721

**Benefits**

Users can use ES with Kibana in the same installation.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files