### PR TITLE
[bitnami/node-exporter]: Add metricRelabelings to ServiceMonitor

### DIFF
--- a/bitnami/node-exporter/Chart.yaml
+++ b/bitnami/node-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.18.1
 description: Prometheus exporter for hardware and OS metrics exposed by UNIX kernels, with pluggable metric collectors.
 name: node-exporter
-version: 0.1.1
+version: 0.1.2
 keywords:
   - prometheus
   - node-exporter

--- a/bitnami/node-exporter/README.md
+++ b/bitnami/node-exporter/README.md
@@ -109,6 +109,7 @@ The following table lists the configurable parameters of the Node Exporter chart
 | `serviceMonitor.interval`            | Scrape interval (use by default, falling back to Prometheus' default)                                    | `nil`                                                                     |
 | `serviceMonitor.jobLabel`            | The name of the label on the target service to use as the job name in prometheus.                        | `nil`                                                                     |
 | `serviceMonitor.selector`            | ServiceMonitor selector labels                                                                           | `[]`                                                                      |
+| `serviceMonitor.metricRelabelings`   | ServiceMonitor metricRelabelings                                                                         | `[]`                                                                      |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example the following command sets the `minReadySeconds` of the Node Exporter Pods to `120` seconds.
 

--- a/bitnami/node-exporter/templates/servicemonitor.yaml
+++ b/bitnami/node-exporter/templates/servicemonitor.yaml
@@ -24,6 +24,9 @@ spec:
       {{- if .Values.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
       {{- end }}
+      {{- if .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- include "node-exporter.tplValue" ( dict "value" .Values.serviceMonitor.metricRelabelings "context" $) | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/bitnami/node-exporter/values.yaml
+++ b/bitnami/node-exporter/values.yaml
@@ -220,3 +220,8 @@ serviceMonitor:
   ##
   # selector:
   #   prometheus: my-prometheus
+
+  ## Metric relabeling
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+  ##
+  # metricRelabelings: []


### PR DESCRIPTION
Signed-off-by: Christian Kotzbauer <christian.kotzbauer@gmail.com>

**Description of the change**
Add metricRelabelings to ServiceMonitor definition.

**Benefits**
MetricRelabelings can be configured for ServiceMonitor.

**Possible drawbacks**

**Applicable issues**

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
