### PR TITLE
[bitnami/prometheus-operator]: Fix additionalScrapeConfig usage

### DIFF
--- a/bitnami/prometheus-operator/Chart.yaml
+++ b/bitnami/prometheus-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.34.0
 description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 name: prometheus-operator
-version: 0.7.6
+version: 0.7.7
 keywords:
 - prometheus
 - alertmanager

--- a/bitnami/prometheus-operator/Chart.yaml
+++ b/bitnami/prometheus-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.34.0
 description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 name: prometheus-operator
-version: 0.7.7
+version: 0.8.0
 keywords:
 - prometheus
 - alertmanager

--- a/bitnami/prometheus-operator/README.md
+++ b/bitnami/prometheus-operator/README.md
@@ -210,7 +210,7 @@ The following table lists the configurable parameters of the Prometheus Operator
 | `prometheus.storageSpec`                      | Prometheus StorageSpec for persistent data                                           | `{}`                                                                   |
 | `prometheus.priorityClassName`                | Priority class assigned to the Pods                                                  | ``                                                                     |
 | `prometheus.containers`                       | Containers allows injecting additional containers                                    | `[]`                                                                   |
-| `prometheus.additionalScrapeConfigsExternal`  | Enable additional scrape configs that are managed externally to this chart           | `false` See [docs](##additional-scrape-configurations) for details.    |
+| `prometheus.additionalScrapeConfigsExternal`  | Enable additional scrape configs that are managed externally to this chart           | `false` See [docs](#additional-scrape-configurations) for details.    |
 
 ### Alertmanager Parameters
 

--- a/bitnami/prometheus-operator/README.md
+++ b/bitnami/prometheus-operator/README.md
@@ -210,7 +210,7 @@ The following table lists the configurable parameters of the Prometheus Operator
 | `prometheus.storageSpec`                      | Prometheus StorageSpec for persistent data                                           | `{}`                                                                   |
 | `prometheus.priorityClassName`                | Priority class assigned to the Pods                                                  | ``                                                                     |
 | `prometheus.containers`                       | Containers allows injecting additional containers                                    | `[]`                                                                   |
-| `prometheus.additionalScrapeConfigsExternal`  | Enable additional scrape configs that are managed externally to this chart           | `false` See [docs](#additionalScrape) for details.                     |
+| `prometheus.additionalScrapeConfigsExternal`  | Enable additional scrape configs that are managed externally to this chart           | `false` See [docs](##additional-scrape-configurations) for details.    |
 
 ### Alertmanager Parameters
 
@@ -351,7 +351,7 @@ This chart includes a `values-production.yaml` file where you can find some para
 +   logLevel: error
 ```
 
-### <a name="additionalScrape"></a>Additonal scrape configurations
+### Additional scrape configurations
 
 It is possible to inject externally managed scrape configurations in a ConfigMap by enabling `prometheus.additionalScrapeConfigsExternal`. The ConfigMap must exist in the same namespace when Prometheus is starting. Its name is generated using the `prometheus-operator.prometheus.fullname` template with a `-scrape-config` suffix. The file it contains has to be named `additional-scrape-configs.yaml`.
 

--- a/bitnami/prometheus-operator/README.md
+++ b/bitnami/prometheus-operator/README.md
@@ -210,7 +210,7 @@ The following table lists the configurable parameters of the Prometheus Operator
 | `prometheus.storageSpec`                      | Prometheus StorageSpec for persistent data                                           | `{}`                                                                   |
 | `prometheus.priorityClassName`                | Priority class assigned to the Pods                                                  | ``                                                                     |
 | `prometheus.containers`                       | Containers allows injecting additional containers                                    | `[]`                                                                   |
-| `prometheus.additionalScrapeConfigsExternal`  | Enable additional scrape configs that are managed externally to this chart           | `false`                                                                |
+| `prometheus.additionalScrapeConfigsExternal`  | Enable additional scrape configs that are managed externally to this chart           | `false` See [docs](#additionalScrape) for details.                     |
 
 ### Alertmanager Parameters
 
@@ -350,6 +350,10 @@ This chart includes a `values-production.yaml` file where you can find some para
 -   logLevel: info
 +   logLevel: error
 ```
+
+### <a name="additionalScrape"></a>Additonal scrape configurations
+
+It is possible to inject externally managed scrape configurations in a ConfigMap by enabling `prometheus.additionalScrapeConfigsExternal`. The ConfigMap must exist in the same namespace when Prometheus is starting. Its name is generated using the `prometheus-operator.prometheus.fullname` template with a `-scrape-config` suffix. The file it contains has to be named `additional-scrape-configs.yaml`.
 
 ## Upgrading
 

--- a/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -137,7 +137,7 @@ spec:
     {{- if .Values.prometheus.podAffinity }}
     podAffinity: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.podAffinity "context" $) | nindent 6 }}
     {{- end }}
-    {{- if or .Values.prometheus.additionalScrapeConfigsExternal }}
+    {{- if .Values.prometheus.additionalScrapeConfigsExternal }}
     additionalScrapeConfigs:
       name: {{ template "prometheus-operator.prometheus.fullname" . }}-scrape-config
       key: additional-scrape-configs.yaml

--- a/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -137,6 +137,11 @@ spec:
     {{- if .Values.prometheus.podAffinity }}
     podAffinity: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.podAffinity "context" $) | nindent 6 }}
     {{- end }}
+    {{- if or .Values.prometheus.additionalScrapeConfigsExternal }}
+    additionalScrapeConfigs:
+      name: {{ template "prometheus-operator.prometheus.fullname" . }}-scrape-config
+      key: additional-scrape-configs.yaml
+    {{- end }}
 {{- include "prometheus-operator.prometheus.imagePullSecrets" . | indent 2 }}
   {{- if .Values.prometheus.containers }}
   containers: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.containers "context" $) | nindent 4 }}


### PR DESCRIPTION
Signed-off-by: Christian Kotzbauer <christian.kotzbauer@gmail.com>

**Description of the change**
- The flag "additionalScrapeConfigsExternal" in values.yaml was never used before. If it is true now, a "additionalScrapeConfigs" Block is added to the Prometheus CRD.

**Benefits**
- Scrape configs can be defined in external configMaps.

**Possible drawbacks**

**Applicable issues**

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
