### PR TITLE
[bitnami/airflow] Fix the wrong env var name for Airflow fernet key

### DIFF
--- a/bitnami/airflow/templates/deployment-scheduler.yaml
+++ b/bitnami/airflow/templates/deployment-scheduler.yaml
@@ -161,7 +161,7 @@ spec:
                   key: redis-password
             - name: AIRFLOW_EXECUTOR
               value: "CeleryExecutor"
-            - name: AIRFLOW_FERNET_KEY
+            - name: AIRFLOW__CORE__FERNET_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ if .Values.airflow.auth.existingSecret }}{{ .Values.airflow.auth.existingSecret }}{{ else }}{{ template "airflow.fullname" . }}{{ end }}

--- a/bitnami/airflow/templates/deployment-web.yaml
+++ b/bitnami/airflow/templates/deployment-web.yaml
@@ -168,7 +168,7 @@ spec:
                 secretKeyRef:
                   name: {{ if .Values.airflow.auth.existingSecret }}{{ .Values.airflow.auth.existingSecret }}{{ else }}{{ template "airflow.fullname" . }}{{ end }}
                   key: airflow-password
-            - name: AIRFLOW_FERNET_KEY
+            - name: AIRFLOW__CORE__FERNET_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ if .Values.airflow.auth.existingSecret }}{{ .Values.airflow.auth.existingSecret }}{{ else }}{{ template "airflow.fullname" . }}{{ end }}

--- a/bitnami/airflow/templates/statefulset-worker.yaml
+++ b/bitnami/airflow/templates/statefulset-worker.yaml
@@ -166,7 +166,7 @@ spec:
                   key: redis-password
             - name: AIRFLOW_EXECUTOR
               value: "CeleryExecutor"
-            - name: AIRFLOW_FERNET_KEY
+            - name: AIRFLOW__CORE__FERNET_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ if .Values.airflow.auth.existingSecret }}{{ .Values.airflow.auth.existingSecret }}{{ else }}{{ template "airflow.fullname" . }}{{ end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

There's an issue with the fernet key deployed with the current config. The vars which
are created throught the Airflow UI cannot be properly read by all workers because
they are using different fernet keys. The reason for this is the fact that the fernet
key env var name is not the right one. It is named AIRFLOW_FERNET_KEY and it must be
AIRFLOW__CORE__FERNET_KEY according to the Airflow documentation -
https://airflow.readthedocs.io/en/stable/howto/secure-connections.html

**Benefits**

It is possible to use Airflow variables. Previously it was not possible.

**Possible drawbacks**

No

**Applicable issues**

There's no open bug that I am aware of. This is a new issue that we discovered and fixed.
<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
