### PR TITLE
[bitnami/postgresql-ha] Allow specifying pgpool configuration via configmap

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql-ha
-version: 1.1.5
+version: 1.2.0
 appVersion: 11.6.0
 description: Chart for PostgreSQL with HA architecture (using Replication Manager (repmgr) and Pgpool).
 keywords:

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -130,6 +130,8 @@ The following table lists the configurable parameters of the PostgreSQL HA chart
 | `pgpool.pdb.maxUnavailable`                    | Maximum number / percentage of pods that may be made unavailable                                                                                                     | `nil`                                                        |
 | `pgpool.adminUsername`                         | Pgpool Admin username                                                                                                                                                | `admin`                                                      |
 | `pgpool.adminPassword`                         | Pgpool Admin password                                                                                                                                                | `nil`                                                        |
+| `pgpool.configuration`                         | Content of pgpool.conf                                                                                                                                               | `nil`                                                        |
+| `pgpool.configurationCM`                       | ConfigMap with the Pgpool configuration file (Note: Overrides `pgpol.configuration`)                                                                                 | `nil` (The value is evaluated as a template)                 |
 | **LDAP**                                       |                                                                                                                                                                      |                                                              |
 | `ldap.enabled`                                 | Enable LDAP support                                                                                                                                                  | `false`                                                      |
 | `ldap.existingSecret`                          | Name of existing secret to use for LDAP passwords                                                                                                                    | `nil`                                                        |
@@ -294,15 +296,15 @@ Next, login to the PostgreSQL server using the `psql` client and add the PAM aut
 
 > Note: Parameters including commas must be escaped as shown in the above example. More information at: https://github.com/helm/helm/blob/master/docs/using_helm.md#the-format-and-limitations-of---set
 
-### repmgr.conf / postgresql.conf / pg_hba.conf files as configMap
+### repmgr.conf / postgresql.conf / pg_hba.conf / pgpool.conf files as configMap
 
 This helm chart also supports to customize the whole configuration file.
 
-Add your custom files to "files" in your working directory. Those files will be mounted as configMap to the containers and it will be used for configuring Repmgr and the PostgreSQL server.
+Add your custom files to "files" in your working directory. Those files will be mounted as configMap to the containers and it will be used for configuring Pgpool, Repmgr and the PostgreSQL server.
 
-Alternatively, you can specify the PostgreSQL and Repmgr configuration using the `postgresql.configuration`, `postgresql.pgHbaConfiguration`, and `postgresql.repmgrConfiguration` parameters.
+Alternatively, you can specify the Pgpool, PostgreSQL and Repmgr configuration using the `pgpool.configuration`, `postgresql.configuration`, `postgresql.pgHbaConfiguration`, and `postgresql.repmgrConfiguration` parameters.
 
-In addition to these options, you can also set an external ConfigMap with all the configuration files. This is done by setting the `postgresql.configurationCM` parameter. Note that this will override the two previous options.
+In addition to these options, you can also set an external ConfigMap(s) with all the configuration files. This is done by setting the `postgresql.configurationCM` and `pgpool.configurationCM` parameters. Note that this will override the two previous options.
 
 ### Allow settings to be loaded from files other than the default `postgresql.conf`
 

