### PR TITLE
[bitnami/kafka] Fix dependencies

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 7.2.1
+version: 7.2.2
 appVersion: 2.4.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/requirements.lock
+++ b/bitnami/kafka/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: zookeeper
   repository: https://charts.bitnami.com/bitnami
   version: 5.4.0
-digest: sha256:68d585c7ec07070c669ee7464d2bf9ef069cad0200baa7e3eeb5a545ac7c4e81
-generated: "2020-02-03T14:56:00.591520443Z"
+digest: sha256:2f3c43ce02e3966648b8c89be121fe39537f62ea1d161ad908f51ddc90e4243e
+generated: "2020-02-07T09:08:16.127554+01:00"


### PR DESCRIPTION
**Description of the change**

The `requirements.lock` file has a wrong "digest"

**Possible drawbacks**

None

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
