### PR TITLE
[bitnami/etcd] Ensure disaster recovery snapshot script works.

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: etcd
-version: 4.4.14
+version: 4.4.15
 appVersion: 3.4.3
 description: etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines
 keywords:

--- a/bitnami/etcd/templates/cronjob.yaml
+++ b/bitnami/etcd/templates/cronjob.yaml
@@ -31,6 +31,8 @@ spec:
               command:
                 - /scripts/save-snapshot.sh
               env:
+              - name: BITNAMI_DEBUG
+                value: {{ ternary "true" "false" .Values.image.debug | quote }}
               - name: ETCDCTL_API
                 value: "3"
               {{- if .Values.auth.client.secureTransport }}

--- a/bitnami/etcd/templates/scripts-configmap.yaml
+++ b/bitnami/etcd/templates/scripts-configmap.yaml
@@ -254,14 +254,27 @@ data:
     AUTH_OPTIONS="{{ $etcdAuthOptions }}"
     ETCDCTL_ENDPOINTS="{{range $i, $e := until $replicaCount }}{{ $etcdClientProtocol }}://{{ $etcdFullname }}-{{ $e }}.{{ $etcdHeadlessServiceName }}.{{ $releaseNamespace }}.svc.{{ $clusterDomain }}:{{ $clientPort }},{{ end }}"
     # Remove the last comma "," introduced in the string
-    export ETCDCTL_ENDPOINTS="$(sed 's/,/ /g' <<< $ETCDCTL_ENDPOINTS | awk '{$1=$1};1' | sed 's/ /,/g')"
+    export ETCDCTL_ENDPOINTS="${ETCDCTL_ENDPOINTS%%,}"
+    # prepare space separated list of endpoints
+    export etcdctl_endpoints_list="$(sed 's/,/ /g' <<< $ETCDCTL_ENDPOINTS)"
 
     mkdir -p "/snapshots" 1>&3 2>&4
-    if etcdctl $AUTH_OPTIONS endpoint health; then
-        echo "Snapshotting the keyspace..." 1>&3 2>&4
-        etcdctl $AUTH_OPTIONS snapshot save "/snapshots/db" 1>&3 2>&4
-    else
-        echo "Cluster isn't responding!!" 1>&3 2>&4
-        exit 1
-    fi
+
+    # walk over each node in the list, check if node healthy make snapshot and exit, otherwise try another node
+    for etcd_endpoint in $etcdctl_endpoints_list; do
+        export ETCDCTL_ENDPOINTS="${etcd_endpoint}"
+        echo "Using etcd endpoint ${etcd_endpoint}" 1>&3 2>&4
+        if etcdctl $AUTH_OPTIONS endpoint health; then
+            echo "Snapshotting the keyspace..." 1>&3 2>&4
+            etcdctl $AUTH_OPTIONS snapshot save "/snapshots/db" 1>&3 2>&4
+            exit 0
+        else
+            echo "Warning - etcd endpoint not healthy ${etcd_endpoint}" 1>&3 2>&4
+            echo "Trying another endpoint." 1>&3 2>&4
+        fi
+    done
+
+    # exit with error if all endpoints are bad
+    echo "Error - all etcd endpoits are unhealthy!" 1>&3 2>&4
+    exit 1
 {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Ensure etcd snapshot works as expected.

**Benefits**

Snapshots works.

**Possible drawbacks**

None.

**Applicable issues**

  - fixes #1921 

**Additional information**

Example output with failed first node in the cluster
```text
kubectl get pods -n bitnami-r3
NAME                                      READY   STATUS      RESTARTS   AGE
bn-etcd-r3-0                              0/1     Error       11         34m
bn-etcd-r3-1                              1/1     Running     0          44m
bn-etcd-r3-2                              1/1     Running     0          44m
bn-etcd-r3-snapshotter-1581632100-7pptq   0/1     Completed   0          5m10s
bn-etcd-r3-snapshotter-1581632400-fdmps   1/1     Running     0          7s

kubectl get pods -n bitnami-r3
NAME                                      READY   STATUS             RESTARTS   AGE
bn-etcd-r3-0                              0/1     CrashLoopBackOff   11         35m
bn-etcd-r3-1                              1/1     Running            0          45m
bn-etcd-r3-2                              1/1     Running            0          45m
bn-etcd-r3-snapshotter-1581632400-fdmps   0/1     Completed          0          49s
```

Output from snapshot executing pod
```text
Using etcd endpoint http://bn-etcd-r3-0.bn-etcd-r3-headless.bitnami-r3.svc.cluster.local:2379
Warning - etcd endpoint not healthy http://bn-etcd-r3-0.bn-etcd-r3-headless.bitnami-r3.svc.cluster.local:2379
Trying another endpoint.
Using etcd endpoint http://bn-etcd-r3-1.bn-etcd-r3-headless.bitnami-r3.svc.cluster.local:2379
Snapshotting the keyspace...
Snapshot saved at /snapshots/db

```

And in case of failed cluster:
```text
NAME                                      READY   STATUS             RESTARTS   AGE
bn-etcd-r3-0                              0/1     CrashLoopBackOff   17         70m
bn-etcd-r3-1                              0/1     Running            0          27s
bn-etcd-r3-2                              1/1     Running            0          80m
bn-etcd-r3-snapshotter-1581634200-xv9ww   0/1     Completed          0          5m44s
bn-etcd-r3-snapshotter-1581634500-mm2sh   0/1     Error              1          41s

```

```text
Error - all etcd endpoits are unhealthy!
```

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

