### PR TITLE
[bitnami/fluentd] mount /var/lib/docker/containers as readonly

### DIFF
--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd
-version: 0.4.15
+version: 0.4.16
 appVersion: 1.9.2
 description: Fluentd is an open source data collector for unified logging layer
 keywords:

--- a/bitnami/fluentd/templates/forwarder-daemonset.yaml
+++ b/bitnami/fluentd/templates/forwarder-daemonset.yaml
@@ -95,6 +95,7 @@ spec:
               mountPath: /var/log
             - name: varlibdockercontainers
               mountPath: /var/lib/docker/containers
+              readOnly: true
       volumes:
         {{- if .Values.tls.enabled }}
         - name: certs


### PR DESCRIPTION
**Description of the change**

Mounts the `/var/lib/docker/containers` host path as readonly.

**Benefits**

<!-- What benefits will be realized by the code change? -->
The proper mount will be sent to the CSI driver: https://kubernetes.io/docs/concepts/storage/volumes/


**Possible drawbacks**

<!-- Describe any known limitations with your change -->
None.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - possibly related to #1905

**Additional information**

Other fluentd charts that do the same:
- https://github.com/kiwigrid/helm-charts/blob/92ae60e00f7753c28e62ca37e8e2f1d6005ab92d/charts/fluentd-elasticsearch/templates/daemonset.yaml#L137-L139
- https://github.com/helm/charts/blob/7ccc9f99d7ab6b9554624985d9c9b9723b7253c0/incubator/fluentd-cloudwatch/templates/daemonset.yaml#L69-L71

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