--- a/bitnami/postgresql-ha/templates/_helpers.tpl
+++ b/bitnami/postgresql-ha/templates/_helpers.tpl
@@ -525,6 +525,17 @@ Return the PostgreSQL extended configuration configmap.
 {{- end -}}
 
 {{/*
+Return the Pgpool configuration configmap.
+*/}}
+{{- define "postgresql-ha.pgpoolConfigurationCM" -}}
+{{- if .Values.pgpool.configurationCM -}}
+{{- printf "%s" (tpl .Values.pgpool.configurationCM $) -}}
+{{- else -}}
+{{- printf "%s-configuration" (include "postgresql-ha.pgpool" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the PostgreSQL initdb scripts configmap.
 */}}
 {{- define "postgresql-ha.postgresqlInitdbScriptsCM" -}}

--- a/bitnami/postgresql-ha/templates/pgpool/configmap.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/configmap.yaml
@@ -10,6 +10,6 @@ data:
   {{- (.Files.Glob "files/pgpool.conf").AsConfig | nindent 2 }}
   {{- else if .Values.pgpool.configuration }}
   pgpool.conf: |
-  {{- .Values.pgpool.configuration | nindent 4 }}
+  {{- include "postgresql-ha.tplValue" (dict "value" .Values.pgpool.configuration "context" $) | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/bitnami/postgresql-ha/templates/pgpool/configmap.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/configmap.yaml
@@ -1,0 +1,15 @@
+{{- if and (or (.Files.Glob "files/pgpool.conf") .Values.pgpool.configuration) (not .Values.pgpool.configurationCM) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-configuration" (include "postgresql-ha.pgpool" .) }}
+  labels: {{- include "postgresql-ha.labels" . | nindent 4 }}
+    app.kubernetes.io/component: pgpool
+data:
+  {{- if (.Files.Glob "files/pgpool.conf") }}
+  {{- (.Files.Glob "files/pgpool.conf").AsConfig | nindent 2 }}
+  {{- else if .Values.pgpool.configuration }}
+  pgpool.conf: |
+  {{- .Values.pgpool.configuration | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
@@ -210,6 +210,10 @@ spec:
           resources: {{- toYaml .Values.pgpool.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
+            {{- if or (.Files.Glob "files/pgool.conf") .Values.pgpool.configuration }}
+            - name: pgpool-config
+              mountPath: /opt/bitnami/pgpool/conf/
+            {{- end }}
             {{- if .Values.postgresql.usePasswordFile }}
             - name: postgresql-password
               mountPath: /opt/bitnami/pgpool/secrets/
@@ -220,6 +224,11 @@ spec:
             {{- end }}
       {{- if or .Values.postgresql.usePasswordFile .Values.pgpool.usePasswordFile }}
       volumes:
+        {{- if or (.Files.Glob "files/pgool.conf") .Values.pgpool.configuration }}
+        - name: pgpool-config
+          configMap:
+            name: {{ include "postgresql-ha.pgpoolConfigurationCM" . }}
+        {{- end }}
         {{- if .Values.postgresql.usePasswordFile }}
         - name: postgresql-password
           secret:
@@ -238,4 +247,5 @@ spec:
               - key: admin-password
                 path: admin-password
         {{- end }}
+
       {{- end }}

--- a/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
@@ -247,5 +247,4 @@ spec:
               - key: admin-password
                 path: admin-password
         {{- end }}
-
       {{- end }}

--- a/bitnami/postgresql-ha/values-production.yaml
+++ b/bitnami/postgresql-ha/values-production.yaml
@@ -364,6 +364,18 @@ pgpool:
   adminUsername: admin
   # adminPassword:
 
+  ## Pgpool configuration
+  ## Specify content for pgpool.conf
+  ## Alternatively, you can put your pgpool.conf under the files/ directory
+  ## ref: https://github.com/bitnami/bitnami-docker-pgpool#configuration-file
+  ##
+  # configuration:
+
+  ## ConfigMap with Pgpool configuration
+  ## NOTE: This will override pgpool.configuration parameter
+  ##
+  # configurationCM:
+
 ## LDAP parameters
 ##
 ldap:

--- a/bitnami/postgresql-ha/values.yaml
+++ b/bitnami/postgresql-ha/values.yaml
@@ -364,6 +364,18 @@ pgpool:
   adminUsername: admin
   # adminPassword:
 
+  ## Pgpool configuration
+  ## Specify content for pgpool.conf
+  ## Alternatively, you can put your pgpool.conf under the files/ directory
+  ## ref: https://github.com/bitnami/bitnami-docker-pgpool#configuration-file
+  ##
+  # configuration:
+
+  ## ConfigMap with Pgpool configuration
+  ## NOTE: This will override pgpool.configuration parameter
+  ##
+  # configurationCM:
+
 ## LDAP parameters
 ##
 ldap:


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

This PR allows specifying pgpool configuration (`pgpool.conf) via configmap as it's possible for other configuration files (e.g. `postgresql.conf` or `pg_hba.conf`)

**Benefits**

More flexibility to configure Pgpool 

**Possible drawbacks**

None


**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

