### PR TITLE
[bitnami/jenkins] Move Jenkins to non-root

### DIFF
--- a/bitnami/jenkins/Chart.yaml
+++ b/bitnami/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: jenkins
-version: 4.1.9
+version: 5.0.0
 appVersion: 2.204.4
 description: The leading open source automation server
 keywords:

--- a/bitnami/jenkins/README.md
+++ b/bitnami/jenkins/README.md
@@ -83,7 +83,9 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 | `persistence.storageClass`           | PVC Storage Class for Jenkins volume                            | `nil` (uses alpha storage class annotation)             |
 | `persistence.accessMode`             | PVC Access Mode for Jenkins volume                              | `ReadWriteOnce`                                         |
 | `persistence.size`                   | PVC Storage Request for Jenkins volume                          | `8Gi`                                                   |
-| `resources`                          | CPU/Memory resource requests/limits                             | `requests: { cpu: "300m", memory: "512Mi" }`            |
+| `persistence.annotations`            | Prsistence annotations                                          | `{}`                                                    |
+| `resources.limits`                   | Jenkins resource  limits                                        | `{}`                                                    |
+| `resources.requests`                 | Jenkins resource  requests                                      | `{ cpu: "300m", memory: "512Mi" }`                      |
 | `livenessProbe.enabled`              | Turn on and off liveness probe                                  | `true`                                                  |
 | `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                        | `180`                                                   |
 | `livenessProbe.periodSeconds`        | How often to perform the probe                                  | `10`                                                    |
@@ -100,8 +102,8 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 | `affinity`                           | Map of node/pod affinities                                      | `{}` (The value is evaluated as a template)             |
 | `nodeSelector`                       | Node labels for pod assignment                                  | `{}` (The value is evaluated as a template)             |
 | `tolerations`                        | Tolerations for pod assignment                                  | `[]` (The value is evaluated as a template)             |
-| `podSecurityContext`                 | Jenkins pods' Security Context                                  | `{}`                                                    |
-| `containerSecurityContext`           | Jenkins containers' Security Context                            | `{}`                                                    |
+| `podSecurityContext`                 | Jenkins pods' Security Context                                  | `{ fsGroup: "1001" }`                                   |
+| `containerSecurityContext`           | Jenkins containers' Security Context                            | `{ runAsUser: "1001" }`                                 |
 
 ### Exposure parameters
 
@@ -114,14 +116,15 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 | `service.nodePorts.https`         | Kubernetes https node port                                                           | `""`                       |
 | `service.externalTrafficPolicy`   | Enable client source IP preservation                                                 | `Cluster`                  |
 | `service.loadBalancerIP`          | LoadBalancer service IP address                                                      | `""`                       |
+| `service.annotations`             | Service annotations                                                                  | `{}`                       |
 | `ingress.enabled`                 | Enable ingress controller resource                                                   | `false`                    |
-| `ingress.annotations`             | Ingress annotations                                                                  | `[]`                       |
+| `ingress.annotations`             | Ingress annotations                                                                  | `{}`                       |
 | `ingress.certManager`             | Add annotations for cert-manager                                                     | `false`                    |
-| `ingress.hosts[0].name`           | Hostname to your jenkins installation                                                | `jenkins.local`            |
-| `ingress.hosts[0].path`           | Path within the url structure                                                        | `/`                        |
-| `ingress.hosts[0].tls`            | Utilize TLS backend in ingress                                                       | `false`                    |
-| `ingress.hosts[0].tlsHosts`       | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`) | `nil`                      |
-| `ingress.hosts[0].tlsSecret`      | TLS Secret (certificates)                                                            | `jenkins.local-tls-secret` |
+| `ingress.hostname`                | Default host for the ingress resource                                                | `jenkins.local`            |
+| `ingress.extraHosts[0].name`      | Additional hostnames to be covered                                                   | `nil`                      |
+| `ingress.extraHosts[0].path`      | Additional hostnames to be covered                                                   | `nil`                      |
+| `ingress.extraTls[0].hosts[0]`    | TLS configuration for additional hostnames to be covered                             | `nil`                      |
+| `ingress.extraTls[0].secretName`  | TLS configuration for additional hostnames to be covered                             | `nil`                      |
 | `ingress.secrets[0].name`         | TLS Secret Name                                                                      | `nil`                      |
 | `ingress.secrets[0].certificate`  | TLS Secret Certificate                                                               | `nil`                      |
 | `ingress.secrets[0].key`          | TLS Secret Key                                                                       | `nil`                      |
