### PR TITLE
[bitnami/influxdb] use the POD_IP in health checks

### DIFF
--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: influxdb
 sources:
   - https://github.com/bitnami/bitnami-docker-influxdb
-version: 0.3.0
+version: 0.3.1

--- a/bitnami/influxdb/templates/influxdb/standalone-dpl.yaml
+++ b/bitnami/influxdb/templates/influxdb/standalone-dpl.yaml
@@ -80,6 +80,10 @@ spec:
           env:
             - name: BITNAMI_DEBUG
               value: {{ ternary "true" "false" .Values.image.debug | quote }}
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: INFLUXDB_HTTP_AUTH_ENABLED
               value: {{ .Values.authEnabled | quote }}
             {{- if .Values.adminUser.name }}
@@ -163,7 +167,7 @@ spec:
                   if [[ -f "${INFLUXDB_ADMIN_USER_PASSWORD_FILE:-}" ]]; then
                       export INFLUXDB_ADMIN_USER_PASSWORD="$(< "${INFLUXDB_ADMIN_USER_PASSWORD_FILE}")"
                   fi
-                  {{ if .Values.authEnabled }}INFLUX_USERNAME="$INFLUXDB_ADMIN_USER" INFLUX_PASSWORD="$INFLUXDB_ADMIN_USER_PASSWORD"{{ end }} timeout {{ $livenessTimeout }}s influx -host 127.0.0.1 -port {{ .Values.influxdb.containerPorts.http }} -execute "SHOW DATABASES"
+                  {{ if .Values.authEnabled }}INFLUX_USERNAME="$INFLUXDB_ADMIN_USER" INFLUX_PASSWORD="$INFLUXDB_ADMIN_USER_PASSWORD"{{ end }} timeout {{ $livenessTimeout }}s influx -host $POD_IP -port {{ .Values.influxdb.containerPorts.http }} -execute "SHOW DATABASES"
             initialDelaySeconds: {{ .Values.influxdb.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.influxdb.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.influxdb.livenessProbe.timeoutSeconds }}
@@ -181,7 +185,7 @@ spec:
                   if [[ -f "${INFLUXDB_ADMIN_USER_PASSWORD_FILE:-}" ]]; then
                       export INFLUXDB_ADMIN_USER_PASSWORD="$(< "${INFLUXDB_ADMIN_USER_PASSWORD_FILE}")"
                   fi
-                  {{ if .Values.authEnabled }}INFLUX_USERNAME="$INFLUXDB_ADMIN_USER" INFLUX_PASSWORD="$INFLUXDB_ADMIN_USER_PASSWORD"{{ end }} timeout {{ $readinessTimeout }}s influx -host 127.0.0.1 -port {{ .Values.influxdb.containerPorts.http }} -execute "SHOW DATABASES"
+                  {{ if .Values.authEnabled }}INFLUX_USERNAME="$INFLUXDB_ADMIN_USER" INFLUX_PASSWORD="$INFLUXDB_ADMIN_USER_PASSWORD"{{ end }} timeout {{ $readinessTimeout }}s influx -host $POD_IP -port {{ .Values.influxdb.containerPorts.http }} -execute "SHOW DATABASES"
             initialDelaySeconds: {{ .Values.influxdb.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.influxdb.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.influxdb.readinessProbe.timeoutSeconds }}

--- a/bitnami/influxdb/templates/influxdb/statefulset.yaml
+++ b/bitnami/influxdb/templates/influxdb/statefulset.yaml
@@ -81,6 +81,10 @@ spec:
           env:
             - name: BITNAMI_DEBUG
               value: {{ ternary "true" "false" .Values.image.debug | quote }}
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: INFLUXDB_HTTP_AUTH_ENABLED
               value: {{ .Values.authEnabled | quote }}
             {{- if .Values.adminUser.name }}
