### PR TITLE
[bitnami/prometheus-operator]: Fix additionalScrapeConfig indents

### DIFF
--- a/bitnami/prometheus-operator/Chart.yaml
+++ b/bitnami/prometheus-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.34.0
 description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 name: prometheus-operator
-version: 0.8.0
+version: 0.8.1
 keywords:
 - prometheus
 - alertmanager

--- a/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -137,11 +137,11 @@ spec:
     {{- if .Values.prometheus.podAffinity }}
     podAffinity: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.podAffinity "context" $) | nindent 6 }}
     {{- end }}
-    {{- if .Values.prometheus.additionalScrapeConfigsExternal }}
-    additionalScrapeConfigs:
-      name: {{ template "prometheus-operator.prometheus.fullname" . }}-scrape-config
-      key: additional-scrape-configs.yaml
-    {{- end }}
+  {{- if .Values.prometheus.additionalScrapeConfigsExternal }}
+  additionalScrapeConfigs:
+    name: {{ template "prometheus-operator.prometheus.fullname" . }}-scrape-config
+    key: additional-scrape-configs.yaml
+  {{- end }}
 {{- include "prometheus-operator.prometheus.imagePullSecrets" . | indent 2 }}
   {{- if .Values.prometheus.containers }}
   containers: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.containers "context" $) | nindent 4 }}


### PR DESCRIPTION
Signed-off-by: Christian Kotzbauer <christian.kotzbauer@gmail.com>

**Description of the change**
Fix wrong indents for additionalScrapeConfig.

**Benefits**
Correct provisioning from Prometheus CRD

**Possible drawbacks**

**Applicable issues**

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
