### PR TITLE
[bitnami/wildfly] fix typo in container name

### DIFF
--- a/bitnami/wildfly/Chart.yaml
+++ b/bitnami/wildfly/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wildfly
-version: 3.5.0
+version: 3.5.1
 appVersion: 18.0.1
 description: Chart for Wildfly
 keywords:

--- a/bitnami/wildfly/templates/deployment.yaml
+++ b/bitnami/wildfly/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
               mountPath: /bitnami/wildfly
       {{- end }}
       containers:
-        - name: wildlfy
+        - name: wildfly
           image: {{ template "wildfly.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           env:


### PR DESCRIPTION
**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files