### PR TITLE
[bitnami/etcd] Use auto-generated TLS certificates when ETCD_AUTO_TLS is true

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: etcd
-version: 4.4.6
+version: 4.4.7
 appVersion: 3.4.3
 description: etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines
 keywords:

--- a/bitnami/etcd/templates/_helpers.tpl
+++ b/bitnami/etcd/templates/_helpers.tpl
@@ -124,15 +124,18 @@ Return the proper etcdctl authentication options
 {{- define "etcd.authOptions" -}}
 {{- $rbacOption := "--user root:$ETCD_ROOT_PASSWORD" -}}
 {{- $certsOption := " --cert=\"$ETCD_CERT_FILE\" --key=\"$ETCD_KEY_FILE\"" -}}
+{{- $autoCertsOption := " --cert=\"/bitnami/etcd/data/fixtures/client/cert.pem\" --key=\"/bitnami/etcd/data/fixtures/client/key.pem\"" -}}
 {{- $caOption := " --cacert=\"$ETCD_TRUSTED_CA_FILE\"" -}}
 {{- if .Values.auth.rbac.enabled -}}
 {{- printf "%s" $rbacOption -}}
 {{- end -}}
-{{- if .Values.auth.client.secureTransport -}}
+{{- if and .Values.auth.client.secureTransport .Values.auth.client.useAutoTLS -}}
+{{- printf "%s" $autoCertsOption -}}
+{{- else if and .Values.auth.client.secureTransport (not .Values.auth.client.useAutoTLS) -}}
 {{- printf "%s" $certsOption -}}
-{{- end -}}
 {{- if .Values.auth.client.enableAuthentication -}}
 {{- printf "%s" $caOption -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/etcd/templates/scripts-configmap.yaml
+++ b/bitnami/etcd/templates/scripts-configmap.yaml
@@ -58,9 +58,9 @@ data:
             echo "==> Configuring RBAC authentication!" 1>&3 2>&4
             etcd &
             ETCD_PID=$!
-            while ! etcdctl member list; do sleep 1; done
-            echo "$ETCD_ROOT_PASSWORD" | etcdctl user add root --interactive=false
-            etcdctl auth enable
+            while ! etcdctl $AUTH_OPTIONS member list; do sleep 1; done
+            echo "$ETCD_ROOT_PASSWORD" | etcdctl $AUTH_OPTIONS user add root --interactive=false
+            etcdctl $AUTH_OPTIONS auth enable
             kill "$ETCD_PID"
             sleep 5
         fi


### PR DESCRIPTION
**Description of the change**

Fixes an issue when auto-generated TLS certificates are used. 

More info at referenced issue

**Applicable issues**

  - fixes #1743 

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
