### PR TITLE
[bitnami/kafka] Add optional log4j config to overwrite log4j.properties.

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 9.0.6
+version: 10.0.0
 appVersion: 2.4.1
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -116,6 +116,8 @@ The following tables lists the configurable parameters of the Kafka chart and th
 | `auth.zookeeperUser`                   | Kafka Zookeeper user                                                                                     | `nil`                                                   |
 | `auth.zookeeperPassword`               | Kafka Zookeeper password                                                                                 | `nil`                                                   |
 | `auth.existingSecret`                  | Name of the existing secret containing credentials for brokerUser, interBrokerUser and zookeeperUser     | `nil`                                                   |
+| `log4j`                                | An optional log4j.properties file to overwrite the default of the Kafka brokers.                         | `nil`                                                   |
+| `existingLog4jConfigMap`               | The name of an existing ConfigMap containing a log4j.properties file.                                    | `nil`                                                   |
 
 ### Statefulset parameters
 
@@ -479,6 +481,10 @@ As an alternative, this chart supports using an initContainer to change the owne
 You can enable this initContainer by setting `volumePermissions.enabled` to `true`.
 
 ## Upgrading
+
+### To 10.0.0
+
+If you are setting the `config` or `log4j` parameter, backwards compatibility is not guaranteed, because the `KAFKA_MOUNTED_CONFDIR` has moved from `/opt/bitnami/kafka/conf` to `/bitnami/kafka/config`. In order to continue using these parameters, you must also upgrade your image to `docker.io/bitnami/kafka:2.4.1-debian-10-r38` or later.
 
 ### To 9.0.0
 

--- a/bitnami/kafka/requirements.lock
+++ b/bitnami/kafka/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: zookeeper
   repository: https://charts.bitnami.com/bitnami
-  version: 5.7.2
-digest: sha256:dd65a1a177a3b16c2988a3bc7dc9162a62371e840b8a1c864f00b2ec5083b569
-generated: "2020-03-26T16:16:46.346003694Z"
+  version: 5.8.0
+digest: sha256:e4814d7eda55cb7d59351cebf8e69b0f877434b5a1f11562f9e9c7c439e25a95
+generated: "2020-04-06T07:08:29.125125266Z"

--- a/bitnami/kafka/templates/_helpers.tpl
+++ b/bitnami/kafka/templates/_helpers.tpl
@@ -317,6 +317,26 @@ Return true if a configmap object should be created
 {{- end -}}
 
 {{/*
+Return the Kafka log4j ConfigMap name.
+*/}}
+{{- define "kafka.log4j.configMapName" -}}
+{{- if .Values.existingConfigmap -}}
+    {{- printf "%s" (tpl .Values.existingLog4jConfigMap $) -}}
+{{- else -}}
+    {{- printf "%s-log4j-configuration" (include "kafka.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if a log4j ConfigMap object should be created.
+*/}}
+{{- define "kafka.log4j.createConfigMap" -}}
+{{- if and .Values.log4j (not .Values.existingLog4jConfigMap) }}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the Kafka configuration configmap
 */}}
 {{- define "kafka.metrics.jmx.configmapName" -}}