@@ -164,7 +168,7 @@ spec:
                   if [[ -f "${INFLUXDB_ADMIN_USER_PASSWORD_FILE:-}" ]]; then
                       export INFLUXDB_ADMIN_USER_PASSWORD="$(< "${INFLUXDB_ADMIN_USER_PASSWORD_FILE}")"
                   fi
-                  {{ if .Values.authEnabled }}INFLUX_USERNAME="$INFLUXDB_ADMIN_USER" INFLUX_PASSWORD="$INFLUXDB_ADMIN_USER_PASSWORD"{{ end }} timeout {{ $livenessTimeout }}s influx -host 127.0.0.1 -port {{ .Values.influxdb.containerPorts.http }} -execute "SHOW DATABASES"
+                  {{ if .Values.authEnabled }}INFLUX_USERNAME="$INFLUXDB_ADMIN_USER" INFLUX_PASSWORD="$INFLUXDB_ADMIN_USER_PASSWORD"{{ end }} timeout {{ $livenessTimeout }}s influx -host $POD_IP -port {{ .Values.influxdb.containerPorts.http }} -execute "SHOW DATABASES"
             initialDelaySeconds: {{ .Values.influxdb.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.influxdb.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.influxdb.livenessProbe.timeoutSeconds }}
@@ -182,7 +186,7 @@ spec:
                   if [[ -f "${INFLUXDB_ADMIN_USER_PASSWORD_FILE:-}" ]]; then
                       export INFLUXDB_ADMIN_USER_PASSWORD="$(< "${INFLUXDB_ADMIN_USER_PASSWORD_FILE}")"
                   fi
-                  {{ if .Values.authEnabled }}INFLUX_USERNAME="$INFLUXDB_ADMIN_USER" INFLUX_PASSWORD="$INFLUXDB_ADMIN_USER_PASSWORD"{{ end }} timeout {{ $readinessTimeout }}s influx -host 127.0.0.1 -port {{ .Values.influxdb.containerPorts.http }} -execute "SHOW DATABASES"
+                  {{ if .Values.authEnabled }}INFLUX_USERNAME="$INFLUXDB_ADMIN_USER" INFLUX_PASSWORD="$INFLUXDB_ADMIN_USER_PASSWORD"{{ end }} timeout {{ $readinessTimeout }}s influx -host $POD_IP -port {{ .Values.influxdb.containerPorts.http }} -execute "SHOW DATABASES"
             initialDelaySeconds: {{ .Values.influxdb.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.influxdb.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.influxdb.readinessProbe.timeoutSeconds }}

--- a/bitnami/influxdb/values-production.yaml
+++ b/bitnami/influxdb/values-production.yaml
@@ -193,14 +193,14 @@ influxdb:
   ##
   livenessProbe:
     enabled: true
-    initialDelaySeconds: 30
+    initialDelaySeconds: 180
     periodSeconds: 45
     timeoutSeconds: 30
     successThreshold: 1
     failureThreshold: 6
   readinessProbe:
     enabled: true
-    initialDelaySeconds: 5
+    initialDelaySeconds: 60
     periodSeconds: 45
     timeoutSeconds: 30
     successThreshold: 1

--- a/bitnami/influxdb/values.yaml
+++ b/bitnami/influxdb/values.yaml
@@ -193,14 +193,14 @@ influxdb:
   ##
   livenessProbe:
     enabled: true
-    initialDelaySeconds: 30
+    initialDelaySeconds: 180
     periodSeconds: 45
     timeoutSeconds: 30
     successThreshold: 1
     failureThreshold: 6
   readinessProbe:
     enabled: true
-    initialDelaySeconds: 5
+    initialDelaySeconds: 60
     periodSeconds: 45
     timeoutSeconds: 30
     successThreshold: 1


### PR DESCRIPTION
**Description of the change**

Since the host address 127.0.0.1 was being used in the health checks, they were incorrectly 
reporting the pods to be ready when the influxdb container was being initialized.

In this PR we switched to using the POD_IP and as a result the health checks should 
report the pods as ready only when they are ready to accept external connection (i.e.
after the initialization and setup is complete)

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files