### PR TITLE
[bitnami/spark] Fix spark notes errors

### DIFF
--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 1.2.0
+version: 1.2.1
 appVersion: 2.4.4
 description: Spark is a fast and general-purpose cluster computing system.
 name: spark

--- a/bitnami/spark/ci/values-with-ingress-and-autoscaling.yaml
+++ b/bitnami/spark/ci/values-with-ingress-and-autoscaling.yaml
@@ -1,6 +1,5 @@
 # Test values file for generating all of the yaml and check that
 # the rendering is correct
-
 ingress:
   enabled: true
 

--- a/bitnami/spark/templates/NOTES.txt
+++ b/bitnami/spark/templates/NOTES.txt
@@ -4,16 +4,17 @@
   echo "Spark-master URL: http://$HOSTNAME/"
 {{- else }}
 {{- if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "spark.fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "spark.master.service.name" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "spark.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "spark.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+    You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "spark.master.service.name" . }}'
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} | awk '/{{ include "spark.master.service.name" . }}/ { print $4 }')
   echo http://$SERVICE_IP:{{ .Values.service.webPort }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "spark.fullname" . }}-master-svc {{ default "80" .Values.service.webPort }}:{{ default "80" .Values.service.webPort }}
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "spark.master.service.name" . }} {{ default "80" .Values.service.webPort }}:{{ default "80" .Values.service.webPort }}
   echo "Visit http://127.0.0.1:{{ .Values.service.webPort }} to use your application"
 {{- end }}
 {{- end }}
@@ -21,16 +22,19 @@
 2. Submit an application to the cluster:
 
   To submit an application to the cluster the spark-submit script must be used. That script can be
-  obtained at https://github.com/apache/spark/tree/master/bin.
+  obtained at https://github.com/apache/spark/tree/master/bin. Also you can use bitnami/spark docker image. 
 
   First, obtain the master IP, to do that the service type must be NodePort or LoadBalancer. Run the following command to obtain the master IP and submit your application:
 
-{{- if or (contains "NodePort" .Values.service.type) (contains "LoadBalancer" .Values.service.type) }}
-  $ export MASTER_IP=$(kubectl get services | awk '/{{ include "spark.fullname" . }}/ { print $3 }')
-  $ spark-submit --master spark://$MASTER_IP:{{ .Values.service.clusterPort }} --deploy-mode cluster  /path/to/application 1000
+{{ if or (eq "NodePort" .Values.service.type) (eq "LoadBalancer" .Values.service.type) }}
+  export MASTER_IP=$(kubectl get services | awk '/{{ include "spark.master.service.name" . }}/ { print $4 }')
+  docker run -ti bitnami/spark spark-submit --master spark://$MASTER_IP:{{ .Values.service.clusterPort }} \
+    --deploy-mode cluster \
+    --class org.apache.spark.examples.SparkPi \
+    examples/jars/spark-examples_2.11-2.4.4.jar 1000
 {{- else }}
-  $ kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "spark.fullname" . }}-master-svc {{ default "7077" .Values.service.clusterPort }}:{{ default "7077" .Values.service.clusterPort }}
-  $ spark-submit --master spark://127.0.0.1:{{ .Values.master.clusterPort }} --deploy-mode cluster  /path/to/application 1000
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "spark.master.service.name" . }} {{ default "7077" .Values.service.clusterPort }}:{{ default "7077" .Values.service.clusterPort }}
+  spark-submit --master spark://127.0.0.1:{{ .Values.master.clusterPort }} --deploy-mode cluster  /path/to/application 1000
 {{- end }}
 
 ** IMPORTANT: When submit an application the --master parameter should be set to the service IP, if not, the application will not resolve the master. **

--- a/bitnami/spark/templates/_helpers.tpl
+++ b/bitnami/spark/templates/_helpers.tpl
@@ -48,6 +48,14 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 {{- end -}}
 
+{{- /* 
+As we use a headless service we need to append -master-svc to 
+the service name. 
+*/ -}}
+{{- define "spark.master.service.name" -}}
+{{ include "spark.fullname" . }}-master-svc
+{{- end -}}
+
 {{- /*
 Create chart name and version as used by the chart label.
 */}}

--- a/bitnami/spark/templates/ingress.yaml
+++ b/bitnami/spark/templates/ingress.yaml
@@ -20,7 +20,7 @@ spec:
         paths:
           - path: {{ default "/" .path }}
             backend:
-              serviceName: {{ include "spark.fullname" $ }}-master-svc
+              serviceName: {{ include "spark.master.service.name" $ }}
               servicePort: http
     {{- end }}
   {{- if .Values.ingress.tls }}

