### PR TITLE
[bitnami/ghost] chart standardization

### DIFF
--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -1,21 +1,21 @@
 apiVersion: v1
 name: ghost
-version: 9.2.8
+version: 10.0.0
 appVersion: 3.14.0
 description: A simple, powerful publishing platform that allows you to share your stories with the world
 keywords:
-- ghost
-- blog
-- http
-- web
-- application
-- nodejs
-- javascript
+  - ghost
+  - blog
+  - http
+  - web
+  - application
+  - nodejs
+  - javascript
 home: http://www.ghost.org/
 icon: https://bitnami.com/assets/stacks/ghost/img/ghost-stack-220x234.png
 sources:
-- https://github.com/bitnami/bitnami-docker-ghost
+  - https://github.com/bitnami/bitnami-docker-ghost
 maintainers:
-- name: Bitnami
-  email: containers@bitnami.com
+  - name: Bitnami
+    email: containers@bitnami.com
 engine: gotpl

--- a/bitnami/ghost/README.md
+++ b/bitnami/ghost/README.md
@@ -210,6 +210,19 @@ See the [Parameters](#parameters) section to configure the PVC or to disable per
 
 ## Upgrading
 
+### To 10.0.0
+
+This version introduces `bitnami/common`, a [library chart](https://helm.sh/docs/topics/library_charts/#helm) as a dependency. More documentation about this new utility could be found [here](https://github.com/bitnami/charts/tree/master/bitnami/common#bitnami-common-library-chart). Please, make sure that you have updated the chart dependencies before executing any upgrade.
+
+Also, `allowEmptyPassword` has changed its value type from string to boolean, if you were using it please make sure that you are pasing the proper value.
+
+```console
+# before
+--set allowEmptyPassword="no"
+# after
+--set allowEmptyPassword=false
+```
+
 ### To 9.0.0
 
 Helm performs a lookup for the object based on its group (apps), version (v1), and kind (Deployment). Also known as its GroupVersionKind, or GVK. Changing the GVK is considered a compatibility breaker from Kubernetes' point of view, so you cannot "upgrade" those objects to the new GVK in-place. Earlier versions of Helm 3 did not perform the lookup correctly which has since been fixed to match the spec.

--- a/bitnami/ghost/README.md
+++ b/bitnami/ghost/README.md
@@ -50,88 +50,102 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Ghost chart and their default values.
 
-| Parameter                           | Description                                                   | Default                                                  |
-|-------------------------------------|---------------------------------------------------------------|----------------------------------------------------------|
-| `global.imageRegistry`              | Global Docker image registry                                  | `nil`                                                    |
-| `global.imagePullSecrets`           | Global Docker registry secret names as an array               | `[]` (does not add image pull secrets to deployed pods)  |
-| `global.storageClass`               | Global storage class for dynamic provisioning                 | `nil`                                                    |
-| `image.registry`                    | Ghost image registry                                          | `docker.io`                                              |
-| `image.repository`                  | Ghost Image name                                              | `bitnami/ghost`                                          |
-| `image.tag`                         | Ghost Image tag                                               | `{TAG_NAME}`                                             |
-| `image.pullPolicy`                  | Image pull policy                                             | `IfNotPresent`                                           |
-| `image.pullSecrets`                 | Specify docker-registry secret names as an array              | `[]` (does not add image pull secrets to deployed pods)  |
-| `nameOverride`                      | String to partially override ghost.fullname template with a string (will prepend the release name) | `nil`               |
-| `fullnameOverride`                  | String to fully override ghost.fullname template with a string                                     | `nil`               |
-| `volumePermissions.image.registry`  | Init container volume-permissions image registry              | `docker.io`                                              |
-| `volumePermissions.image.repository`| Init container volume-permissions image name                  | `bitnami/minideb`                                        |
-| `volumePermissions.image.tag`       | Init container volume-permissions image tag                   | `buster`                                                 |
-| `volumePermissions.image.pullPolicy`| Init container volume-permissions image pull policy           | `Always`                                                 |
-| `ghostHost`                         | Ghost host to create application URLs                         | `nil`                                                    |
-| `ghostPort`                         | Ghost port to use in application URLs (defaults to `service.port` if `nil`) | `nil`                                      |
-| `ghostProtocol`                     | Protocol (http or https) to use in the application URLs       | `http`                                                   |
-| `ghostPath`                         | Ghost path to create application URLs                         | `nil`                                                    |
-| `ghostUsername`                     | User of the application                                       | `user@example.com`                                       |
-| `ghostPassword`                     | Application password                                          | Randomly generated                                       |
-| `ghostEmail`                        | Admin email                                                   | `user@example.com`                                       |
-| `ghostBlogTitle`                    | Ghost Blog name                                               | `User's Blog`                                            |
-| `smtpHost`                          | SMTP host                                                     | `nil`                                                    |
-| `smtpPort`                          | SMTP port                                                     | `nil`                                                    |
-| `smtpUser`                          | SMTP user                                                     | `nil`                                                    |
-| `smtpPassword`                      | SMTP password                                                 | `nil`                                                    |
-| `smtpFromAddress`                   | SMTP from address                                             | `nil`                                                    |
-| `smtpService`                       | SMTP service                                                  | `nil`                                                    |
-| `allowEmptyPassword`                | Allow DB blank passwords                                      | `yes`                                                    |
-| `livenessProbe.enabled`             | Would you like a livenessProbe to be enabled                  | `true`                                                   |
-| `livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated                      | 120                                                      |
-| `livenessProbe.periodSeconds`       | How often to perform the probe                                | 3                                                        |
-| `livenessProbe.timeoutSeconds`      | When the probe times out                                      | 5                                                        |
-| `livenessProbe.failureThreshold`    | Minimum consecutive failures to be considered failed          | 6                                                        |
-| `livenessProbe.successThreshold`    | Minimum consecutive successes to be considered successful     | 1                                                        |
-| `readinessProbe.enabled`            | Would you like a readinessProbe to be enabled                 | `true`                                                   |
-| `readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated                     | 30                                                       |
-| `readinessProbe.periodSeconds`      | How often to perform the probe                                | 3                                                        |
-| `readinessProbe.timeoutSeconds`     | When the probe times out                                      | 5                                                        |
-| `readinessProbe.failureThreshold`   |  Minimum consecutive failures to be considered failed         | 6                                                        |
-| `readinessProbe.successThreshold`   | Minimum consecutive successes to be considered successful     | 1                                                        |
-| `securityContext.enabled`           | Enable security context                                       | `true`                                                   |
-| `securityContext.fsGroup`           | Group ID for the container                                    | `1001`                                                   |
-| `securityContext.runAsUser`         | User ID for the container                                     | `1001`                                                   |
-| `service.type`                      | Kubernetes Service type                                       | `LoadBalancer`                                           |
-| `service.port`                      | Service HTTP port                                             | `80`                                                     |
-| `service.nodePorts.http`            | Kubernetes http node port                                     | `""`                                                     |
-| `service.externalTrafficPolicy`     | Enable client source IP preservation                          | `Cluster`                                                |
-| `service.loadBalancerIP`            | LoadBalancerIP for the Ghost service                          | ``                                                       |
-| `service.annotations`               | Service annotations                                           | ``                                                       |
-| `ingress.enabled`                   | Enable ingress controller resource                            | `false`                                                  |
-| `ingress.annotations`               | Ingress annotations                                           | `[]`                                                     |
-| `ingress.certManager`               | Add annotations for cert-manager                              | `false`                                                  |
-| `ingress.hosts[0].name`             | Hostname to your Ghost installation                           | `ghost.local`                                            |
-| `ingress.hosts[0].path`             | Path within the url structure                                 | `/`                                                      |
-| `ingress.hosts[0].tls`              | Utilize TLS backend in ingress                                | `false`                                                  |
-| `ingress.hosts[0].tlsHosts`         | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`)                               | `nil`                                                  |
-| `ingress.hosts[0].tlsSecret`        | TLS Secret (certificates)                                     | `ghost.local-tls-secret`                                 |
-| `ingress.secrets[0].name`           | TLS Secret Name                                               | `nil`                                                    |
-| `ingress.secrets[0].certificate`    | TLS Secret Certificate                                        | `nil`                                                    |
-| `ingress.secrets[0].key`            | TLS Secret Key                                                | `nil`                                                    |
-| `externalDatabase.host`             | Host of the external database                                 | `localhost`                                              |
-| `externalDatabase.port`             | Port of the external database                                 | `3306`                                                   |
-| `externalDatabase.user`             | Existing username in the external db                          | `bn_ghost`                                               |
-| `externalDatabase.password`         | Password for the above username                               | `""`                                                     |
-| `externalDatabase.database`         | Name of the existing database                                 | `bitnami_ghost`                                          |
-| `mariadb.enabled`                   | Whether or not to install MariaDB (disable if using external) | `true`                                                   |
-| `mariadb.rootUser.password`         | MariaDB admin password                                        | `nil`                                                    |
-| `mariadb.db.name`                   | MariaDB Database name to create                               | `bitnami_ghost`                                          |
-| `mariadb.db.user`                   | MariaDB Database user to create                               | `bn_ghost`                                               |
-| `mariadb.db.password`               | MariaDB Password for user                                     | _random 10 character long alphanumeric string_           |
-| `persistence.enabled`               | Enable persistence using PVC                                  | `true`                                                   |
-| `persistence.existingClaim`         | Use an existing PVC                                           | `""`
-| `persistence.storageClass`          | PVC Storage Class for Ghost volume                            | `nil` (uses alpha storage annotation)                    |
-| `persistence.accessMode`            | PVC Access Mode for Ghost volume                              | `ReadWriteOnce`                                          |
-| `persistence.size`                  | PVC Storage Request for Ghost volume                          | `8Gi`                                                    |
-| `persistence.path`                  | Path to mount the volume at, to use other images              | `/bitnami`                                               |
-| `resources`                         | CPU/Memory resource requests/limits                           | Memory: `512Mi`, CPU: `300m`                             |
-| `nodeSelector`                      | Node selector for pod assignment                              | `{}`                                                     |
-| `affinity`                          | Map of node/pod affinities                                    | `{}`                                                     |
+| Parameter                            | Description                                                                                        | Default                                                                                       |
+|--------------------------------------|----------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
+| `global.imageRegistry`               | Global Docker image registry                                                                       | `nil`                                                                                         |
+| `global.imagePullSecrets`            | Global Docker registry secret names as an array                                                    | `[]` (does not add image pull secrets to deployed pods)                                       |
+| `global.storageClass`                | Global storage class for dynamic provisioning                                                      | `nil`                                                                                         |
+| `image.registry`                     | Ghost image registry                                                                               | `docker.io`                                                                                   |
+| `image.repository`                   | Ghost Image name                                                                                   | `bitnami/ghost`                                                                               |
+| `image.tag`                          | Ghost Image tag                                                                                    | `{TAG_NAME}`                                                                                  |
+| `image.pullPolicy`                   | Image pull policy                                                                                  | `IfNotPresent`                                                                                |
+| `image.pullSecrets`                  | Specify docker-registry secret names as an array                                                   | `[]` (does not add image pull secrets to deployed pods)                                       |
+| `nameOverride`                       | String to partially override ghost.fullname template with a string (will prepend the release name) | `nil`                                                                                         |
+| `fullnameOverride`                   | String to fully override ghost.fullname template with a string                                     | `nil`                                                                                         |
+| `volumePermissions.image.registry`   | Init container volume-permissions image registry                                                   | `docker.io`                                                                                   |
+| `volumePermissions.image.repository` | Init container volume-permissions image name                                                       | `bitnami/minideb`                                                                             |
+| `volumePermissions.image.tag`        | Init container volume-permissions image tag                                                        | `buster`                                                                                      |
+| `volumePermissions.image.pullPolicy` | Init container volume-permissions image pull policy                                                | `Always`                                                                                      |
+| `ghostHost`                          | Ghost host to create application URLs                                                              | `nil`                                                                                         |
+| `ghostPort`                          | Ghost port to use in application URLs (defaults to `service.port` if `nil`)                        | `nil`                                                                                         |
+| `ghostProtocol`                      | Protocol (http or https) to use in the application URLs                                            | `http`                                                                                        |
+| `ghostPath`                          | Ghost path to create application URLs                                                              | `nil`                                                                                         |
+| `ghostUsername`                      | User of the application                                                                            | `user@example.com`                                                                            |
+| `ghostPassword`                      | Application password                                                                               | Randomly generated                                                                            |
+| `ghostEmail`                         | Admin email                                                                                        | `user@example.com`                                                                            |
+| `ghostBlogTitle`                     | Ghost Blog name                                                                                    | `User's Blog`                                                                                 |
+| `smtpHost`                           | SMTP host                                                                                          | `nil`                                                                                         |
+| `smtpPort`                           | SMTP port                                                                                          | `nil`                                                                                         |
+| `smtpUser`                           | SMTP user                                                                                          | `nil`                                                                                         |
+| `smtpPassword`                       | SMTP password                                                                                      | `nil`                                                                                         |
+| `smtpFromAddress`                    | SMTP from address                                                                                  | `nil`                                                                                         |
+| `smtpService`                        | SMTP service                                                                                       | `nil`                                                                                         |
+| `allowEmptyPassword`                 | Allow DB blank passwords                                                                           | `true`                                                                                        |
+| `existingSecret`                     | Allow to use an existing secret for passwords data                                                 | [ExistingSecret](https://github.com/bitnami/charts/tree/master/bitnami/common#existingsecret) |
+| `livenessProbe.enabled`              | Would you like a livenessProbe to be enabled                                                       | `true`                                                                                        |
+| `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                                                           | 120                                                                                           |
+| `livenessProbe.periodSeconds`        | How often to perform the probe                                                                     | 3                                                                                             |
+| `livenessProbe.timeoutSeconds`       | When the probe times out                                                                           | 5                                                                                             |
+| `livenessProbe.failureThreshold`     | Minimum consecutive failures to be considered failed                                               | 6                                                                                             |
+| `livenessProbe.successThreshold`     | Minimum consecutive successes to be considered successful                                          | 1                                                                                             |
+| `readinessProbe.enabled`             | Would you like a readinessProbe to be enabled                                                      | `true`                                                                                        |
+| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                                                          | 30                                                                                            |
+| `readinessProbe.periodSeconds`       | How often to perform the probe                                                                     | 3                                                                                             |
+| `readinessProbe.timeoutSeconds`      | When the probe times out                                                                           | 5                                                                                             |
+| `readinessProbe.failureThreshold`    | Minimum consecutive failures to be considered failed                                               | 6                                                                                             |
+| `readinessProbe.successThreshold`    | Minimum consecutive successes to be considered successful                                          | 1                                                                                             |
+| `securityContext.enabled`            | Enable security context                                                                            | `true`                                                                                        |
+| `securityContext.fsGroup`            | Group ID for the container                                                                         | `1001`                                                                                        |
+| `securityContext.runAsUser`          | User ID for the container                                                                          | `1001`                                                                                        |
+| `service.type`                       | Kubernetes Service type                                                                            | `LoadBalancer`                                                                                |
+| `service.port`                       | Service HTTP port                                                                                  | `80`                                                                                          |
+| `service.nodePorts.http`             | Kubernetes http node port                                                                          | `""`                                                                                          |
+| `service.externalTrafficPolicy`      | Enable client source IP preservation                                                               | `Cluster`                                                                                     |
+| `service.loadBalancerIP`             | LoadBalancerIP for the Ghost service                                                               | ``                                                                                            |
+| `service.annotations`                | Service annotations. Evaluated as a template                                                       | `{}`                                                                                          |
+| `service.extraPorts`                 | Service extra ports, normally used with the `sidecar` value. Evaluated as a template               | `[]`                                                                                          |
+| `ingress.enabled`                    | Enable ingress controller resource                                                                 | `false`                                                                                       |
+| `ingress.annotations`                | Ingress annotations. Evaluated as a template                                                       | `{}`                                                                                          |
+| `ingress.certManager`                | Add annotations for cert-manager                                                                   | `false`                                                                                       |
+| `ingress.hosts[0].name`              | Hostname to your Ghost installation                                                                | `ghost.local`                                                                                 |
+| `ingress.hosts[0].path`              | Path within the url structure                                                                      | `/`                                                                                           |
+| `ingress.hosts[0].tls`               | Utilize TLS backend in ingress                                                                     | `false`                                                                                       |
+| `ingress.hosts[0].tlsHosts`          | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`)               | `nil`                                                                                         |
+| `ingress.hosts[0].tlsSecret`         | TLS Secret (certificates)                                                                          | `ghost.local-tls-secret`                                                                      |
+| `ingress.secrets[0].name`            | TLS Secret Name                                                                                    | `nil`                                                                                         |
+| `ingress.secrets[0].certificate`     | TLS Secret Certificate                                                                             | `nil`                                                                                         |
+| `ingress.secrets[0].key`             | TLS Secret Key                                                                                     | `nil`                                                                                         |
+| `externalDatabase.host`              | Host of the external database                                                                      | `localhost`                                                                                   |
+| `externalDatabase.port`              | Port of the external database                                                                      | `3306`                                                                                        |
+| `externalDatabase.user`              | Existing username in the external db                                                               | `bn_ghost`                                                                                    |
+| `externalDatabase.password`          | Password for the above username                                                                    | `""`                                                                                          |
+| `externalDatabase.database`          | Name of the existing database                                                                      | `bitnami_ghost`                                                                               |
+| `mariadb.enabled`                    | Whether or not to install MariaDB (disable if using external)                                      | `true`                                                                                        |
+| `mariadb.replication.enabled`        | Whether or not to use MariaDB replication (disable if using external)                              | `false`                                                                                       |
+| `mariadb.rootUser.password`          | MariaDB admin password                                                                             | `nil`                                                                                         |
+| `mariadb.db.name`                    | MariaDB Database name to create                                                                    | `bitnami_ghost`                                                                               |
+| `mariadb.db.user`                    | MariaDB Database user to create                                                                    | `bn_ghost`                                                                                    |
+| `mariadb.db.password`                | MariaDB Password for user                                                                          | _random 10 character long alphanumeric string_                                                |
+| `mariadb.persistence.enabled`        | Whether or not to MariaDB persistence                                                              | `true`                                                                                        |
+| `mariadb.persistence.accessMode`     | Persistent Volume Access Modes                                                                     | `[ReadWriteOnce]`                                                                             |
+| `mariadb.persistence.size`           | Persistent Volume Size                                                                             | `8Gi`                                                                                         |
+| `persistence.enabled`                | Enable persistence using PVC                                                                       | `true`                                                                                        |
+| `persistence.existingClaim`          | Use an existing PVC                                                                                | `""`                                                                                          |
+| `persistence.storageClass`           | PVC Storage Class for Ghost volume                                                                 | `nil` (uses alpha storage annotation)                                                         |
+| `persistence.accessMode`             | PVC Access Mode for Ghost volume                                                                   | `ReadWriteOnce`                                                                               |
+| `persistence.size`                   | PVC Storage Request for Ghost volume                                                               | `8Gi`                                                                                         |
+| `persistence.path`                   | Path to mount the volume at, to use other images                                                   | `/bitnami`                                                                                    |
+| `resources`                          | CPU/Memory resource requests/limits                                                                | Memory: `512Mi`, CPU: `300m`                                                                  |
+| `nodeSelector`                       | Node selector for pod assignment                                                                   | `{}`                                                                                          |
+| `affinity`                           | Affinity for pod assignment (evaluated as a template)                                              | `{}`                                                                                          |
+| `sidecars`                           | Attach additional containers to all pods (evaluated as a template)                                 | `[]`                                                                                          |
+| `initContainers`                     | Attach additional init containers to all pods (evaluated as a template)                            | `[]`                                                                                          |
+| `extraVolumes`                       | Extra volumes for pods (evaluated as a template). Requires setting `extraVolumeMounts`             | `[]`                                                                                          |
+| `extraVolumeMounts`                  | Extra volume mounts for pods (evaluated as a template). Normally used with `extraVolumes`          | `[]`                                                                                          |
+| `extraEnvVars`                       | Array containing extra env vars to be added to all pods (evaluated as a template)                  | `[]`                                                                                          |
+| `extraEnvVarsConfigMap`              | ConfigMap containing extra env vars to be added to all pods (evaluated as a template)              | `nil`                                                                                         |
+| `extraEnvVarsSecret`                 | Secret containing extra env vars to be added to all pods (evaluated as a template)                 | `nil`                                                                                         |
+| `podAnnotations`                     | Additional pod annotations to be added to all pods (evaluated as a template)                       | `{}`                                                                                          |
 
 The above parameters map to the env variables defined in [bitnami/ghost](http://github.com/bitnami/bitnami-docker-ghost). For more information please refer to the [bitnami/ghost](http://github.com/bitnami/bitnami-docker-ghost) image documentation.
 

--- a/bitnami/ghost/requirements.lock
+++ b/bitnami/ghost/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
-- name: mariadb
-  repository: https://charts.bitnami.com/bitnami
-  version: 7.3.21
+  - name: mariadb
+    repository: https://charts.bitnami.com/bitnami
+    version: 7.3.21
 digest: sha256:297f56e3a68da0d549786d70724c391711e7d776a1cf2f354cc94416e9061153
 generated: "2020-04-22T06:30:21.580152666Z"

--- a/bitnami/ghost/requirements.lock
+++ b/bitnami/ghost/requirements.lock
@@ -1,6 +1,9 @@
 dependencies:
-  - name: mariadb
-    repository: https://charts.bitnami.com/bitnami
-    version: 7.3.21
-digest: sha256:297f56e3a68da0d549786d70724c391711e7d776a1cf2f354cc94416e9061153
-generated: "2020-04-22T06:30:21.580152666Z"
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 0.2.0
+- name: mariadb
+  repository: https://charts.bitnami.com/bitnami
+  version: 7.3.21
+digest: sha256:754266106946779fe2ff263b80bcec57ef647d0777a2d1a59d9fae6d90b94533
+generated: "2020-04-30T09:22:22.091929059Z"

--- a/bitnami/ghost/requirements.yaml
+++ b/bitnami/ghost/requirements.yaml
@@ -1,7 +1,12 @@
 dependencies:
-- name: mariadb
-  version: 7.x.x
-  repository: https://charts.bitnami.com/bitnami
-  condition: mariadb.enabled
-  tags:
-    - ghost-database
+  - name: common
+    version: 0.x.x
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+  - name: mariadb
+    version: 7.x.x
+    repository: https://charts.bitnami.com/bitnami
+    condition: mariadb.enabled
+    tags:
+      - ghost-database

--- a/bitnami/ghost/templates/NOTES.txt
+++ b/bitnami/ghost/templates/NOTES.txt
@@ -1,4 +1,4 @@
-{{- $ghostPasswordKey := ( include "common.secrets.key" (dict "existingSecret" .Values.existingSecret "key" "ghostPassword") ) -}}
+{{- $ghostPasswordKey := ( include "common.secrets.key" (dict "existingSecret" .Values.existingSecret "key" "ghost-password") ) -}}
 {{- if empty (include "ghost.host" .) -}}
 ###############################################################################
 ### ERROR: You did not provide an external host in your 'helm install' call ###

--- a/bitnami/ghost/templates/NOTES.txt
+++ b/bitnami/ghost/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{- $ghostPasswordKey := ( include "common.secrets.key" (dict "existingSecret" .Values.existingSecret "key" "ghostPassword") ) -}}
 {{- if empty (include "ghost.host" .) -}}
 ###############################################################################
 ### ERROR: You did not provide an external host in your 'helm install' call ###
@@ -18,10 +19,12 @@ host. To configure Ghost with the URL of your service:
         Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "ghost.fullname" . }}'
 
   export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "ghost.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
