### PR TITLE
[bitnami/wildfly] fix annotation indentation

### DIFF
--- a/bitnami/wildfly/Chart.yaml
+++ b/bitnami/wildfly/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wildfly
-version: 3.5.5
+version: 3.5.6
 appVersion: 18.0.1
 description: Chart for Wildfly
 keywords:

--- a/bitnami/wildfly/templates/deployment.yaml
+++ b/bitnami/wildfly/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels: {{- include "wildfly.labels" . | nindent 8 }}
     {{- if .Values.podAnnotations }}
-    annotations: {{- toYaml .Values.podAnnotations | nindent 8 }}
+      annotations: {{- toYaml .Values.podAnnotations | nindent 8 }}
     {{- end }}
     spec:
 {{- include "wildfly.imagePullSecrets" . | indent 6 }}


### PR DESCRIPTION
**Description of the change**

Indent annotation field properly in `deployment.yaml`

**Benefits**

The chart can be installed with `podAnnotanions` values

**Possible drawbacks**

N/A

**Applicable issues**

  - fixes #1995

**Additional information**

N/A

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

