### PR TITLE
[bitnami/postgresql-ha] Update statefulset.yaml

### DIFF
--- a/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
@@ -48,6 +48,7 @@ spec:
             - |
               mkdir -p {{ .Values.persistence.mountPath }}/data
               chmod 700 {{ .Values.persistence.mountPath }}/data
+              mkdir -p {{ .Values.persistence.mountPath }}/conf/conf.d
               find {{ .Values.persistence.mountPath }} -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | \
                 xargs chown -R {{ .Values.postgresql.securityContext.runAsUser }}:{{ .Values.postgresql.securityContext.fsGroup }}
           securityContext:


### PR DESCRIPTION
**Description of the change**

Fix issue with PostgreSQL-ha extended conf

**Benefits**

**Possible drawbacks**

**Applicable issues**

fixes #1961

**Additional information**

**Checklist**

- [x]  Chart version bumped in Chart.yaml according to semver.
- [X]  Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/chart])
- [X]  If the chart contains a values-production.yaml apart from values.yaml, ensure that you implement the changes in both files

⚠️ Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the kubeapps repository. This is only a synchronized mirror.
