### PR TITLE
[bitnami/mariadb-galera] Move MariaDB Galera to non-root

### DIFF
--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb-galera
-version: 0.8.5
+version: 1.0.0
 appVersion: 10.4.12
 description: MariaDB Galera is a multi-master database cluster solution for synchronous replication and high availability.
 keywords:

--- a/bitnami/mariadb-galera/README.md
+++ b/bitnami/mariadb-galera/README.md
@@ -20,8 +20,6 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 - Kubernetes 1.10+
 - PV provisioner support in the underlying infrastructure
 
-> Note: Please, note that mariadb-galera container runs as root by default in order to enable LDAP support for now.
-
 ## Installing the Chart
 
 Add the `bitnami` charts repo to Helm:
@@ -85,7 +83,7 @@ The following table lists the configurable parameters of the MariaDB Galera char
 | `serviceAccount.create`              | Specify whether a ServiceAccount should be created                                                                                                          | `false`                                                           |
 | `serviceAccount.name`                | The name of the ServiceAccount to create                                                                                                                    | Generated using the mariadb-galera.fullname template              |
 | `rbac.create`                        | Specify whether RBAC resources should be created and used                                                                                                   | `false`                                                           |
-| `securityContext.enabled`            | Enable security context                                                                                                                                     | `false`                                                           |
+| `securityContext.enabled`            | Enable security context                                                                                                                                     | `true`                                                            |
 | `securityContext.fsGroup`            | Group ID for the container filesystem                                                                                                                       | `1001`                                                            |
 | `securityContext.runAsUser`          | User ID for the container                                                                                                                                   | `1001`                                                            |
 | `existingSecret`                     | Use existing secret for password details (`rootUser.password`, `db.password`, `galera.mariabackup.password` will be ignored and picked up from this secret) | `nil`                                                             |
