### PR TITLE
[bitnami/memcached] Warning users regarding authentication/ & read-only filesystems

### DIFF
--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: memcached
-version: 4.1.2
+version: 4.2.0
 appVersion: 1.5.20
 description: Chart for Memcached
 keywords:

--- a/bitnami/memcached/README.md
+++ b/bitnami/memcached/README.md
@@ -59,9 +59,9 @@ The following tables lists the configurable parameters of the Memcached chart an
 | `nameOverride`                | String to partially override memcached.fullname template with a string (will prepend the release name) | `nil`                                                        |
 | `fullnameOverride`            | String to fully override memcached.fullname template with a string                                     | `nil`                                                        |
 | `clusterDomain`               | Kubernetes cluster domain                                                                              | `cluster.local`                                              |
-|`replicas`                     | Number of containers       | `1`                     |
-|`extraEnv`                     | Additional env vars to pass| `{}`                     |
-|`arguments`                    | Arguments to pass          | `["/run.sh"]`                     |
+|`replicas`                     | Number of containers                                                                                   | `1`                                                          |
+|`extraEnv`                     | Additional env vars to pass                                                                            | `{}`                                                         |
+|`arguments`                    | Arguments to pass                                                                                      | `["/run.sh"]`                                                |
 | `memcachedUsername`           | Memcached admin user                                                                                   | `nil`                                                        |
 | `memcachedPassword`           | Memcached admin password                                                                               | `nil`                                                        |
 | `service.type`                | Kubernetes service type for Memcached                                                                  | `ClusterIP`                                                  |
@@ -72,13 +72,14 @@ The following tables lists the configurable parameters of the Memcached chart an
 | `service.annotations`         | Additional annotations for Memcached service                                                           | `{}`                                                         |
 | `resources.requests`          | CPU/Memory resource requests                                                                           | `{memory: "256Mi", cpu: "250m"}`                             |
 | `resources.limits`            | CPU/Memory resource limits                                                                             | `{}`                                                         |
-| `persistence.enabled`                | Enable persistence using PVC                                                                    | `true`                                                       |
-| `persistence.storageClass`           | PVC Storage Class for Jenkins volume                                                            | `nil` (uses alpha storage class annotation)                  |
-| `persistence.accessMode`             | PVC Access Mode for Jenkins volume                                                              | `ReadWriteOnce`                                              |
-| `persistence.size`                   | PVC Storage Request for Jenkins volume                                                          | `8Gi`                                                        |
+| `persistence.enabled`         | Enable persistence using PVC                                                                           | `true`                                                       |
+| `persistence.storageClass`    | PVC Storage Class for Jenkins volume                                                                   | `nil` (uses alpha storage class annotation)                  |
+| `persistence.accessMode`      | PVC Access Mode for Jenkins volume                                                                     | `ReadWriteOnce`                                              |
+| `persistence.size`            | PVC Storage Request for Jenkins volume                                                                 | `8Gi`                                                        |
 | `securityContext.enabled`     | Enable security context                                                                                | `true`                                                       |
 | `securityContext.fsGroup`     | Group ID for the container                                                                             | `1001`                                                       |
 | `securityContext.runAsUser`   | User ID for the container                                                                              | `1001`                                                       |
+| `securityContext.readOnlyRootFilesystem` | Enable read-only filesystem                                                                 | `false`                                                      |
 | `podAnnotations`              | Pod annotations                                                                                        | `{}`                                                         |
 | `affinity`                    | Map of node/pod affinities                                                                             | `{}` (The value is evaluated as a template)                  |
 | `nodeSelector`                | Node labels for pod assignment                                                                         | `{}` (The value is evaluated as a template)                  |
@@ -100,7 +101,7 @@ The above parameters map to the env variables defined in [bitnami/memcached](htt
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
-$ helm install --name my-release --set memcachedUser=user,memcachedPassword=password bitnami/memcached
+$ helm install --name my-release --set memcachedUsername=user,memcachedPassword=password bitnami/memcached
 ```
 
 The above command sets the Memcached admin account username and password to `user` and `password` respectively.
@@ -126,9 +127,17 @@ Bitnami will release a new chart updating its containers if a new version of the
 This chart includes a `values-production.yaml` file where you can find some parameters oriented to production configuration in comparison to the regular `values.yaml`. You can use this file instead of the default one.
 
 - Start a side-car prometheus exporter:
+
 ```diff
 - metrics.enabled: false
 + metrics.enabled: true
+```
+
+- Enable read-only filesystem:
+
+```diff
+- securityContext.readOnlyRootFilesystem=false
++ securityContext.readOnlyRootFilesystem=true
 ```
 
 ## Persistence

--- a/bitnami/memcached/templates/_helpers.tpl
+++ b/bitnami/memcached/templates/_helpers.tpl
@@ -172,6 +172,7 @@ Compile all warnings into a single message, and call fail.
 {{- $messages := list -}}
 {{- $messages := append $messages (include "memcached.validateValues.architecture" .) -}}
 {{- $messages := append $messages (include "memcached.validateValues.replicaCount" .) -}}
+{{- $messages := append $messages (include "memcached.validateValues.readOnlyRootFilesystem" .) -}}
 {{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}
 
@@ -200,6 +201,14 @@ memcached: replicaCount
 {{- end -}}
 {{- end -}}
 
+{{/* Validate values of Memcached - securityContext.readOnlyRootFilesystem */}}
+{{- define "memcached.validateValues.readOnlyRootFilesystem" -}}
+{{- if and .Values.securityContext.enabled .Values.securityContext.readOnlyRootFilesystem (not (empty .Values.memcachedPassword)) -}}
+memcached: securityContext.readOnlyRootFilesystem
+    Enabling authentication is not compatible with using a read-only filesystem.
+    Please disable it (--set securityContext.readOnlyRootFilesystem=false)
+{{- end -}}
+{{- end -}}
 
 {{/*
 Renders a value that contains template.

--- a/bitnami/memcached/templates/deployment.yaml
+++ b/bitnami/memcached/templates/deployment.yaml
@@ -42,6 +42,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           args: {{- toYaml .Values.arguments | nindent 12 }}
           env:
+            - name: BITNAMI_DEBUG
+              value: {{ ternary "true" "false" .Values.image.debug | quote }}
             - name: MEMCACHED_USERNAME
               value: {{ default "" .Values.memcachedUsername | quote }}
             - name: MEMCACHED_PASSWORD

--- a/bitnami/memcached/values-production.yaml
+++ b/bitnami/memcached/values-production.yaml
@@ -26,6 +26,10 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+  ## Set to true if you would like to see extra information on logs
+  ##
+  debug: false
+
 ## Extra environment vars to pass.
 ## ref: https://github.com/bitnami/bitnami-docker-memcached#configuration
 extraEnv: []

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -26,6 +26,10 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+  ## Set to true if you would like to see extra information on logs
+  ##
+  debug: false
+
 ## Extra environment vars to pass.
 ## ref: https://github.com/bitnami/bitnami-docker-memcached#configuration
 extraEnv: []
@@ -102,7 +106,7 @@ securityContext:
   enabled: true
   fsGroup: 1001
   runAsUser: 1001
-  readOnlyRootFilesystem: true
+  readOnlyRootFilesystem: false
 
 ## Pod annotations
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

This PR adds a warning for users when authentication is enabled and a read-only filesystem is used (since this combination is not compatible). 
It also disable the read-only filesystem by default (this should only be activated on **values-production.yaml**)

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/1833

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files