### PR TITLE
[bitnami/zookeeper] fix metrics pod labels

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zookeeper
-version: 5.3.0
+version: 5.3.1
 appVersion: 3.5.6
 description: A centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services for distributed applications.
 keywords:

--- a/bitnami/zookeeper/templates/metrics-deployment.yaml
+++ b/bitnami/zookeeper/templates/metrics-deployment.yaml
@@ -16,6 +16,7 @@ spec:
       annotations: {{- toYaml .Values.metrics.podAnnotations | nindent 8 }}
       {{- end }}
       labels: {{- include "zookeeper.labels" . | nindent 8 }}
+        app.kubernetes.io/component: metrics
       {{- if .Values.metrics.podLabels }}
       {{- toYaml .Values.metrics.podLabels | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
**Description of the change**

The zookeeper exporter deployment would fail because the `selector` did not match template `labels`. This PR 
fixes the labels accordingly.

**Benefits**

Metrics exporter can be abled on the chart

**Possible drawbacks**

None

**Applicable issues**

  - #1796

**Additional information**

The zookeeper version in the kafka chart should be updated after merging this PR

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files