### PR TITLE
[bitnami/postgresql-ha] Add support for running custom init scripts on Pgpool

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql-ha
-version: 1.3.1
+version: 1.4.0
 appVersion: 11.6.0
 description: Chart for PostgreSQL with HA architecture (using Replication Manager (repmgr) and Pgpool).
 keywords:

--- a/bitnami/postgresql-ha/files/pgpool-entrypoint-initdb.d/README.md
+++ b/bitnami/postgresql-ha/files/pgpool-entrypoint-initdb.d/README.md
@@ -1,0 +1,3 @@
+You can copy here your custom `.sh` file(s) so they are executed everytime Pgpool container is initialized
+
+More info in the [bitnami-docker-pgpool](https://github.com/bitnami/bitnami-docker-postgresql-repmgr#initializing-with-custom-scripts) repository.

--- a/bitnami/postgresql-ha/templates/_helpers.tpl
+++ b/bitnami/postgresql-ha/templates/_helpers.tpl
@@ -547,6 +547,17 @@ Return the PostgreSQL initdb scripts configmap.
 {{- end -}}
 
 {{/*
+Return the Pgpool initdb scripts configmap.
+*/}}
+{{- define "postgresql-ha.pgpoolInitdbScriptsCM" -}}
+{{- if .Values.pgpool.initdbScriptsCM -}}
+{{- printf "%s" (tpl .Values.pgpool.initdbScriptsCM $) -}}
+{{- else -}}
+{{- printf "%s-initdb-scripts" (include "postgresql-ha.pgpool" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the LDAP bind password
 */}}
 {{- define "postgresql-ha.ldapPassword" -}}

--- a/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
@@ -216,6 +216,10 @@ spec:
             - name: pgpool-config
               mountPath: /opt/bitnami/pgpool/conf/
             {{- end }}
+            {{- if or (.Files.Glob "files/pgpool-entrypoint-initdb.d/*.sh") .Values.pgpool.initdbScripts .Values.pgpool.initdbScriptsCM  }}
+            - name: custom-init-scripts
+              mountPath: /docker-entrypoint-initdb.d/
+            {{- end }}
             {{- if .Values.postgresql.usePasswordFile }}
             - name: postgresql-password
               mountPath: /opt/bitnami/pgpool/secrets/
@@ -224,12 +228,16 @@ spec:
             - name: pgpool-password
               mountPath: /opt/bitnami/pgpool/secrets/
             {{- end }}
-      {{- if or .Values.postgresql.usePasswordFile .Values.pgpool.usePasswordFile }}
       volumes:
         {{- if or (.Files.Glob "files/pgool.conf") .Values.pgpool.configuration }}
         - name: pgpool-config
           configMap:
             name: {{ include "postgresql-ha.pgpoolConfigurationCM" . }}
+        {{- end }}
+        {{- if or (.Files.Glob "files/pgpool-entrypoint-initdb.d/*.sh") .Values.pgpool.initdbScripts .Values.pgpool.initdbScriptsCM }}
+        - name: custom-init-scripts
+          configMap:
+            name: {{ template "postgresql-ha.pgpoolInitdbScriptsCM" . }}
         {{- end }}
         {{- if .Values.postgresql.usePasswordFile }}
         - name: postgresql-password
@@ -249,4 +257,3 @@ spec:
               - key: admin-password
                 path: admin-password
         {{- end }}
-      {{- end }}

--- a/bitnami/postgresql-ha/templates/pgpool/initdb-scripts-configmap.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/initdb-scripts-configmap.yaml
@@ -1,0 +1,15 @@
+{{- if and (or (.Files.Glob "files/pgpool-entrypoint-initdb.d/*.sh") .Values.pgpool.initdbScripts) (not .Values.pgpool.initdbScriptsCM) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-initdb-scripts" (include "postgresql-ha.pgpool" .) }}
+  labels: {{- include "postgresql-ha.labels" . | nindent 4 }}
+    app.kubernetes.io/component: pgpool
+data:
+  {{- with .Files.Glob "files/pgpool-entrypoint-initdb.d/*.sh" }}
+  {{- .AsConfig | nindent 2 }}
+  {{- end }}
+  {{- with .Values.pgpool.initdbScripts }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/bitnami/postgresql-ha/values-production.yaml
+++ b/bitnami/postgresql-ha/values-production.yaml
@@ -51,7 +51,7 @@ postgresqlImage:
 pgpoolImage:
   registry: docker.io
   repository: bitnami/pgpool
-  tag: CHANGEME
+  tag: 4.1.0-debian-10-r2
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##

--- a/bitnami/postgresql-ha/values-production.yaml
+++ b/bitnami/postgresql-ha/values-production.yaml
@@ -51,7 +51,7 @@ postgresqlImage:
 pgpoolImage:
   registry: docker.io
   repository: bitnami/pgpool
-  tag: 4.1.0-debian-10-r0
+  tag: CHANGEME
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -375,6 +375,20 @@ pgpool:
   ## NOTE: This will override pgpool.configuration parameter
   ##
   # configurationCM:
+
+  ## initdb scripts
+  ## Specify dictionary of scripts to be run everytime Pgpool container is initialized
+  ## Alternatively, you can put your scripts under the files/pgpool-entrypoint-initdb.d directory
+  ##
+  # initdbScripts:
+  #   my_init_script.sh: |
+  #      #!/bin/sh
+  #      echo "Do something."
+
+  ## ConfigMap with scripts to be run everytime Pgpool container is initialized
+  ## NOTE: This will override pgpool.initdbScripts
+  ##
+  # initdbScriptsCM:
 
   ## Use Pgpool Load-Balancing
   ##

--- a/bitnami/postgresql-ha/values.yaml
+++ b/bitnami/postgresql-ha/values.yaml
@@ -51,7 +51,7 @@ postgresqlImage:
 pgpoolImage:
   registry: docker.io
   repository: bitnami/pgpool
-  tag: CHANGEME
+  tag: 4.1.0-debian-10-r2
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##

--- a/bitnami/postgresql-ha/values.yaml
+++ b/bitnami/postgresql-ha/values.yaml
@@ -51,7 +51,7 @@ postgresqlImage:
 pgpoolImage:
   registry: docker.io
   repository: bitnami/pgpool
-  tag: 4.1.0-debian-10-r0
+  tag: CHANGEME
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -375,6 +375,20 @@ pgpool:
   ## NOTE: This will override pgpool.configuration parameter
   ##
   # configurationCM:
+
+  ## initdb scripts
+  ## Specify dictionary of scripts to be run everytime Pgpool container is initialized
+  ## Alternatively, you can put your scripts under the files/pgpool-entrypoint-initdb.d directory
+  ##
+  # initdbScripts:
+  #   my_init_script.sh: |
+  #      #!/bin/sh
+  #      echo "Do something."
+
+  ## ConfigMap with scripts to be run everytime Pgpool container is initialized
+  ## NOTE: This will override pgpool.initdbScripts
+  ##
+  # initdbScriptsCM:
 
   ## Use Pgpool Load-Balancing
   ##


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

This PR adds support for running custom init scripts on Pgpool everytime it's initialized.

**Benefits**

This can be very useful for people that want to automate certain actions. E.g. adding users/passwords using a script like the one below:

```bash
#!/bin/bash

USERS=("user1:password1" "user2:password2" "user3:password3")

for user in "${USERS[@]}"; do
    user_info=(${user//:/ })
    /opt/bitnami/pgpool/bin/pg_md5 -m --config-file="/opt/bitnami/pgpool/conf/pgpool.conf" -u "${user_info[0]}" "${user_info[1]}"
done
```

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/1741

**Additional information**

Please don't merge this PR until the new `bitnami/pgpool` container adding support to this feature is released.

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