-  export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "ghost.fullname" . }} -o jsonpath="{.data.ghost-password}" | base64 --decode)
+
+  {{- end }}
+
+  export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "ghost.fullname" . }} -o jsonpath="{.data.{{- $ghostPasswordKey -}}}" | base64 --decode)
   {{- if .Values.mariadb.mariadbRootPassword }}
   export DATABASE_ROOT_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "ghost.mariadb.fullname" . }} -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)
-  {{- end }}
   {{- end }}
   export APP_DATABASE_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "ghost.mariadb.fullname" . }} -o jsonpath="{.data.mariadb-password}" | base64 --decode)
 
@@ -35,7 +38,7 @@ host. To configure Ghost with the URL of your service:
 {{- if eq .Values.service.type "ClusterIP" }}
 
   echo Blog URL  : http://127.0.0.1:{{ default "80" .Values.service.port }}{{ .Values.ghostPath }}
-  echo Admin URL : http://127.0.0.1:{{ default "80" .Values.service.port }}{{ .Values.ghostPath }}ghost
+  echo Admin URL : http://127.0.0.1:{{ default "80" .Values.service.port }}{{ default "/" .Values.ghostPath }}ghost
   kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "ghost.fullname" . }} {{ default "80" .Values.service.port }}:{{ default "80" .Values.service.port }}
 
 {{- else if eq .Values.service.type "NodePort" }}
