### PR TITLE
[bitnami/kafka] Fix metrics ports on servicemonitor

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 9.0.3
+version: 9.0.4
 appVersion: 2.4.1
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/requirements.lock
+++ b/bitnami/kafka/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: zookeeper
   repository: https://charts.bitnami.com/bitnami
-  version: 5.7.1
-digest: sha256:3bfa6357c14e0e9605defd4325f5721b94bd2730edab1a3730baa740e44889a8
-generated: "2020-03-23T17:16:30.676937467Z"
+  version: 5.7.2
+digest: sha256:dd65a1a177a3b16c2988a3bc7dc9162a62371e840b8a1c864f00b2ec5083b569
+generated: "2020-03-26T16:16:46.346003694Z"

--- a/bitnami/kafka/templates/servicemonitor-jmx-metrics.yaml
+++ b/bitnami/kafka/templates/servicemonitor-jmx-metrics.yaml
@@ -16,7 +16,7 @@ spec:
     matchLabels: {{- include "kafka.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: kafka
   endpoints:
-    - port: metrics
+    - port: http-metrics
       path: "/"
       {{- if .Values.metrics.serviceMonitor.interval }}
       interval: {{ .Values.metrics.serviceMonitor.interval }}

--- a/bitnami/kafka/templates/servicemonitor-metrics.yaml
+++ b/bitnami/kafka/templates/servicemonitor-metrics.yaml
@@ -16,7 +16,7 @@ spec:
     matchLabels: {{- include "kafka.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: metrics
   endpoints:
-    - port: metrics
+    - port: http-metrics
       path: "/metrics"
       {{- if .Values.metrics.serviceMonitor.interval }}
       interval: {{ .Values.metrics.serviceMonitor.interval }}

--- a/bitnami/kafka/values-production.yaml
+++ b/bitnami/kafka/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/kafka
-  tag: 2.4.1-debian-10-r20
+  tag: 2.4.1-debian-10-r21
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/kafka
-  tag: 2.4.1-debian-10-r20
+  tag: 2.4.1-debian-10-r21
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

As reported by @oranje42 once we adapted the svc ports to follow Istio naming conventions, we broke the integration with Prometheus Operator since we didn't update the name of the ports in the `ServiceMonitor` definitions. This PR addresses that issue. 

**Possible drawbacks**

None

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
