### PR TITLE
[bitnami/consul] Create pods in parallel

### DIFF
--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: consul
-version: 6.1.3
+version: 7.0.0
 appVersion: 1.7.0
 description: Highly available and distributed service discovery and key-value store designed with support for the modern data center to make distributed systems and configuration easy.
 home: https://www.consul.io/

--- a/bitnami/consul/README.md
+++ b/bitnami/consul/README.md
@@ -263,6 +263,17 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 
 ## Upgrading
 
+### 7.0.0
+
+Consul pods are now deployed in parallel in order to bootstrap the cluster and be discovered.
+
+The field `podManagementPolicy` can't be updated in a StatefulSet, so you need to destroy it before you upgrade the chart to this version.
+
+```console
+$ kubectl delete statefulset consul
+$ helm upgrade <DEPLOYMENT_NAME> bitnami/consul
+```
+
 ### To 6.0.0
 
 This release updates the Bitnami Consul container to `1.6.1-debian-9-r6`, which is based on Bash instead of Node.js.

--- a/bitnami/consul/templates/statefulset.yaml
+++ b/bitnami/consul/templates/statefulset.yaml
@@ -8,6 +8,7 @@ spec:
     matchLabels: {{- include "consul.matchLabels" . | nindent 6 }}
   serviceName: {{ template "consul.fullname" . }}
   replicas: {{ .Values.replicas }}
+  podManagementPolicy: Parallel
   updateStrategy:
     type: {{ .Values.updateStrategy.type }}
     {{- if (eq "Recreate" .Values.updateStrategy.type) }}
@@ -182,7 +183,7 @@ spec:
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
           command:
             - /bin/consul_exporter
-            - --consul.server={{ template "consul.fullname" . }}:{{ .Values.port }}'
+            - --consul.server={{ template "consul.fullname" . }}:{{ .Values.service.port }}
           ports:
             - name: metrics
               containerPort: 9107


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

Deploy master pods in parallel by modifying the "podManagementPolicy". See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies

**Additional information**

Similar to https://github.com/bitnami/charts/pull/1875

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)