### PR TITLE
[bitnami/etcd] support snapshot restore on single node deployment

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: etcd
-version: 4.4.7
+version: 4.4.8
 appVersion: 3.4.3
 description: etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines
 keywords:

--- a/bitnami/etcd/templates/scripts-configmap.yaml
+++ b/bitnami/etcd/templates/scripts-configmap.yaml
@@ -115,18 +115,18 @@ data:
 
     if [[ ! -d "$ETCD_DATA_DIR" ]]; then
         echo "==> Creating data dir..." 1>&3 2>&4
-        mkdir -p "$ETCD_DATA_DIR" 1>&3 2>&4
         echo "==> There is no data at all. Initializing a new member of the cluster..." 1>&3 2>&4
 {{- if .Values.startFromSnapshot.enabled }}
         if [[ -f "/init-snapshot/{{ $initSnapshotFilename }}" ]]; then
             echo "==> Initializing member by restoring etcd cluster from snapshot..." 1>&3 2>&4
-
             etcdctl snapshot restore /init-snapshot/{{ $initSnapshotFilename }} \
+            {{- if gt $replicaCount 1 }}
               --name $ETCD_NAME \
-              --data-dir $ETCD_DATA_DIR \
               --initial-cluster $ETCD_INITIAL_CLUSTER \
               --initial-cluster-token $ETCD_INITIAL_CLUSTER_TOKEN \
-              --initial-advertise-peer-urls $ETCD_INITIAL_ADVERTISE_PEER_URLS 1>&3 2>&4
+              --initial-advertise-peer-urls $ETCD_INITIAL_ADVERTISE_PEER_URLS \
+            {{- end }}
+              --data-dir $ETCD_DATA_DIR 1>&3 2>&4
             store_member_id & 1>&3 2>&4
         else
             echo "==> There was no snapshot to perform data recovery!!" 1>&3 2>&4


### PR DESCRIPTION
**Description of the change**

Snapshot restore does not work for single node deployments. 

**Applicable issues**

  - fixes #1784

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.