### PR TITLE
[bitnami/external-dns] Resuse service account

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.20.5
+version: 3.0.0
 appVersion: 0.7.0
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/bitnami/external-dns/README.md
+++ b/bitnami/external-dns/README.md
@@ -170,7 +170,8 @@ The following table lists the configurable parameters of the external-dns chart 
 | `service.loadBalancerSourceRanges`  | List of IP CIDRs allowed access to load balancer (if supported)                                          | `[]`                                                        |
 | `service.annotations`               | Annotations to add to service                                                                            | `{}`                                                        |
 | `rbac.create`                       | Weather to create & use RBAC resources or not                                                            | `true`                                                      |
-| `rbac.serviceAccountName`           | ServiceAccount (ignored if rbac.create == true)                                                          | `default`                                                   |
+| `rbac.serviceAccount.create`        | If true and rbac.create is also true, a service account will be created                                  | `true`                                                      |
+| `rbac.serviceAccount.name`          | existing ServiceAccount to use (ignored if rbac.create=true and rbac.serviceAccount.create=true)         | `default`                                                   |
 | `rbac.serviceAccountAnnotations`    | Additional Service Account annotations                                                                   | `{}`                                                        |
 | `rbac.apiVersion`                   | Version of the RBAC API                                                                                  | `v1beta1`                                                   |
 | `rbac.pspEnabled`                   | PodSecurityPolicy                                                                                        | `false`                                                     |

--- a/bitnami/external-dns/templates/_helpers.tpl
+++ b/bitnami/external-dns/templates/_helpers.tpl
@@ -428,3 +428,14 @@ external-dns: transip.apiKey
     Please set the apiKey parameter (--set transip.apiKey="xxxx")
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the service account name.	Return the service account name used by the pod.
+*/}}
+{{- define "serviceaccount.name" -}}
+{{- if and .Values.rbac.create .Values.rbac.serviceAccount.create -}}
+{{ include "external-dns.fullname" . }}
+{{- else -}}
+{{ .Values.rbac.serviceAccount.name }}
+{{- end -}}	
+{{- end -}}

--- a/bitnami/external-dns/templates/clusterrolebinding.yaml
+++ b/bitnami/external-dns/templates/clusterrolebinding.yaml
@@ -10,6 +10,6 @@ roleRef:
   name: {{ template "external-dns.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "external-dns.fullname" . }}
+  name: {{ template "serviceaccount.name" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -34,11 +34,7 @@ spec:
       {{- with .Values.tolerations }}
       tolerations: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
-      {{- if .Values.rbac.create }}
-      serviceAccountName: {{ template "external-dns.fullname" . }}
-      {{- else }}
-      serviceAccountName: {{ .Values.rbac.serviceAccountName | quote }}
-      {{- end }}
+      serviceAccountName: {{ template "serviceaccount.name" . }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}

--- a/bitnami/external-dns/templates/serviceaccount.yaml
+++ b/bitnami/external-dns/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and .Values.rbac.create .Values.rbac.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/bitnami/external-dns/values.yaml
+++ b/bitnami/external-dns/values.yaml
@@ -419,10 +419,11 @@ service:
 ##
 rbac:
   create: true
-  ## Service Account for pods
-  ## https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-  ##
-  serviceAccountName: default
+  ## if rbac.create is false or (if rbac.create is true and rbac.serviceAccount.create is false)
+  ## the service account rbac.serviceAccount.name will be used instead
+  serviceAccount:
+    create: true
+    name: default
   ## Annotations for the Service Account
   ##
   serviceAccountAnnotations: {}


### PR DESCRIPTION
**Description of the change**

This PR allows to reuse an existing service accounts (for instance created with eksctl with its related IAM role) and still manage the role and cluster role bindings with the chart.

**Benefits**

An IAM role created by eksctl has a condition on the service account name it also creates, so we cannot just use the serviceAccountAnnotations value to do the mapping, unless we modify the role.
We are aware of the --override-existing-serviceaccounts eksctl argument will put the annotation on the service account if it already exists, and create the missing ones.
I'm interested in a workflow where the infra is created first (applying a YAML config file with eksctl specifying the cluster, including the IAM Roles for Service Accounts) and then the add-ons are deployed with Helm, including external-dns. Being able to specify all of that in config files in git and apply it to get a cluster fully configured is a challenge which today requires an extra step that could be eliminated with the help of this PR.


**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

I've tested the PR, with the default value it behaves as before. The new feature is enabled only when both rbac.create is true, and rbac.serviceAccount is either true or false.

Tested with Helm 3.1.1.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.

