### PR TITLE
[bitnami/redmine] Fix servicePort between ingress and service

### DIFF
--- a/upstreamed/redmine/templates/ingress.yaml
+++ b/upstreamed/redmine/templates/ingress.yaml
@@ -20,7 +20,7 @@ spec:
         - path: /
           backend:
             serviceName: "{{ template "redmine.fullname" . }}"
-            servicePort: http
+            servicePort: http-redmine
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
     - host: {{ .name }}
@@ -29,7 +29,7 @@ spec:
         - path: {{ default "/" .path }}
           backend:
             serviceName: "{{ template "redmine.fullname" $ }}"
-            servicePort: http
+            servicePort: http-redmine
     {{- end }}
   {{- if or .Values.ingress.tls .Values.ingress.extraTls .Values.ingress.hosts }}
   tls:


### PR DESCRIPTION
Description:

It fixes port name. There is a mismatching between the service port name referenced on the ingress template and the service. (templates/svc.yaml and templates/ingress.yaml)

The mistake was introduced on commit Dec 11, 2019: https://github.com/bitnami/charts/commit/0eed732cc102e83b7da42ea00505bef71361a993

Benefits:

Nowadays, when the chart is deployed and we access throught the ingress-controller, it returns http error "503 Temporarily Unavailable openresty/1.15.8.2". It is because the ingress references servicePort "http" when it should "http-redmine".

Possible drawbacks:


<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
