### PR TITLE
[bitnami/mysql] Fix for initContainer volume-permissions

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mysql
-version: 6.9.0
+version: 6.9.1
 appVersion: 8.0.19
 description: Chart to create a Highly available MySQL cluster
 keywords:

--- a/bitnami/mysql/templates/master-statefulset.yaml
+++ b/bitnami/mysql/templates/master-statefulset.yaml
@@ -54,7 +54,7 @@ spec:
           resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: data
+            - name: {{ default "data" .Values.master.persistence.existingClaim | quote }}
               mountPath: {{ .Values.master.persistence.mountPath }}
       {{- end }}
       containers:

--- a/bitnami/mysql/templates/master-statefulset.yaml
+++ b/bitnami/mysql/templates/master-statefulset.yaml
@@ -54,7 +54,7 @@ spec:
           resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: {{ default "data" .Values.master.persistence.existingClaim | quote }}
+            - name: data
               mountPath: {{ .Values.master.persistence.mountPath }}
       {{- end }}
       containers:
@@ -149,11 +149,7 @@ spec:
           resources: {{- toYaml .Values.master.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
-            {{- if .Values.master.persistence.existingClaim }}
-            - name: {{ .Values.master.persistence.existingClaim }}
-            {{- else }}
             - name: data
-            {{- end }}
               mountPath: {{ .Values.master.persistence.mountPath }}
             {{- if or (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql,sql.gz}") .Values.initdbScriptsConfigMap .Values.initdbScripts }}
             - name: custom-init-scripts
@@ -249,7 +245,7 @@ spec:
         - name: "data"
           emptyDir: {}
 {{- else if and .Values.master.persistence.enabled .Values.master.persistence.existingClaim }}
-        - name: {{ .Values.master.persistence.existingClaim }}
+        - name: "data"
           persistentVolumeClaim:
             claimName: {{ .Values.master.persistence.existingClaim }}
 {{- else if and .Values.master.persistence.enabled (not .Values.master.persistence.existingClaim) }}

--- a/bitnami/mysql/templates/slave-statefulset.yaml
+++ b/bitnami/mysql/templates/slave-statefulset.yaml
@@ -136,11 +136,7 @@ spec:
           resources: {{- toYaml .Values.slave.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
-            {{- if .Values.slave.persistence.existingClaim }}
-            - name: {{ .Values.slave.persistence.existingClaim }}
-            {{- else }}
             - name: data
-            {{- end }}
               mountPath: {{ .Values.slave.persistence.mountPath }}
             {{- if .Values.slave.config }}
             - name: config
@@ -223,7 +219,7 @@ spec:
         - name: "data"
           emptyDir: {}
 {{- else if and .Values.slave.persistence.enabled .Values.slave.persistence.existingClaim }}
-        - name: {{ .Values.slave.persistence.existingClaim }}
+        - name: "data"
           persistentVolumeClaim:
             claimName: {{ .Values.slave.persistence.existingClaim }}
 {{- else if and .Values.slave.persistence.enabled (not .Values.slave.persistence.existingClaim) }}


### PR DESCRIPTION
The initcontainer volume permission fails when the existing volume claim is specified and its value is not "data". As in case existing volume claim name is different from "data", then this specified name should be referenced in the initcontainer volume permission. But as per current implementation the volumeMount name of initcontainer is hardcoded to "data". Due to this reason the initcontainer fails due to volumeMount name not found when existing volume claim name is different from "data".
I have purposed to use default template function with default value as "data" in case existing volume claim name is not provided. 


