### PR TITLE
[bitnami/tomcat] adds `updateStrategy` chart parameter

### DIFF
--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: tomcat
-version: 6.1.6
+version: 6.2.0
 appVersion: 9.0.30
 description: Chart for Apache Tomcat
 keywords:

--- a/bitnami/tomcat/README.md
+++ b/bitnami/tomcat/README.md
@@ -49,8 +49,8 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the Tomcat chart and their default values.
 
-| Parameter                            | Description                                                                                         | Default                                                 |
-| ------------------------------------ | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+|              Parameter               |                                             Description                                             |                         Default                         |
+|--------------------------------------|-----------------------------------------------------------------------------------------------------|---------------------------------------------------------|
 | `global.imageRegistry`               | Global Docker image registry                                                                        | `nil`                                                   |
 | `global.imagePullSecrets`            | Global Docker registry secret names as an array                                                     | `[]` (does not add image pull secrets to deployed pods) |
 | `global.storageClass`                | Global storage class for dynamic provisioning                                                       | `nil`                                                   |
@@ -67,6 +67,7 @@ The following tables lists the configurable parameters of the Tomcat chart and t
 | `volumePermissions.resources`        | Init container resource requests/limit                                                              | `{}`                                                    |
 | `nameOverride`                       | String to partially override tomcat.fullname template with a string (will prepend the release name) | `nil`                                                   |
 | `fullnameOverride`                   | String to fully override tomcat.fullname template with a string                                     | `nil`                                                   |
+| `updateStrategy`                     | Set to Recreate if you use persistent volume that cannot be mounted by more than one pods           | `RollingUpdate`                                         |
 | `tomcatUsername`                     | Tomcat admin user                                                                                   | `user`                                                  |
 | `tomcatPassword`                     | Tomcat admin password                                                                               | _random 10 character alphanumeric string_               |
 | `tomcatAllowRemoteManagement`        | Enable remote access to management interface                                                        | `0` (disabled)                                          |

--- a/bitnami/tomcat/templates/deployment.yaml
+++ b/bitnami/tomcat/templates/deployment.yaml
@@ -4,6 +4,11 @@ metadata:
   name: {{ template "tomcat.fullname" . }}
   labels: {{- include "tomcat.labels" . | nindent 4 }}
 spec:
+  strategy:
+    type: {{ .Values.updateStrategy }}
+    {{- if (eq "Recreate" .Values.updateStrategy) }}
+    rollingUpdate: null
+    {{- end }}
   selector:
     matchLabels: {{- include "tomcat.matchLabels" . | nindent 6 }}
   template:

--- a/bitnami/tomcat/values.yaml
+++ b/bitnami/tomcat/values.yaml
@@ -66,6 +66,10 @@ volumePermissions:
     #   cpu: 100m
     #   memory: 128Mi
 
+## Set to Recreate if you use persistent volume that cannot be mounted by more than one pods
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+updateStrategy: RollingUpdate
+
 ## Admin user
 ## ref: https://github.com/bitnami/bitnami-docker-tomcat#creating-a-custom-user
 ##

--- a/bitnami/tomcat/values.yaml
+++ b/bitnami/tomcat/values.yaml
@@ -68,6 +68,7 @@ volumePermissions:
 
 ## Set to Recreate if you use persistent volume that cannot be mounted by more than one pods
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+##
 updateStrategy: RollingUpdate
 
 ## Admin user


### PR DESCRIPTION
Allows setting updateStrategy to `Recreate` if the persistent volume that cannot be mounted by more than one pods

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files