### PR TITLE
[bitnami/postgresql-ha] Fix mount point for extended PostgreSQL configuration

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql-ha
-version: 1.4.1
+version: 1.4.2
 appVersion: 11.6.0
 description: Chart for PostgreSQL with HA architecture (using Replication Manager (repmgr) and Pgpool).
 keywords:

--- a/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
@@ -180,7 +180,7 @@ spec:
             {{- end }}
             {{- if or (.Files.Glob "files/conf.d/*.conf") .Values.postgresql.extendedConf .Values.postgresql.extendedConfCM }}
             - name: postgresql-extended-config
-              mountPath: /bitnami/repmgr/conf/conf.d/
+              mountPath: /bitnami/postgresql/conf/conf.d/
             {{- end }}
             {{- if or (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql,sql.gz}") .Values.postgresql.initdbScriptsCM .Values.postgresql.initdbScripts }}
             - name: custom-init-scripts


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

**postgresql.conf** must me mounted at `/bitnami/repmgr/conf/` since the "repmgr" logic will detect the file and put in the right place instead of auto-generating a new config file for PostgreSQL (check the line below):

- https://github.com/bitnami/bitnami-docker-postgresql-repmgr/blob/master/12/debian-10/rootfs/librepmgr.sh#L416

However, that logic doesn't take into account the "extended configuration", which should be directly mounted at `/bitnami/postgresql/conf/conf.d/`.

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/1884

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)