### PR TITLE
[bitnami/nginx-ingress-controller]: Add metricRelabelings to ServiceMonitor

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress-controller
-version: 5.2.0
+version: 5.2.1
 appVersion: 0.26.1
 description: Chart for the nginx Ingress controller
 keywords:

--- a/bitnami/nginx-ingress-controller/README.md
+++ b/bitnami/nginx-ingress-controller/README.md
@@ -132,6 +132,7 @@ Parameter | Description | Default
 `metrics.serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`
 `metrics.serviceMonitor.namespace` | namespace where servicemonitor resource should be created | `the same namespace as nginx ingress`
 `metrics.serviceMonitor.honorLabels` | honorLabels chooses the metric's labels on collisions with target labels. | `false`
+`metrics.serviceMonitor.metricRelabelings` | metricRelabelings which should be applied to the ServiceMonitor. | `[]`
 `metrics.prometheusRule.enabled` | Set this to `true` to create prometheusRules for Prometheus operator | `false`
 `metrics.prometheusRule.additionalLabels` | Additional labels that can be used so prometheusRules will be discovered by Prometheus | `{}`
 `metrics.prometheusRule.namespace` | Namespace where prometheusRules resource should be created | `the same namespace as nginx ingress`

--- a/bitnami/nginx-ingress-controller/templates/controller-servicemonitor.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-servicemonitor.yaml
@@ -18,6 +18,9 @@ spec:
       {{- if .Values.metrics.serviceMonitor.honorLabels }}
       honorLabels: true
       {{- end }}
+      {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- include "nginx-ingress.tplValue" ( dict "value" .Values.metrics.serviceMonitor.metricRelabelings "context" $) | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}


### PR DESCRIPTION
Signed-off-by: Christian Kotzbauer <christian.kotzbauer@gmail.com>

**Description of the change**
Add metricRelabelings to ServiceMonitor definition.

**Benefits**
MetricRelabelings can be configured for ServiceMonitor.

**Possible drawbacks**

**Applicable issues**

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
