### PR TITLE
[bitnami/rabbitmq] adding possibility to have extras volumes/volumesm…

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 6.18.10
+version: 6.19.9
 appVersion: 3.8.3
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 6.18.9
+version: 6.18.10
 appVersion: 3.8.3
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/bitnami/rabbitmq/README.md
+++ b/bitnami/rabbitmq/README.md
@@ -185,6 +185,8 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 | `volumePermissions.resources`                | Init container resource requests/limit               | `nil`                                               |
 | `forceBoot.enabled`                          | Executes 'rabbitmqctl force_boot' to force boot cluster shut down unexpectedly in an unknown order. Use it only if you prefer availability over integrity. | `false` |
 | `extraSecrets`                               | Optionally specify extra secrets to be created by the chart. | `{}`                                        |
+| `extraVolumeMounts`                          | Optionally specify extra list of additional volumeMounts . | `{}`                                        |
+| `extraVolumes`                               | Optionally specify extra list of additional volumes . | `{}`                                        |
 
 The above parameters map to the env variables defined in [bitnami/rabbitmq](http://github.com/bitnami/bitnami-docker-rabbitmq). For more information please refer to the [bitnami/rabbitmq](http://github.com/bitnami/bitnami-docker-rabbitmq) image documentation.
 

--- a/bitnami/rabbitmq/templates/statefulset.yaml
+++ b/bitnami/rabbitmq/templates/statefulset.yaml
@@ -106,6 +106,9 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
         {{- end }}
         volumeMounts:
+          {{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 10 }}
+          {{- end }}
           - name: config-volume
             mountPath: /opt/bitnami/rabbitmq/conf
           - name: healthchecks
@@ -344,6 +347,9 @@ spec:
         - name: load-definition-volume
           secret:
             secretName: {{ .Values.rabbitmq.loadDefinition.secretName | quote }}
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
         {{- end }}
       {{- if not .Values.persistence.enabled }}
         - name: data

--- a/bitnami/rabbitmq/values-production.yaml
+++ b/bitnami/rabbitmq/values-production.yaml
@@ -572,3 +572,13 @@ extraSecrets: {}
   #     {
   #       ...
   #     }
+
+## Adding optionals volumeMount
+extraVolumeMounts: []
+  # - name: extras
+  #   mountPath: /usr/share/extras
+#   readOnly: true
+
+extraVolumes: []
+  # - name: extras
+#   emptyDir: {}

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -553,3 +553,13 @@ extraSecrets: {}
   #     {
   #       ...
   #     }
+
+## Adding optionals volumeMount
+extraVolumeMounts: []
+  # - name: extras
+  #   mountPath: /usr/share/extras
+  #   readOnly: true
+
+extraVolumes: []
+  # - name: extras
+  #   emptyDir: {}


### PR DESCRIPTION
**Description of the change**

Ability to add volumes/volumeMounts in rabbitMq

**Benefits**

Be able to share a pvc between several pods


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] Chart version bumped in Chart.yaml according to semver.
- [X] If the chart contains a values-production.yaml apart from values.yaml, ensure that you implement the changes in both files