--- a/bitnami/kafka/templates/log4j-configmap.yaml
+++ b/bitnami/kafka/templates/log4j-configmap.yaml
@@ -1,0 +1,10 @@
+{{- if (include "kafka.log4j.createConfigMap" .) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kafka.log4j.configMapName" . }}
+  labels: {{- include "kafka.labels" . | nindent 4 }}
+data:
+  log4j.properties: |-
+    {{ .Values.log4j | indent 4 }}
+{{- end -}}

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -298,8 +298,13 @@ spec:
               mountPath: /bitnami/kafka
             {{- if or .Values.config .Values.existingConfigmap }}
             - name: kafka-config
-              mountPath: /opt/bitnami/kafka/conf/server.properties
+              mountPath: /bitnami/kafka/config/server.properties
               subPath: server.properties
+            {{- end }}
+            {{- if or .Values.log4j .Values.existingLog4jConfigMap }}
+            - name: log4j-config
+              mountPath: /bitnami/kafka/config/log4j.properties
+              subPath: log4j.properties
             {{- end }}
             - name: scripts
               mountPath: /scripts/setup.sh
@@ -346,6 +351,11 @@ spec:
           configMap:
             name: {{ include "kafka.configmapName" . }}
         {{- end }}
+        {{- if or .Values.log4j .Values.existingLog4jConfigMap }}
+        - name: log4j-config
+          configMap:
+            name: {{ include "kafka.log4j.configMapName" . }}
+        {{ end }}
         - name: scripts
           configMap:
             name: {{ include "kafka.fullname" . }}-scripts

--- a/bitnami/kafka/values-production.yaml
+++ b/bitnami/kafka/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/kafka
-  tag: 2.4.1-debian-10-r41
+  tag: 2.4.1-debian-10-r45
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -591,7 +591,7 @@ metrics:
     image:
       registry: docker.io
       repository: bitnami/kafka-exporter
-      tag: 1.2.0-debian-10-r66
+      tag: 1.2.0-debian-10-r69
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -666,7 +666,7 @@ metrics:
     image:
       registry: docker.io
       repository: bitnami/jmx-exporter
-      tag: 0.12.0-debian-10-r65
+      tag: 0.12.0-debian-10-r68
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/kafka/values-production.yaml
+++ b/bitnami/kafka/values-production.yaml
@@ -799,3 +799,16 @@ externalZookeeper:
   ## Server or list of external zookeeper servers to use.
   ##
   servers: []
+
+## Kafka Log4J Configuration
+## An optional log4j.properties file to overwrite the default of the Kafka brokers.
+## See an example log4j.properties at:
+## https://github.com/apache/kafka/blob/trunk/config/log4j.properties
+##
+# log4j:
+
+## Kafka Log4j ConfigMap
+## The name of an existing ConfigMap containing a log4j.properties file.
+## NOTE: this will override log4j.
+##
+# existingLog4jConfigMap:

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -802,3 +802,16 @@ externalZookeeper:
   ## Server or list of external zookeeper servers to use.
   ##
   servers: []
+
+## Kafka Log4J Configuration
+## An optional log4j.properties file to overwrite the default of the Kafka brokers.
+## See an example log4j.properties at:
+## https://github.com/apache/kafka/blob/trunk/config/log4j.properties
+##
+# log4j:
+
+## Kafka Log4j ConfigMap
+## The name of an existing ConfigMap containing a log4j.properties file.
+## NOTE: this will override log4j.
+##
+# existingLog4jConfigMap:

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/kafka
-  tag: 2.4.1-debian-10-r41
+  tag: 2.4.1-debian-10-r45
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -593,7 +593,7 @@ metrics:
     image:
       registry: docker.io
       repository: bitnami/kafka-exporter
-      tag: 1.2.0-debian-10-r66
+      tag: 1.2.0-debian-10-r69
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -668,7 +668,7 @@ metrics:
     image:
       registry: docker.io
       repository: bitnami/jmx-exporter
-      tag: 0.12.0-debian-10-r65
+      tag: 0.12.0-debian-10-r68
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Allows a user of the bitnami/kafka helm chart to specify an optional log4j value that, if defined, will be used to create a configMap that will be used to overwrite the existing log4j.properties file of the Kafka brokers.
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Allows users the ability to change the Kafka log4j.properties file. One example would be to change the last two lines to be DEBUG and true, respectively. So that the Kafka brokers write Approved and Denied Access requests to STDOUT (instead of just a file), where it is easier to log them to a centralized location.
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

Allows users to possibly mess up the log4j configuration, but if this will only happen if they change from the default.
<!-- Describe any known limitations with your change -->

**Applicable issues**

  - fixes #2027

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
