### PR TITLE
[bitnami/prometheus-thanos] Thanos ports

### DIFF
--- a/bitnami/prometheus-operator/Chart.yaml
+++ b/bitnami/prometheus-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.35.1
 description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 name: prometheus-operator
-version: 0.12.0
+version: 0.12.1
 keywords:
 - prometheus
 - alertmanager

--- a/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -153,10 +153,10 @@ spec:
         - --grpc-address=0.0.0.0:10901
         - --http-address=0.0.0.0:10902
       ports:
-        - name: grpc-thanos
+        - name: grpc
           containerPort: 10901
           protocol: TCP
-        - name: http-thanos
+        - name: http
           containerPort: 10902
           protocol: TCP
     {{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus/thanos-service.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/thanos-service.yaml
@@ -22,9 +22,9 @@ spec:
   clusterIP: {{ .Values.prometheus.thanos.service.clusterIP }}
   {{- end }}
   ports:
-    - name: grpc-thanos
+    - name: grpc
       port: {{ .Values.prometheus.thanos.service.port }}
-      targetPort: grpc-thanos
+      targetPort: grpc
       protocol: TCP
       {{- if and .Values.prometheus.thanos.service.nodePort (or (eq .Values.prometheus.thanos.service.type "NodePort") (eq .Values.prometheus.thanos.service.type "LoadBalancer")) }}
       nodePort: {{ .Values.prometheus.thanos.service.nodePort }}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

Standardize port names for Thanos.

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
