### PR TITLE
[bitnami/rabbitmq] Introduced `.Release.Namespace`  in objects meta

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 6.20.1
+version: 6.21.0
 appVersion: 3.8.3
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/bitnami/rabbitmq/templates/certs.yaml
+++ b/bitnami/rabbitmq/templates/certs.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "rabbitmq.fullname" . }}-certs
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "rabbitmq.name" . }}
     chart: {{ template "rabbitmq.chart" .  }}

--- a/bitnami/rabbitmq/templates/configuration.yaml
+++ b/bitnami/rabbitmq/templates/configuration.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "rabbitmq.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "rabbitmq.name" . }}
     chart: {{ template "rabbitmq.chart" .  }}

--- a/bitnami/rabbitmq/templates/healthchecks.yaml
+++ b/bitnami/rabbitmq/templates/healthchecks.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "rabbitmq.fullname" . }}-healthchecks
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "rabbitmq.name" . }}
     chart: {{ template "rabbitmq.chart" .  }}

--- a/bitnami/rabbitmq/templates/ingress.yaml
+++ b/bitnami/rabbitmq/templates/ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: "{{ template "rabbitmq.fullname" . }}"
+  namespace: {{ .Release.Namespace }}
   labels:
     app: "{{ template "rabbitmq.name" . }}"
     chart: "{{ template "rabbitmq.chart" .  }}"

--- a/bitnami/rabbitmq/templates/networkpolicy.yaml
+++ b/bitnami/rabbitmq/templates/networkpolicy.yaml
@@ -3,6 +3,7 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: {{ template "rabbitmq.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "rabbitmq.name" . }}
     chart: {{ template "rabbitmq.chart" . }}

--- a/bitnami/rabbitmq/templates/pdb.yaml
+++ b/bitnami/rabbitmq/templates/pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "rabbitmq.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "rabbitmq.name" . }}
     chart: {{ template "rabbitmq.chart" .  }}

--- a/bitnami/rabbitmq/templates/prometheusrule.yaml
+++ b/bitnami/rabbitmq/templates/prometheusrule.yaml
@@ -3,8 +3,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ template "rabbitmq.fullname" . }}
-{{- with .Values.metrics.prometheusRule.namespace }}
-  namespace: {{ . }}
+{{- if .Values.metrics.prometheusRule.namespace }}
+  namespace: {{ .Values.metrics.prometheusRule.namespace }}
+{{- else }}
+  namespace: {{ .Release.Namespace }}
 {{- end }}
   labels:
     app: {{ template "rabbitmq.name" . }}

--- a/bitnami/rabbitmq/templates/role.yaml
+++ b/bitnami/rabbitmq/templates/role.yaml
@@ -3,6 +3,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "rabbitmq.fullname" . }}-endpoint-reader
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "rabbitmq.name" . }}
     chart: {{ template "rabbitmq.chart" .  }}

--- a/bitnami/rabbitmq/templates/rolebinding.yaml
+++ b/bitnami/rabbitmq/templates/rolebinding.yaml
@@ -3,6 +3,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "rabbitmq.fullname" . }}-endpoint-reader
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "rabbitmq.name" . }}
     chart: {{ template "rabbitmq.chart" .  }}

--- a/bitnami/rabbitmq/templates/secrets.yaml
+++ b/bitnami/rabbitmq/templates/secrets.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "rabbitmq.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "rabbitmq.name" . }}
     chart: {{ template "rabbitmq.chart" .  }}
@@ -27,6 +28,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $key }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "rabbitmq.name" $ }}
     chart: {{ template "rabbitmq.chart" $ }}

--- a/bitnami/rabbitmq/templates/serviceaccount.yaml
+++ b/bitnami/rabbitmq/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "rabbitmq.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "rabbitmq.name" . }}
     chart: {{ template "rabbitmq.chart" .  }}

--- a/bitnami/rabbitmq/templates/servicemonitor.yaml
+++ b/bitnami/rabbitmq/templates/servicemonitor.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ template "rabbitmq.fullname" . }}
   {{- if .Values.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
   {{- end }}
   labels:
     app: {{ template "rabbitmq.name" . }}

--- a/bitnami/rabbitmq/templates/statefulset.yaml
+++ b/bitnami/rabbitmq/templates/statefulset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "rabbitmq.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "rabbitmq.name" . }}
     chart: {{ template "rabbitmq.chart" .  }}

--- a/bitnami/rabbitmq/templates/svc-headless.yaml
+++ b/bitnami/rabbitmq/templates/svc-headless.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "rabbitmq.fullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "rabbitmq.name" . }}
     chart: {{ template "rabbitmq.chart" .  }}

--- a/bitnami/rabbitmq/templates/svc.yaml
+++ b/bitnami/rabbitmq/templates/svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "rabbitmq.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "rabbitmq.name" . }}
     chart: {{ template "rabbitmq.chart" .  }}

--- a/bitnami/rabbitmq/values-production.yaml
+++ b/bitnami/rabbitmq/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/rabbitmq
-  tag: 3.8.3-debian-10-r21
+  tag: 3.8.3-debian-10-r26
 
   ## set to true if you would like to see extra information on logs
   ## it turns BASH and NAMI debugging in minideb
@@ -407,7 +407,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/rabbitmq-exporter
-    tag: 0.29.0-debian-10-r58
+    tag: 0.29.0-debian-10-r63
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/rabbitmq
-  tag: 3.8.3-debian-10-r21
+  tag: 3.8.3-debian-10-r26
 
   ## set to true if you would like to see extra information on logs
   ## it turns BASH and NAMI debugging in minideb
@@ -390,7 +390,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/rabbitmq-exporter
-    tag: 0.29.0-debian-10-r58
+    tag: 0.29.0-debian-10-r63
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This PR adds `.Release.Namespace` to objects meta for Rabbitmq chart. Related to discussion in [this issue](https://github.com/bitnami/charts/issues/2006).

**Benefits**

Ability to use the helm chart when having declarative definition of all cluster objects rendered using `helm template`, for example in tools like Spinnaker.

**Possible drawbacks**

I don't see any, it will work as previously for `helm install`.

**Applicable issues**

#2006 

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
