### PR TITLE
[bitnami/elasticsearch] Fix nameOverride issue

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: elasticsearch
-version: 10.0.0
+version: 10.0.1
 appVersion: 7.5.0
 description: A highly scalable open-source full-text search and analytics engine
 keywords:

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: elasticsearch
-version: 10.0.1
+version: 10.1.0
 appVersion: 7.5.0
 description: A highly scalable open-source full-text search and analytics engine
 keywords:

--- a/bitnami/elasticsearch/README.md
+++ b/bitnami/elasticsearch/README.md
@@ -247,7 +247,7 @@ The following table lists the configurable parameters of the Elasticsearch chart
 
 ### Kibana Parameters
 
-| `kibana.enabled`               | Use bundled Kibana                                                                  | `false`                                                                                 |
+| `global.kibanaEnabled`         | Use bundled Kibana                                                                  | `false`                                                                                 |
 | `kibana.elasticsearch.hosts`   | Array containing hostnames for the ES instances. Used to generate the URL           | `{{ include "elasticsearch.coordinating.fullname" . }}` Coordinating service (fullname) |
 | `kibana.elasticsearch.port`    | Port to connect Kibana and ES instance. Used to generate the URL                    | `9200`                                                                                  |
 
@@ -441,8 +441,8 @@ This chart includes a `values-production.yaml` file where you can find some para
 
 - Enable bundled Kibana:
 ```diff
-- kibana.enabled: false
-+ kibana.enabled: true
+- global.kibanaEnabled: false
++ global.kibanaEnabled: true
 ```
 
 ### Default kernel settings
@@ -457,7 +457,7 @@ You can disable the initContainer using the `sysctlImage.enabled=false` paramete
 
 ### Enable bundled Kibana
 
-This Elasticsearch chart contains Kibana as subchart, you can enable it just setting the `kibana.enabled=true` parameter. It is enabled by default using the `values-production.yaml` file.
+This Elasticsearch chart contains Kibana as subchart, you can enable it just setting the `global.kibanaEnabled=true` parameter. It is enabled by default using the `values-production.yaml` file.
 To see the notes with some operational instructions from the Kibana chart, please use the `--render-subchart-notes` as part of your `helm install` command, in this way you can see the Kibana and ES notes in your terminal.
 
 ## Persistence

--- a/bitnami/elasticsearch/README.md
+++ b/bitnami/elasticsearch/README.md
@@ -250,7 +250,6 @@ The following table lists the configurable parameters of the Elasticsearch chart
 | `kibana.enabled`               | Use bundled Kibana                                                                  | `false`                                                                                 |
 | `kibana.elasticsearch.hosts`   | Array containing hostnames for the ES instances. Used to generate the URL           | `{{ include "elasticsearch.coordinating.fullname" . }}` Coordinating service (fullname) |
 | `kibana.elasticsearch.port`    | Port to connect Kibana and ES instance. Used to generate the URL                    | `9200`                                                                                  |
-| `kibana.nameOverride`          | String to partially override elasticsearch.fullname template in the kibana subchart | `elasticsearch`                                                                         |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -459,7 +458,7 @@ You can disable the initContainer using the `sysctlImage.enabled=false` paramete
 ### Enable bundled Kibana
 
 This Elasticsearch chart contains Kibana as subchart, you can enable it just setting the `kibana.enabled=true` parameter. It is enabled by default using the `values-production.yaml` file.
-If you want to modify the `nameOverride` parameter in the Elasticsearch chart, you also need to set the same value for the `kibana.nameOverride` in order to use the same value in both charts.
+To see the notes with some operational instructions from the Kibana chart, please use the `--render-subchart-notes` as part of your `helm install` command, in this way you can see the Kibana and ES notes in your terminal.
 
 ## Persistence
 

--- a/bitnami/elasticsearch/requirements.lock
+++ b/bitnami/elasticsearch/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: kibana
   repository: https://charts.bitnami.com/bitnami
   version: 5.0.0
