### PR TITLE
[bitnami/magento] Bump elasticsearch dependency

### DIFF
--- a/bitnami/magento/Chart.yaml
+++ b/bitnami/magento/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: magento
-version: 10.0.0
+version: 11.0.0
 appVersion: 2.3.3
 description: A feature-rich flexible e-commerce solution. It includes transaction options, multi-store functionality, loyalty programs, product categorization and shopper filtering, promotion rules, and more.
 keywords:

--- a/bitnami/magento/requirements.lock
+++ b/bitnami/magento/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 7.0.1
+  version: 7.3.1
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
-  version: 8.2.5
-digest: sha256:913775f6b0070a31ac74ad6304cc65ee19fd0950e55e2d81cbe03eca920cd7a1
-generated: "2019-11-15T14:16:56.71275685+05:30"
+  version: 10.1.0
+digest: sha256:bad621518ab9d12662436062824ce1a8c4656b6bc8ae4dc7ccb1decc5c91fd09
+generated: "2019-12-17T13:12:07.830004+01:00"

--- a/bitnami/magento/requirements.yaml
+++ b/bitnami/magento/requirements.yaml
@@ -4,6 +4,6 @@ dependencies:
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: mariadb.enabled
   - name: elasticsearch
-    version: 8.x.x
+    version: 10.x.x
     repository: https://charts.bitnami.com/bitnami
     condition: elasticsearch.enabled

--- a/bitnami/magento/values.yaml
+++ b/bitnami/magento/values.yaml
@@ -290,7 +290,7 @@ ingress:
   ##
   ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
-  annotations:
+  annotations: {}
   #  kubernetes.io/ingress.class: nginx
 
   ## The list of hostnames to be covered with this ingress record.


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>


**Description of the change**

Bumps Magento major version to update the dependencies (elasticsearch) to latest major version

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
