### PR TITLE
templates/pgpool: fixed typo in deployment yaml pgool -> pgpool

### DIFF
--- a/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
@@ -149,7 +149,7 @@ spec:
           resources: {{- toYaml .Values.pgpool.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
-            {{- if or (.Files.Glob "files/pgool.conf") .Values.pgpool.configuration }}
+            {{- if or (.Files.Glob "files/pgpool.conf") .Values.pgpool.configuration }}
             - name: pgpool-config
               mountPath: /opt/bitnami/pgpool/conf/
             {{- end }}
@@ -166,7 +166,7 @@ spec:
               mountPath: /opt/bitnami/pgpool/secrets/
             {{- end }}
       volumes:
-        {{- if or (.Files.Glob "files/pgool.conf") .Values.pgpool.configuration }}
+        {{- if or (.Files.Glob "files/pgpool.conf") .Values.pgpool.configuration }}
         - name: pgpool-config
           configMap:
             name: {{ include "postgresql-ha.pgpoolConfigurationCM" . }}


### PR DESCRIPTION
**Description of the change**

Fixed typo in pgpool deployment yaml causing custom config not to take effect