-digest: sha256:25180f145e2b144df74901fa1825cedd396faa2d5d1881a45b28d61a9e000bde
-generated: "2019-12-12T18:42:40.963383539Z"
+digest: sha256:4970b5ac3743b773c6608e77e28eb0928d45c3379bbe6660a35d8d4ef07613df
+generated: "2019-12-13T12:46:10.381126027Z"

--- a/bitnami/elasticsearch/requirements.yaml
+++ b/bitnami/elasticsearch/requirements.yaml
@@ -2,4 +2,4 @@ dependencies:
   - name: kibana
     version: 5.x.x
     repository: https://charts.bitnami.com/bitnami
-    condition: kibana.enabled
+    condition: global.kibanaEnabled

--- a/bitnami/elasticsearch/templates/_helpers.tpl
+++ b/bitnami/elasticsearch/templates/_helpers.tpl
@@ -126,13 +126,8 @@ Create a default fully qualified coordinating name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "elasticsearch.coordinating.fullname" -}}
-{{/* If Kibana is enabled. Evaluated in the Kibana subchart */}}
-{{- if .Values.enabled -}}
+{{- if .Values.global.kibanaEnabled -}}
 {{- printf "%s-%s" .Release.Name .Values.global.coordinating.name | trunc 63 | trimSuffix "-" -}}
