### PR TITLE
[bitnami/mariadb] Remove line break from mariadb metrics extraargs

### DIFF
--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb
-version: 7.3.14
+version: 7.3.15
 appVersion: 10.3.22
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/bitnami/mariadb/templates/master-statefulset.yaml
+++ b/bitnami/mariadb/templates/master-statefulset.yaml
@@ -238,10 +238,7 @@ spec:
               if [ -f "${MARIADB_ROOT_PASSWORD_FILE:-}" ]; then
                   password_aux=$(cat $MARIADB_ROOT_PASSWORD_FILE)
               fi
-              DATA_SOURCE_NAME="root:${password_aux}@(localhost:3306)/" /bin/mysqld_exporter
-              {{- range .Values.metrics.extraArgs.master }}
-              {{ . }}
-              {{- end }}
+              DATA_SOURCE_NAME="root:${password_aux}@(localhost:3306)/" /bin/mysqld_exporter {{- range .Values.metrics.extraArgs.master }} {{ . }} {{- end }}
           ports:
             - name: metrics
               containerPort: 9104

--- a/bitnami/mariadb/templates/slave-statefulset.yaml
+++ b/bitnami/mariadb/templates/slave-statefulset.yaml
@@ -222,10 +222,7 @@ spec:
               if [ -f "${MARIADB_ROOT_PASSWORD_FILE:-}" ]; then
                   password_aux=$(cat $MARIADB_ROOT_PASSWORD_FILE)
               fi
-              DATA_SOURCE_NAME="root:${password_aux}@(localhost:3306)/" /bin/mysqld_exporter
-              {{- range .Values.metrics.extraArgs.slave }}
-              {{ . }}
-              {{- end }}
+              DATA_SOURCE_NAME="root:${password_aux}@(localhost:3306)/" /bin/mysqld_exporter {{- range .Values.metrics.extraArgs.slave }} {{ . }} {{- end }}
           ports:
             - name: metrics
               containerPort: 9104


### PR DESCRIPTION
**Description of the change**

Fix metrics.extraArgs. implementation for MariaDB Metrics Container. 

**Benefits**
Remove line break in Slave and Master StatefulSet template for metrics extraArgs. The line break has the effect that the arguments defined in values.yaml are not added as parameters to `/bin/mysqld_exporter`

**Possible drawbacks**

-

**Applicable issues**

-

**Additional information**

Test changes:

values.yaml:
```
  extraArgs:
    slave:
      - --collect.info_schema.processlist
      - --collect.info_schema.tablestats
      - --collect.info_schema.tables
```

Before:
```
$ kubectl exec cl-mysql-mariadb-slave-0 -c metrics -- ps aux | grep mysqld_exporter

...
1001         6  0.3  0.4 113696  9516 ?        Sl   07:23   0:00 /bin/mysqld_exporter

$ kubectl logs cl-mysql-mariadb-slave-0 -c metrics | grep "schema"
time="2020-03-23T08:06:25Z" level=info msg=" --collect.info_schema.query_response_time" source="mysqld_exporter.go:273"
time="2020-03-23T08:06:25Z" level=info msg=" --collect.info_schema.innodb_cmp" source="mysqld_exporter.go:273"
time="2020-03-23T08:06:25Z" level=info msg=" --collect.info_schema.innodb_cmpmem" source="mysqld_exporter.go:273"
```
After:
```
$ kubectl exec cl-mysql-mariadb-slave-0 -c metrics -- ps aux | grep mysqld_exporter
...
1001         6  0.5  0.5 113696 10272 ?        Sl   07:41   0:03 /bin/mysqld_exporter --collect.info_schema.processlist --collect.info_schema.tablestats --collect.info_schema.tables

$ kubectl logs cl-mysql-mariadb-slave-0 -c metrics | grep "schema"
time="2020-03-23T08:10:41Z" level=info msg=" --collect.info_schema.processlist" source="mysqld_exporter.go:273"
time="2020-03-23T08:10:41Z" level=info msg=" --collect.info_schema.tables" source="mysqld_exporter.go:273"
time="2020-03-23T08:10:41Z" level=info msg=" --collect.info_schema.tablestats" source="mysqld_exporter.go:273"
time="2020-03-23T08:10:41Z" level=info msg=" --collect.info_schema.innodb_cmp" source="mysqld_exporter.go:273"
time="2020-03-23T08:10:41Z" level=info msg=" --collect.info_schema.innodb_cmpmem" source="mysqld_exporter.go:273"
time="2020-03-23T08:10:41Z" level=info msg=" --collect.info_schema.query_response_time" source="mysqld_exporter.go:273"
$ 
```

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
