### PR TITLE
[bitnami/postgresql-ha] Fix extended ConfigMap and NetworkPolicy

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql-ha
-version: 1.1.1
+version: 1.1.2
 appVersion: 11.6.0
 description: Chart for PostgreSQL with HA architecture (using Replication Manager (repmgr) and Pgpool).
 keywords:

--- a/bitnami/postgresql-ha/templates/networkpolicy.yaml
+++ b/bitnami/postgresql-ha/templates/networkpolicy.yaml
@@ -12,15 +12,15 @@ spec:
     # Allow inbound connections
     - ports:
         - port: 5432
-          {{- if not .Values.networkPolicy.allowExternal }}
-          from:
-            - podSelector:
-                matchLabels:
-                  {{ template "postgresql-ha.fullname" . }}-client: "true"
-            - podSelector:
-                matchLabels: {{- include "postgresql-ha.matchLabels" . | nindent 18 }}
-                  app.kubernetes.io/component: pgpool
-          {{- end }}
+      {{- if not .Values.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels:
+              {{ template "postgresql-ha.fullname" . }}-client: "true"
+        - podSelector:
+            matchLabels: {{- include "postgresql-ha.matchLabels" . | nindent 14 }}
+              app.kubernetes.io/component: pgpool
+      {{- end }}
     # Allow prometheus scrapes
     - ports:
         - port: 9187

--- a/bitnami/postgresql-ha/templates/postgresql/extended-configmap.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/extended-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Files.Glob "files/conf.d/*.conf") .Values.postgresql.extendedConf (not .Values.postgresql.extendedConfCM) }}
+{{- if and (or (.Files.Glob "files/conf.d/*.conf") .Values.postgresql.extendedConf) (not .Values.postgresql.extendedConfCM) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
**Description of the change**
Changes the condition that defines whether the `extended-configmap.yaml` manifest is applied. The previous one was wrong because it depended on some local files to exist.

Also fixes the NetworkPolicy, which had an invalid definition.

**Applicable issues**

  - fixes #1755

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
