### PR TITLE
[bitnami/postgresql-ha] Move Pgpool to non-root

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql-ha
-version: 1.4.12
+version: 2.0.0
 appVersion: 11.7.0
 description: Chart for PostgreSQL with HA architecture (using Replication Manager (repmgr) and Pgpool).
 keywords:

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -391,7 +391,7 @@ The [Bitnami Pgpool](https://github.com/bitnami/bitnami-docker-pgpool) image was
 
 Consequences:
 
-- No backwards compatibility issues are expected.
+- No backwards compatibility issues are expected since all the data is at PostgreSQL pods, and Pgpool uses a deployment without persistence. Therefore, upgrades should work smoothly from `1.x.x` versions.
 - Environment variables related to LDAP configuration were renamed removing the `PGPOOL_` prefix. For instance, to indicate the LDAP URI to use, you must set `LDAP_URI` instead of `PGPOOL_LDAP_URI`
 
 ## 1.0.0
@@ -423,9 +423,9 @@ $ helm upgrade my-release --version 1.0.0 bitnami/postgresql-ha \
 
 In this version, the chart will use PostgreSQL-Repmgr container images with the Postgis extension included. The version used in Postgresql version 10, 11 and 12 is Postgis 2.5, and in Postgresql 9.6 is Postgis 2.3. Postgis has been compiled with the following dependencies:
 
- - protobuf
- - protobuf-c
- - json-c
- - geos
- - proj
- - gdal
+- protobuf
+- protobuf-c
+- json-c
+- geos
+- proj
+- gdal

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -21,8 +21,6 @@ This [Helm](https://github.com/kubernetes/helm) chart installs [PostgreSQL](http
 - Kubernetes 1.12+
 - Helm 2.11+ or Helm 3.0-beta3+
 
-> Note: Please, note that pgpool runs the container as root by default setting the `pgpool.securityContext.runAsUser` to `0` (_root_ user) in order to enable LDAP support for now.
-
 ## Installing the Chart
 
 Install the PostgreSQL HA helm chart with a release name `my-release`:
@@ -122,8 +120,8 @@ The following table lists the configurable parameters of the PostgreSQL HA chart
 | `pgpool.nodeSelector`                          | Node labels for pod assignment                                                                                                                                       | `{}` (The value is evaluated as a template)                  |
 | `pgpool.tolerations`                           | Tolerations for pod assignment                                                                                                                                       | `[]` (The value is evaluated as a template)                  |
 | `pgpool.securityContext.enabled`               | Enable security context for Pgpool                                                                                                                                   | `true`                                                       |
-| `pgpool.securityContext.fsGroup`               | Group ID for the Pgpool filesystem                                                                                                                                   | `0`                                                          |
-| `pgpool.securityContext.runAsUser`             | User ID for the Pgpool container                                                                                                                                     | `0`                                                          |
+| `pgpool.securityContext.fsGroup`               | Group ID for the Pgpool filesystem                                                                                                                                   | `1001`                                                       |
+| `pgpool.securityContext.runAsUser`             | User ID for the Pgpool container                                                                                                                                     | `1001`                                                       |
 | `pgpool.resources`                             | The [resources] to allocate for container                                                                                                                            | `{}`                                                         |
 | `pgpool.livenessProbe`                         | Liveness probe configuration for Pgpool                                                                                                                              | `Check values.yaml file`                                     |
 | `pgpool.readinessProbe`                        | Readiness probe configuration for Pgpool                                                                                                                             | `Check values.yaml file`                                     |
@@ -170,7 +168,7 @@ The following table lists the configurable parameters of the PostgreSQL HA chart
 | `volumePermissionsImage.pullPolicy`            | Bitnami Minideb exporter image pull policy                                                                                                                           | `Always`                                                     |
 | `volumePermissionsImage.pullSecrets`           | Specify docker-registry secret names as an array                                                                                                                     | `[]` (does not add image pull secrets to deployed pods)      |
 | `volumePermissions.enabled`                    | Enable init container to adapt volume permissions                                                                                                                    | `false`                                                      |
-| `volumePermissions.securityContext.enabled`    | Enable security context for Bitnami Minideb                                                                                                                          | `true`                                                       |
+| `volumePermissions.securityContext.enabled`    | Enable security context for Bitnami Minideb                                                                                                                          | `false`                                                      |
 | `volumePermissions.securityContext.runAsUser`  | User ID for the Bitnami Minideb container                                                                                                                            | `0`                                                          |
 | **Persistence**                                |                                                                                                                                                                      |                                                              |
 | `persistence.enabled`                          | Enable data persistence                                                                                                                                              | `true`                                                       |
@@ -386,6 +384,15 @@ $ helm upgrade my-release bitnami/postgresql-ha \
 ```
 
 > Note: you need to substitute the placeholders _[POSTGRESQL_PASSWORD]_, and _[REPMGR_PASSWORD]_ with the values obtained from instructions in the installation notes.
+
+## 2.0.0
+
+The [Bitnami Pgpool](https://github.com/bitnami/bitnami-docker-pgpool) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Pgpool daemon was started as the `pgpool` user. From now on, both the container and the Pgpool daemon run as user `1001`. You can revert this behavior by setting the parameters `pgpool.securityContext.runAsUser`, and `pgpool.securityContext.fsGroup` to `0`.
+
+Consequences:
+
+- No backwards compatibility issues are expected.
+- Environment variables related to LDAP configuration were renamed removing the `PGPOOL_` prefix. For instance, to indicate the LDAP URI to use, you must set `LDAP_URI` instead of `PGPOOL_LDAP_URI`
 
 ## 1.0.0
 

--- a/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
@@ -67,30 +67,30 @@ spec:
             - name: PGPOOL_ENABLE_LDAP
               value: {{ ternary "yes" "no" .Values.ldap.enabled | quote }}
             {{- if .Values.ldap.enabled }}
-            - name: PGPOOL_LDAP_URI
+            - name: LDAP_URI
               value: {{ .Values.ldap.uri | quote }}
-            - name: PGPOOL_LDAP_BASE
+            - name: LDAP_BASE
               value: {{ .Values.ldap.base | quote }}
-            - name: PGPOOL_LDAP_BIND_DN
+            - name: LDAP_BIND_DN
               value: {{ .Values.ldap.binddn | quote }}
-            - name: PGPOOL_LDAP_BIND_PASSWORD
+            - name: LDAP_BIND_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "postgresql-ha.ldapSecretName" . }}
                   key: bind-password
             {{- if .Values.ldap.bslookup }}
-            - name: PGPOOL_LDAP_BASE_LOOKUP
+            - name: LDAP_BASE_LOOKUP
               value: {{ .Values.ldap.bslookup | quote }}
             {{- end }}
             {{- if .Values.ldap.scope }}
-            - name: PGPOOL_LDAP_SCOPE
+            - name: LDAP_SCOPE
               value: {{ .Values.ldap.scope | quote }}
             {{- end }}
             {{- if .Values.ldap.tlsReqcert }}
-            - name: PGPOOL_LDAP_TLS_REQCERT
+            - name: LDAP_TLS_REQCERT
               value: {{ .Values.ldap.tlsReqcert | quote }}
             {{- end }}
-            - name: PGPOOL_LDAP_NSS_INITGROUPS_IGNOREUSERS
+            - name: LDAP_NSS_INITGROUPS_IGNOREUSERS
               value: {{ .Values.ldap.nssInitgroupsIgnoreusers | quote }}
             {{- end }}
             - name: PGPOOL_POSTGRES_USERNAME

--- a/bitnami/postgresql-ha/values-production.yaml
+++ b/bitnami/postgresql-ha/values-production.yaml
@@ -314,8 +314,8 @@ pgpool:
   ##
   securityContext:
     enabled: true
-    fsGroup: 0
-    runAsUser: 0
+    fsGroup: 1001
+    runAsUser: 1001
 
   ## Pgpool containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/bitnami/postgresql-ha/values-production.yaml
+++ b/bitnami/postgresql-ha/values-production.yaml
@@ -29,7 +29,7 @@
 postgresqlImage:
   registry: docker.io
   repository: bitnami/postgresql-repmgr
-  tag: 11.7.0-debian-10-r42
+  tag: 11.7.0-debian-10-r50
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -51,7 +51,7 @@ postgresqlImage:
 pgpoolImage:
   registry: docker.io
   repository: bitnami/pgpool
-  tag: 4.1.1-debian-10-r32
+  tag: 4.1.1-debian-10-r35
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -90,7 +90,7 @@ volumePermissionsImage:
 metricsImage:
   registry: docker.io
   repository: bitnami/postgres-exporter
-  tag: 0.8.0-debian-10-r55
+  tag: 0.8.0-debian-10-r57
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##

--- a/bitnami/postgresql-ha/values.yaml
+++ b/bitnami/postgresql-ha/values.yaml
@@ -314,8 +314,8 @@ pgpool:
   ##
   securityContext:
     enabled: true
-    fsGroup: 0
-    runAsUser: 0
+    fsGroup: 1001
+    runAsUser: 1001
 
   ## Pgpool containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/bitnami/postgresql-ha/values.yaml
+++ b/bitnami/postgresql-ha/values.yaml
@@ -29,7 +29,7 @@
 postgresqlImage:
   registry: docker.io
   repository: bitnami/postgresql-repmgr
-  tag: 11.7.0-debian-10-r42
+  tag: 11.7.0-debian-10-r50
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -51,7 +51,7 @@ postgresqlImage:
 pgpoolImage:
   registry: docker.io
   repository: bitnami/pgpool
-  tag: 4.1.1-debian-10-r32
+  tag: 4.1.1-debian-10-r35
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -90,7 +90,7 @@ volumePermissionsImage:
 metricsImage:
   registry: docker.io
   repository: bitnami/postgres-exporter
-  tag: 0.8.0-debian-10-r55
+  tag: 0.8.0-debian-10-r57
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### Is this a new chart

No

#### What this PR does / why we need it:

This PR transforms the PostgreSQL-HA chart into a "non-root" chart by default. This practice is very extended on K8s and, indeed, it is mandatory for some K8s distributions such as **OpenShift** or **VMware Tanzu Kubernetes Grid.**

#### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files