### PR TITLE
[bitnami/apache] add some useful information to NOTE.txt

### DIFF
--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: apache
-version: 7.3.0
+version: 7.3.1
 appVersion: 2.4.41
 description: Chart for Apache HTTP Server
 keywords:

--- a/bitnami/apache/templates/NOTES.txt
+++ b/bitnami/apache/templates/NOTES.txt
@@ -1,12 +1,47 @@
-{{ include "apache.validateValues" . }}
 
-{{- if not (include "apache.useHtdocs" .)}}
+** Please be patient while the chart is being deployed **
+
+1. Get the Apache URL by running:
+
+{{- if .Values.ingress.enabled }}
+
+  You should be able to access your new Apache installation through:
+
+  {{- if .Values.ingress.hostname }}
+      - http://{{ .Values.ingress.hostname }}
+  {{- end }}
+  {{- range $host := .Values.ingress.hosts }}
+    {{- range .paths }}
+      - http://{{ $host.name }}{{ . }}
+    {{- end }}
+  {{- end }}
+
+{{- else if contains "NodePort" .Values.service.type }}
+
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "apache.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT/
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+** Please ensure an external IP is associated to the {{ template "apache.fullname" . }} service before proceeding **
+** Watch the status using: kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "apache.fullname" . }} **
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "apache.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+{{- $port:=.Values.service.port | toString }}
+  echo URL            : http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}/
+{{- else if contains "ClusterIP"  .Values.service.type }}
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "apache.fullname" . }} 8080:{{ .Values.service.port}}
+  echo URL            : http://127.0.0.1:8080/
+{{- end }}
+
+{{/* WARNINGS */}}
+{{- if not (include "apache.useHtdocs" .) }}
 WARNING: You did not provide a custom web application. Apache will be deployed with a default page. Check the README section "Deploying your custom web application" in https://github.com/bitnami/charts/blob/master/bitnami/apache/README.md#deploying-your-custom-web-application.
 {{- end }}
-
 {{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
-
 WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
 +info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
-
 {{- end }}
+
+{{ include "apache.validateValues" . }}

--- a/bitnami/apache/templates/_helpers.tpl
+++ b/bitnami/apache/templates/_helpers.tpl
@@ -126,7 +126,7 @@ Also, we can't use a single if because lazy evaluation is not an option
 Return true if mouting a static web page
 */}}
 {{- define "apache.useHtdocs" -}}
-{{ or .Values.cloneHtdocsFromGit.enabled .Values.htdocsConfigMap .Values.htdocsPVC }}
+{{ default "" (or .Values.cloneHtdocsFromGit.enabled .Values.htdocsConfigMap .Values.htdocsPVC) }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
**Description of the change**

- Add some useful information to the `NOTE.txt`.

- Fix a helper that was not working properly.

**Benefits**

- The user of the chart can easily find information about the deployment such as the URL of the apache server.

**Possible drawbacks**

NO

**Applicable issues**

NO

**Additional information**

NO

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
