### PR TITLE
Elasticsearch master nodes persistency

### DIFF
--- a/bitnami/elasticsearch/templates/master-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/master-statefulset.yaml
@@ -63,7 +63,7 @@ spec:
           resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: data
+            - name: "data"
               mountPath: "/bitnami/elasticsearch/data"
         {{- end }}
       {{- end }}

--- a/bitnami/elasticsearch/templates/master-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/master-statefulset.yaml
@@ -63,7 +63,7 @@ spec:
           resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: "data"
+            - name: data
               mountPath: "/bitnami/elasticsearch/data"
         {{- end }}
       {{- end }}


### PR DESCRIPTION
This is a small fix regarding the inability to attach a persistence storage for elasticsearch master nodes, as described on: https://github.com/bitnami/charts/issues/1509

Adding double-quotes to the volumeMount's name fixed the issue on my kubernetes cluster and now I'm able to take the entire elasticsearch cluster down and up without any issues with differences in cluster uuid.

This is my first contribution on Github, let me know if anything else is needed.