-{{/* If Kibana is enabled. Evaluated in the ES chart */}}
-{{- else if .Values.kibana.enabled -}}
-{{- printf "%s-%s" .Release.Name .Values.global.coordinating.name | trunc 63 | trimSuffix "-" -}}
-{{/* If Kibana is not enabled */}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s-%s" .Release.Name $name .Values.global.coordinating.name | trunc 63 | trimSuffix "-" -}}

--- a/bitnami/elasticsearch/templates/_helpers.tpl
+++ b/bitnami/elasticsearch/templates/_helpers.tpl
@@ -126,8 +126,17 @@ Create a default fully qualified coordinating name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "elasticsearch.coordinating.fullname" -}}
+{{/* If Kibana is enabled. Evaluated in the Kibana subchart */}}
+{{- if .Values.enabled -}}
+{{- printf "%s-%s" .Release.Name .Values.global.coordinating.name | trunc 63 | trimSuffix "-" -}}
+{{/* If Kibana is enabled. Evaluated in the ES chart */}}
+{{- else if .Values.kibana.enabled -}}
+{{- printf "%s-%s" .Release.Name .Values.global.coordinating.name | trunc 63 | trimSuffix "-" -}}
+{{/* If Kibana is not enabled */}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s-%s" .Release.Name $name .Values.global.coordinating.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/elasticsearch/values-production.yaml
+++ b/bitnami/elasticsearch/values-production.yaml
@@ -11,6 +11,7 @@ global:
   ##
   coordinating:
     name: coordinating-only
+  kibanaEnabled: true
 
 ## Bitnami Elasticsearch image version
 ## ref: https://hub.docker.com/r/bitnami/elasticsearch/tags/
@@ -734,10 +735,9 @@ metrics:
     # selector:
     #   prometheus: my-prometheus
 
-## Enable bundled Kibana
+## Bundled Kibana parameters
 ##
 kibana:
-  enabled: true
   elasticsearch:
     hosts:
       - '{{ include "elasticsearch.coordinating.fullname" . }}'

--- a/bitnami/elasticsearch/values-production.yaml
+++ b/bitnami/elasticsearch/values-production.yaml
@@ -742,6 +742,3 @@ kibana:
     hosts:
       - '{{ include "elasticsearch.coordinating.fullname" . }}'
     port: 9200
-  ## String to partially override elasticsearch.fullname template in the kibana subchart
-  ##
-  nameOverride: elasticsearch

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -11,6 +11,7 @@ global:
   ##
   coordinating:
     name: coordinating-only
+  kibanaEnabled: false
 
 ## Bitnami Elasticsearch image version
 ## ref: https://hub.docker.com/r/bitnami/elasticsearch/tags/
@@ -734,10 +735,9 @@ metrics:
     # selector:
     #   prometheus: my-prometheus
 
-## Enable bundled Kibana
+## Bundled Kibana parameters
 ##
 kibana:
-  enabled: false
   elasticsearch:
     hosts:
       - '{{ include "elasticsearch.coordinating.fullname" . }}'

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -742,6 +742,3 @@ kibana:
     hosts:
       - '{{ include "elasticsearch.coordinating.fullname" . }}'
     port: 9200
-  ## String to partially override elasticsearch.fullname template in the kibana subchart
-  ##
-  nameOverride: elasticsearch


### PR DESCRIPTION
**Description of the change**
The source of the issue is that we need to use the same template for the main chart and the subchart. This template is using:
```
{{- define "elasticsearch.coordinating.fullname" -}}
{{- $name := default .Chart.Name .Values.nameOverride -}}
{{- printf "%s-%s-%s" .Release.Name $name .Values.global.coordinating.name | trunc 63 | trimSuffix "-" -}}
{{- end -}}
```
the problem is that when the template is evaluated in the main chart `.Chart.Name` is `elasticsearch` while when it is evaluated in the subchart, `.Chart.Name` is `kibana`.

Because of that, the coordinating service name is not the same in both charts. To avoid this issue I used the `nameOverride` option in the kibana subchart:
```yaml
## Enable bundled Kibana
##
kibana:
  ## String to partially override elasticsearch.fullname template in the kibana subchart
  ##
  nameOverride: elasticsearch
```

Using it, the service is the same in both charts, because in the ES chart is using `.Chart.Name` (`elasticsearch`) and in the Kibana subchart is using `nameOverride` set to the same value.

The problem now is that `nameOverride` set to `elasticsearch` in the Kibana subchart implies that the Kibana resources are renamed to `elasticsearch`, for example:
```
▶ kubectl get pods --namespace assets-privileged
NAME                                                             READY   STATUS    RESTARTS   AGE
elasticsearch-5cd6db77c6-2rgbx                                   1/1     Running   0          2m36s             <-- This is the Kibana pod
elasticsearch-elasticsearch-coordinating-only-55c49b6f8f-tk7hr   1/1     Running   0          2m36s
elasticsearch-elasticsearch-data-0                               1/1     Running   0          2m36s
elasticsearch-elasticsearch-master-0                             1/1     Running   0          2m36s

▶ kubectl get svc --namespace assets-privileged
NAME                                            TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)     AGE
elasticsearch                                   ClusterIP   10.30.250.191   <none>        80/TCP      5m49s     <-- This is the Kibana service
elasticsearch-elasticsearch-coordinating-only   ClusterIP   10.30.241.253   <none>        9200/TCP    5m49s
elasticsearch-elasticsearch-discovery           ClusterIP   None            <none>        9300/TCP    5m49s
elasticsearch-elasticsearch-master              ClusterIP   10.30.252.252   <none>        9300/TCP    5m49s
```

This PR avoid using `nameOverride` in Kibana, so Kibana resources maintain the same naming as previously. The change is in the coordinating service name if we know that Kibana is enabled the coordinating service name doesn't use 
```
{{- $name := default .Chart.Name .Values.nameOverride -}}
```
so the service name is not following the rest of the services approach (only when Kibana is enabled):
```
kubectl get pods --namespace assets-privileged
NAME                                       READY   STATUS    RESTARTS   AGE
petete-coordinating-only-ff9b57694-9mx2p   1/1     Running   0          29m
petete-coordinating-only-ff9b57694-v2w4w   1/1     Running   0          29m
petete-elasticsearch-data-0                1/1     Running   0          29m
petete-elasticsearch-data-1                1/1     Running   0          28m
petete-elasticsearch-master-0              1/1     Running   0          29m
petete-elasticsearch-master-1              1/1     Running   0          28m
petete-kibana-5d4d9b7789-k6c46             1/1     Running   0          29m
tiller-deploy-75ccc659f8-pvhmt             1/1     Running   0          2d21h
```

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files