### PR TITLE
[bitnami/prometheus-operator] adds parameter to scrape kubelet over HTTPS

### DIFF
--- a/bitnami/prometheus-operator/Chart.yaml
+++ b/bitnami/prometheus-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.35.0
 description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 name: prometheus-operator
-version: 0.9.1
+version: 0.10.0
 keywords:
 - prometheus
 - alertmanager

--- a/bitnami/prometheus-operator/README.md
+++ b/bitnami/prometheus-operator/README.md
@@ -277,6 +277,7 @@ The following table lists the configurable parameters of the Prometheus Operator
 | `exporters.kube-state-metrics.enabled`             | Deploy `kube-state-metrics`                                                                            | `true`        |
 | `kubelet.namespace`                                | Namespace where kubelet service is deployed. Related configuration `operator.kubeletService.namespace` | `kube-system` |
 | `kubelet.enabled`                                  | Create a ServiceMonitor to scrape kubelet service                                                      | `true`        |
+| `kubelet.serviceMonitor.https`                     | Enable scraping of the kubelet over HTTPS                                                              | `true`        |
 | `kubelet.serviceMonitor.interval`                  | Scrape interval (use by default, falling back to Prometheus' default)                                  | `nil`         |
 | `kubelet.serviceMonitor.metricRelabelings`         | Metric relabeling                                                                                      | `[]`          |
 | `kubelet.serviceMonitor.relabelings`               | Relabel configs                                                                                        | `[]`          |

--- a/bitnami/prometheus-operator/templates/exporters/kubelet/servicemonitor.yaml
+++ b/bitnami/prometheus-operator/templates/exporters/kubelet/servicemonitor.yaml
@@ -14,6 +14,43 @@ spec:
     matchNames:
       - {{ .Values.kubelet.namespace }}
   endpoints:
+    {{- if .Values.kubelet.serviceMonitor.https }}
+    - port: https-metrics
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        serverName: kubernetes
+        insecureSkipVerify: true
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      honorLabels: true
+      {{- if .Values.kubelet.serviceMonitor.interval }}
+      interval: {{ .Values.kubelet.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.kubelet.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- include "prometheus-operator.tplValue" ( dict "value" .Values.kubelet.serviceMonitor.metricRelabelings "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.kubelet.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml .Values.kubelet.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
+    - port: https-metrics
+      path: /metrics/cadvisor
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        serverName: kubernetes
+        insecureSkipVerify: true
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      honorLabels: true
+      {{- if .Values.kubelet.serviceMonitor.interval }}
+      interval: {{ .Values.kubelet.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.kubelet.serviceMonitor.cAdvisorMetricRelabelings }}
+      metricRelabelings: {{- include "prometheus-operator.tplValue" ( dict "value" .Values.kubelet.serviceMonitor.cAdvisorMetricRelabelings "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.kubelet.serviceMonitor.cAdvisorRelabelings }}
+      relabelings: {{- toYaml .Values.kubelet.serviceMonitor.cAdvisorRelabelings | nindent 8 }}
+      {{- end }}
+    {{- else }}
     - port: http-metrics
       scheme: http
       tlsConfig:
@@ -43,4 +80,5 @@ spec:
       {{- if .Values.kubelet.serviceMonitor.cAdvisorRelabelings }}
       relabelings: {{- toYaml .Values.kubelet.serviceMonitor.cAdvisorRelabelings | nindent 8 }}
       {{- end }}
+    {{- end }}
 {{- end }}

--- a/bitnami/prometheus-operator/values-production.yaml
+++ b/bitnami/prometheus-operator/values-production.yaml
@@ -817,6 +817,9 @@ kubelet:
   namespace: kube-system
 
   serviceMonitor:
+    ## Scrape kubelet over https
+    https: true
+
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
     ##

--- a/bitnami/prometheus-operator/values.yaml
+++ b/bitnami/prometheus-operator/values.yaml
@@ -816,6 +816,9 @@ kubelet:
   namespace: kube-system
 
   serviceMonitor:
+    ## Scrape kubelet over https
+    https: true
+
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
     ##


### PR DESCRIPTION
**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files