@@ -202,6 +205,7 @@ See the [Parameters](#parameters) section to configure the PVC or to disable per
 ### To 5.0.0
 
 The [Bitnami Jenkins](https://github.com/bitnami/bitnami-docker-jenkins) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Jenkins service was started as the `jenkins` user. From now on, both the container and the Jenkins service run as user `jenkins` (`uid=1001`). You can revert this behavior by setting the parameters `securityContext.runAsUser`, and `securityContext.fsGroup` to `root`.
+Ingress configuration was also adapted to follow the Helm charts best practices.
 
 Consequences:
 

--- a/bitnami/jenkins/README.md
+++ b/bitnami/jenkins/README.md
@@ -5,8 +5,8 @@
 ## TL;DR;
 
 ```console
-$ helm repo add bitnami https://charts.bitnami.com/bitnami
-$ helm install my-release bitnami/jenkins
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm install my-release bitnami/jenkins
 ```
 
 ## Introduction
@@ -27,8 +27,8 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm repo add bitnami https://charts.bitnami.com/bitnami
-$ helm install my-release bitnami/jenkins
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm install my-release bitnami/jenkins
 ```
 
 These commands deploy Jenkins on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
@@ -40,79 +40,127 @@ These commands deploy Jenkins on the Kubernetes cluster in the default configura
 To uninstall/delete the `my-release` deployment:
 
 ```console
-$ helm delete my-release
+helm delete my-release
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
 ## Parameters
 
-The following tables lists the configurable parameters of the Jenkins chart and their default values.
+The following tables lists the configurable parameters of the Jenkins chart and their default values per section/component:
 
-| Parameter                            | Description                                                                                          | Default                                                      |
-| ------------------------------------ | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| `global.imageRegistry`               | Global Docker image registry                                                                         | `nil`                                                        |
-| `global.imagePullSecrets`            | Global Docker registry secret names as an array                                                      | `[]` (does not add image pull secrets to deployed pods)      |
-| `global.storageClass`                | Global storage class for dynamic provisioning                                                        | `nil`                                                        |
-| `image.registry`                     | Jenkins image registry                                                                               | `docker.io`                                                  |
-| `image.repository`                   | Jenkins Image name                                                                                   | `bitnami/jenkins`                                            |
-| `image.tag`                          | Jenkins Image tag                                                                                    | `{TAG_NAME}`                                                 |
-| `image.pullPolicy`                   | Jenkins image pull policy                                                                            | `IfNotPresent`                                               |
-| `image.pullSecrets`                  | Specify docker-registry secret names as an array                                                     | `[]` (does not add image pull secrets to deployed pods)      |
-| `nameOverride`                       | String to partially override jenkins.fullname template with a string (will prepend the release name) | `nil`                                                        |
-| `fullnameOverride`                   | String to fully override jenkins.fullname template with a string                                     | `nil`                                                        |
-| `jenkinsUser`                        | User of the application                                                                              | `user`                                                       |
-| `jenkinsPassword`                    | Application password                                                                                 | _random 10 character alphanumeric string_                    |
-| `jenkinsHome`                        | Jenkins home directory                                                                               | `/opt/bitnami/jenkins/jenkins_home`                          |
-| `disableInitialization`              | Allows to disable the initial Bitnami configuration for Jenkins                                      | `no`                                                         |
-| `javaOpts`                           | Customize JVM parameters                                                                             | `nil`                                                        |
-| `persistence.enabled`                | Enable persistence using PVC                                                                         | `true`                                                       |
-| `persistence.storageClass`           | PVC Storage Class for Jenkins volume                                                                 | `nil` (uses alpha storage class annotation)                  |
-| `persistence.accessMode`             | PVC Access Mode for Jenkins volume                                                                   | `ReadWriteOnce`                                              |
-| `persistence.size`                   | PVC Storage Request for Jenkins volume                                                               | `8Gi`                                                        |
-| `resources`                          | CPU/Memory resource requests/limits                                                                  | `requests: { cpu: "300m", memory: "512Mi" }`                 |
-| `livenessProbe.enabled`              | Turn on and off liveness probe                                                                       | `true`                                                       |
-| `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                                                             | `180`                                                        |
-| `livenessProbe.periodSeconds`        | How often to perform the probe                                                                       | `10`                                                         |
-| `livenessProbe.timeoutSeconds`       | When the probe times out                                                                             | `5`                                                          |
-| `livenessProbe.successThreshold`     | Minimum consecutive successes for the probe                                                          | `1`                                                          |
-| `livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe                                                           | `6`                                                          |
-| `readinessProbe.enabled`             | Turn on and off readiness probe                                                                      | `true`                                                       |
-| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                                                            | `30`                                                         |
-| `readinessProbe.periodSeconds`       | How often to perform the probe                                                                       | `5`                                                          |
-| `readinessProbe.timeoutSeconds`      | When the probe times out                                                                             | `3`                                                          |
-| `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe                                                          | `1`                                                          |
-| `readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe                                                           | `3`                                                          |
-| `podAnnotations`                     | Pod annotations                                                                                      | `{}`                                                         |
-| `affinity`                           | Map of node/pod affinities                                                                           | `{}` (The value is evaluated as a template)                  |
-| `nodeSelector`                       | Node labels for pod assignment                                                                       | `{}` (The value is evaluated as a template)                  |
-| `tolerations`                        | Tolerations for pod assignment                                                                       | `[]` (The value is evaluated as a template)                  |
-| `service.type`                       | Kubernetes Service type                                                                              | `LoadBalancer`                                               |
-| `service.port`                       | Service HTTP port                                                                                    | `80`                                                         |
-| `service.httpsPort`                  | Service HTTPS port                                                                                   | `443`                                                        |
-| `service.nodePorts.http`             | Kubernetes http node port                                                                            | `""`                                                         |
-| `service.nodePorts.https`            | Kubernetes https node port                                                                           | `""`                                                         |
-| `service.externalTrafficPolicy`      | Enable client source IP preservation                                                                 | `Cluster`                                                    |
-| `service.loadBalancerIP`             | LoadBalancer service IP address                                                                      | `""`                                                         |
-| `ingress.enabled`                    | Enable ingress controller resource                                                                   | `false`                                                      |
-| `ingress.annotations`                | Ingress annotations                                                                                  | `[]`                                                         |
-| `ingress.certManager`                | Add annotations for cert-manager                                                                     | `false`                                                      |
-| `ingress.hosts[0].name`              | Hostname to your jenkins installation                                                                | `jenkins.local`                                              |
-| `ingress.hosts[0].path`              | Path within the url structure                                                                        | `/`                                                          |
-| `ingress.hosts[0].tls`               | Utilize TLS backend in ingress                                                                       | `false`                                                      |
-| `ingress.hosts[0].tlsHosts`          | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`)                 | `nil`                                                        |
-| `ingress.hosts[0].tlsSecret`         | TLS Secret (certificates)                                                                            | `jenkins.local-tls-secret`                                   |
-| `ingress.secrets[0].name`            | TLS Secret Name                                                                                      | `nil`                                                        |
-| `ingress.secrets[0].certificate`     | TLS Secret Certificate                                                                               | `nil`                                                        |
-| `ingress.secrets[0].key`             | TLS Secret Key                                                                                       | `nil`                                                        |
-| `metrics.enabled`                    | Start a side-car Jenkins prometheus exporter                                                         | `false`                                                      |
-| `metrics.image.registry`             | Jenkins exporter image registry                                                                      | `docker.io`                                                  |
-| `metrics.image.repository`           | Jenkins exporter image name                                                                          | `bitnami/jenkins-exporter`                                   |
-| `metrics.image.tag`                  | Jenkins exporter image tag                                                                           | `{TAG_NAME}`                                                 |
-| `metrics.image.pullPolicy`           | Image pull policy                                                                                    | `IfNotPresent`                                               |
-| `metrics.image.pullSecrets`          | Specify docker-registry secret names as an array                                                     | `[]` (does not add image pull secrets to deployed pods)      |
-| `metrics.podAnnotations`             | Additional annotations for Metrics exporter pod                                                      | `{prometheus.io/scrape: "true", prometheus.io/port: "9118"}` |
-| `metrics.resources`                  | Exporter resource requests/limit                                                                     | `requests: { cpu: "256m", memory: "100Mi" }`                 |
+### Global parameters
+
+| Parameter                 | Description                                     | Default                                                 |
+|---------------------------|-------------------------------------------------|---------------------------------------------------------|
+| `global.imageRegistry`    | Global Docker image registry                    | `nil`                                                   |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
+| `global.storageClass`     | Global storage class for dynamic provisioning   | `nil`                                                   |
+
+### Common parameters
+
+| Parameter           | Description                                                                                          | Default         |
+|---------------------|------------------------------------------------------------------------------------------------------|-----------------|
+| `nameOverride`      | String to partially override jenkins.fullname template with a string (will prepend the release name) | `nil`           |
+| `fullnameOverride`  | String to fully override jenkins.fullname template with a string                                     | `nil`           |
+| `clusterDomain`     | Default Kubernetes cluster domain                                                                    | `cluster.local` |
+
+### Jenkins parameters
+
+| Parameter                            | Description                                                     | Default                                                 |
+|--------------------------------------|-----------------------------------------------------------------|---------------------------------------------------------|
+| `image.registry`                     | Jenkins image registry                                          | `docker.io`                                             |
+| `image.repository`                   | Jenkins Image name                                              | `bitnami/jenkins`                                       |
+| `image.tag`                          | Jenkins Image tag                                               | `{TAG_NAME}`                                            |
+| `image.pullPolicy`                   | Jenkins image pull policy                                       | `IfNotPresent`                                          |
+| `image.pullSecrets`                  | Specify docker-registry secret names as an array                | `[]` (does not add image pull secrets to deployed pods) |
+| `jenkinsUser`                        | User of the application                                         | `user`                                                  |
+| `jenkinsPassword`                    | Application password                                            | _random 10 character alphanumeric string_               |
+| `jenkinsHome`                        | Jenkins home directory                                          | `/opt/bitnami/jenkins/jenkins_home`                     |
+| `disableInitialization`              | Allows to disable the initial Bitnami configuration for Jenkins | `no`                                                    |
+| `javaOpts`                           | Customize JVM parameters                                        | `nil`                                                   |
+| `persistence.enabled`                | Enable persistence using PVC                                    | `true`                                                  |
+| `persistence.storageClass`           | PVC Storage Class for Jenkins volume                            | `nil` (uses alpha storage class annotation)             |
+| `persistence.accessMode`             | PVC Access Mode for Jenkins volume                              | `ReadWriteOnce`                                         |
+| `persistence.size`                   | PVC Storage Request for Jenkins volume                          | `8Gi`                                                   |
+| `resources`                          | CPU/Memory resource requests/limits                             | `requests: { cpu: "300m", memory: "512Mi" }`            |
+| `livenessProbe.enabled`              | Turn on and off liveness probe                                  | `true`                                                  |
+| `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                        | `180`                                                   |
+| `livenessProbe.periodSeconds`        | How often to perform the probe                                  | `10`                                                    |
+| `livenessProbe.timeoutSeconds`       | When the probe times out                                        | `5`                                                     |
+| `livenessProbe.successThreshold`     | Minimum consecutive successes for the probe                     | `1`                                                     |
+| `livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe                      | `6`                                                     |
+| `readinessProbe.enabled`             | Turn on and off readiness probe                                 | `true`                                                  |
+| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                       | `30`                                                    |
+| `readinessProbe.periodSeconds`       | How often to perform the probe                                  | `5`                                                     |
+| `readinessProbe.timeoutSeconds`      | When the probe times out                                        | `3`                                                     |
+| `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe                     | `1`                                                     |
+| `readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe                      | `3`                                                     |
+| `podAnnotations`                     | Pod annotations                                                 | `{}`                                                    |
+| `affinity`                           | Map of node/pod affinities                                      | `{}` (The value is evaluated as a template)             |
+| `nodeSelector`                       | Node labels for pod assignment                                  | `{}` (The value is evaluated as a template)             |
+| `tolerations`                        | Tolerations for pod assignment                                  | `[]` (The value is evaluated as a template)             |
+| `podSecurityContext`                 | Jenkins pods' Security Context                                  | `{}`                                                    |
+| `containerSecurityContext`           | Jenkins containers' Security Context                            | `{}`                                                    |
+
+### Exposure parameters
+
+| Parameter                         | Description                                                                          | Default                    |
+|-----------------------------------|--------------------------------------------------------------------------------------|----------------------------|
+| `service.type`                    | Kubernetes Service type                                                              | `LoadBalancer`             |
+| `service.port`                    | Service HTTP port                                                                    | `80`                       |
+| `service.httpsPort`               | Service HTTPS port                                                                   | `443`                      |
+| `service.nodePorts.http`          | Kubernetes http node port                                                            | `""`                       |
+| `service.nodePorts.https`         | Kubernetes https node port                                                           | `""`                       |
+| `service.externalTrafficPolicy`   | Enable client source IP preservation                                                 | `Cluster`                  |
+| `service.loadBalancerIP`          | LoadBalancer service IP address                                                      | `""`                       |
+| `ingress.enabled`                 | Enable ingress controller resource                                                   | `false`                    |
+| `ingress.annotations`             | Ingress annotations                                                                  | `[]`                       |
+| `ingress.certManager`             | Add annotations for cert-manager                                                     | `false`                    |
+| `ingress.hosts[0].name`           | Hostname to your jenkins installation                                                | `jenkins.local`            |
+| `ingress.hosts[0].path`           | Path within the url structure                                                        | `/`                        |
+| `ingress.hosts[0].tls`            | Utilize TLS backend in ingress                                                       | `false`                    |
+| `ingress.hosts[0].tlsHosts`       | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`) | `nil`                      |
+| `ingress.hosts[0].tlsSecret`      | TLS Secret (certificates)                                                            | `jenkins.local-tls-secret` |
+| `ingress.secrets[0].name`         | TLS Secret Name                                                                      | `nil`                      |
+| `ingress.secrets[0].certificate`  | TLS Secret Certificate                                                               | `nil`                      |
+| `ingress.secrets[0].key`          | TLS Secret Key                                                                       | `nil`                      |
+
+### Volume Permissions parameters
+
+| Parameter                              | Description                                                                                                          | Default                                                 |
+|----------------------------------------|----------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `volumePermissions.enabled`            | Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup` | `false`                                                 |
+| `volumePermissions.image.registry`     | Init container volume-permissions image registry                                                                     | `docker.io`                                             |
+| `volumePermissions.image.repository`   | Init container volume-permissions image name                                                                         | `bitnami/minideb`                                       |
+| `volumePermissions.image.tag`          | Init container volume-permissions image tag                                                                          | `buster`                                                |
+| `volumePermissions.image.pullPolicy`   | Init container volume-permissions image pull policy                                                                  | `Always`                                                |
+| `volumePermissions.image.pullSecrets`  | Specify docker-registry secret names as an array                                                                     | `[]` (does not add image pull secrets to deployed pods) |
+| `volumePermissions.resources.limits`   | Init container volume-permissions resource  limits                                                                   | `{}`                                                    |
+| `volumePermissions.resources.requests` | Init container volume-permissions resource  requests                                                                 | `{}`                                                    |
+
+### Metrics parameters
+
+| Parameter                               | Description                                                                                            | Default                                                      |
+|-----------------------------------------|--------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `metrics.enabled`                       | Start a side-car Jenkins prometheus exporter                                                           | `false`                                                      |
+| `metrics.image.registry`                | Jenkins exporter image registry                                                                        | `docker.io`                                                  |
+| `metrics.image.repository`              | Jenkins exporter image name                                                                            | `bitnami/jenkins-exporter`                                   |
+| `metrics.image.tag`                     | Jenkins exporter image tag                                                                             | `{TAG_NAME}`                                                 |
+| `metrics.image.pullPolicy`              | Image pull policy                                                                                      | `IfNotPresent`                                               |
+| `metrics.image.pullSecrets`             | Specify docker-registry secret names as an array                                                       | `[]` (does not add image pull secrets to deployed pods)      |
+| `metrics.podAnnotations`                | Additional annotations for Metrics exporter pod                                                        | `{}`                                                         |
+| `metrics.resources`                     | Exporter resource requests/limit                                                                       | `requests: { cpu: "256m", memory: "100Mi" }`                 |
+| `metrics.service.type`                  | Kubernetes service type (`ClusterIP`, `NodePort` or `LoadBalancer`)                                    | `ClusterIP`                                                  |
+| `metrics.service.port`                  | Jenkins Prometheus exporter service port                                                               | `9122`                                                       |
+| `metrics.service.nodePort`              | Kubernetes node port                                                                                   | `""`                                                         |
+| `metrics.service.annotations`           | Annotations for Jenkins Prometheus exporter service                                                    | `{prometheus.io/scrape: "true", prometheus.io/port: "9118"}` |
+| `metrics.service.loadBalancerIP`        | loadBalancerIP if service type is `LoadBalancer`                                                       | `nil`                                                        |
+| `metrics.serviceMonitor.enabled`        | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`) | `false`                                                      |
+| `metrics.serviceMonitor.namespace`      | Namespace in which Prometheus is running                                                               | `nil`                                                        |
+| `metrics.serviceMonitor.interval`       | Interval at which metrics should be scraped.                                                           | `nil` (Prometheus Operator default value)                    |
+| `metrics.serviceMonitor.scrapeTimeout`  | Timeout after which the scrape is ended                                                                | `nil` (Prometheus Operator default value)                    |
+| `metrics.serviceMonitor.selector`       | Prometheus instance selector labels                                                                    | `nil`                                                        |
 
 The above parameters map to the env variables defined in [bitnami/jenkins](http://github.com/bitnami/bitnami-docker-jenkins). For more information please refer to the [bitnami/jenkins](http://github.com/bitnami/bitnami-docker-jenkins) image documentation.
 
@@ -129,7 +177,7 @@ The above command sets the Jenkins administrator account username and password t
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-$ helm install my-release -f values.yaml bitnami/jenkins
+helm install my-release -f values.yaml bitnami/jenkins
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
@@ -151,6 +199,17 @@ See the [Parameters](#parameters) section to configure the PVC or to disable per
 
 ## Upgrading
 
+### To 5.0.0
+
+The [Bitnami Jenkins](https://github.com/bitnami/bitnami-docker-jenkins) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Jenkins service was started as the `jenkins` user. From now on, both the container and the Jenkins service run as user `jenkins` (`uid=1001`). You can revert this behavior by setting the parameters `securityContext.runAsUser`, and `securityContext.fsGroup` to `root`.
+
+Consequences:
+
+- No "privileged" actions are allowed anymore.
+- Backwards compatibility is not guaranteed when persistence is enabled.
+
+To upgrade to `5.0.0`, install a new Jenkins chart, and migrate your Jenkins data ensuring the `jenkins` user has the appropiate permissions.
+
 ### To 4.0.0
 
 Helm performs a lookup for the object based on its group (apps), version (v1), and kind (Deployment). Also known as its GroupVersionKind, or GVK. Changing the GVK is considered a compatibility breaker from Kubernetes' point of view, so you cannot "upgrade" those objects to the new GVK in-place. Earlier versions of Helm 3 did not perform the lookup correctly which has since been fixed to match the spec.
@@ -165,5 +224,5 @@ Backwards compatibility is not guaranteed unless you modify the labels used on t
 Use the workaround below to upgrade from versions previous to 1.0.0. The following example assumes that the release name is jenkins:
 
 ```console
-$ kubectl patch deployment jenkins --type=json -p='[{"op": "remove", "path": "/spec/selector/matchLabels/chart"}]'
+kubectl patch deployment jenkins --type=json -p='[{"op": "remove", "path": "/spec/selector/matchLabels/chart"}]'
 ```

--- a/bitnami/jenkins/templates/_helpers.tpl
+++ b/bitnami/jenkins/templates/_helpers.tpl
@@ -72,6 +72,29 @@ Also, we can't use a single if because lazy evaluation is not an option
 {{- end -}}
 
 {{/*
+Return the proper image name (for the init container volume-permissions image)
+*/}}
+{{- define "jenkins.volumePermissions.image" -}}
+{{- $registryName := .Values.volumePermissions.image.registry -}}
+{{- $repositoryName := .Values.volumePermissions.image.repository -}}
+{{- $tag := .Values.volumePermissions.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the proper image name (for the metrics image)
 */}}
 {{- define "jenkins.metrics.image" -}}
@@ -109,18 +132,24 @@ imagePullSecrets:
 {{- range .Values.global.imagePullSecrets }}
   - name: {{ . }}
 {{- end }}
-{{- else if or .Values.image.pullSecrets .Values.metrics.image.pullSecrets }}
+{{- else if or .Values.image.pullSecrets .Values.volumePermissions.image.pullSecrets .Values.metrics.image.pullSecrets }}
 imagePullSecrets:
 {{- range .Values.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.volumePermissions.image.pullSecrets }}
   - name: {{ . }}
 {{- end }}
 {{- range .Values.metrics.image.pullSecrets }}
   - name: {{ . }}
 {{- end }}
 {{- end -}}
-{{- else if or .Values.image.pullSecrets .Values.metrics.image.pullSecrets }}
+{{- else if or .Values.image.pullSecrets .Values.volumePermissions.image.pullSecrets .Values.metrics.image.pullSecrets }}
 imagePullSecrets:
 {{- range .Values.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.volumePermissions.image.pullSecrets }}
   - name: {{ . }}
 {{- end }}
 {{- range .Values.metrics.image.pullSecrets }}

--- a/bitnami/jenkins/templates/deployment.yaml
+++ b/bitnami/jenkins/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
             - -ec
             - |
               mkdir -p /bitnami/jenkins
-              chown -R "{{ .Values.podSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }}" "/bitnami/jenkins"
+              chown -R "{{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }}" "/bitnami/jenkins"
           securityContext:
             runAsUser: 0
           {{- if .Values.volumePermissions.resources }}
@@ -58,7 +58,7 @@ spec:
           image: {{ template "jenkins.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           {{- if .Values.containerSecurityContext }}
-          securityContext: {{- toYaml .Values.containerSecurityContext | nindent 8 }}
+          securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           {{- end }}
           env:
             - name: JENKINS_USERNAME

--- a/bitnami/jenkins/templates/deployment.yaml
+++ b/bitnami/jenkins/templates/deployment.yaml
@@ -29,10 +29,37 @@ spec:
       {{- if .Values.tolerations }}
       tolerations: {{- include "jenkins.tplValue" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.podSecurityContext }}
+      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
+      {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
+      initContainers:
+        - name: volume-permissions
+          image: {{ include "jenkins.volumePermissions.image" . }}
+          imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
+          command:
+            - /bin/bash
+          args:
+            - -ec
+            - |
+              mkdir -p /bitnami/jenkins
+              chown -R "{{ .Values.podSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }}" "/bitnami/jenkins"
+          securityContext:
+            runAsUser: 0
+          {{- if .Values.volumePermissions.resources }}
+          resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: jenkins-data
+              mountPath: /bitnami/jenkins
+      {{- end }}
       containers:
         - name: jenkins
           image: {{ template "jenkins.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          {{- if .Values.containerSecurityContext }}
+          securityContext: {{- toYaml .Values.containerSecurityContext | nindent 8 }}
+          {{- end }}
           env:
             - name: JENKINS_USERNAME
               value: {{ .Values.jenkinsUser | quote }}

--- a/bitnami/jenkins/templates/ingress.yaml
+++ b/bitnami/jenkins/templates/ingress.yaml
@@ -8,8 +8,8 @@ metadata:
     {{- if .Values.ingress.certManager }}
     kubernetes.io/tls-acme: "true"
     {{- end }}
-    {{- range $key, $value := .Values.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
+    {{- if .Values.ingress.annotations }}
+    {{- include "jenkins.tplValue" (dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:
   rules:
@@ -19,10 +19,10 @@ spec:
         paths:
           - path: /
             backend:
-              serviceName: {{ template "jenkins.fullname" $ }}
+              serviceName: {{ template "jenkins.fullname" . }}
               servicePort: http
     {{- end }}
-    {{- range .Values.ingress.hosts }}
+    {{- range .Values.ingress.extraHosts }}
     - host: {{ .name }}
       http:
         paths:
@@ -31,7 +31,15 @@ spec:
               serviceName: {{ template "jenkins.fullname" $ }}
               servicePort: http
     {{- end }}
-  {{- if .Values.ingress.tls }}
-  tls: {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
+  tls:
+    {{- if .Values.ingress.tls }}
+    - hosts:
+        - {{ .Values.ingress.hostname }}
+      secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
+    {{- end }}
+    {{- if .Values.ingress.extraTls }}
+    {{- toYaml .Values.ingress.extraTls | nindent 4 }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/bitnami/jenkins/templates/metrics-svc .yaml
+++ b/bitnami/jenkins/templates/metrics-svc .yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "jenkins.fullname" . }}-metrics
+  labels: {{- include "jenkins.labels" . | nindent 4 }}
+  {{- if .Values.metrics.service.annotations }}
+  annotations: {{ include "jenkins.tplValue" ( dict "value" .Values.metrics.service.annotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.metrics.service.type }}
+  {{- if and (eq .Values.metrics.service.type "LoadBalancer") (not (empty .Values.metrics.service.loadBalancerIP)) }}
+  loadBalancerIP: {{ .Values.metrics.service.loadBalancerIP }}
+  {{- end }}
+  ports:
+    - name: metrics
+      port: {{ .Values.metrics.service.port }}
+      targetPort: metrics
+      {{- if (and (or (eq .Values.metrics.service.type "NodePort") (eq .Values.metrics.service.type "LoadBalancer")) (not (empty .Values.metrics.service.nodePort))) }}
+      nodePort: {{ .Values.metrics.service.nodePort }}
+      {{- else if eq .Values.metrics.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+  selector: {{- include "jenkins.matchLabels" . | nindent 4 }}

--- a/bitnami/jenkins/templates/servicemonitor.yaml
+++ b/bitnami/jenkins/templates/servicemonitor.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "jenkins.fullname" . }}
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- end }}
+  labels: {{- include "jenkins.labels" . | nindent 4 }}
+    {{- range $key, $value := .Values.metrics.serviceMonitor.selector }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels: {{ include "jenkins.matchLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: "/metrics"
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+    namespaceSelector:
+      matchNames:
+        - {{ .Release.Namespace }}
+{{- end }}

--- a/bitnami/jenkins/values.yaml
+++ b/bitnami/jenkins/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/jenkins
-  tag: 2.204.4-debian-10-r0
+  tag: 2.204.4-debian-10-r3
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -282,7 +282,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/jenkins-exporter
-    tag: 0.20171225.0-debian-10-r34
+    tag: 0.20171225.0-debian-10-r37
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/jenkins/values.yaml
+++ b/bitnami/jenkins/values.yaml
@@ -111,6 +111,23 @@ nodeSelector: {}
 ##
 tolerations: {}
 
+## Jenkins pods' Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+##
+podSecurityContext:
+  fsGroup: 1001
+  runAsUser: 1001
+
+## Jenkins containers' Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+## Example:
+##   containerSecurityContext:
+##     capabilities:
+##       drop: ["NET_RAW"]
+##     readOnlyRootFilesystem: true
+##
+containerSecurityContext: {}
+
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##
@@ -221,6 +238,46 @@ ingress:
   #   key:
   #   certificate:
 
+## Init Container paramaters
+## Change the owner and group of the persistent volume(s) mountpoint(s) to 'runAsUser:fsGroup' on each component
+## values from the podSecurityContext section of the component
+##
+volumePermissions:
+  enabled: false
+  ## Bitnami Minideb image
+  ## ref: https://hub.docker.com/r/bitnami/minideb/tags/
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/minideb
+    tag: buster
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: Always
+    ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+  ## Init Container resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+    requests: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+
 ## Prometheus Exporter / Metrics
 ##
 metrics:
@@ -242,12 +299,7 @@ metrics:
   ## Metrics exporter pod Annotation and Labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##
-  podAnnotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9118"
-    ## Metrics exporter resource requests and limits
-    ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-    ##
+  podAnnotations: {}
   ## Jenkins Prometheus exporter resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
@@ -262,3 +314,48 @@ metrics:
     requests: {}
     #   cpu: 100m
     #   memory: 128Mi
+  ## Metrics exporter service configuration
+  ##
+  service:
+    ## Service type
+    ##
+    type: ClusterIP
+    ## Metrics exporter port
+    ##
+    port: 9122
+    ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+    ##
+    nodePort: ""
+    ## Set the LoadBalancer service type to internal only.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    # loadBalancerIP:
+    ## Annotations for the Prometheus metrics service
+    ##
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "{{ .Values.metrics.service.port }}"
+  ## Prometheus Operator ServiceMonitor configuration
+  ##
+  serviceMonitor:
+    enabled: false
+    ## Namespace in which Prometheus is running
+    ##
+    # namespace: monitoring
+
+    ## Interval at which metrics should be scraped.
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    # interval: 10s
+
+    ## Timeout after which the scrape is ended
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    # scrapeTimeout: 10s
+
+    ## ServiceMonitor selector labels
+    ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
+    ##
+    # selector:
+    #   prometheus: my-prometheus

--- a/bitnami/jenkins/values.yaml
+++ b/bitnami/jenkins/values.yaml
@@ -116,17 +116,12 @@ tolerations: {}
 ##
 podSecurityContext:
   fsGroup: 1001
-  runAsUser: 1001
 
-## Jenkins containers' Security Context
+## Jenkins containers' Security Context (only main container)
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
-## Example:
-##   containerSecurityContext:
-##     capabilities:
-##       drop: ["NET_RAW"]
-##     readOnlyRootFilesystem: true
 ##
-containerSecurityContext: {}
+containerSecurityContext:
+  runAsUser: 1001
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
@@ -205,26 +200,23 @@ ingress:
   ## For a full list of possible ingress annotations, please see
   ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   ##
-  ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+  ##
   annotations: {}
-  #  kubernetes.io/ingress.class: nginx
 
   ## The list of additional hostnames to be covered with this ingress record.
   ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
-  ## hosts:
+  ## extraHosts:
   ## - name: jenkins.local
   ##   path: /
 
-  ## The tls configuration for the ingress
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
-  ##
-  tls:
-    - hosts:
-        - example.local
-      secretName: example.local-tls
+  ## The tls configuration for additional hostnames to be covered with this ingress record.
+  ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## extraTls:
+  ## - hosts:
+  ##     - jenkins.local
+  ##   secretName: jenkins.local-tls
 
-  secrets:
   ## If you're providing your own certificates, please use this to add the certificates as secrets
   ## key and certificate should start with -----BEGIN CERTIFICATE----- or
   ## -----BEGIN RSA PRIVATE KEY-----
@@ -234,9 +226,11 @@ ingress:
   ##
   ## It is also possible to create and manage the certificates outside of this helm chart
   ## Please see README.md for more information
-  # - name: apache.local-tls
-  #   key:
-  #   certificate:
+  ##
+  secrets: []
+  ## - name: jenkins.local-tls
+  ##   key:
+  ##   certificate:
 
 ## Init Container paramaters
 ## Change the owner and group of the persistent volume(s) mountpoint(s) to 'runAsUser:fsGroup' on each component


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### Is this a new chart

No

#### What this PR does / why we need it:

This PR transforms the Jenkins chart into a "non-root" chart by default. This practice is very extended on K8s and, indeed, it is mandatory for some K8s distributions such as **OpenShift** or **VMware Tanzu Kubernetes Grid.**

This **PR breaks backwards compatibility** and a migration will be required to upgrade to the latest version.

#### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)