### PR TITLE
[bitnami/prometheus-operator] adds service monitors for kube-apiserver and kubelet services

### DIFF
--- a/bitnami/prometheus-operator/Chart.yaml
+++ b/bitnami/prometheus-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.35.0
 description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 name: prometheus-operator
-version: 0.8.3
+version: 0.9.0
 keywords:
 - prometheus
 - alertmanager

--- a/bitnami/prometheus-operator/README.md
+++ b/bitnami/prometheus-operator/README.md
@@ -270,11 +270,18 @@ The following table lists the configurable parameters of the Prometheus Operator
 
 ### Exporters
 
-|               Parameter                |         Description         | Default |
-|----------------------------------------|-----------------------------|---------|
-| `exporters.enabled`                    | Deploy exporters            | `true`  |
-| `exporters.node-exporter.enabled`      | Deploy `node-exporter`      | `true`  |
-| `exporters.kube-state-metrics.enabled` | Deploy `kube-state-metrics` | `true`  |
+|                     Parameter                      |                                              Description                                               |    Default    |
+|----------------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------|
+| `exporters.enabled`                                | Deploy exporters                                                                                       | `true`        |
+| `exporters.node-exporter.enabled`                  | Deploy `node-exporter`                                                                                 | `true`        |
+| `exporters.kube-state-metrics.enabled`             | Deploy `kube-state-metrics`                                                                            | `true`        |
+| `kubelet.namespace`                                | Namespace where kubelet service is deployed. Related configuration `operator.kubeletService.namespace` | `kube-system` |
+| `kubelet.enabled`                                  | Create a ServiceMonitor to scrape kubelet service                                                      | `true`        |
+| `kubelet.serviceMonitor.interval`                  | Scrape interval (use by default, falling back to Prometheus' default)                                  | `nil`         |
+| `kubelet.serviceMonitor.metricRelabelings`         | Metric relabeling                                                                                      | `[]`          |
+| `kubelet.serviceMonitor.relabelings`               | Relabel configs                                                                                        | `[]`          |
+| `kubelet.serviceMonitor.cAdvisorMetricRelabelings` | Metric relabeling for scraping cAdvisor                                                                | `[]`          |
+| `kubelet.serviceMonitor.cAdvisorRelabelings`       | Relabel configs for scraping cAdvisor                                                                  | `[]`          |
 
 The above parameters map to the env variables defined in [bitnami/prometheus-operator](http://github.com/bitnami/bitnami-docker-prometheus-operator). For more information please refer to the [bitnami/prometheus-operator](http://github.com/bitnami/bitnami-docker-prometheus-operator) image documentation.
 

--- a/bitnami/prometheus-operator/README.md
+++ b/bitnami/prometheus-operator/README.md
@@ -282,6 +282,10 @@ The following table lists the configurable parameters of the Prometheus Operator
 | `kubelet.serviceMonitor.relabelings`               | Relabel configs                                                                                        | `[]`          |
 | `kubelet.serviceMonitor.cAdvisorMetricRelabelings` | Metric relabeling for scraping cAdvisor                                                                | `[]`          |
 | `kubelet.serviceMonitor.cAdvisorRelabelings`       | Relabel configs for scraping cAdvisor                                                                  | `[]`          |
+| `kubeApiServer.enabled`                            | Create a ServiceMonitor to scrape kube-apiserver service                                               | `true`        |
+| `kubeApiServer.serviceMonitor.interval`            | Scrape interval (use by default, falling back to Prometheus' default)                                  | `nil`         |
+| `kubeApiServer.serviceMonitor.metricRelabelings`   | Metric relabeling                                                                                      | `[]`          |
+| `kubeApiServer.serviceMonitor.relabelings`         | Relabel configs                                                                                        | `[]`          |
 
 The above parameters map to the env variables defined in [bitnami/prometheus-operator](http://github.com/bitnami/bitnami-docker-prometheus-operator). For more information please refer to the [bitnami/prometheus-operator](http://github.com/bitnami/bitnami-docker-prometheus-operator) image documentation.
 

--- a/bitnami/prometheus-operator/templates/alertmanager/alertmanager.yaml
+++ b/bitnami/prometheus-operator/templates/alertmanager/alertmanager.yaml
@@ -53,17 +53,17 @@ spec:
     {{- if eq .Values.alertmanager.podAntiAffinity "hard" }}
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
-      - topologyKey: "kubernetes.io/hostname"
-        labelSelector:
-          matchLabels: {{- include "prometheus-operator.alertmanager.matchLabels" . | nindent 12 }}
+        - topologyKey: "kubernetes.io/hostname"
+          labelSelector:
+            matchLabels: {{- include "prometheus-operator.alertmanager.matchLabels" . | nindent 14 }}
     {{- else if eq .Values.alertmanager.podAntiAffinity "soft" }}
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        podAffinityTerm:
-          topologyKey: "kubernetes.io/hostname"
-          labelSelector:
-            matchLabels: {{- include "prometheus-operator.alertmanager.matchLabels" . | nindent 14 }}
+        - weight: 100
+          podAffinityTerm:
+            topologyKey: "kubernetes.io/hostname"
+            labelSelector:
+              matchLabels: {{- include "prometheus-operator.alertmanager.matchLabels" . | nindent 16 }}
     {{- end }}
     {{- if .Values.alertmanager.podAffinity }}
     podAffinity: {{- include "prometheus-operator.tplValue" (dict "value" .Values.alertmanager.podAffinity "context" $) | nindent 6 }}

--- a/bitnami/prometheus-operator/templates/alertmanager/ingress.yaml
+++ b/bitnami/prometheus-operator/templates/alertmanager/ingress.yaml
@@ -13,17 +13,17 @@ metadata:
     {{- end }}
 spec:
   rules:
-  {{- range .Values.alertmanager.ingress.hosts }}
-  - host: {{ .name }}
-    http:
-      paths:
-      - path: {{ default "/" .path }}
-        backend:
-          serviceName: {{ template "prometheus-operator.alertmanager.fullname" $ }}
-          servicePort: http
-  {{- end }}
+    {{- range .Values.alertmanager.ingress.hosts }}
+    - host: {{ .name }}
+      http:
+        paths:
+          - path: {{ default "/" .path }}
+            backend:
+              serviceName: {{ template "prometheus-operator.alertmanager.fullname" $ }}
+              servicePort: http
+    {{- end }}
   {{- if .Values.alertmanager.ingress.tls }}
   tls:
 {{ toYaml .Values.alertmanager.ingress.tls | indent 4 }}
-  {{- end }}
+{{- end }}
 {{- end -}}

--- a/bitnami/prometheus-operator/templates/alertmanager/psp-clusterrole.yaml
+++ b/bitnami/prometheus-operator/templates/alertmanager/psp-clusterrole.yaml
@@ -5,9 +5,9 @@ metadata:
   name: {{ template "prometheus-operator.alertmanager.fullname" . }}-psp
   labels: {{- include "prometheus-operator.alertmanager.labels" . | nindent 4 }}
 rules:
-- apiGroups: ['extensions']
-  resources: ['podsecuritypolicies']
-  verbs: ['use']
-  resourceNames:
-  - {{ template "prometheus-operator.alertmanager.fullname" . }}
+  - apiGroups: ['extensions']
+    resources: ['podsecuritypolicies']
+    verbs: ['use']
+    resourceNames:
+      - {{ template "prometheus-operator.alertmanager.fullname" . }}
 {{- end }}

--- a/bitnami/prometheus-operator/templates/alertmanager/psp.yaml
+++ b/bitnami/prometheus-operator/templates/alertmanager/psp.yaml
@@ -8,7 +8,7 @@ spec:
   privileged: false
   allowPrivilegeEscalation: false
   requiredDropCapabilities:
-  - ALL
+    - ALL
   volumes:
     - 'configMap'
     - 'emptyDir'
@@ -22,18 +22,18 @@ spec:
   runAsUser:
     rule: 'MustRunAs'
     ranges:
-    - min: 1001
-      max: 1001
+      - min: 1001
+        max: 1001
   seLinux:
     rule: 'RunAsAny'
   supplementalGroups:
     rule: 'MustRunAs'
     ranges:
-    - min: 1001
-      max: 1001
+      - min: 1001
+        max: 1001
   fsGroup:
     rule: 'MustRunAs'
     ranges:
-    - min: 1001
-      max: 1001
+      - min: 1001
+        max: 1001
 {{- end }}

--- a/bitnami/prometheus-operator/templates/alertmanager/service.yaml
+++ b/bitnami/prometheus-operator/templates/alertmanager/service.yaml
@@ -21,12 +21,12 @@ spec:
   clusterIP: {{ .Values.alertmanager.service.clusterIP }}
   {{- end }}
   ports:
-  - name: http
-    port: {{ .Values.alertmanager.service.port }}
-    targetPort: 9093
-    {{- if and .Values.alertmanager.service.nodePort (or (eq .Values.alertmanager.service.type "NodePort") (eq .Values.alertmanager.service.type "LoadBalancer")) }}
-    nodePort: {{ .Values.alertmanager.service.nodePort }}
-    {{- end }}
+    - name: http
+      port: {{ .Values.alertmanager.service.port }}
+      targetPort: 9093
+      {{- if and .Values.alertmanager.service.nodePort (or (eq .Values.alertmanager.service.type "NodePort") (eq .Values.alertmanager.service.type "LoadBalancer")) }}
+      nodePort: {{ .Values.alertmanager.service.nodePort }}
+      {{- end }}
   selector:
     app: alertmanager
     alertmanager: {{ template "prometheus-operator.alertmanager.fullname" . }}

--- a/bitnami/prometheus-operator/templates/alertmanager/servicemonitor.yaml
+++ b/bitnami/prometheus-operator/templates/alertmanager/servicemonitor.yaml
@@ -11,15 +11,15 @@ spec:
     matchNames:
       - {{ .Release.Namespace }}
   endpoints:
-  - port: http
-    {{- if .Values.alertmanager.serviceMonitor.interval }}
-    interval: {{ .Values.alertmanager.serviceMonitor.interval }}
-    {{- end }}
-    path: "/metrics"
-{{- if .Values.alertmanager.serviceMonitor.metricRelabelings }}
-    metricRelabelings: {{- include "prometheus-operator.tplValue" ( dict "value" .Values.alertmanager.serviceMonitor.metricRelabelings "context" $) | nindent 6 }}
-{{- end }}
-{{- if .Values.alertmanager.serviceMonitor.relabelings }}
-    relabelings: {{- toYaml .Values.alertmanager.serviceMonitor.relabelings | nindent 6 }}
-{{- end }}
+    - port: http
+      {{- if .Values.alertmanager.serviceMonitor.interval }}
+      interval: {{ .Values.alertmanager.serviceMonitor.interval }}
+      {{- end }}
+      path: "/metrics"
+      {{- if .Values.alertmanager.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- include "prometheus-operator.tplValue" ( dict "value" .Values.alertmanager.serviceMonitor.metricRelabelings "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.alertmanager.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml .Values.alertmanager.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/bitnami/prometheus-operator/templates/exporters/kube-apiserver/servicemonitor.yaml
+++ b/bitnami/prometheus-operator/templates/exporters/kube-apiserver/servicemonitor.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.kubeApiServer.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "prometheus-operator.fullname" . }}-apiserver
+  labels: {{- include "prometheus-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: apiserver
+spec:
+  jobLabel: component
+  selector:
+    matchLabels:
+      component: apiserver
+      provider: kubernetes
+  namespaceSelector:
+    matchNames:
+    - default
+  endpoints:
+    - port: https
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        serverName: kubernetes
+        insecureSkipVerify: true
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      {{- if .Values.kubeApiServer.serviceMonitor.interval }}
+      interval: {{ .Values.kubeApiServer.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.kubeApiServer.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- include "prometheus-operator.tplValue" ( dict "value" .Values.kubeApiServer.serviceMonitor.metricRelabelings "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.kubeApiServer.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml .Values.kubeApiServer.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/bitnami/prometheus-operator/templates/exporters/kube-apiserver/servicemonitor.yaml
+++ b/bitnami/prometheus-operator/templates/exporters/kube-apiserver/servicemonitor.yaml
@@ -13,7 +13,7 @@ spec:
       provider: kubernetes
   namespaceSelector:
     matchNames:
-    - default
+      - default
   endpoints:
     - port: https
       scheme: https

--- a/bitnami/prometheus-operator/templates/exporters/kubelet/servicemonitor.yaml
+++ b/bitnami/prometheus-operator/templates/exporters/kubelet/servicemonitor.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.kubelet.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "prometheus-operator.fullname" . }}-kubelet
+  labels: {{- include "prometheus-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kubelet
+spec:
+  jobLabel: k8s-app
+  selector:
+    matchLabels:
+      k8s-app: kubelet
+  namespaceSelector:
+    matchNames:
+      - {{ .Values.kubelet.namespace }}
+  endpoints:
+    - port: http-metrics
+      scheme: http
+      tlsConfig:
+        insecureSkipVerify: false
+      honorLabels: true
+      {{- if .Values.kubelet.serviceMonitor.interval }}
+      interval: {{ .Values.kubelet.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.kubelet.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- include "prometheus-operator.tplValue" ( dict "value" .Values.kubelet.serviceMonitor.metricRelabelings "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.kubelet.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml .Values.kubelet.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
+    - port: http-metrics
+      path: /metrics/cadvisor
+      scheme: http
+      tlsConfig:
+        insecureSkipVerify: false
+      honorLabels: true
+      {{- if .Values.kubelet.serviceMonitor.interval }}
+      interval: {{ .Values.kubelet.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.kubelet.serviceMonitor.cAdvisorMetricRelabelings }}
+      metricRelabelings: {{- include "prometheus-operator.tplValue" ( dict "value" .Values.kubelet.serviceMonitor.cAdvisorMetricRelabelings "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.kubelet.serviceMonitor.cAdvisorRelabelings }}
+      relabelings: {{- toYaml .Values.kubelet.serviceMonitor.cAdvisorRelabelings | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus-operator/clusterrole.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/clusterrole.yaml
@@ -5,68 +5,68 @@ metadata:
   name: {{ template "prometheus-operator.operator.fullname" . }}
   labels: {{- include "prometheus-operator.operator.labels" . | nindent 4 }}
 rules:
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - '*'
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - alertmanagers
-  - prometheuses
-  - prometheuses/finalizers
-  - alertmanagers/finalizers
-  - servicemonitors
-  - podmonitors
-  - prometheusrules
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - secrets
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - list
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - services
-  - services/finalizers
-  - endpoints
-  verbs:
-  - get
-  - create
-  - update
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-  - list
-  - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - '*'
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - alertmanagers
+      - prometheuses
+      - prometheuses/finalizers
+      - alertmanagers/finalizers
+      - servicemonitors
+      - podmonitors
+      - prometheusrules
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - services/finalizers
+      - endpoints
+    verbs:
+      - get
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
 {{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus-operator/clusterrolebinding.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/clusterrolebinding.yaml
@@ -9,7 +9,7 @@ roleRef:
   kind: ClusterRole
   name: {{ template "prometheus-operator.operator.fullname" . }}
 subjects:
-- kind: ServiceAccount
-  name: {{ template "prometheus-operator.operator.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ template "prometheus-operator.operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus-operator/deployment.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/deployment.yaml
@@ -45,49 +45,49 @@ spec:
         {{- else if eq .Values.operator.podAntiAffinity "soft" }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            podAffinityTerm:
-              topologyKey: "kubernetes.io/hostname"
-              labelSelector:
-                matchLabels: {{- include "prometheus-operator.operator.matchLabels" . | nindent 18 }}
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: "kubernetes.io/hostname"
+                labelSelector:
+                  matchLabels: {{- include "prometheus-operator.operator.matchLabels" . | nindent 20 }}
         {{- end }}
         {{- if .Values.operator.podAffinity }}
         podAffinity: {{- include "prometheus-operator.tplValue" (dict "value" .Values.operator.podAffinity "context" $) | nindent 10 }}
         {{- end }}
       containers:
-      - name: {{ template "prometheus-operator.name" . }}
-        image: {{ template "prometheus-operator.image" . }}
-        imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
-        args:
-          {{- if .Values.operator.kubeletService.enabled }}
-          - --kubelet-service={{ .Values.operator.kubeletService.namespace }}/{{ template "prometheus-operator.fullname" . }}-kubelet
-          {{- end }}
-          {{- if .Values.operator.logFormat }}
-          - --log-format={{ .Values.operator.logFormat }}
-          {{- end }}
-          {{- if .Values.operator.logLevel }}
-          - --log-level={{ .Values.operator.logLevel }}
-          {{- end }}
-          - --logtostderr=true
-          - --localhost=127.0.0.1
-          - --config-reloader-image={{ template "prometheus-operator.configmapReload.image" . }}
-          - --prometheus-config-reloader={{ template "prometheus-operator.prometheusConfigReloader.image" . }}
-        ports:
-          - name: http
-            containerPort: 8080
-            protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /metrics
-            port: http
-{{ toYaml .Values.operator.livenessProbe | indent 10 }}
-        readinessProbe:
-          httpGet:
-            path: /metrics
-            port: http
-{{ toYaml .Values.operator.readinessProbe | indent 10 }}
-        resources: {{- toYaml .Values.operator.resources | nindent 10 }}
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: false
+        - name: {{ template "prometheus-operator.name" . }}
+          image: {{ template "prometheus-operator.image" . }}
+          imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
+          args:
+            {{- if .Values.operator.kubeletService.enabled }}
+            - --kubelet-service={{ .Values.operator.kubeletService.namespace }}/{{ template "prometheus-operator.fullname" . }}-kubelet
+            {{- end }}
+            {{- if .Values.operator.logFormat }}
+            - --log-format={{ .Values.operator.logFormat }}
+            {{- end }}
+            {{- if .Values.operator.logLevel }}
+            - --log-level={{ .Values.operator.logLevel }}
+            {{- end }}
+            - --logtostderr=true
+            - --localhost=127.0.0.1
+            - --config-reloader-image={{ template "prometheus-operator.configmapReload.image" . }}
+            - --prometheus-config-reloader={{ template "prometheus-operator.prometheusConfigReloader.image" . }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: http
+{{ toYaml .Values.operator.livenessProbe | indent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: http
+{{ toYaml .Values.operator.readinessProbe | indent 12 }}
+          resources: {{- toYaml .Values.operator.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
 {{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus-operator/psp-clusterrole.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/psp-clusterrole.yaml
@@ -5,9 +5,9 @@ metadata:
   name: {{ template "prometheus-operator.operator.fullname" . }}-psp
   labels: {{- include "prometheus-operator.operator.labels" . | nindent 4 }}
 rules:
-- apiGroups: ['extensions']
-  resources: ['podsecuritypolicies']
-  verbs: ['use']
-  resourceNames:
-  - {{ template "prometheus-operator.operator.fullname" . }}
+  - apiGroups: ['extensions']
+    resources: ['podsecuritypolicies']
+    verbs: ['use']
+    resourceNames:
+      - {{ template "prometheus-operator.operator.fullname" . }}
 {{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus-operator/psp.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/psp.yaml
@@ -8,7 +8,7 @@ spec:
   privileged: false
   allowPrivilegeEscalation: false
   requiredDropCapabilities:
-  - ALL
+    - ALL
   volumes:
     - 'configMap'
     - 'emptyDir'
@@ -22,18 +22,18 @@ spec:
   runAsUser:
     rule: 'MustRunAs'
     ranges:
-    - min: 1001
-      max: 1001
+      - min: 1001
+        max: 1001
   seLinux:
     rule: 'RunAsAny'
   supplementalGroups:
     rule: 'MustRunAs'
     ranges:
-    - min: 1001
-      max: 1001
+      - min: 1001
+        max: 1001
   fsGroup:
     rule: 'MustRunAs'
     ranges:
-    - min: 1001
-      max: 1001
+      - min: 1001
+        max: 1001
 {{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus-operator/service.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/service.yaml
@@ -21,11 +21,11 @@ spec:
   clusterIP: {{ .Values.operator.service.clusterIP }}
   {{- end }}
   ports:
-  - name: http
-    port: {{ .Values.operator.service.port }}
-    targetPort: http
-    {{- if and .Values.operator.service.nodePort (or (eq .Values.operator.service.type "NodePort") (eq .Values.operator.service.type "LoadBalancer")) }}
-    nodePort: {{ .Values.operator.service.nodePort }}
-    {{- end }}
+    - name: http
+      port: {{ .Values.operator.service.port }}
+      targetPort: http
+      {{- if and .Values.operator.service.nodePort (or (eq .Values.operator.service.type "NodePort") (eq .Values.operator.service.type "LoadBalancer")) }}
+      nodePort: {{ .Values.operator.service.nodePort }}
+      {{- end }}
   selector: {{- include "prometheus-operator.operator.matchLabels" . | nindent 4 }}
 {{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus-operator/servicemonitor.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/servicemonitor.yaml
@@ -6,16 +6,16 @@ metadata:
   labels: {{- include "prometheus-operator.operator.labels" . | nindent 4 }}
 spec:
   endpoints:
-  - port: http
-    honorLabels: true
-    {{- if .Values.operator.serviceMonitor.interval }}
-    interval: {{ .Values.operator.serviceMonitor.interval }}
-    {{- end }}
-{{- if .Values.operator.serviceMonitor.metricRelabelings }}
-    metricRelabelings: {{- include "prometheus-operator.tplValue" ( dict "value" .Values.operator.serviceMonitor.metricRelabelings "context" $) | nindent 6 }}
-{{- end }}
-{{- if .Values.operator.serviceMonitor.relabelings }}
-    relabelings: {{- toYaml .Values.operator.serviceMonitor.relabelings | nindent 6 }}
+    - port: http
+      honorLabels: true
+      {{- if .Values.operator.serviceMonitor.interval }}
+      interval: {{ .Values.operator.serviceMonitor.interval }}
+      {{- end }}
+  {{- if .Values.operator.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- include "prometheus-operator.tplValue" ( dict "value" .Values.operator.serviceMonitor.metricRelabelings "context" $) | nindent 8 }}
+  {{- end }}
+  {{- if .Values.operator.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml .Values.operator.serviceMonitor.relabelings | nindent 8 }}
 {{- end }}
   selector:
     matchLabels: {{- include "prometheus-operator.operator.matchLabels" . | nindent 6 }}

--- a/bitnami/prometheus-operator/templates/prometheus/clusterrole.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/clusterrole.yaml
@@ -5,28 +5,37 @@ metadata:
   name: {{ template "prometheus-operator.prometheus.fullname" . }}
   labels: {{- include "prometheus-operator.prometheus.labels" . | nindent 4 }}
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes/metrics
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups: [""]
-  resources:
-  - nodes
-  - nodes/proxy
-  - services
-  - endpoints
-  - pods
-  verbs: ["get", "list", "watch"]
-- apiGroups:
-  - extensions
-  - "networking.k8s.io"
-  resources:
-  - ingresses
-  verbs: ["get", "list", "watch"]
-- nonResourceURLs: ["/metrics"]
-  verbs: ["get"]
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/metrics
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - nodes/proxy
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+  - apiGroups:
+      - extensions
+      - "networking.k8s.io"
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - "/metrics"
+    verbs:
+      - "get"
 {{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus/clusterrolebinding.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/clusterrolebinding.yaml
@@ -9,7 +9,7 @@ roleRef:
   kind: ClusterRole
   name: {{ template "prometheus-operator.prometheus.fullname" . }}
 subjects:
-- kind: ServiceAccount
-  name: {{ template "prometheus-operator.prometheus.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ template "prometheus-operator.prometheus.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus/ingress.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/ingress.yaml
@@ -13,15 +13,15 @@ metadata:
     {{- end }}
 spec:
   rules:
-  {{- range .Values.prometheus.ingress.hosts }}
-  - host: {{ .name }}
-    http:
-      paths:
-      - path: {{ default "/" .path }}
-        backend:
-          serviceName: {{ template "prometheus-operator.prometheus.fullname" $ }}
-          servicePort: http
-  {{- end }}
+    {{- range .Values.prometheus.ingress.hosts }}
+    - host: {{ .name }}
+      http:
+        paths:
+        - path: {{ default "/" .path }}
+          backend:
+            serviceName: {{ template "prometheus-operator.prometheus.fullname" $ }}
+            servicePort: http
+    {{- end }}
   {{- if .Values.prometheus.ingress.tls }}
   tls:
 {{ toYaml .Values.prometheus.ingress.tls | indent 4 }}

--- a/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -122,17 +122,17 @@ spec:
     {{- if eq .Values.prometheus.podAntiAffinity "hard" }}
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
-      - topologyKey: "kubernetes.io/hostname"
-        labelSelector:
-          matchLabels: {{- include "prometheus-operator.prometheus.matchLabels" . | nindent 12 }}
+        - topologyKey: "kubernetes.io/hostname"
+          labelSelector:
+            matchLabels: {{- include "prometheus-operator.prometheus.matchLabels" . | nindent 14 }}
     {{- else if eq .Values.prometheus.podAntiAffinity "soft" }}
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        podAffinityTerm:
-          topologyKey: "kubernetes.io/hostname"
-          labelSelector:
-            matchLabels: {{- include "prometheus-operator.prometheus.matchLabels" . | nindent 14 }}
+        - weight: 100
+          podAffinityTerm:
+            topologyKey: "kubernetes.io/hostname"
+            labelSelector:
+              matchLabels: {{- include "prometheus-operator.prometheus.matchLabels" . | nindent 16 }}
     {{- end }}
     {{- if .Values.prometheus.podAffinity }}
     podAffinity: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.podAffinity "context" $) | nindent 6 }}

--- a/bitnami/prometheus-operator/templates/prometheus/psp-clusterrole.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/psp-clusterrole.yaml
@@ -5,9 +5,9 @@ metadata:
   name: {{ template "prometheus-operator.prometheus.fullname" . }}-psp
   labels: {{- include "prometheus-operator.prometheus.labels" . | nindent 4 }}
 rules:
-- apiGroups: ['extensions']
-  resources: ['podsecuritypolicies']
-  verbs: ['use']
-  resourceNames:
-  - {{ template "prometheus-operator.prometheus.fullname" . }}
+  - apiGroups: ['extensions']
+    resources: ['podsecuritypolicies']
+    verbs: ['use']
+    resourceNames:
+      - {{ template "prometheus-operator.prometheus.fullname" . }}
 {{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus/psp.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/psp.yaml
@@ -8,7 +8,7 @@ spec:
   privileged: false
   allowPrivilegeEscalation: false
   requiredDropCapabilities:
-  - ALL
+    - ALL
   volumes:
     - 'configMap'
     - 'emptyDir'
@@ -22,18 +22,18 @@ spec:
   runAsUser:
     rule: 'MustRunAs'
     ranges:
-    - min: 1001
-      max: 1001
+      - min: 1001
+        max: 1001
   seLinux:
     rule: 'RunAsAny'
   supplementalGroups:
     rule: 'MustRunAs'
     ranges:
-    - min: 1001
-      max: 1001
+      - min: 1001
+        max: 1001
   fsGroup:
     rule: 'MustRunAs'
     ranges:
-    - min: 1001
-      max: 1001
+      - min: 1001
+        max: 1001
 {{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus/service.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/service.yaml
@@ -21,12 +21,12 @@ spec:
   clusterIP: {{ .Values.prometheus.service.clusterIP }}
   {{- end }}
   ports:
-  - name: http
-    port: {{ .Values.prometheus.service.port }}
-    targetPort: 9090
-    {{- if and .Values.prometheus.service.nodePort (or (eq .Values.prometheus.service.type "NodePort") (eq .Values.prometheus.service.type "LoadBalancer")) }}
-    nodePort: {{ .Values.prometheus.service.nodePort }}
-    {{- end }}
+    - name: http
+      port: {{ .Values.prometheus.service.port }}
+      targetPort: 9090
+      {{- if and .Values.prometheus.service.nodePort (or (eq .Values.prometheus.service.type "NodePort") (eq .Values.prometheus.service.type "LoadBalancer")) }}
+      nodePort: {{ .Values.prometheus.service.nodePort }}
+      {{- end }}
   selector:
     app: prometheus
     prometheus: {{ template "prometheus-operator.prometheus.fullname" . }}

--- a/bitnami/prometheus-operator/templates/prometheus/servicemonitor.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/servicemonitor.yaml
@@ -11,15 +11,15 @@ spec:
     matchNames:
       - {{ .Release.Namespace }}
   endpoints:
-  - port: http
-    {{- if .Values.prometheus.serviceMonitor.interval }}
-    interval: {{ .Values.prometheus.serviceMonitor.interval }}
-    {{- end }}
-    path: "/metrics"
-{{- if .Values.prometheus.serviceMonitor.metricRelabelings }}
-    metricRelabelings: {{- include "prometheus-operator.tplValue" ( dict "value" .Values.prometheus.serviceMonitor.metricRelabelings "context" $) | nindent 6 }}
-{{- end }}
-{{- if .Values.prometheus.serviceMonitor.relabelings }}
-    relabelings: {{- toYaml .Values.prometheus.serviceMonitor.relabelings | nindent 6 }}
-{{- end }}
+    - port: http
+      {{- if .Values.prometheus.serviceMonitor.interval }}
+      interval: {{ .Values.prometheus.serviceMonitor.interval }}
+      {{- end }}
+      path: "/metrics"
+      {{- if .Values.prometheus.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- include "prometheus-operator.tplValue" ( dict "value" .Values.prometheus.serviceMonitor.metricRelabelings "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.prometheus.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml .Values.prometheus.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/bitnami/prometheus-operator/values-production.yaml
+++ b/bitnami/prometheus-operator/values-production.yaml
@@ -786,3 +786,37 @@ kube-state-metrics:
   replicaCount: 2
   serviceMonitor:
     enabled: true
+
+# Component scraping for kubelet and kubelet hosted cAdvisor
+kubelet:
+  ## Create a ServiceMonitor to scrape kubelet service
+  enabled: true
+
+  ## Namespace where kubelet service is deployed
+  namespace: kube-system
+
+  serviceMonitor:
+    ## Scrape interval. If not set, the Prometheus default scrape interval is used.
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    interval: ""
+
+    ## Metric relabeling
+    ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+    ##
+    metricRelabelings: []
+
+    ## Relabel configs
+    ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+    ##
+    relabelings: []
+
+    ## Metric relabeling for scraping cAdvisor
+    ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+    ##
+    cAdvisorMetricRelabelings: []
+
+    ## Relabel configs for scraping cAdvisor
+    ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+    ##
+    cAdvisorRelabelings: []

--- a/bitnami/prometheus-operator/values-production.yaml
+++ b/bitnami/prometheus-operator/values-production.yaml
@@ -787,6 +787,27 @@ kube-state-metrics:
   serviceMonitor:
     enabled: true
 
+## Component scraping the kube-apiserver
+kubeApiServer:
+  ## Create a ServiceMonitor to scrape kube-apiserver service
+  enabled: true
+
+  serviceMonitor:
+    ## Scrape interval. If not set, the Prometheus default scrape interval is used.
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    interval: ""
+
+    ## Metric relabeling
+    ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+    ##
+    metricRelabelings: []
+
+    ## Relabel configs
+    ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+    ##
+    relabelings: []
+
 # Component scraping for kubelet and kubelet hosted cAdvisor
 kubelet:
   ## Create a ServiceMonitor to scrape kubelet service

--- a/bitnami/prometheus-operator/values.yaml
+++ b/bitnami/prometheus-operator/values.yaml
@@ -785,3 +785,37 @@ node-exporter:
 kube-state-metrics:
   serviceMonitor:
     enabled: true
+
+# Component scraping for kubelet and kubelet hosted cAdvisor
+kubelet:
+  ## Create a ServiceMonitor to scrape kubelet service
+  enabled: true
+
+  ## Namespace where kubelet service is deployed
+  namespace: kube-system
+
+  serviceMonitor:
+    ## Scrape interval. If not set, the Prometheus default scrape interval is used.
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    interval: ""
+
+    ## Metric relabeling
+    ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+    ##
+    metricRelabelings: []
+
+    ## Relabel configs
+    ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+    ##
+    relabelings: []
+
+    ## Metric relabeling for scraping cAdvisor
+    ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+    ##
+    cAdvisorMetricRelabelings: []
+
+    ## Relabel configs for scraping cAdvisor
+    ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+    ##
+    cAdvisorRelabelings: []

--- a/bitnami/prometheus-operator/values.yaml
+++ b/bitnami/prometheus-operator/values.yaml
@@ -786,6 +786,27 @@ kube-state-metrics:
   serviceMonitor:
     enabled: true
 
+## Component scraping the kube-apiserver
+kubeApiServer:
+  ## Create a ServiceMonitor to scrape kube-apiserver service
+  enabled: true
+
+  serviceMonitor:
+    ## Scrape interval. If not set, the Prometheus default scrape interval is used.
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    interval: ""
+
+    ## Metric relabeling
+    ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+    ##
+    metricRelabelings: []
+
+    ## Relabel configs
+    ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+    ##
+    relabelings: []
+
 # Component scraping for kubelet and kubelet hosted cAdvisor
 kubelet:
   ## Create a ServiceMonitor to scrape kubelet service


### PR DESCRIPTION
**Description of the change**

adds service monitors for kube-apiserver and kubelet services

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files