### PR TITLE
[bitnami/cassandra] Fix resources in metrics

### DIFF
--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cassandra
-version: 4.1.11
+version: 4.1.12
 appVersion: 3.11.5
 description: Apache Cassandra is a free and open-source distributed database management system designed to handle large amounts of data across many commodity servers, providing high availability with no single point of failure. Cassandra offers robust support for clusters spanning multiple datacenters, with asynchronous masterless replication allowing low latency operations for all clients.
 keywords:

--- a/bitnami/cassandra/templates/statefulset.yaml
+++ b/bitnami/cassandra/templates/statefulset.yaml
@@ -214,6 +214,9 @@ spec:
               protocol: TCP
             - name: jmx
               containerPort: 5555
+          {{- if .Values.metrics.resources }}
+          resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
+          {{- end }}
           livenessProbe:
             tcpSocket:
               port: metrics


### PR DESCRIPTION
**Description of the change**
Enable resources for metrics.
```bash
$ helm template . --set metrics.enabled=true --set metrics.resources.requests.cpu=100m -x templates/statefulset.yaml
```
```yaml
        - name: metrics
          image: docker.io/bitnami/cassandra-exporter:2.3.0-debian-9-r102
          imagePullPolicy: "IfNotPresent"
          ports:
            - name: metrics
              containerPort: 8080
              protocol: TCP
            - name: jmx
              containerPort: 5555
          resources:
            limits: {}
            requests:
              cpu: 100m
          livenessProbe:
            tcpSocket:
              port: metrics
          readinessProbe:
            httpGet:
              path: /metrics
              port: metrics
            initialDelaySeconds: 20
            timeoutSeconds: 45
```

**Applicable issues**

  - fixes #1745 

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files