@@ -43,23 +46,18 @@ host. To configure Ghost with the URL of your service:
   export APP_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "ghost.fullname" . }})
 
   echo Blog URL  : http://$APP_HOST:$APP_PORT{{ .Values.ghostPath }}
-  echo Admin URL : http://$APP_HOST:$APP_PORT{{ .Values.ghostPath }}ghost
+  echo Admin URL : http://$APP_HOST:$APP_PORT{{ default "/" .Values.ghostPath }}ghost
 
 {{- else }}
 
-  echo Blog URL  : http://{{ include "ghost.host" . }}
-  echo Admin URL : http://{{ include "ghost.host" . }}ghost
+  echo Blog URL  : http://{{ include "ghost.endpoint" . }}
+  echo Admin URL : http://{{ include "ghost.endpoint" . }}ghost
 {{- end }}
 
 2. Get your Ghost login credentials by running:
 
   echo Email:    {{ .Values.ghostEmail }}
-  echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "ghost.fullname" . }} -o jsonpath="{.data.ghost-password}" | base64 --decode)
+  echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "ghost.fullname" . }} -o jsonpath="{.data.{{- $ghostPasswordKey -}}}" | base64 --decode)
 {{- end }}
 
-{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
-
-WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
-+info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
-
-{{- end }}
+{{ include "common.warnings.rollingTag" .Values.image }}

--- a/bitnami/ghost/templates/_helpers.tpl
+++ b/bitnami/ghost/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "ghost.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- include "common.names.name" . -}}
 {{- end -}}
 
 {{/*
@@ -12,16 +12,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "ghost.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
+{{- include "common.names.fullname" . -}}
 {{- end -}}
 
 {{/*
@@ -30,6 +21,41 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "ghost.mariadb.fullname" -}}
 {{- printf "%s-%s" .Release.Name "mariadb" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ghost.chart" -}}
+{{- include "common.names.chart" . -}}
+{{- end -}}
+
+{{/*
+Return the proper Ghost image name
+*/}}
+{{- define "ghost.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper image name to change the volume permissions
+*/}}
+{{- define "ghost.volumePermissions.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.volumePermissions.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "ghost.imagePullSecrets" -}}
+{{ include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.volumePermissions.image) "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return  the proper Storage Class
+*/}}
+{{- define "ghost.storageClass" -}}
+{{ include "common.storage.class" ( dict "persistence" .Values.persistence "global" .Values.global) }}
 {{- end -}}
 
 {{/*
@@ -49,144 +75,23 @@ Gets the host to be used for this application.
 If not using ClusterIP, or if a host or LoadBalancerIP is not defined, the value will be empty.
 */}}
 {{- define "ghost.host" -}}
-{{- if .Values.ghostHost -}}
-{{- $host := printf "%s%s" .Values.ghostHost .Values.ghostPath -}}
-{{- default (include "ghost.serviceIP" .) $host -}}
-{{- else -}}
-{{- default (include "ghost.serviceIP" .) "" -}}
-{{- end -}}
+{{- default (include "ghost.serviceIP" .) .Values.ghostHost -}}
 {{- end -}}
 
 {{/*
-Create chart name and version as used by the chart label.
+Gets the endpoint to be used for this application.
+If not using ClusterIP, or if a host or LoadBalancerIP is not defined, the value will be empty.
 */}}
-{{- define "ghost.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- define "ghost.endpoint" -}}
+{{- $host := include "ghost.host" . -}}
+{{- $path := trimSuffix "/" (trimPrefix "/" .Values.ghostPath)  -}}
+
+{{- printf "%s/%s" $host $path -}}
 {{- end -}}
 
 {{/*
-Return the proper Ghost image name
+Get external db secret name.
 */}}
-{{- define "ghost.image" -}}
-{{- $registryName := .Values.image.registry -}}
-{{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
-{{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return the proper image name to change the volume permissions
-*/}}
-{{- define "ghost.volumePermissions.image" -}}
-{{- $registryName := .Values.volumePermissions.image.registry -}}
-{{- $repositoryName := .Values.volumePermissions.image.repository -}}
-{{- $tag := .Values.volumePermissions.image.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
-{{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return the proper Docker Image Registry Secret Names
-*/}}
-{{- define "ghost.imagePullSecrets" -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
-Also, we can not use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets:
-{{- range .Values.global.imagePullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- else if or .Values.image.pullSecrets .Values.volumePermissions.image.pullSecrets }}
-imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- range .Values.volumePermissions.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end -}}
-{{- else if or .Values.image.pullSecrets .Values.volumePermissions.image.pullSecrets }}
-imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- range .Values.volumePermissions.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return  the proper Storage Class
-*/}}
-{{- define "ghost.storageClass" -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
-*/}}
-{{- if .Values.global -}}
-    {{- if .Values.global.storageClass -}}
-        {{- if (eq "-" .Values.global.storageClass) -}}
-            {{- printf "storageClassName: \"\"" -}}
-        {{- else }}
-            {{- printf "storageClassName: %s" .Values.global.storageClass -}}
-        {{- end -}}
-    {{- else -}}
-        {{- if .Values.persistence.storageClass -}}
-              {{- if (eq "-" .Values.persistence.storageClass) -}}
-                  {{- printf "storageClassName: \"\"" -}}
-              {{- else }}
-                  {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
-              {{- end -}}
-        {{- end -}}
-    {{- end -}}
-{{- else -}}
-    {{- if .Values.persistence.storageClass -}}
-        {{- if (eq "-" .Values.persistence.storageClass) -}}
-            {{- printf "storageClassName: \"\"" -}}
-        {{- else }}
-            {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
-        {{- end -}}
-    {{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return the appropriate apiVersion for deployment.
-*/}}
-{{- define "ghost.deployment.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
-{{- print "apps/v1" -}}
-{{- end -}}
+{{- define "ghost.externalDb.secret.name" -}}
+{{ include "ghost.fullname" . }}-external-db
 {{- end -}}

--- a/bitnami/ghost/templates/deployment.yaml
+++ b/bitnami/ghost/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "common.secrets.name" (dict "existingSecret" .Values.existingSecret "context" $) }}
-                  key: {{ include "common.secrets.key" (dict "existingSecret" .Values.existingSecret "key" "ghostPassword") }}
+                  key: {{ include "common.secrets.key" (dict "existingSecret" .Values.existingSecret "key" "ghost-password") }}
             - name: GHOST_EMAIL
               value: {{ .Values.ghostEmail | quote }}
             - name: BLOG_TITLE
@@ -99,7 +99,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "common.secrets.name" (dict "existingSecret" .Values.existingSecret "context" $) }}
-                  key: {{ include "common.secrets.key" (dict "existingSecret" .Values.existingSecret "key" "smtpPassword") }}
+                  key: {{ include "common.secrets.key" (dict "existingSecret" .Values.existingSecret "key" "smtp-password") }}
             {{- end }}
             {{- if .Values.smtpFromAddress }}
             - name: SMTP_FROM_ADDRESS

--- a/bitnami/ghost/templates/deployment.yaml
+++ b/bitnami/ghost/templates/deployment.yaml
@@ -1,197 +1,194 @@
 {{- if include "ghost.host" . -}}
-apiVersion: {{ template "ghost.deployment.apiVersion" . }}
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
-  name: {{ template "ghost.fullname" . }}
-  labels:
-    app: "{{ template "ghost.fullname" . }}"
-    chart: "{{ template "ghost.chart" . }}"
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  name: {{ include "ghost.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   selector:
-    matchLabels:
-      app: "{{ template "ghost.fullname" . }}"
-      release: {{ .Release.Name | quote }}
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
   replicas: 1
   template:
     metadata:
-      labels:
-        app: "{{ template "ghost.fullname" . }}"
-        chart: "{{ template "ghost.chart" . }}"
-        release: {{ .Release.Name | quote }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+    {{- if .Values.podAnnotations }}
+    annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.podAnnotations "context" $ ) | nindent 6 }}
+    {{- end }}
     spec:
+      {{- include "ghost.imagePullSecrets" . | indent 6 }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
-      {{- else }}
+      {{- end }}
       initContainers:
-      - name: volume-permissions
-        image: {{ template "ghost.volumePermissions.image" . }}
-        imagePullPolicy: "{{ .Values.volumePermissions.image.pullPolicy }}"
-        command: ['sh', '-c', 'chmod -R g+rwX {{ .Values.persistence.path }}']
-        volumeMounts:
-        - mountPath: {{ .Values.persistence.path }}
-          name: ghost-data
+      {{- if not .Values.securityContext.enabled }}
+        - name: volume-permissions
+          image: {{ include "ghost.volumePermissions.image" . }}
+          imagePullPolicy: "{{ .Values.volumePermissions.image.pullPolicy }}"
+          command: ['sh', '-c', 'chmod -R g+rwX {{ .Values.persistence.path }}']
+          volumeMounts:
+            - mountPath: {{ .Values.persistence.path }}
+              name: ghost-data
       {{- end }}
-{{- include "ghost.imagePullSecrets" . | indent 6 }}
+      {{- if .Values.initContainers }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.initContainers "context" $ ) | indent 8 }}
+      {{- end }}
       containers:
-      - name: {{ template "ghost.fullname" . }}
-        image: {{ template "ghost.image" . }}
-        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-        env:
-        - name: ALLOW_EMPTY_PASSWORD
-        {{- if .Values.allowEmptyPassword }}
-          value: "yes"
-        {{- else }}
-          value: "no"
-        {{- end }}
-        - name: MARIADB_HOST
-        {{- if .Values.mariadb.enabled }}
-          value: {{ template "ghost.mariadb.fullname" . }}
-        {{- else }}
-          value: {{ .Values.externalDatabase.host | quote }}
-        {{- end }}
-        - name: MARIADB_PORT_NUMBER
-        {{- if .Values.mariadb.enabled }}
-          value: "3306"
-        {{- else }}
-          value: {{ .Values.externalDatabase.port | quote }}
-        {{- end }}
-        - name: GHOST_DATABASE_NAME
-        {{- if .Values.mariadb.enabled }}
-          value: {{ .Values.mariadb.db.name | quote }}
-        {{- else }}
-          value: {{ .Values.externalDatabase.database | quote }}
-        {{- end }}
-        - name: GHOST_DATABASE_USER
-        {{- if .Values.mariadb.enabled }}
-          value: {{ .Values.mariadb.db.user | quote }}
-        {{- else }}
-          value: {{ .Values.externalDatabase.user | quote }}
-        {{- end }}
-        - name: GHOST_DATABASE_PASSWORD
-        {{- if .Values.mariadb.enabled }}
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "ghost.mariadb.fullname" . }}
-              key: mariadb-password
-        {{- else }}
-          value: {{ .Values.externalDatabase.password | quote }}
-        {{- end }}
-        - name: GHOST_HOST
-          value: {{ include "ghost.host" . | quote }}
-        - name: GHOST_PROTOCOL
-          value: {{  .Values.ghostProtocol | quote }}
-        - name: GHOST_PORT_NUMBER
-        {{- if .Values.ghostPort }}
-          value: {{ .Values.ghostPort | quote }}
-        {{- else }}
-          value: {{ .Values.service.port | quote }}
-        {{- end }}
-        - name: GHOST_USERNAME
-          value: {{ .Values.ghostUsername | quote }}
-        - name: GHOST_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "ghost.fullname" . }}
-              key: ghost-password
-        - name: GHOST_EMAIL
-          value: {{ .Values.ghostEmail | quote }}
-        - name: BLOG_TITLE
-          value: {{ .Values.ghostBlogTitle | quote }}
-        {{- if .Values.smtpHost }}
-        - name: SMTP_HOST
-          value: {{ .Values.smtpHost | quote }}
-        {{- end }}
-        {{- if .Values.smtpPort }}
-        - name: SMTP_PORT
-          value: {{ .Values.smtpPort | quote }}
-        {{- end }}
-        {{- if .Values.smtpUser }}
-        - name: SMTP_USER
-          value: {{ .Values.smtpUser | quote }}
-        {{- end }}
-        {{- if .Values.smtpPassword }}
-        - name: SMTP_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "ghost.fullname" . }}
-              key: smtp-password
-        {{- end }}
-        {{- if .Values.smtpFromAddress }}
-        - name: SMTP_FROM_ADDRESS
-          value: {{ .Values.smtpFromAddress | quote }}
-        {{- end }}
-        {{- if .Values.smtpService }}
-        - name: SMTP_SERVICE
-          value: {{ .Values.smtpService | quote }}
-        {{- end }}
-        ports:
-        - name: http
-          containerPort: 2368
-        {{- if .Values.livenessProbe.enabled }}
-        livenessProbe:
-          httpGet:
-            path: {{ .Values.ghostPath }}
-            port: http
-            httpHeaders:
-            - name: Host
-              value: {{ include "ghost.host" . | quote }}
-            {{- if eq .Values.ghostProtocol "https" }}
-            - name: X-Forwarded-Proto
-              value: https
+        - name: ghost
+          image: {{ include "ghost.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          env:
+            - name: ALLOW_EMPTY_PASSWORD
+              value: {{ ternary "yes" "no" .Values.allowEmptyPassword | quote }}
+            {{- $host := .Values.externalDatabase.host -}}
+            {{- $port := .Values.externalDatabase.port -}}
+            {{- $database := .Values.externalDatabase.database -}}
+            {{- $user := .Values.externalDatabase.user -}}
+
+            {{- if .Values.mariadb.enabled -}}
+              {{- $host = (include "ghost.mariadb.fullname" .) -}}
+              {{- $port = .Values.mariadb.service.port -}}
+              {{- $database = .Values.mariadb.db.name -}}
+              {{- $user = .Values.mariadb.db.user -}}
             {{- end }}
-          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.livenessProbe.successThreshold }}
-          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
-        {{- end }}
-        {{- if .Values.readinessProbe.enabled }}
-        readinessProbe:
-          httpGet:
-            path: {{ .Values.ghostPath }}
-            port: http
-            httpHeaders:
-            - name: Host
-              value: {{ include "ghost.host" . | quote }}
-            {{- if eq .Values.ghostProtocol "https" }}
-            - name: X-Forwarded-Proto
-              value: https
+            - name: MARIADB_HOST
+              value: {{ $host | quote }}
+            - name: MARIADB_PORT_NUMBER
+              value: {{ $port | quote }}
+            - name: GHOST_DATABASE_NAME
+              value: {{ $database | quote }}
+            - name: GHOST_DATABASE_USER
+              value: {{ $user | quote }}
+            - name: GHOST_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ ternary ( include "ghost.mariadb.fullname" . ) (include "ghost.externalDb.secret.name" .) .Values.mariadb.enabled }}
+                  key: mariadb-password
+            - name: GHOST_HOST
+              value: {{ include "ghost.endpoint" . | quote }}
+            - name: GHOST_PROTOCOL
+              value: {{ .Values.ghostProtocol | quote }}
+            - name: GHOST_PORT_NUMBER
+              value: {{ default .Values.service.port .Values.ghostPort | quote }}
+            - name: GHOST_USERNAME
+              value: {{ .Values.ghostUsername | quote }}
+            - name: GHOST_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "common.secrets.name" (dict "existingSecret" .Values.existingSecret "context" $) }}
+                  key: {{ include "common.secrets.key" (dict "existingSecret" .Values.existingSecret "key" "ghostPassword") }}
+            - name: GHOST_EMAIL
+              value: {{ .Values.ghostEmail | quote }}
+            - name: BLOG_TITLE
+              value: {{ .Values.ghostBlogTitle | quote }}
+            {{- if .Values.smtpHost }}
+            - name: SMTP_HOST
+              value: {{ .Values.smtpHost | quote }}
             {{- end }}
