### PR TITLE
[bitnami/consul] fix volume path for persistence

### DIFF
--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: consul
-version: 6.0.15
+version: 6.1.0
 appVersion: 1.6.3
 description: Highly available and distributed service discovery and key-value store designed with support for the modern data center to make distributed systems and configuration easy.
 home: https://www.consul.io/

--- a/bitnami/consul/templates/statefulset.yaml
+++ b/bitnami/consul/templates/statefulset.yaml
@@ -50,7 +50,7 @@ spec:
             - /bin/bash
             - -ec
             - |
-              chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} /bitnami/consul/data
+              chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} /bitnami/consul
           securityContext:
             runAsUser: 0
           {{- if .Values.volumePermissions.resources }}
@@ -58,7 +58,7 @@ spec:
           {{- end }}
           volumeMounts:
             - name: data
-              mountPath: /bitnami/consul/data
+              mountPath: /bitnami/consul
         {{- end }}
       containers:
         - name: consul
@@ -166,7 +166,7 @@ spec:
             {{- end }}
             {{- if .Values.persistence.enabled }}
             - name: data
-              mountPath: /bitnami/consul/data
+              mountPath: /bitnami/consul
             {{- end }}
             {{- if .Values.configmap }}
             - name: consul-config


### PR DESCRIPTION
**Description of the change**

The volume for data persistence was wrongly mounted at `/bitnami/consul/data`.
No data gets persisted at this location.

**Benefits**

Fixes consul data persistence

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files