### PR TITLE
[bitnami/spark] Copy configmap files using init container

### DIFF
--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 1.1.0
+version: 1.1.1
 appVersion: 2.4.4
 description: Spark is a fast and general-purpose cluster computing system.
 name: spark

--- a/bitnami/spark/templates/statefulset-master.yaml
+++ b/bitnami/spark/templates/statefulset-master.yaml
@@ -30,6 +30,17 @@ spec:
         fsGroup: {{ .Values.master.securityContext.fsGroup }}
         runAsUser: {{ .Values.master.securityContext.runAsUser }}
       {{- end }}
+      {{- if .Values.master.configurationConfigMap }}
+      initContainers:
+        - name: configmap-data
+          image: busybox
+          command: ["sh","-c","cp -Lr /configmap-data/* /config"]
+          volumeMounts:
+          - name: config
+            mountPath: /config
+          - name: configmap-data
+            mountPath: /configmap-data
+      {{- end }}
       containers:
         - name: spark-master
           image: {{ template "spark.image" . }}
@@ -145,9 +156,11 @@ spec:
           {{- end }}
       volumes:
         {{- if .Values.master.configurationConfigMap }}
-        - name: config
+        - name: configmap-data
           configMap:
             name: {{ .Values.master.configurationConfigMap }}
+        - name: config
+          emptyDir: {}
         {{- end }}
         {{- if .Values.security.certificatesSecretName }}
         - name: certs

--- a/bitnami/spark/templates/statefulset-worker.yaml
+++ b/bitnami/spark/templates/statefulset-worker.yaml
@@ -30,6 +30,17 @@ spec:
         fsGroup: {{ .Values.worker.securityContext.fsGroup }}
         runAsUser: {{ .Values.worker.securityContext.runAsUser }}
       {{- end }}
+      {{- if .Values.worker.configurationConfigMap }}
+      initContainers:
+        - name: configmap-data
+          image: busybox
+          command: ["sh","-c","cp -Lr /configmap-data/* /config"]
+          volumeMounts:
+          - name: config
+            mountPath: /config
+          - name: configmap-data
+            mountPath: /configmap-data
+      {{- end }}
       containers:
         - name: spark-worker
           image: {{ template "spark.image" . }}
@@ -164,9 +175,11 @@ spec:
           {{- end }}
       volumes:
         {{- if .Values.worker.configurationConfigMap }}
-        - name: config
+        - name: configmap-data
           configMap:
             name: {{ .Values.worker.configurationConfigMap }}
+        - name: config
+          emptyDir: {}
         {{- end }}
         {{- if .Values.security.certificatesSecretName }}
         - name: certs


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Implement an init container to copy configmap files to an emptydir and use that volume in the main spark container

**Benefits**

Allows for external configs to be mounted from the configmap; a feature that is currently documented, but not working properly

**Possible drawbacks**

None known

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #1732 

**Additional information**

Doesn't affect charts that aren't using `master. configurationConfigMap` or `worker. configurationConfigMap`

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
