### PR TITLE
[bitnami/harbor] Update dependencies to latest major version

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: harbor
-version: 3.1.5
+version: 4.0.0
 appVersion: 1.10.1
 description: Harbor is an an open source trusted cloud native registry project that stores, signs, and scans content
 keywords:

--- a/bitnami/harbor/README.md
+++ b/bitnami/harbor/README.md
@@ -395,6 +395,13 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 
 ## Upgrade
 
+## 4.0.0
+
+PostgreSQL and Redis dependencies were updated to the use the latest major versions, `8.x.x` and `10.x.x`, respectively. These major versions do not include changes that should break backwards compatibilities, check the links below for more information:
+
+- [PostgreSQL Upgrade notes](https://github.com/bitnami/charts/blob/master/upstreamed/postgresql/README.md#upgrade)
+- [Redis Upgrade notes](https://github.com/bitnami/charts/blob/master/upstreamed/redis/README.md#upgrading-an-existing-release-to-a-new-major-version)
+
 ## 3.0.0
 
 Helm performs a lookup for the object based on its group (apps), version (v1), and kind (Deployment). Also known as its GroupVersionKind, or GVK. Changing the GVK is considered a compatibility breaker from Kubernetes' point of view, so you cannot "upgrade" those objects to the new GVK in-place. Earlier versions of Helm 3 did not perform the lookup correctly which has since been fixed to match the spec.

--- a/bitnami/harbor/requirements.lock
+++ b/bitnami/harbor/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 7.7.3
+  version: 8.3.4
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 9.5.5
-digest: sha256:223091aed6d69ebade1594073dccfba2a9aac6bb050663627f13967df10a2dda
-generated: "2020-02-14T13:47:50.224270453Z"
+  version: 10.5.2
+digest: sha256:90c87eddb384b12d74b18afc5244679dc71469d8cea81335ffe9603c58deaf76
+generated: "2020-02-17T15:04:05.342586+01:00"

--- a/bitnami/harbor/requirements.yaml
+++ b/bitnami/harbor/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
   - name: postgresql
-    version: 7.x.x
+    version: 8.x.x
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: redis
-    version: 9.x.x
+    version: 10.x.x
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled


### PR DESCRIPTION
**Description of the change**

Bumps the major version of the dependencies and, therefore, the chart itself.

**Benefits**

Use the latest features included in the Redis&PostgreSQL charts

**Possible drawbacks**

None

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
