### PR TITLE
[bitnami/grafana] Fix notes obtaining secret

### DIFF
--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 1.3.3
+version: 1.3.4
 appVersion: 6.6.2
 description: Grafana is an open source, feature rich metrics dashboard and graph editor for Graphite, Elasticsearch, OpenTSDB, Prometheus and InfluxDB.
 keywords:

--- a/bitnami/grafana/templates/NOTES.txt
+++ b/bitnami/grafana/templates/NOTES.txt
@@ -25,7 +25,7 @@
 2. Get the admin credentials:
 
     echo "User: {{ .Values.admin.user }}"
-    echo "Password: $(kubectl get secret {{ include "grafana.fullname" . }}-secret --namespace {{ .Release.Namespace }} -o jsonpath="{.data.GF_SECURITY_ADMIN_PASSWORD}" | base64 --decode)"
+    echo "Password: $(kubectl get secret {{ include "grafana.fullname" . }}-admin --namespace {{ .Release.Namespace }} -o jsonpath="{.data.GF_SECURITY_ADMIN_PASSWORD}" | base64 --decode)"
 
 {{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
 


### PR DESCRIPTION
**Description of the change**

Notes were not updated after changes introduced in [this commit](https://github.com/bitnami/charts/commit/b68f39fe8c4fc1e50b835776aa43663d936a608a#diff-9ceb7dc7b056dde66dda2f5553152c2dR5).

**Applicable issues**

  - fixes #2081

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files