### PR TITLE
[bitnami/kafka] Fix typo in truststore file name in README

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 7.3.3
+version: 7.3.4
 appVersion: 2.4.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -301,7 +301,7 @@ If you enabled the authentication for Kafka, the SASL_SSL listener will be confi
  * interBrokerUser/interBrokerPassword: To authenticate kafka brokers between them.
  * zookeeperUser/zookeeperPassword: In the case that the Zookeeper chart is deployed with SASL authentication enabled.
 
-In order to configure the authentication, you **must** create a secret containing the *kafka.keystore.jks* and *kafka.trustore.jks* certificates and pass the secret name with the `--auth.certificatesSecret` option when deploying the chart.
+In order to configure the authentication, you **must** create a secret containing the *kafka.keystore.jks* and *kafka.truststore.jks* certificates and pass the secret name with the `--auth.certificatesSecret` option when deploying the chart.
 
 You can create the secret and deploy the chart with authentication using the following parameters:
 


### PR DESCRIPTION
Signed-off-by: Rafael Rios Saavedra <rafael.rios.saavedra@gmail.com>

**Description of the change**
This fix a small typo in the filename.
If you don't set the right filenames in the secret then the container is not able to find them.

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
