### PR TITLE
[bitnami/thanos] fixed indentation in thanos compactor pvc.yaml

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
-version: 0.1.4
+version: 0.1.5

--- a/bitnami/thanos/templates/compactor/pvc.yaml
+++ b/bitnami/thanos/templates/compactor/pvc.yaml
@@ -13,5 +13,5 @@ spec:
   resources:
     requests:
       storage: {{ .Values.compactor.persistence.size | quote }}
-  {{- include "thanos.compactor.storageClass" . | nindent 8 }}
+  {{- include "thanos.compactor.storageClass" . | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Thanos Compactor's `pvc.yaml` has the `storageClassName` indented 8 spaces when it should only be indented 2 spaces.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

A PVC can be provisioned for the Thanos compactor
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
