### PR TITLE
[bitnami/mysql] Fixed nodePort definition (typo)

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mysql
-version: 6.9.1
+version: 6.9.2
 appVersion: 8.0.19
 description: Chart to create a Highly available MySQL cluster
 keywords:

--- a/bitnami/mysql/templates/master-svc.yaml
+++ b/bitnami/mysql/templates/master-svc.yaml
@@ -24,7 +24,7 @@ spec:
     - name: mysql
       port: {{ .Values.service.port }}
       targetPort: mysql
-      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePortl)) }}
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePort)) }}
       nodePort: {{ .Values.service.nodePort }}
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null

--- a/bitnami/mysql/templates/slave-svc.yaml
+++ b/bitnami/mysql/templates/slave-svc.yaml
@@ -25,7 +25,7 @@ spec:
     - name: mysql
       port: {{ .Values.service.port }}
       targetPort: mysql
-      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePortl)) }}
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePort)) }}
       nodePort: {{ .Values.service.nodePort }}
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Chart bitnami/MySQL : Fix the definition of the nodePort : Due to a typo, the value of the nodePort was always null, so Kubernetes affect an random port in the nodePort range.

**Benefits**

MySQL use the defined port in the values instead a random one

**Possible drawbacks**

_none_

**Applicable issues**

_none yet_

**Additional information**

_none_

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
