### PR TITLE
[bitnami/mongodb-sharded] Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To install Helm, refer to the [Helm install guide](https://github.com/helm/helm#
 The stable charts are contributed to the upstream [helm/charts](https://github.com/helm/charts) repository. The following command allows you to download and install all the charts from this repository, both the bitnami and the upstreamed ones.
 
 ```bash
-$ helm repo add bitnami https://charts.bitnami.com
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
 ```
 
 ### Using Helm
@@ -47,12 +47,12 @@ Please refer to the [Quick Start guide](https://github.com/helm/helm/blob/master
 
 Useful Helm Client Commands:
 * View available charts: `helm search`
-* Install a chart: `helm install stable/<package-name>`
+* Install a chart: `helm install bitnami/<package-name>`
 * Upgrade your application: `helm upgrade`
 
 # License
 
-Copyright (c) 2018-2019 Bitnami
+Copyright (c) 2020 Bitnami
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb-sharded
-version: 1.0.3
+version: 1.0.4
 appVersion: 4.0.14
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications. Sharded topology.
 keywords:

--- a/bitnami/mongodb-sharded/README.md
+++ b/bitnami/mongodb-sharded/README.md
@@ -7,7 +7,7 @@ This chart uses the [sharding method](https://docs.mongodb.com/manual/sharding/)
 ## TL;DR;
 
 ```bash
-$ helm install stable/mongodb-sharded
+$ helm install bitnami/mongodb-sharded
 ```
 
 ## Introduction
@@ -28,7 +28,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 To install the chart with the release name `my-release`:
 
 ```bash
-$ helm install --name my-release stable/mongodb-sharded
+$ helm install --name my-release bitnami/mongodb-sharded
 ```
 
 The command deploys MongoDB on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
@@ -274,7 +274,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```bash
 $ helm install --name my-release \
   --set mongodbRootPassword=secretpassword,mongodbUsername=my-user,mongodbPassword=my-password,mongodbDatabase=my-database \
-    stable/mongodb
+    bitnami/mongodb-sharded
 ```
 
 The above command sets the MongoDB `root` account password to `secretpassword`. Additionally, it creates a standard database user named `my-user`, with the password `my-password`, who has access to a database named `my-database`.
@@ -282,7 +282,7 @@ The above command sets the MongoDB `root` account password to `secretpassword`. 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install --name my-release -f values.yaml stable/mongodb
+$ helm install --name my-release -f values.yaml bitnami/mongodb-sharded
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)

--- a/bitnami/mongodb-sharded/README.md
+++ b/bitnami/mongodb-sharded/README.md
@@ -7,6 +7,7 @@ This chart uses the [sharding method](https://docs.mongodb.com/manual/sharding/)
 ## TL;DR;
 
 ```bash
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
 $ helm install bitnami/mongodb-sharded
 ```
 


### PR DESCRIPTION
**Description of the change**
There are two changes:

- Unify registry URL and replace stable by Bitnami in the main README (https://github.com/bitnami/charts/commit/97f07e4c5429160dfab25c8e93ba600bb0bf6a9b)
- Fix install instructions for mongodb-sharded (it is in bitnami and not in stable) (https://github.com/bitnami/charts/commit/266f3dd6dacef52751c19ccb56c30d6356f3aeb8)

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files