-          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-          successThreshold: {{ .Values.readinessProbe.successThreshold }}
-          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
-        {{- end }}
-        {{- if .Values.resources }}
-        resources: {{- toYaml .Values.resources | nindent 10 }}
-        {{- end }}
-        volumeMounts:
-        - name: ghost-data
-          mountPath: /bitnami/ghost
+            {{- if .Values.smtpPort }}
+            - name: SMTP_PORT
+              value: {{ .Values.smtpPort | quote }}
+            {{- end }}
+            {{- if .Values.smtpUser }}
+            - name: SMTP_USER
+              value: {{ .Values.smtpUser | quote }}
+            {{- end }}
+            {{- if .Values.smtpPassword }}
+            - name: SMTP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "common.secrets.name" (dict "existingSecret" .Values.existingSecret "context" $) }}
+                  key: {{ include "common.secrets.key" (dict "existingSecret" .Values.existingSecret "key" "smtpPassword") }}
+            {{- end }}
+            {{- if .Values.smtpFromAddress }}
+            - name: SMTP_FROM_ADDRESS
+              value: {{ .Values.smtpFromAddress | quote }}
+            {{- end }}
+            {{- if .Values.smtpService }}
+            - name: SMTP_SERVICE
+              value: {{ .Values.smtpService | quote }}
+            {{- end }}
+            {{- if .Values.extraEnvVars }}
+            {{- include "common.tplvalues.render" ( dict "value" .Values.extraEnvVars "context" $ ) | nindent 10 }}
+            {{- end }}
+          {{- if or .Values.extraEnvVarsConfigMap .Values.extraEnvVarsSecret }}
+          envFrom:
+            {{- if .Values.extraEnvVarsConfigMap }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" ( dict "value" .Values.extraEnvVarsConfigMap "context" $ ) }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" ( dict "value" .Values.extraEnvVarsSecret "context" $ ) }}
+            {{- end }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 2368
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.ghostPath }}
+              port: http
+              httpHeaders:
+                - name: Host
+                  value: {{ include "ghost.host" . | quote }}
+                {{- if eq .Values.ghostProtocol "https" }}
+                - name: X-Forwarded-Proto
+                  value: https
+                {{- end }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.ghostPath }}
+              port: http
+              httpHeaders:
+                - name: Host
+                  value: {{ include "ghost.host" . | quote }}
+                {{- if eq .Values.ghostProtocol "https" }}
+                - name: X-Forwarded-Proto
+                  value: https
+                {{- end }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.resources }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: ghost-data
+              mountPath: /bitnami/ghost
+          {{- if .Values.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" ( dict "value" .Values.extraVolumeMounts "context" $ ) | nindent 10 }}
+          {{- end }}
+      {{- if .Values.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $ ) | nindent 8 }}
+      {{- end }}
       volumes:
-      - name: ghost-data
-      {{- if .Values.persistence.enabled }}
-        {{- if .Values.persistence.existingClaim }}
-        persistentVolumeClaim:
-          claimName: {{ .Values.persistence.existingClaim }}
+        - name: ghost-data
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ default (include "ghost.fullname" .) .Values.persistence.existingClaim }}
         {{- else }}
