### PR TITLE
[bitnami/mysql] Fix pod annotations

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mysql
-version: 6.7.5
+version: 6.7.6
 appVersion: 8.0.19
 description: Chart to create a Highly available MySQL cluster
 keywords:

--- a/bitnami/mysql/templates/master-statefulset.yaml
+++ b/bitnami/mysql/templates/master-statefulset.yaml
@@ -19,8 +19,8 @@ spec:
     metadata:
       labels: {{- include "mysql.labels" . | nindent 8 }}
         component: master
-      {{- if .Values.master.annotations }}
-      annotations: {{ include "mysql.tplValue" ( dict "value" .Values.master.annotations "context" $) | nindent 8 }}
+      {{- if .Values.master.podAnnotations }}
+      annotations: {{ include "mysql.tplValue" ( dict "value" .Values.master.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
     spec:
 {{- include "mysql.imagePullSecrets" . | indent 6 }}

--- a/bitnami/mysql/templates/slave-statefulset.yaml
+++ b/bitnami/mysql/templates/slave-statefulset.yaml
@@ -20,8 +20,8 @@ spec:
     metadata:
       labels: {{- include "mysql.labels" . | nindent 8 }}
         component: slave
-      {{- if .Values.slave.annotations }}
-      annotations: {{ include "mysql.tplValue" ( dict "value" .Values.slave.annotations "context" $) | nindent 8 }}
+      {{- if .Values.slave.podAnnotations }}
+      annotations: {{ include "mysql.tplValue" ( dict "value" .Values.slave.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
     spec:
 {{- include "mysql.imagePullSecrets" . | indent 6 }}


### PR DESCRIPTION
**Description of the change**
Sets the right parameter for pod annotations.

**Benefits**
Pod annotations are now correctly loaded following our documentation.

**Applicable issues**
  - fixes #1854 

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

