### PR TITLE
[bitnami/etcd] Use debug env parameter in bash scripts

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: etcd
-version: 4.4.5
+version: 4.4.6
 appVersion: 3.4.3
 description: etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines
 keywords:

--- a/bitnami/etcd/templates/scripts-configmap.yaml
+++ b/bitnami/etcd/templates/scripts-configmap.yaml
@@ -27,7 +27,7 @@ data:
     exec 3>&1
     exec 4>&2
 
-    if [ ${BASH_DEBUG:-0} -eq 1 ]; then
+    if [ "${BITNAMI_DEBUG}" = true ]; then
       echo "==> Bash debug is on"
     else
       echo "==> Bash debug is off"
@@ -190,7 +190,7 @@ data:
     exec 3>&1
     exec 4>&2
 
-    if [ ${BASH_DEBUG:-0} -eq 1 ]; then
+    if [ "${BITNAMI_DEBUG}" = true ]; then
       echo "==> Bash debug is on"
     else
       echo "==> Bash debug is off"
@@ -216,7 +216,7 @@ data:
     exec 3>&1
     exec 4>&2
 
-    if [ ${BASH_DEBUG:-0} -eq 1 ]; then
+    if [ "${BITNAMI_DEBUG}" = true ]; then
       echo "==> Bash debug is on"
     else
       echo "==> Bash debug is off"
@@ -242,7 +242,7 @@ data:
     exec 3>&1
     exec 4>&2
 
-    if [ ${BASH_DEBUG:-0} -eq 1 ]; then
+    if [ "${BITNAMI_DEBUG}" = true ]; then
       echo "==> Bash debug is on"
     else
       echo "==> Bash debug is off"


### PR DESCRIPTION
According to https://github.com/bitnami/charts/blob/master/bitnami/etcd/values.yaml#L33 this chart value should also enable bash debugging.

But this chart value sets BITNAMI_DEBUG, https://github.com/bitnami/charts/blob/master/bitnami/etcd/templates/statefulset.yaml#L97

The bash scripts on the other check BASH_DEBUG, https://github.com/bitnami/charts/blob/master/bitnami/etcd/templates/scripts-configmap.yaml#L30

This PR adds another env parameter to toggle bash script debugging based on the chart debug value. An other possibility would be to change the scripts and have them check the BITNAMI_DEBUG env parameter as well, so we only have to set 1 env parameter. Any thoughts?