### PR TITLE
[bitnami/harbor] Fix wrong value configmap (#1720)

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: harbor
-version: 3.0.9
+version: 3.0.10
 appVersion: 1.10.0
 description: Harbor is an an open source trusted cloud native registry project that stores, signs, and scans content
 keywords:

--- a/bitnami/harbor/templates/core/core-cm-envvars.yaml
+++ b/bitnami/harbor/templates/core/core-cm-envvars.yaml
@@ -8,7 +8,7 @@ data:
   POSTGRESQL_HOST: "{{ template "harbor.database.host" . }}"
   POSTGRESQL_PORT: "{{ template "harbor.database.port" . }}"
   POSTGRESQL_USERNAME: "{{ template "harbor.database.username" . }}"
-  POSTGRESQL_DATABASE: "registry"
+  POSTGRESQL_DATABASE: "{{ template "harbor.database.coreDatabase" . }}"
   POSTGRESQL_SSLMODE: "{{ template "harbor.database.sslmode" . }}"
   EXT_ENDPOINT: "{{ template "harbor.externalUrl" . }}"
   CORE_URL: "http://{{ template "harbor.core" . }}"


### PR DESCRIPTION
**Description of the change**
In order to be able to use properly an external database, this env. var in the configmap should use the following template instead of the hardcoded value:
```
{{- define "harbor.database.coreDatabase" -}}
  {{- if eq .Values.postgresql.enabled true -}}
    {{- printf "%s" "registry" -}}
  {{- else -}}
    {{- .Values.externalDatabase.coreDatabase -}}
  {{- end -}}
{{- end -}}
```

This is a continuation of the fixes done in this previous PR: #1720

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files