### PR TITLE
[bitnami/postgresql-ha] Update NOTES.txt to correct postgresql client version

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql-ha
-version: 1.1.0
+version: 1.1.1
 appVersion: 11.6.0
 description: Chart for PostgreSQL with HA architecture (using Replication Manager (repmgr) and Pgpool).
 keywords:

--- a/bitnami/postgresql-ha/templates/NOTES.txt
+++ b/bitnami/postgresql-ha/templates/NOTES.txt
@@ -17,7 +17,7 @@ To get the password for {{ (include "postgresql-ha.postgresqlRepmgrUsername" .) 
 
 To connect to your database run the following command:
 
-    kubectl run {{ include "postgresql-ha.fullname" . }}-client --rm --tty -i --restart='Never' --namespace {{ .Release.Namespace }} --image bitnami/postgresql:10 --env="PGPASSWORD=$POSTGRES_PASSWORD" {{ if and (.Values.networkPolicy.enabled) (not .Values.networkPolicy.allowExternal) }}--labels="{{ include "postgresql-ha.fullname" . }}-client=true" {{- end }} \
+    kubectl run {{ include "postgresql-ha.fullname" . }}-client --rm --tty -i --restart='Never' --namespace {{ .Release.Namespace }} --image bitnami/postgresql:11 --env="PGPASSWORD=$POSTGRES_PASSWORD" {{ if and (.Values.networkPolicy.enabled) (not .Values.networkPolicy.allowExternal) }}--labels="{{ include "postgresql-ha.fullname" . }}-client=true" {{- end }} \
         --command -- psql -h {{ include "postgresql-ha.pgpool" . }} -p {{ .Values.service.port }} -U {{ include "postgresql-ha.postgresqlUsername" . }}{{- if not (empty (include "postgresql-ha.postgresqlDatabase" .)) }} -d {{ include "postgresql-ha.postgresqlDatabase" . }}{{- end }}
 
 {{- if and (.Values.networkPolicy.enabled) (not .Values.networkPolicy.allowExternal) }}


### PR DESCRIPTION
**Description of the change**

Update NOTES.txt so that the "Connect to your database command" uses the postgresql client version that matches the version of the database (`11.x`) being used instead of `10.x`

**Benefits**

Postgresql client matches the server version

**Possible drawbacks**

None

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
