### PR TITLE
[bitnami/magento] Add parameter to allow configuring secure access to admin panel

### DIFF
--- a/bitnami/magento/Chart.yaml
+++ b/bitnami/magento/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: magento
-version: 11.0.5
+version: 11.1.0
 appVersion: 2.3.4
 description: A feature-rich flexible e-commerce solution. It includes transaction options, multi-store functionality, loyalty programs, product categorization and shopper filtering, promotion rules, and more.
 keywords:

--- a/bitnami/magento/README.md
+++ b/bitnami/magento/README.md
@@ -72,6 +72,7 @@ The following table lists the configurable parameters of the Magento chart and t
 | `magentoFirstName`                      | Magento Admin First Name                                                                             | `FirstName`                                                  |
 | `magentoLastName`                       | Magento Admin Last Name                                                                              | `LastName`                                                   |
 | `magentoMode`                           | Magento mode                                                                                         | `developer`                                                  |
+| `magentoUseSecureAdmin`                 | Use SSL to access the Magento Admin.                                                                 | `false`                                                      |
 | `magentoAdminUri`                       | Magento prefix to access Magento Admin                                                               | `admin`                                                      |
 | `allowEmptyPassword`                    | Allow DB blank passwords                                                                             | `yes`                                                        |
 | `ingress.enabled`                       | Enable ingress controller resource                                                                   | `false`                                                      |

--- a/bitnami/magento/templates/deployment.yaml
+++ b/bitnami/magento/templates/deployment.yaml
@@ -115,6 +115,8 @@ spec:
               value: {{ .Values.magentoLastName | quote }}
             - name: MAGENTO_MODE
               value: {{ .Values.magentoMode | quote }}
+            - name: MAGENTO_USE_SECURE_ADMIN
+              value: {{ ternary "yes" "no" .Values.magentoUseSecureAdmin | quote }}
           ports:
             - name: http
               containerPort: 80

--- a/bitnami/magento/values-production.yaml
+++ b/bitnami/magento/values-production.yaml
@@ -86,6 +86,11 @@ magentoLastName: LastName
 ##
 magentoMode: developer
 
+## Use SSL to access the Magento Admin. Valid values: `true`, `false`
+## ref: https://github.com/bitnami/bitnami-docker-magento#configuration
+##
+magentoUseSecureAdmin: false
+
 ## Set to `yes` to allow the container to be started with blank passwords
 ## ref: https://github.com/bitnami/bitnami-docker-magento#environment-variables
 allowEmptyPassword: "yes"

--- a/bitnami/magento/values-production.yaml
+++ b/bitnami/magento/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/magento
-  tag: 2.3.4-debian-10-r8
+  tag: 2.3.4-debian-10-r14
   ## Set to true if you would like to see extra information on logs
   ## It turns BASH and NAMI debugging in minideb
   ## ref:  https://github.com/bitnami/minideb-extras/#turn-on-bash-debugging

--- a/bitnami/magento/values.yaml
+++ b/bitnami/magento/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/magento
-  tag: 2.3.4-debian-10-r8
+  tag: 2.3.4-debian-10-r14
   ## Set to true if you would like to see extra information on logs
   ## It turns BASH and NAMI debugging in minideb
   ## ref:  https://github.com/bitnami/minideb-extras/#turn-on-bash-debugging
@@ -85,6 +85,11 @@ magentoLastName: LastName
 ## ref: https://github.com/bitnami/bitnami-docker-magento#configuration
 ##
 magentoMode: developer
+
+## Use SSL to access the Magento Admin. Valid values: `true`, `false`
+## ref: https://github.com/bitnami/bitnami-docker-magento#configuration
+##
+magentoUseSecureAdmin: false
 
 ## Set to `yes` to allow the container to be started with blank passwords
 ## ref: https://github.com/bitnami/bitnami-docker-magento#environment-variables


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

Add a new parameter to allow configuring secure access to admin panel

**Possible drawbacks**

None

**Additional information**

Related to https://github.com/bitnami/bitnami-docker-magento/issues/129

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
