### PR TITLE
[bitnami/influxdb] Bump chart version. Follow-up of #1962

### DIFF
--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: influxdb
 sources:
   - https://github.com/bitnami/bitnami-docker-influxdb
-version: 0.3.9
+version: 0.4.0


### PR DESCRIPTION
The chart version wasn't updated in #1962.

This commit https://github.com/bitnami/charts/commit/21bd05eec78151f9bf6ac550b8d2c2da3075d187 was bumping the `appVersion` but not the chart version. Fortunately, no changes in the `Charts.yaml` file were merged onto master.