### PR TITLE
[bitnami/zookeeper] Added network policy

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zookeeper
-version: 5.5.1
+version: 5.6.0
 appVersion: 3.5.7
 description: A centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services for distributed applications.
 keywords:

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -141,6 +141,8 @@ The following tables lists the configurable parameters of the ZooKeeper chart an
 | `metrics.serviceMonitor.interval`      | Interval at which metrics should be scraped.                                                                                                              | `nil` (Prometheus Operator default value)                    |  |
 | `metrics.serviceMonitor.scrapeTimeout` | Timeout after which the scrape is ended                                                                                                                   | `nil` (Prometheus Operator default value)                    |  |
 | `metrics.serviceMonitor.selector`      | Prometheus instance selector labels                                                                                                                       | `nil`                                                        |  |
+| `networkPolicy.enabled`                | Enable NetworkPolicy                                                                                                                                      | `false`                                                        |  |
+| `networkPolicy.allowExternal`          | Don't require client label for connections                                                                                                                | `true`                                                        |  |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/zookeeper/templates/networkpolicy.yaml
+++ b/bitnami/zookeeper/templates/networkpolicy.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ include "zookeeper.fullname" . }}
+  labels: {{- include "zookeeper.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels: {{- include "zookeeper.matchLabels" . | nindent 6 }}
+  ingress:
+    # Allow inbound connections to zookeeper
+    - ports:
+        - port: {{ .Values.service.port }}
+      from:
+      {{- if not .Values.networkPolicy.allowExternal }}
+        - podSelector:
+            matchLabels:
+              {{ include "zookeeper.fullname" . }}-client: "true"
+        - podSelector:
+            matchLabels: {{- include "zookeeper.matchLabels" . | nindent 14 }}
+      {{- else }}
+        - podSelector:
+            matchLabels: {}
+      {{- end }}
+    # Internal ports
+    - ports:
+        - port: {{ .Values.service.followerPort }}
+        - port: {{ .Values.service.electionPort }}
+      from:
+        - podSelector:
+            matchLabels: {{- include "zookeeper.matchLabels" . | nindent 14 }}
+{{- end }}

--- a/bitnami/zookeeper/values-production.yaml
+++ b/bitnami/zookeeper/values-production.yaml
@@ -233,6 +233,21 @@ readinessProbe:
   failureThreshold: 6
   successThreshold: 1
 
+## Network policies
+## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+##
+networkPolicy:
+  ## Specifies whether a NetworkPolicy should be created
+  ##
+  enabled: true
+
+  ## The Policy model to apply. When set to false, only pods with the correct
+  ## client label will have network access to the port Redis is listening
+  ## on. When true, zookeeper accept connections from any source
+  ## (with the correct destination port).
+  ##
+  allowExternal: true
+
 ## Prometheus Exporter / Metrics
 ##
 metrics:

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -241,6 +241,21 @@ readinessProbe:
   failureThreshold: 6
   successThreshold: 1
 
+## Network policies
+## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+##
+networkPolicy:
+  ## Specifies whether a NetworkPolicy should be created
+  ##
+  enabled: false
+
+  ## The Policy model to apply. When set to false, only pods with the correct
+  ## client label will have network access to the port Redis is listening
+  ## on. When true, zookeeper accept connections from any source
+  ## (with the correct destination port).
+  ##
+  # allowExternal: true
+
 ## Prometheus Exporter / Metrics
 ##
 metrics:


### PR DESCRIPTION
**Description of the change**

Added networkpolicy.yaml template, which is activated only when the parameter .Values.networkpolicy exists.

**Benefits**

It make possible to activate and configure network policy (ingress and egress) for zookeeper statefulset.
Configurable with bare network policy blocks for maximum flexibility.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

Example of configuration:
```
networkpolicy:
  ingress:
  - from:
    - podSelector:
        matchLabels:
          app: your-app
    ports:
    - protocol: TCP
      port: 2181
  egress: 
    - {}
```
Tested in our infrastructure.

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