@@ -333,3 +331,16 @@ $ helm upgrade my-release bitnami/mariadb-galera \
 ```
 
 | Note: you need to substitute the placeholders _[ROOT_PASSWORD]_, _[MARIADB_PASSWORD]_ and _[MARIABACKUP_PASSWORD]_ with the values obtained from instructions in the installation notes.
+
+### To 1.0.0
+
+The [Bitnami MariaDB Galera](https://github.com/bitnami/bitnami-docker-mariadb-galera) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the MySQL daemon was started as the `mysql` user. From now on, both the container and the MySQL daemon run as user `1001`. You can revert this behavior by setting the parameters `securityContext.runAsUser`, and `securityContext.fsGroup` to `0`.
+
+Consequences:
+
+- Backwards compatibility is not guaranteed.
+- Environment variables related to LDAP configuration were renamed removing the `MARIADB_` prefix. For instance, to indicate the LDAP URI to use, you must set `LDAP_URI` instead of `MARIADB_LDAP_URI`
+
+To upgrade to `1.0.0`, install a new release of the MariaDB Galera chart, and migrate your data by creating a backup of the databse, and restoring it on the new release. In the link below you can find a guide that explain the whole process:
+
+- [Create And Restore MySQL/MariaDB Backups](https://docs.bitnami.com/general/infrastructure/mariadb/administration/backup-restore-mysql-mariadb/)

--- a/bitnami/mariadb-galera/README.md
+++ b/bitnami/mariadb-galera/README.md
@@ -341,6 +341,6 @@ Consequences:
 - Backwards compatibility is not guaranteed.
 - Environment variables related to LDAP configuration were renamed removing the `MARIADB_` prefix. For instance, to indicate the LDAP URI to use, you must set `LDAP_URI` instead of `MARIADB_LDAP_URI`
 
-To upgrade to `1.0.0`, install a new release of the MariaDB Galera chart, and migrate your data by creating a backup of the databse, and restoring it on the new release. In the link below you can find a guide that explain the whole process:
+To upgrade to `1.0.0`, install a new release of the MariaDB Galera chart, and migrate your data by creating a backup of the database, and restoring it on the new release. In the link below you can find a guide that explain the whole process:
 
 - [Create And Restore MySQL/MariaDB Backups](https://docs.bitnami.com/general/infrastructure/mariadb/administration/backup-restore-mysql-mariadb/)

--- a/bitnami/mariadb-galera/templates/statefulset.yaml
+++ b/bitnami/mariadb-galera/templates/statefulset.yaml
@@ -91,14 +91,16 @@ spec:
                   name: {{ template "mariadb-galera.fullname" . }}
                   {{- end }}
                   key: mariadb-galera-mariabackup-password
+            - name: MARIADB_ENABLE_LDAP
+              value: {{ ternary "yes" "no" .Values.ldap.enabled | quote }}
             {{- if .Values.ldap.enabled }}
-            - name: MARIADB_LDAP_URI
+            - name: LDAP_URI
               value: {{ .Values.ldap.uri }}
-            - name: MARIADB_LDAP_BASE
+            - name: LDAP_BASE
               value: {{ .Values.ldap.base }}
-            - name: MARIADB_LDAP_BIND_DN
+            - name: LDAP_BIND_DN
               value: {{ .Values.ldap.binddn }}
-            - name: MARIADB_LDAP_BIND_PASSWORD
+            - name: LDAP_BIND_PASSWORD
               valueFrom:
                 secretKeyRef:
                   {{- if .Values.existingSecret }}
@@ -107,18 +109,18 @@ spec:
                   name: {{ template "mariadb-galera.fullname" . }}
                   {{- end }}
                   key: ldap-bindpw
-            - name: MARIADB_LDAP_NSS_INITGROUPS_IGNOREUSERS
+            - name: LDAP_NSS_INITGROUPS_IGNOREUSERS
               value: {{ .Values.ldap.nss_initgroups_ignoreusers | quote }}
             {{- if .Values.ldap.bslookup }}
-            - name: MARIADB_LDAP_BASE_LOOKUP
+            - name: LDAP_BASE_LOOKUP
               value: {{ .Values.ldap.bslookup }}
             {{- end }}
             {{- if .Values.ldap.scope }}
-            - name: MARIADB_LDAP_SCOPE
+            - name: LDAP_SCOPE
               value: {{ .Values.ldap.scope }}
             {{- end }}
             {{- if .Values.ldap.tls_reqcert }}
-            - name: MARIADB_LDAP_TLS_REQCERT
+            - name: LDAP_TLS_REQCERT
               value: {{ .Values.ldap.tls_reqcert }}
             {{- end }}
             {{- end }}

--- a/bitnami/mariadb-galera/values-production.yaml
+++ b/bitnami/mariadb-galera/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/mariadb-galera
-  tag: 10.4.12-debian-10-r42
+  tag: 10.4.12-debian-10-r53
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -482,7 +482,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mysqld-exporter
-    tag: 0.12.1-debian-10-r45
+    tag: 0.12.1-debian-10-r57
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/mariadb-galera/values-production.yaml
+++ b/bitnami/mariadb-galera/values-production.yaml
@@ -103,7 +103,7 @@ rbac:
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 ##
 securityContext:
-  enabled: false
+  enabled: true
   fsGroup: 1001
   runAsUser: 1001
 

--- a/bitnami/mariadb-galera/values.yaml
+++ b/bitnami/mariadb-galera/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/mariadb-galera
-  tag: 10.4.12-debian-10-r42
+  tag: 10.4.12-debian-10-r53
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -482,7 +482,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mysqld-exporter
-    tag: 0.12.1-debian-10-r45
+    tag: 0.12.1-debian-10-r57
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/mariadb-galera/values.yaml
+++ b/bitnami/mariadb-galera/values.yaml
@@ -103,7 +103,7 @@ rbac:
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 ##
 securityContext:
-  enabled: false
+  enabled: true
   fsGroup: 1001
   runAsUser: 1001
 


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### Is this a new chart

No

#### What this PR does / why we need it:

This PR transforms the MariaDB Galera chart into a "non-root" chart by default. This practice is very extended on K8s and, indeed, it is mandatory for some K8s distributions such as **OpenShift** or **VMware Tanzu Kubernetes Grid.**

This **PR breaks backwards compatibility** and a migration will be required to upgrade to the latest version.

#### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files