### PR TITLE
[bitnami/memcached] Fix service annotations not being applied

### DIFF
--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: memcached
-version: 4.2.4
+version: 4.2.5
 appVersion: 1.5.22
 description: Chart for Memcached
 keywords:

--- a/bitnami/memcached/templates/service.yaml
+++ b/bitnami/memcached/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "memcached.fullname" . }}
   labels: {{- include "memcached.labels" . | nindent 4 }}
   {{- if .Values.service.annotations }}
-  annotations: {{- include "memcached.tplValue" (dict "value" .Values.service.annotation "context" $) | nindent 4 }}
+  annotations: {{- include "memcached.tplValue" (dict "value" .Values.service.annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Fix for issue #1894

**Benefits**

The service annotations will applied as configured in `service.annotations`.

**Possible drawbacks**

None.

**Applicable issues**

None

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
