### PR TITLE
[bitnami/cassandra] fix cassandra upgrade

### DIFF
--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cassandra
-version: 4.1.15
+version: 5.0.0
 appVersion: 3.11.5
 description: Apache Cassandra is a free and open-source distributed database management system designed to handle large amounts of data across many commodity servers, providing high availability with no single point of failure. Cassandra offers robust support for clusters spanning multiple datacenters, with asynchronous masterless replication allowing low latency operations for all clients.
 keywords:

--- a/bitnami/cassandra/README.md
+++ b/bitnami/cassandra/README.md
@@ -241,6 +241,15 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 
 ## Upgrade
 
+### 5.0.0
+
+An issue in StatefulSet manifest of the 4.x chart series rendered chart upgrades to be broken. The 5.0.0 series fixes this issue. To upgrade to the 5.x series you need to manually delete the Cassandra StatefulSet before executing the `helm upgrade` command.
+
+```bash
+$ kubectl delete sts -l release=<RELEASE_NAME>
+$ helm upgrade <RELEASE_NAME> ...
+```
+
 ### 4.0.0
 
 This release changes uses Bitnami Cassandra container `3.11.4-debian-9-r188`, based on Bash.

--- a/bitnami/cassandra/templates/statefulset.yaml
+++ b/bitnami/cassandra/templates/statefulset.yaml
@@ -255,7 +255,7 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: data
-        labels: {{- include "cassandra.labels" . | nindent 10 }}
+        labels: {{- include "cassandra.matchLabels" . | nindent 10 }}
         {{- if .Values.persistence.annotations }}
         annotations: {{- toYaml .Values.persistence.annotations | nindent 10 }}
         {{- end }}


### PR DESCRIPTION
**Description of the change**
This PR removes the `chart: {{ include "cassandra.chart" . }}` label
from the `volumeClainTemplate` metadata as it breaks chart upgrades

**Benefits**

Cassandra deployments can be upgraded 

**Possible drawbacks**

None

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.