-        persistentVolumeClaim:
-          claimName: {{ template "ghost.fullname" . }}
+          emptyDir: {}
         {{- end }}
-      {{- else }}
-        emptyDir: {}
+        {{- if .Values.extraVolumes }}
+          {{- include "common.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 8 }}
+        {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.affinity }}
+      affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- end }}
 {{- end -}}

--- a/bitnami/ghost/templates/ingress.yaml
+++ b/bitnami/ghost/templates/ingress.yaml
@@ -2,42 +2,38 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "ghost.fullname" . }}
-  labels:
-    app: "{{ template "ghost.fullname" . }}"
-    chart: "{{ template "ghost.chart" . }}"
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  name: {{ include "ghost.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
   annotations:
-    {{- if .Values.ingress.certManager }}
+  {{- if .Values.service.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $) | indent 4 }}
+  {{- end }}
+  {{- if .Values.ingress.certManager }}
     kubernetes.io/tls-acme: "true"
-    {{- end }}
-    {{- range $key, $value := .Values.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
+  {{- end }}
 spec:
   rules:
   {{- range .Values.ingress.hosts }}
-  - host: {{ .name }}
-    http:
-      paths:
-      - path: {{ default "/" .path }}
-        backend:
-          serviceName: {{ template "ghost.fullname" $ }}
-          servicePort: http
+    - host: {{ .name }}
+      http:
+        paths:
+          - path: {{ default "/" .path }}
+            backend:
+              serviceName: {{ include "ghost.fullname" $ }}
+              servicePort: http
   {{- end }}
   tls:
   {{- range .Values.ingress.hosts }}
-  {{- if .tls }}
-  - hosts:
-  {{- if .tlsHosts }}
-  {{- range $host := .tlsHosts }}
-    - {{ $host }}
-  {{- end }}
-  {{- else }}
-    - {{ .name }}
-  {{- end }}
-    secretName: {{ .tlsSecret }}
-  {{- end }}
+    {{- if .tls }}
+    - hosts:
+    {{- if .tlsHosts }}
+    {{- range $host := .tlsHosts }}
+      - {{ $host }}
+    {{- end }}
+    {{- else }}
+      - {{ .name }}
+    {{- end }}
+      secretName: {{ .tlsSecret }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/bitnami/ghost/templates/pvc.yaml
+++ b/bitnami/ghost/templates/pvc.yaml
@@ -2,12 +2,8 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ template "ghost.fullname" . }}
-  labels:
-    app: "{{ template "ghost.fullname" . }}"
-    chart: "{{ template "ghost.chart" . }}"
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  name: {{ include "ghost.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/bitnami/ghost/templates/secrets-external-db.yaml
+++ b/bitnami/ghost/templates/secrets-external-db.yaml
@@ -1,0 +1,12 @@
+{{- if not .Values.mariadb.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ghost.externalDb.secret.name" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if .Values.externalDatabase.password }}
+  mariadb-password: {{ .Values.externalDatabase.password | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/bitnami/ghost/templates/secrets.yaml
+++ b/bitnami/ghost/templates/secrets.yaml
@@ -1,19 +1,17 @@
+{{- if empty .Values.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "ghost.fullname" . }}
-  labels:
-    app: "{{ template "ghost.fullname" . }}"
-    chart: "{{ template "ghost.chart" . }}"
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  name: {{ include "ghost.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
 type: Opaque
 data:
   {{- if .Values.ghostPassword }}
-  ghost-password: {{ .Values.ghostPassword | b64enc | quote }}
+  ghostPassword: {{ .Values.ghostPassword | b64enc | quote }}
   {{- else }}
-  ghost-password: {{ randAlphaNum 10 | b64enc | quote }}
+  ghostPassword: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
   {{- if .Values.smtpPassword }}
-  smtp-password: {{ default "" .Values.smtpPassword | b64enc | quote }}
+  smtpPassword: {{ default "" .Values.smtpPassword | b64enc | quote }}
   {{- end }}
+{{- end }}

--- a/bitnami/ghost/templates/secrets.yaml
+++ b/bitnami/ghost/templates/secrets.yaml
@@ -7,11 +7,11 @@ metadata:
 type: Opaque
 data:
   {{- if .Values.ghostPassword }}
-  ghostPassword: {{ .Values.ghostPassword | b64enc | quote }}
+  ghost-password: {{ .Values.ghostPassword | b64enc | quote }}
   {{- else }}
-  ghostPassword: {{ randAlphaNum 10 | b64enc | quote }}
+  ghost-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
   {{- if .Values.smtpPassword }}
-  smtpPassword: {{ default "" .Values.smtpPassword | b64enc | quote }}
+  smtp-password: {{ default "" .Values.smtpPassword | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/bitnami/ghost/templates/svc.yaml
+++ b/bitnami/ghost/templates/svc.yaml
@@ -1,17 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "ghost.fullname" . }}
-  labels:
-    app: "{{ template "ghost.fullname" . }}"
-    chart: "{{ template "ghost.chart" . }}"
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
-  annotations:
-    {{- range $key, $value := .Values.service.annotations }}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
-
+  name: {{ include "ghost.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  {{- if .Values.service.annotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}
@@ -24,8 +18,12 @@ spec:
     - name: http
       port: {{ .Values.service.port }}
       targetPort: http
-      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePorts.http)))}}
+      {{- if (and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.http))) }}
       nodePort: {{ .Values.service.nodePorts.http }}
+      {{- else if eq .Values.service.type "ClusterIP" }}
+      nodePort: null
       {{- end }}
-  selector:
-    app: "{{ template "ghost.fullname" . }}"
+    {{- if .Values.service.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
+  selector: {{ include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/ghost/values.yaml
+++ b/bitnami/ghost/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/ghost
-  tag: 3.14.0-debian-10-r0
+  tag: 3.14.0-debian-10-r2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/ghost/values.yaml
+++ b/bitnami/ghost/values.yaml
@@ -80,9 +80,9 @@ ghostEmail: user@example.com
 ##
 ghostBlogTitle: User's Blog
 
-## Set to `yes` to allow the container to be started with blank passwords
+## Set to `true` to allow the container to be started with blank passwords
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
-allowEmptyPassword: "yes"
+allowEmptyPassword: true
 
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/bitnami-docker-redmine/#smtp-configuration
@@ -93,6 +93,19 @@ allowEmptyPassword: "yes"
 # smtpPassword:
 # smtpFromAddress
 # smtpService:
+
+## Use an existing secrets which already store your password data
+##
+# existingSecret:
+#   ## Name of the existing secret
+#   ##
+#   name: mySecret
+#   ## Key mapping where <key> is the value which the deployment is expecting and 
+#   ## <value> is the name of the key in the existing secret.
+#   ##
+#   keyMapping:
+#     ghostPassword: myGhostPasswordKey
+#     smtpPassword: mySmtpPasswordKey
 
 ## Configure extra options for liveness and readiness probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
@@ -182,20 +195,33 @@ mariadb:
 ##
 service:
   type: LoadBalancer
-  # HTTP Port
+
+  ## HTTP Port
   port: 80
-  ## loadBalancerIP:
+
+  ## Extra ports to expose (normally used with the `sidecar` value)
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#multi-port-services
   ##
+  extraPorts: []
+
+  ## Specify the loadBalancerIP value for LoadBalancer service types.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+  ##
+  loadBalancerIP:
+
   ## nodePorts:
   ##   http: <to set explicitly, choose port between 30000-32767>
   nodePorts:
     http: ""
+
   ## Enable client source IP preservation
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   ##
   externalTrafficPolicy: Cluster
-  ## Service annotations done as key:value pairs
-  annotations:
+
+  ## Service annotations. Evaluated as a template
+  ##
+  annotations: {}
 
 ## Pod Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -241,33 +267,33 @@ ingress:
   ## Set this to true in order to add the corresponding annotations for cert-manager
   certManager: false
 
-  ## Ingress annotations done as key:value pairs
+  ## Ingress annotations. Evaluated as a template.
   ## For a full list of possible ingress annotations, please see
   ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   ##
   ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
-  annotations:
+  annotations: {}
   #  kubernetes.io/ingress.class: nginx
 
   ## The list of hostnames to be covered with this ingress record.
   ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
   hosts:
-  - name: ghost.local
-    path: /
+    - name: ghost.local
+      path: /
 
-    ## Set this to true in order to enable TLS on the ingress record
-    tls: false
+      ## Set this to true in order to enable TLS on the ingress record
+      tls: false
 
-    ## Optionally specify the TLS hosts for the ingress record
-    ## Useful when the Ingress controller supports www-redirection
-    ## If not specified, the above host name will be used
-    # tlsHosts:
-    # - www.ghost.local
-    # - ghost.local
+      ## Optionally specify the TLS hosts for the ingress record
+      ## Useful when the Ingress controller supports www-redirection
+      ## If not specified, the above host name will be used
+      # tlsHosts:
+      # - www.ghost.local
+      # - ghost.local
 
-    ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
-    tlsSecret: ghost.local-tls
+      ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
+      tlsSecret: ghost.local-tls
 
   secrets:
   ## If you're providing your own certificates, please use this to add the certificates as secrets
@@ -288,7 +314,56 @@ ingress:
 ##
 nodeSelector: {}
 
-## Affinity for pod assignment
+## Affinity for pod assignment (evaluated as a template)
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 ##
 affinity: {}
+
+## Additional pod annotations
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+
+## Add sidecars to the pod
+## For example:
+## sidecars:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+sidecars: []
+
+## Add init containers to the pod
+## For example:
+## initContainers:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##
+initContainers: []
+
+## Array to add extra volumes
+##
+extraVolumes: []
+
+## Array to add extra mounts (normally used with extraVolumes)
+##
+extraVolumeMounts: []
+
+## An array to add extra env vars
+## For example:
+## extraEnvVars:
+##  - name: MY_ENV_VAR
+##    value: env_var_value
+##
+extraEnvVars: []
+
+## Name of a ConfigMap containing extra env vars
+##
+extraEnvVarsConfigMap:
+
+## Name of a Secret containing extra env vars
+##
+extraEnvVarsSecret:

--- a/bitnami/ghost/values.yaml
+++ b/bitnami/ghost/values.yaml
@@ -100,12 +100,12 @@ allowEmptyPassword: true
 #   ## Name of the existing secret
 #   ##
 #   name: mySecret
-#   ## Key mapping where <key> is the value which the deployment is expecting and 
+#   ## Key mapping where <key> is the value which the deployment is expecting and
 #   ## <value> is the name of the key in the existing secret.
 #   ##
 #   keyMapping:
-#     ghostPassword: myGhostPasswordKey
-#     smtpPassword: mySmtpPasswordKey
+#     ghost-password: myGhostPasswordKey
+#     smtp-password: mySmtpPasswordKey
 
 ## Configure extra options for liveness and readiness probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)


### PR DESCRIPTION
Signed-off-by: darteaga <darteaga@bitnami.com>

**Description of the change**

- Adding common things to `bitnami/ghost`

**Benefits**

Having clear charts and standardized for common things like affinity, sidecars, images, etc. 

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
