### PR TITLE
Fix add repo command and wrong link

### DIFF
--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -5,7 +5,7 @@
 ## TL;DR;
 
 ```bash
-$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm repo add stable https://kubernetes-charts.storage.googleapis.com
 $ helm install my-release bitnami/mysql
 ```
 
@@ -26,7 +26,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 To install the chart with the release name `my-release`:
 
 ```bash
-$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm repo add stable https://kubernetes-charts.storage.googleapis.com
 $ helm install my-release bitnami/mysql
 ```
 
@@ -225,7 +225,7 @@ The allowed extensions are `.sh`, `.sql` and `.sql.gz`.
 
 The [Bitnami MySQL](https://github.com/bitnami/bitnami-docker-mysql) image stores the MySQL data and configurations at the `/bitnami/mysql` path of the container.
 
-The chart mounts a [Persistent Volume](kubernetes.io/docs/user-guide/persistent-volumes/) volume at this location. The volume is created using dynamic volume provisioning by default. An existing PersistentVolumeClaim can be defined.
+The chart mounts a [Persistent Volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) volume at this location. The volume is created using dynamic volume provisioning by default. An existing PersistentVolumeClaim can be defined.
 
 ### Adjust permissions of persistent volume mountpoint
 

--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -5,7 +5,7 @@
 ## TL;DR;
 
 ```bash
-$ helm repo add stable https://kubernetes-charts.storage.googleapis.com
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
 $ helm install my-release bitnami/mysql
 ```
 


### PR DESCRIPTION
The command for adding the stable helm charts repo should be fixed in all README files.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Replace the add repo command to use the helm stable repo instead of the bitnami one. Fix the link to the Kubernetes documentation about persistent volumes. 

**Benefits**

Helm 3 users can install the chart repository in their clusters.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

The replacing of the helm repo add command should be done in all READMEs for all the charts. 

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
