### PR TITLE
Make creation of service account optional.

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.20.6
+version: 2.21.0
 appVersion: 0.7.0
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/bitnami/external-dns/README.md
+++ b/bitnami/external-dns/README.md
@@ -170,7 +170,8 @@ The following table lists the configurable parameters of the external-dns chart 
 | `service.loadBalancerSourceRanges`  | List of IP CIDRs allowed access to load balancer (if supported)                                          | `[]`                                                        |
 | `service.annotations`               | Annotations to add to service                                                                            | `{}`                                                        |
 | `rbac.create`                       | Weather to create & use RBAC resources or not                                                            | `true`                                                      |
-| `rbac.serviceAccountName`           | ServiceAccount (ignored if rbac.create == true)                                                          | `default`                                                   |
+| `rbac.serviceAccount.name`          | ServiceAccount (ignored if rbac.create == true)                                                          | `default`                                                   |
+| `rbac.serviceAccount.create`        | Whether to create a ServiceAccount (ignored if rbac.create == false)                                     | `true`                                                      |
 | `rbac.serviceAccountAnnotations`    | Additional Service Account annotations                                                                   | `{}`                                                        |
 | `rbac.apiVersion`                   | Version of the RBAC API                                                                                  | `v1beta1`                                                   |
 | `rbac.pspEnabled`                   | PodSecurityPolicy                                                                                        | `false`                                                     |

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       {{- if .Values.rbac.create }}
       serviceAccountName: {{ template "external-dns.fullname" . }}
       {{- else }}
-      serviceAccountName: {{ .Values.rbac.serviceAccountName | quote }}
+      serviceAccountName: {{ .Values.rbac.serviceAccount.name | quote }}
       {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}

--- a/bitnami/external-dns/templates/serviceaccount.yaml
+++ b/bitnami/external-dns/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if .Values.rbac.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/bitnami/external-dns/templates/serviceaccount.yaml
+++ b/bitnami/external-dns/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.serviceAccount.create }}
+{{- if and .Values.rbac.create .Values.rbac.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/bitnami/external-dns/values-production.yaml
+++ b/bitnami/external-dns/values-production.yaml
@@ -413,7 +413,7 @@ rbac:
   ##
   serviceAccount:
     create: true
-  serviceAccountName: default
+    name: default
   ## Annotations for the Service Account
   ##
   serviceAccountAnnotations: {}

--- a/bitnami/external-dns/values-production.yaml
+++ b/bitnami/external-dns/values-production.yaml
@@ -411,6 +411,8 @@ rbac:
   ## Service Account for pods
   ## https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
   ##
+  serviceAccount:
+    create: true
   serviceAccountName: default
   ## Annotations for the Service Account
   ##

--- a/bitnami/external-dns/values.yaml
+++ b/bitnami/external-dns/values.yaml
@@ -422,6 +422,8 @@ rbac:
   ## Service Account for pods
   ## https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
   ##
+  serviceAccount: 
+    create: true
   serviceAccountName: default
   ## Annotations for the Service Account
   ##

--- a/bitnami/external-dns/values.yaml
+++ b/bitnami/external-dns/values.yaml
@@ -424,7 +424,7 @@ rbac:
   ##
   serviceAccount: 
     create: true
-  serviceAccountName: default
+    name: default
   ## Annotations for the Service Account
   ##
   serviceAccountAnnotations: {}


### PR DESCRIPTION
Creating a service account for external DNS is not always necessary or desired if the service account already exists.

This is the case when using IAM for Service Accounts with external-dns on AWS EKS.  In that situation, the service account is created outside the helm chart with a token that provides an IAM role to the service account..  We need a way not to create a conflicting service account.

Fixes #2056 