### PR TITLE
[bitnami/prometheus-operator] inherit value of `prometheus-operator.image` for `prometheus-operator.prometheusConfigReloader.image` template

### DIFF
--- a/bitnami/prometheus-operator/Chart.yaml
+++ b/bitnami/prometheus-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.35.0
 description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 name: prometheus-operator
-version: 0.10.1
+version: 0.11.0
 keywords:
 - prometheus
 - alertmanager

--- a/bitnami/prometheus-operator/README.md
+++ b/bitnami/prometheus-operator/README.md
@@ -100,7 +100,7 @@ The following table lists the configurable parameters of the Prometheus Operator
 | `operator.service.loadBalancerSourceRanges`           | Address that are allowed when svc is `LoadBalancer`                                   | `[]`                                                                 |
 | `operator.service.annotations`                        | Additional annotations for Prometheus Operator service                                | `{}`                                                                 |
 | `operator.createCustomResource`                       | Create Prometheus Operator CRD's. With helm v3 use the `--skip-crds` argument instead | `true`                                                               |
-| `operator.customResourceDeletePolicy`                 | Prometheus Operator CRD deletion policy                                               | `nil`                                                                     |
+| `operator.customResourceDeletePolicy`                 | Prometheus Operator CRD deletion policy                                               | `nil`                                                                |
 | `operator.serviceMonitor.enabled`                     | Creates a ServiceMonitor to monitor Prometheus Operator                               | `true`                                                               |
 | `operator.serviceMonitor.interval`                    | Scrape interval (use by default, falling back to Prometheus' default)                 | `nil`                                                                |
 | `operator.serviceMonitor.metricRelabelings`           | Metric relabeling                                                                     | `[]`                                                                 |
@@ -133,9 +133,9 @@ The following table lists the configurable parameters of the Prometheus Operator
 | `operator.configmapReload.image.tag`                  | ConfigMap Reload Image tag                                                            | `{TAG_NAME}`                                                         |
 | `operator.configmapReload.image.pullPolicy`           | ConfigMap Reload image pull policy                                                    | `IfNotPresent`                                                       |
 | `operator.configmapReload.image.pullSecrets`          | Specify docker-registry secret names as an array                                      | `[]` (does not add image pull secrets to deployed pods)              |
-| `operator.prometheusConfigReloader.image.registry`    | Prometheus Config Reloader image registry                                             | `docker.io`                                                          |
-| `operator.prometheusConfigReloader.image.repository`  | Prometheus Config Reloader Image name                                                 | `bitnami/configmap-reload`                                           |
-| `operator.prometheusConfigReloader.image.tag`         | Prometheus Config Reloader Image tag                                                  | `{TAG_NAME}`                                                         |
+| `operator.prometheusConfigReloader.image.registry`    | Prometheus Config Reloader image registry                                             | same as `operator.image.registry`                                    |
+| `operator.prometheusConfigReloader.image.repository`  | Prometheus Config Reloader Image name                                                 | same as `operator.image.repository`                                  |
+| `operator.prometheusConfigReloader.image.tag`         | Prometheus Config Reloader Image tag                                                  | same as `operator.image.tag`                                         |
 | `operator.prometheusConfigReloader.image.pullPolicy`  | Prometheus Config Reloader image pull policy                                          | `IfNotPresent`                                                       |
 | `operator.prometheusConfigReloader.image.pullSecrets` | Specify docker-registry secret names as an array                                      | `[]` (does not add image pull secrets to deployed pods)              |
 

--- a/bitnami/prometheus-operator/templates/_helpers.tpl
+++ b/bitnami/prometheus-operator/templates/_helpers.tpl
@@ -153,6 +153,7 @@ Also, we can't use a single if because lazy evaluation is not an option
 Return the proper Prometheus Operator Reloader image name
 */}}
 {{- define "prometheus-operator.prometheusConfigReloader.image" -}}
+{{- if and .Values.operator.prometheusConfigReloader.image.registry (and .Values.operator.prometheusConfigReloader.image.repository .Values.operator.prometheusConfigReloader.image.tag) }}
 {{- $registryName := .Values.operator.prometheusConfigReloader.image.registry -}}
 {{- $repositoryName := .Values.operator.prometheusConfigReloader.image.repository -}}
 {{- $tag := .Values.operator.prometheusConfigReloader.image.tag | toString -}}
@@ -169,6 +170,9 @@ Also, we can't use a single if because lazy evaluation is not an option
     {{- end -}}
 {{- else -}}
     {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- else -}}
+{{- include "prometheus-operator.image" . -}}
 {{- end -}}
 {{- end -}}
 
@@ -395,9 +399,11 @@ WARNING: Rolling tag detected ({{ .Values.operator.image.repository }}:{{ .Value
 WARNING: Rolling tag detected ({{ .Values.operator.configmapReload.image.repository }}:{{ .Values.operator.configmapReload.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
 +info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
 {{- end }}
+{{- if and .Values.operator.prometheusConfigReloader.image.registry (and .Values.operator.prometheusConfigReloader.image.repository .Values.operator.prometheusConfigReloader.image.tag) }}
 {{- if and (contains "bitnami/" .Values.operator.prometheusConfigReloader.image.repository) (not (.Values.operator.prometheusConfigReloader.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
 WARNING: Rolling tag detected ({{ .Values.operator.prometheusConfigReloader.image.repository }}:{{ .Values.operator.prometheusConfigReloader.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
 +info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
+{{- end }}
 {{- end }}
 {{- if and (contains "bitnami/" .Values.prometheus.image.repository) (not (.Values.prometheus.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
 WARNING: Rolling tag detected ({{ .Values.prometheus.image.repository }}:{{ .Values.prometheus.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.

--- a/bitnami/prometheus-operator/values-production.yaml
+++ b/bitnami/prometheus-operator/values-production.yaml
@@ -217,10 +217,10 @@ operator:
       #   - myRegistryKeySecretName
 
   prometheusConfigReloader:
-    image:
-      registry: docker.io
-      repository: bitnami/prometheus-operator
-      tag: 0.34.0-debian-9-r38
+    image: {}
+      # registry:
+      # repository:
+      # tag:
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/bitnami/prometheus-operator/values.yaml
+++ b/bitnami/prometheus-operator/values.yaml
@@ -217,10 +217,10 @@ operator:
       #   - myRegistryKeySecretName
 
   prometheusConfigReloader:
-    image:
-      registry: docker.io
-      repository: bitnami/prometheus-operator
-      tag: 0.34.0-debian-9-r38
+    image: {}
+      # registry:
+      # repository:
+      # tag:
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION
**Description of the change**

Since the image used for `prometheus-operator.prometheusConfigReloader.image` is the same as the one used for `prometheus-operator.image`, this PR consolidates the default value for the `prometheus-operator.prometheusConfigReloader.image` to be the same as the `prometheus-operator.image` template. 

**Benefits**

Removes redundancy


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files