### PR TITLE
[bitnami/elasticsearch] Fixed bundled kibana table in README.md

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: elasticsearch
-version: 11.0.6
+version: 11.0.7
 appVersion: 7.6.0
 description: A highly scalable open-source full-text search and analytics engine
 keywords:

--- a/bitnami/elasticsearch/README.md
+++ b/bitnami/elasticsearch/README.md
@@ -247,6 +247,8 @@ The following table lists the configurable parameters of the Elasticsearch chart
 
 ### Kibana Parameters
 
+|            Parameter           |                                    Description                                      |                                         Default                                         |
+|--------------------------------|-------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
 | `global.kibanaEnabled`         | Use bundled Kibana                                                                  | `false`                                                                                 |
 | `kibana.elasticsearch.hosts`   | Array containing hostnames for the ES instances. Used to generate the URL           | `{{ include "elasticsearch.coordinating.fullname" . }}` Coordinating service (fullname) |
 | `kibana.elasticsearch.port`    | Port to connect Kibana and ES instance. Used to generate the URL                    | `9200`                                                                                  |


### PR DESCRIPTION
**Description of the change**
The kibiana table was missing headers/table designators.

**Benefits**
I couldn't figure out the imbedded kibana params until I realized the table header was missing because I wasn't reading the raw `md` but rather the rendered github page.

**Possible drawbacks**
None?

**Applicable issues**

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] Appropriately bump semver

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
