### PR TITLE
[bitnami/elasticsearch] Fixed master.persistence.storageClass

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: elasticsearch
-version: 11.0.4
+version: 11.0.5
 appVersion: 7.6.0
 description: A highly scalable open-source full-text search and analytics engine
 keywords:

--- a/bitnami/elasticsearch/templates/_helpers.tpl
+++ b/bitnami/elasticsearch/templates/_helpers.tpl
@@ -278,13 +278,13 @@ Also, we can't use a single if because lazy evaluation is not an option
 
 {{/*
 Return the proper Storage Class
+Usage:
+{{ include "elasticsearch.storageClass" (dict "global" .Values.global "local" .Values.master) }}
 */}}
 {{- define "elasticsearch.storageClass" -}}
 {{/*
 Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
 but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
-Usage:
-{{ include "elasticsearch.storageClass" (dict "global" .Values.global "local" .Values.master) }}
 */}}
 {{- if .global -}}
     {{- if .global.storageClass -}}

--- a/bitnami/elasticsearch/templates/_helpers.tpl
+++ b/bitnami/elasticsearch/templates/_helpers.tpl
@@ -283,6 +283,8 @@ Return the proper Storage Class
 {{/*
 Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
 but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
+Usage:
+{{ include "elasticsearch.storageClass" (dict "global" .Values.global "local" .Values.master) }}
 */}}
 {{- if .global -}}
     {{- if .global.storageClass -}}

--- a/bitnami/elasticsearch/templates/_helpers.tpl
+++ b/bitnami/elasticsearch/templates/_helpers.tpl
@@ -279,33 +279,33 @@ Also, we can't use a single if because lazy evaluation is not an option
 {{/*
 Return the proper Storage Class
 */}}
-{{- define "elasticsearch.data.storageClass" -}}
+{{- define "elasticsearch.storageClass" -}}
 {{/*
 Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
 but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
 */}}
-{{- if .Values.global -}}
-    {{- if .Values.global.storageClass -}}
-        {{- if (eq "-" .Values.global.storageClass) -}}
+{{- if .global -}}
+    {{- if .global.storageClass -}}
+        {{- if (eq "-" .global.storageClass) -}}
             {{- printf "storageClassName: \"\"" -}}
         {{- else }}
-            {{- printf "storageClassName: %s" .Values.global.storageClass -}}
+            {{- printf "storageClassName: %s" .global.storageClass -}}
         {{- end -}}
     {{- else -}}
-        {{- if .Values.data.persistence.storageClass -}}
-              {{- if (eq "-" .Values.data.persistence.storageClass) -}}
+        {{- if .local.persistence.storageClass -}}
+              {{- if (eq "-" .local.persistence.storageClass) -}}
                   {{- printf "storageClassName: \"\"" -}}
               {{- else }}
-                  {{- printf "storageClassName: %s" .Values.data.persistence.storageClass -}}
+                  {{- printf "storageClassName: %s" .local.persistence.storageClass -}}
               {{- end -}}
         {{- end -}}
     {{- end -}}
 {{- else -}}
-    {{- if .Values.data.persistence.storageClass -}}
-        {{- if (eq "-" .Values.data.persistence.storageClass) -}}
+    {{- if .local.persistence.storageClass -}}
+        {{- if (eq "-" .local.persistence.storageClass) -}}
             {{- printf "storageClassName: \"\"" -}}
         {{- else }}
-            {{- printf "storageClassName: %s" .Values.data.persistence.storageClass -}}
+            {{- printf "storageClassName: %s" .local.persistence.storageClass -}}
         {{- end -}}
     {{- end -}}
 {{- end -}}

--- a/bitnami/elasticsearch/templates/data-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/data-statefulset.yaml
@@ -167,7 +167,8 @@ spec:
         {{- end }}
       spec:
         accessModes: {{- toYaml .Values.data.persistence.accessModes | nindent 10 }}
-        {{ include "elasticsearch.data.storageClass" . }}
+        {{ $storage := dict "global" .Values.global "local" .Values.data }}
+        {{ include "elasticsearch.storageClass" $storage }}
         resources:
           requests:
             storage: {{ .Values.data.persistence.size | quote }}

--- a/bitnami/elasticsearch/templates/master-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/master-statefulset.yaml
@@ -171,7 +171,8 @@ spec:
         {{- end }}
       spec:
         accessModes: {{- toYaml .Values.master.persistence.accessModes | nindent 10 }}
-        {{ include "elasticsearch.data.storageClass" . }}
+        {{ $storage := dict "global" .Values.global "local" .Values.master }}
+        {{ include "elasticsearch.storageClass" $storage  }}
         resources:
           requests:
             storage: {{ .Values.master.persistence.size | quote }}


### PR DESCRIPTION
**Description of the change**
The `master.persistence.storageClass` was never read and was always
replaced by the `data.persistence.storageClass`. This change renames the
`elasticsearch.data.storageClass` template to `elasticsearch.storageClass`
and makes it generic so it can be used by both the `data` and `master` nodes.

**Benefits**
The documentation that `master.persistence.storageClass` can be set will be correct.

**Possible drawbacks**
Maybe someone doesn't like the rename of `elasticsearch.data.storageClass` to `elasticsearch.storageClass`?

**Applicable issues**
N/A

**Additional information**
N/A

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
