### PR TITLE
[bitnami/influxdb] Increase readinessProbe parameters

### DIFF
--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: influxdb
 sources:
   - https://github.com/bitnami/bitnami-docker-influxdb
-version: 0.4.1
+version: 0.4.2

--- a/bitnami/influxdb/values-production.yaml
+++ b/bitnami/influxdb/values-production.yaml
@@ -201,8 +201,8 @@ influxdb:
   readinessProbe:
     enabled: true
     initialDelaySeconds: 180
-    periodSeconds: 45
-    timeoutSeconds: 30
+    periodSeconds: 60
+    timeoutSeconds: 60
     successThreshold: 1
     failureThreshold: 6
 

--- a/bitnami/influxdb/values-production.yaml
+++ b/bitnami/influxdb/values-production.yaml
@@ -200,7 +200,7 @@ influxdb:
     failureThreshold: 6
   readinessProbe:
     enabled: true
-    initialDelaySeconds: 60
+    initialDelaySeconds: 180
     periodSeconds: 45
     timeoutSeconds: 30
     successThreshold: 1

--- a/bitnami/influxdb/values.yaml
+++ b/bitnami/influxdb/values.yaml
@@ -201,8 +201,8 @@ influxdb:
   readinessProbe:
     enabled: true
     initialDelaySeconds: 180
-    periodSeconds: 45
-    timeoutSeconds: 30
+    periodSeconds: 60
+    timeoutSeconds: 60
     successThreshold: 1
     failureThreshold: 6
 

--- a/bitnami/influxdb/values.yaml
+++ b/bitnami/influxdb/values.yaml
@@ -200,7 +200,7 @@ influxdb:
     failureThreshold: 6
   readinessProbe:
     enabled: true
-    initialDelaySeconds: 60
+    initialDelaySeconds: 180
     periodSeconds: 45
     timeoutSeconds: 30
     successThreshold: 1


### PR DESCRIPTION
Need to be tested into the internal pipeline, tests are failing in AKS because the pod is not ready.