### PR TITLE
[bitnami/airflow] added option to load DAGs from a specified subfolder in the git repo

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: airflow
-version: 4.0.20
+version: 4.1.0
 appVersion: 1.10.7
 description: Apache Airflow is a platform to programmatically author, schedule and monitor workflows.
 keywords:

--- a/bitnami/airflow/README.md
+++ b/bitnami/airflow/README.md
@@ -85,6 +85,7 @@ The following tables lists the configurable parameters of the Kafka chart and th
 | `airflow.cloneDagFilesFromGit.repository` | Repository where download DAG files from                                                             | `nil`                                                        |
 | `airflow.cloneDagFilesFromGit.branch`     | Branch from repository to checkout                                                                   | `nil`                                                        |
 | `airflow.cloneDagFilesFromGit.interval`   | Interval to pull the repository on sidecar container                                                 | `nil`                                                        |
+| `airflow.cloneDagFilesFromGit.path`       | Path to a folder in the repository containing DAGs. If not set, all DAGS from the repo are loaded.   | `nil`                                                        |
 | `airflow.baseUrl`                         | URL used to access to airflow web ui                                                                 | `nil`                                                        |
 | `airflow.worker.port`                     | Airflow Worker port                                                                                  | `8793`                                                       |
 | `airflow.worker.replicas`                 | Number of Airflow Worker replicas                                                                    | `2`                                                          |
@@ -94,7 +95,7 @@ The following tables lists the configurable parameters of the Kafka chart and th
 | `airflow.auth.fernetKey`                  | Fernet key to secure connections                                                                     | `nil`                                                        |
 | `airflow.auth.existingSecret`             | Name of an existing secret containing airflow password and fernet key                                | `nil`                                                        |
 | `airflow.extraEnvVars`                    | Extra environment variables to add to airflow web, worker and scheduler pods                         | `nil`                                                        |
-| `airflow.webserverConfigMap`              | Config map name for ~/airflow/webserver_config.py                                                   | `nil`                                                        |
+| `airflow.webserverConfigMap`              | Config map name for ~/airflow/webserver_config.py                                                    | `nil`                                                        |
 | `securityContext.enabled`                 | Enable security context                                                                              | `true`                                                       |
 | `securityContext.fsGroup`                 | Group ID for the container                                                                           | `1001`                                                       |
 | `securityContext.runAsUser`               | User ID for the container                                                                            | `1001`                                                       |

--- a/bitnami/airflow/templates/deployment-scheduler.yaml
+++ b/bitnami/airflow/templates/deployment-scheduler.yaml
@@ -180,6 +180,9 @@ spec:
           {{- if .Values.airflow.cloneDagFilesFromGit.enabled }}
             - name: git-cloned-dag-files
               mountPath: /opt/bitnami/airflow/dags/git
+              {{- if .Values.airflow.cloneDagFilesFromGit.path }}
+              subPath: {{ .Values.airflow.cloneDagFilesFromGit.path }}
+              {{- end }}
           {{- end }}
           {{- if .Values.airflow.configurationConfigMap }}
             - name: custom-configuration-file

--- a/bitnami/airflow/templates/deployment-web.yaml
+++ b/bitnami/airflow/templates/deployment-web.yaml
@@ -210,6 +210,9 @@ spec:
             {{- if .Values.airflow.cloneDagFilesFromGit.enabled }}
             - name: git-cloned-dag-files
               mountPath: /opt/bitnami/airflow/dags/git
+              {{- if .Values.airflow.cloneDagFilesFromGit.path }}
+              subPath: {{ .Values.airflow.cloneDagFilesFromGit.path }}
+              {{- end }}
             {{- end }}
             {{- if .Values.airflow.configurationConfigMap }}
             - name: custom-configuration-file

--- a/bitnami/airflow/templates/statefulset-worker.yaml
+++ b/bitnami/airflow/templates/statefulset-worker.yaml
@@ -193,6 +193,9 @@ spec:
             {{- if .Values.airflow.cloneDagFilesFromGit.enabled }}
             - name: git-cloned-dag-files
               mountPath: /opt/bitnami/airflow/dags/git
+              {{- if .Values.airflow.cloneDagFilesFromGit.path }}
+              subPath: {{ .Values.airflow.cloneDagFilesFromGit.path }}
+              {{- end }}
             {{- end }}
             {{- if .Values.airflow.configurationConfigMap }}
             - name: custom-configuration-file

--- a/bitnami/airflow/values-production.yaml
+++ b/bitnami/airflow/values-production.yaml
@@ -132,6 +132,7 @@ airflow:
     # repository:
     # branch:
     # interval:
+    # path:
   ## URL used to access to airflow web ui
   ##
   baseUrl: http://airflow.local

--- a/bitnami/airflow/values.yaml
+++ b/bitnami/airflow/values.yaml
@@ -132,6 +132,7 @@ airflow:
     # repository:
     # branch:
     # interval:
+    # path:
   ## URL used to access to airflow web ui
   ##
   # baseUrl:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

Adds a value `airflow.cloneDagFilesFromGit.path` which, if set, mounts only the specified sub-path of the git repository to the airflow worker, web, and scheduler. This uses the Kubernetes `subPath` directive when mounting the `git-cloned-dag-files` volume.

**Benefits**

<!-- What benefits will be realized by the code change? -->

If one only wants to load DAGs from a given subdirectory in the git repo to the airflow instance. This is helpful if multiple airflow instances are running and reading DAGs from the same repository.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #1809 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
