### PR TITLE
[bitnami/airflow] Allow setting Redis username on external redis

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: airflow
-version: 4.1.3
+version: 4.2.0
 appVersion: 1.10.7
 description: Apache Airflow is a platform to programmatically author, schedule and monitor workflows.
 keywords:

--- a/bitnami/airflow/README.md
+++ b/bitnami/airflow/README.md
@@ -144,6 +144,7 @@ The following tables lists the configurable parameters of the Kafka chart and th
 | `externalRedis.host`                      | External Redis host                                                                                  | `nil`                                                        |
 | `externalRedis.port`                      | External Redis port                                                                                  | `nil`                                                        |
 | `externalRedis.password`                  | External Redis password                                                                              | `nil`                                                        |
+| `externalRedis.username`                  | External Redis username (not required on most Redis implementations)                                 | `nil`                                                        |
 | `metrics.enabled`                         | Start a side-car prometheus exporter                                                                 | `false`                                                      |
 | `metrics.image.registry`                  | Airflow exporter image registry                                                                      | `docker.io`                                                  |
 | `metrics.image.repository`                | Airflow exporter image name                                                                          | `bitnami/airflow-exporter`                                   |

--- a/bitnami/airflow/templates/deployment-scheduler.yaml
+++ b/bitnami/airflow/templates/deployment-scheduler.yaml
@@ -134,6 +134,10 @@ spec:
               {{- else }}
               value: {{ .Values.externalRedis.port | quote }}
               {{- end }}
+            {{- if and (not .Values.redis.enabled) .Values.externalRedis.username }}
+            - name: REDIS_USER
+              value: {{ .Values.externalRedis.username | quote }}
+            {{- end }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/bitnami/airflow/templates/deployment-web.yaml
+++ b/bitnami/airflow/templates/deployment-web.yaml
@@ -134,6 +134,10 @@ spec:
               {{- else }}
               value: {{ .Values.externalRedis.port | quote }}
               {{- end }}
+            {{- if and (not .Values.redis.enabled) .Values.externalRedis.username }}
+            - name: REDIS_USER
+              value: {{ .Values.externalRedis.username | quote }}
+            {{- end }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/bitnami/airflow/templates/statefulset-worker.yaml
+++ b/bitnami/airflow/templates/statefulset-worker.yaml
@@ -136,6 +136,10 @@ spec:
               {{- else }}
               value: {{ .Values.externalRedis.port | quote }}
               {{- end }}
+            {{- if and (not .Values.redis.enabled) .Values.externalRedis.username }}
+            - name: REDIS_USER
+              value: {{ .Values.externalRedis.username | quote }}
+            {{- end }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/bitnami/airflow/values-production.yaml
+++ b/bitnami/airflow/values-production.yaml
@@ -333,11 +333,19 @@ redis:
 externalRedis:
   ## All of these values are only used when redis.enabled is set to false
   ## Redis host
+  ##
   host: localhost
   ## Redis port number
+  ##
   port: 6379
   ## Redis password
+  ##
   password: ""
+  ## Redis username
+  ## Most Redis implementnations do not require a username to authenticate
+  ## and it should be enough with the password
+  ##
+  # username: ""
 
 ## Prometheus Exporter / Metrics
 ##

--- a/bitnami/airflow/values.yaml
+++ b/bitnami/airflow/values.yaml
@@ -333,11 +333,19 @@ redis:
 externalRedis:
   ## All of these values are only used when redis.enabled is set to false
   ## Redis host
+  ##
   host: localhost
   ## Redis port number
+  ##
   port: 6379
   ## Redis password
+  ##
   password: ""
+  ## Redis username
+  ## Most Redis implementnations do not require a username to authenticate
+  ## and it should be enough with the password
+  ##
+  # username: ""
 
 ## Prometheus Exporter / Metrics
 ##


### PR DESCRIPTION
**Description of the change**

This PR allows setting the environment variable **REDIS_USER** (recognised by Airflow, see https://github.com/bitnami/bitnami-docker-airflow#use-an-existing-database) to configure the authentication to Redis.

It's very unlikely to be required since most Redis authentication systems only required the password, but it could be useful on certain scenarios.

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/1881

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

