### PR TITLE
[bitnami/node] Add GitLab autodevops support

### DIFF
--- a/bitnami/node/Chart.yaml
+++ b/bitnami/node/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node
-version: 11.3.1
+version: 11.4.0
 appVersion: 10.18.0
 description: Event-driven I/O server-side JavaScript environment based on V8
 keywords:

--- a/bitnami/node/README.md
+++ b/bitnami/node/README.md
@@ -75,6 +75,7 @@ The following table lists the configurable parameters of the Node chart and thei
 | `git.repository`                        | Git image name                                                              | `bitnami/git`                                           |
 | `git.tag`                               | Git image tag                                                               | `{TAG_NAME}`                                            |
 | `git.pullPolicy`                        | Git image pull policy                                                       | `IfNotPresent`                                          |
+| `getAppFromExternalRepository`          | Whether to get app from external git repo or not                            | `true`                                                  |
 | `repository`                            | Repo of the application                                                     | `https://github.com/bitnami/sample-mean.git`            |
 | `revision`                              | Revision to checkout                                                        | `master`                                                |
 | `replicas`                              | Number of replicas for the application                                      | `1`                                                     |

--- a/bitnami/node/templates/_helpers.tpl
+++ b/bitnami/node/templates/_helpers.tpl
@@ -86,7 +86,7 @@ Also, we can't use a single if because lazy evaluation is not an option
         {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
     {{- end -}}
 {{- else -}}
-    {{- if .Values.image.registry -}}
+    {{- if $registryName -}}
         {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
     {{- else -}}
         {{- printf "%s:%s" $repositoryName $tag -}}
@@ -113,7 +113,7 @@ Also, we can't use a single if because lazy evaluation is not an option
         {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
     {{- end -}}
 {{- else -}}
-    {{- if .Values.git.registry -}}
+    {{- if $registryName -}}
         {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
     {{- else -}}
         {{- printf "%s:%s" $repositoryName $tag -}}
@@ -193,7 +193,7 @@ Also, we can't use a single if because lazy evaluation is not an option
         {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
     {{- end -}}
 {{- else -}}
-    {{- if .Values.volumePermissions.image.registry -}}
+    {{- if $registryName -}}
         {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
     {{- else -}}
         {{- printf "%s:%s" $repositoryName $tag -}}

--- a/bitnami/node/templates/_helpers.tpl
+++ b/bitnami/node/templates/_helpers.tpl
@@ -86,7 +86,11 @@ Also, we can't use a single if because lazy evaluation is not an option
         {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
     {{- end -}}
 {{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- if .Values.image.registry -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s:%s" $repositoryName $tag -}}
+    {{- end -}}
 {{- end -}}
 {{- end -}}
 
@@ -109,7 +113,11 @@ Also, we can't use a single if because lazy evaluation is not an option
         {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
     {{- end -}}
 {{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- if .Values.git.registry -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s:%s" $repositoryName $tag -}}
+    {{- end -}}
 {{- end -}}
 {{- end -}}
 
@@ -185,7 +193,11 @@ Also, we can't use a single if because lazy evaluation is not an option
         {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
     {{- end -}}
 {{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- if .Values.volumePermissions.image.registry -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s:%s" $repositoryName $tag -}}
+    {{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/node/templates/deployment.yaml
+++ b/bitnami/node/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- end }}
       initContainers:
+        {{- if .Values.getAppFromExternalRepository }}
         - name: git-clone-repository
           image: {{ include "git.image" . }}
           imagePullPolicy: {{ .Values.git.pullPolicy | quote }}
@@ -70,6 +71,7 @@ spec:
           volumeMounts:
             - name: data
               mountPath: {{ .Values.persistence.path }}
+        {{- end }}
         {{- end }}
       containers:
         - name: node
@@ -164,13 +166,17 @@ spec:
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
+            {{- if .Values.getAppFromExternalRepository }}
             - name: app
               mountPath: /app
+            {{- end }}
             - name: data
               mountPath: {{ .Values.persistence.path }}
       volumes:
+        {{- if .Values.getAppFromExternalRepository }}
         - name: app
           emptyDir: {}
+        {{- end }}
         - name: data
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:

--- a/bitnami/node/values.yaml
+++ b/bitnami/node/values.yaml
@@ -81,6 +81,11 @@ git:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+## Enable to download app from external git repository.
+## Disable it if your docker image already includes your application at /app
+##
+getAppFromExternalRepository: true
+
 ## Git repository http/https
 ##
 repository: https://github.com/bitnami/sample-mean.git


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This PRs adds a new feature and a small improvement.

**New feature:** It is possible to deploy a custom nodejs image with an application already included. Previously, the chart could only deploy a generic node container and initialize the application by cloning a git repo using initContainers. (Use getAppFromExternalRepository)

**Small improvement**: It modifies images helper functions to allow passing an empty registry. This is needed because GitLab AutoDevops included registry and repository info in our repository variable. If we don't set an empty registry we would get something like `default-registry/gitlab-registry/image-name:tag` 

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