--- a/bitnami/spark/templates/ingress.yaml
+++ b/bitnami/spark/templates/ingress.yaml
@@ -25,6 +25,12 @@ spec:
     {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
-{{ toYaml .Values.ingress.tls | indent 4 }}
-  {{- end }}
+  {{- range $i, $tls := .Values.ingress.tls }}
+    - hosts:
+      {{- range $e, $host := $tls.hosts }}
+        - {{ $host }}
+      {{ end -}}
+      secretName: {{ $tls.secretName }}
+  {{ end -}}
+  {{- end -}}
 {{- end }}

--- a/bitnami/spark/templates/statefulset-worker.yaml
+++ b/bitnami/spark/templates/statefulset-worker.yaml
@@ -88,7 +88,7 @@ spec:
             - name: SPARK_DAEMON_JAVA_OPTS
               value: {{ .Values.worker.javaOptions | quote }}
             - name: SPARK_MASTER_URL
-              value: spark://{{ include "spark.fullname" . }}-master-svc:{{ .Values.service.clusterPort }}
+              value: spark://{{ include "spark.master.service.name" . }}:{{ .Values.service.clusterPort }}
             # If you use a custom properties file, it must be loaded using a ConfigMap
             - name: SPARK_WORKER_OPTS
               value: {{ .Values.worker.configOptions }}

--- a/bitnami/spark/templates/svc-master.yaml
+++ b/bitnami/spark/templates/svc-master.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "spark.fullname" . }}-master-svc
+  name: {{ include "spark.master.service.name" . }}
   labels: {{- include "spark.labels" . | nindent 4 }}
   {{- if .Values.service.annotations }}
   annotations: {{- include "spark.tplValue" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}

--- a/bitnami/spark/values-production.yaml
+++ b/bitnami/spark/values-production.yaml
@@ -224,6 +224,12 @@ worker:
     failureThreshold: 6
     successThreshold: 1
 
+  ## Array to add extra volumes
+  ##
+  ## extraVolumes:
+  ## Array to add extra mounts (normally used with extraVolumes)
+  ##
+  ## extraVolumeMounts: {}
   ## Autoscaling parameters
   ##
   autoscaling:
@@ -232,14 +238,6 @@ worker:
     CpuTargetPercentage: 50
     ## Max number of workers when using autoscaling
     replicasMax: 10
-
-  ## Array to add extra volumes
-  ##
-  ## extraVolumes:
-
-  ## Array to add extra mounts (normally used with extraVolumes)
-  ##
-  ## extraVolumeMounts: {}
 
 ## Security configuration
 ##
@@ -325,6 +323,6 @@ ingress:
     - name: spark.local
       path: /
   tls:
-  - hosts:
-    - spark.domain.com
-    secretName: spark.local-tls
+    - hosts:
+        - spark.domain.com
+      secretName: spark.local-tls

--- a/bitnami/spark/values.yaml
+++ b/bitnami/spark/values.yaml
@@ -223,7 +223,13 @@ worker:
     timeoutSeconds: 5
     failureThreshold: 6
     successThreshold: 1
-
+    
+  ## Array to add extra volumes
+  ##
+  ## extraVolumes:
+  ## Array to add extra mounts (normally used with extraVolumes)
+  ##
+  ## extraVolumeMounts: {}
   ## Autoscaling parameters
   ##
   autoscaling:
@@ -232,14 +238,6 @@ worker:
     CpuTargetPercentage: 50
     ## Max number of workers when using autoscaling
     replicasMax: 5
-
-  ## Array to add extra volumes
-  ##
-  ## extraVolumes:
-
-  ## Array to add extra mounts (normally used with extraVolumes)
-  ##
-  ## extraVolumeMounts: {}
 
 ## Security configuration
 ##
@@ -325,6 +323,6 @@ ingress:
     - name: spark.local
       path: /
   tls:
-  - hosts:
-    - spark.domain.com
-    secretName: spark.local-tls
+    - hosts:
+        - spark.domain.com
+      secretName: spark.local-tls


### PR DESCRIPTION
**Description of the change**

_Fix some wrong/missing information in `NOTE.txt`._
- All k8s service related information was using the wrong service name. Now, it is using a helper to build the proper one.
- When it was the LoadBalancer service type, it was using as SERVICE_IP this value `.status.loadBalancer.ingress[0].ip` for building the URL to access the application. Sometimes it is not enough. e.g AWS internal LoadBalancer return a domain in `.status.loadBalancer.ingress[0].hostname` instead. Now, it was replaced for a more generic value.
- For testing the deployment we previously used `spark-submit` directly on the host machine, that needs to download several files so I added a way to test it using `docker`.

_Fix some linting errors._

**Benefits**

Users can test/deploy spark applications better on their deployments.

**Possible drawbacks**

N/A

**Applicable issues**

  - fixes #

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
