### PR TITLE
[bitnami/kafka] Fix SSL targetport on external-access svc

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 9.0.0
+version: 9.0.1
 appVersion: 2.4.1
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/templates/svc-external-access.yaml
+++ b/bitnami/kafka/templates/svc-external-access.yaml
@@ -39,7 +39,7 @@ spec:
       {{- else if $root.Values.externalAccess.autoDiscovery.enabled }}
       targetPort: null
       {{- else }}
-      targetPort: {{ index $root.Values.externalAccess.service.nodePort $i }}
+      targetPort: {{ index $root.Values.externalAccess.service.nodePorts $i }}
       {{- end }}
   selector: {{- include "kafka.matchLabels" $ | nindent 4 }}
     app.kubernetes.io/component: kafka


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

This PR fixes a typo in the SSL targetport  on external-access svc

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/2123

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
