### PR TITLE
[bitnami/elasticsearch] Deploy master pods in parallel

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: elasticsearch
-version: 10.3.7
+version: 11.0.0
 appVersion: 7.5.2
 description: A highly scalable open-source full-text search and analytics engine
 keywords:

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: elasticsearch
-version: 10.3.6
+version: 10.3.7
 appVersion: 7.5.2
 description: A highly scalable open-source full-text search and analytics engine
 keywords:

--- a/bitnami/elasticsearch/README.md
+++ b/bitnami/elasticsearch/README.md
@@ -485,7 +485,7 @@ The field `podManagementPolicy` can't be updated in a StatefulSet, so you need t
 
 ```console
 $ kubectl delete statefulset elasticsearch-master
-$ helm upgrade bitnami/elasticsearch
+$ helm upgrade <DEPLOYMENT_NAME> bitnami/elasticsearch
 ```
 
 ### 10.0.0

--- a/bitnami/elasticsearch/README.md
+++ b/bitnami/elasticsearch/README.md
@@ -477,6 +477,17 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 
 ## Notable changes
 
+### 11.0.0
+
+Elasticsearch master pods are now deployed in parallel in order to bootstrap de cluster and be discovered.
+
+The field `podManagementPolicy` can't be updated in a StatefulSet, so you need to destroy it before you upgrade the chart to this version.
+
+```console
+$ kubectl delete statefulset elasticsearch-master
+$ helm upgrade bitnami/elasticsearch
+```
+
 ### 10.0.0
 
 In this version, Kibana was added as dependant chart. More info about how to enable and work with this bundled Kibana in the ["Enable bundled Kibana"](#enable-bundled-kibana) section.

--- a/bitnami/elasticsearch/templates/master-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/master-statefulset.yaml
@@ -14,6 +14,7 @@ spec:
     matchLabels: {{- include "elasticsearch.matchLabels" . | nindent 6 }}
       role: master
   serviceName: {{ template "elasticsearch.master.fullname" . }}
+  podManagementPolicy: Parallel
   replicas: {{ .Values.master.replicas }}
   template:
     metadata:


### PR DESCRIPTION
**Description of the change**

Deploy master pods in parallel

**Applicable issues**

  - fixes #1865

**Additional information**

```
master not discovered yet, this node has not previously joined a bootstrapped (v7+) cluster, and this node must discover master-eligible nodes [es-elasticsearch-master-2] to bootstrap a cluster
```

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] ~Variables are documented in the README.md~
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] ~If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files~