### PR TITLE
[bitnami/thanos] Use buster in secondary images

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
-version: 0.1.0
+version: 0.1.1

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -324,7 +324,7 @@ The following tables lists the configurable parameters of the Thanos chart and t
 | `volumePermissions.enabled`           | Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup` | `false`                                                 |
 | `volumePermissions.image.registry`    | Init container volume-permissions image registry                                                                     | `docker.io`                                             |
 | `volumePermissions.image.repository`  | Init container volume-permissions image name                                                                         | `bitnami/minideb`                                       |
-| `volumePermissions.image.tag`         | Init container volume-permissions image tag                                                                          | `stretch`                                               |
+| `volumePermissions.image.tag`         | Init container volume-permissions image tag                                                                          | `buster`                                                |
 | `volumePermissions.image.pullPolicy`  | Init container volume-permissions image pull policy                                                                  | `Always`                                                |
 | `volumePermissions.image.pullSecrets` | Specify docker-registry secret names as an array                                                                     | `[]` (does not add image pull secrets to deployed pods) |
 

--- a/bitnami/thanos/requirements.lock
+++ b/bitnami/thanos/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: minio
   repository: https://charts.bitnami.com/bitnami
-  version: 3.x.x
-digest: sha256:d2ebc0390c4db41014ddd83aab9a66242941500df8fc151c4772c6617467ec13
-generated: "2020-02-06T15:25:39.236719+01:00"
+  version: 3.0.6
+digest: sha256:6844ef1e5d776b7708b40cc7c92c92e920794a9cb1f5bac0d3b2f5034c1f9d40
+generated: "2020-02-13T14:01:51.359157807Z"

--- a/bitnami/thanos/values-production.yaml
+++ b/bitnami/thanos/values-production.yaml
@@ -932,7 +932,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/minideb
-    tag: stretch
+    tag: buster
     ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -932,7 +932,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/minideb
-    tag: stretch
+    tag: buster
     ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>
Use `buster` instead of `stretch` in the secondary images