### PR TITLE
[bitnami/memcached] fix ServiceMonitor

### DIFF
--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: memcached
-version: 4.2.14
+version: 4.2.15
 appVersion: 1.6.3
 description: Chart for Memcached
 keywords:

--- a/bitnami/memcached/templates/servicemonitor.yaml
+++ b/bitnami/memcached/templates/servicemonitor.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   selector:
     matchLabels: {{ include "memcached.matchLabels" . | nindent 6 }}
-    app.kubernetes.io/component: metrics
+      app.kubernetes.io/component: metrics
   endpoints:
     - port: metrics
       path: /metrics

--- a/bitnami/memcached/values-production.yaml
+++ b/bitnami/memcached/values-production.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/memcached
-  tag: 1.6.3-debian-10-r0
+  tag: 1.6.3-debian-10-r1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -170,7 +170,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/memcached-exporter
-    tag: 0.6.0-debian-10-r62
+    tag: 0.6.0-debian-10-r63
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/memcached
-  tag: 1.6.3-debian-10-r0
+  tag: 1.6.3-debian-10-r1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -170,7 +170,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/memcached-exporter
-    tag: 0.6.0-debian-10-r62
+    tag: 0.6.0-debian-10-r63
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
The `ServiceMonitor` is invalid:

```console
error validating data: ValidationError(ServiceMonitor.spec.selector): unknown field "app.kubernetes.io/component" in com.coreos.monitoring.v1.ServiceMonitor.spec.selector
```
This is caused by a label selection statement with a bad indentation

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
