### PR TITLE
[bitnami/mysql] Add datadir path to mysqld configuration

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mysql
-version: 6.7.0
+version: 6.7.1
 appVersion: 8.0.18
 description: Chart to create a Highly available MySQL cluster
 keywords:

--- a/bitnami/mysql/values-production.yaml
+++ b/bitnami/mysql/values-production.yaml
@@ -149,6 +149,7 @@ master:
     plugin_dir=/opt/bitnami/mysql/plugin
     port=3306
     socket=/opt/bitnami/mysql/tmp/mysql.sock
+    datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
     bind-address=0.0.0.0
@@ -287,6 +288,7 @@ slave:
     basedir=/opt/bitnami/mysql
     port=3306
     socket=/opt/bitnami/mysql/tmp/mysql.sock
+    datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
     bind-address=0.0.0.0

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -153,6 +153,7 @@ master:
     plugin_dir=/opt/bitnami/mysql/plugin
     port=3306
     socket=/opt/bitnami/mysql/tmp/mysql.sock
+    datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
     bind-address=0.0.0.0
@@ -291,6 +292,7 @@ slave:
     basedir=/opt/bitnami/mysql
     port=3306
     socket=/opt/bitnami/mysql/tmp/mysql.sock
+    datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
     bind-address=0.0.0.0


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

 Added the corrected path to the mysqld configuration. After crashing, master and slave pods would try and access `/opt/bitnami/mysql/data` instead of `/bitnami/mysql/data`

**Benefits**

 Pods will be able to start up again after a crash.

**Possible drawbacks**

  None

**Applicable issues**

  - fixes #1739

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
