### PR TITLE
[bitnami/minio] Introduced .Release.Namespace in objects meta

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 3.1.4
+version: 3.2.0
 appVersion: 2020.3.25
 description: MinIO is an object storage server, compatible with Amazon S3 cloud storage service, mainly used for storing unstructured data (such as photos, videos, log files, etc.)
 keywords:

--- a/bitnami/minio/templates/deployment-standalone.yaml
+++ b/bitnami/minio/templates/deployment-standalone.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "minio.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "minio.labels" . | nindent 4 }}
 spec:
   {{- if .Values.deployment.updateStrategy }}

--- a/bitnami/minio/templates/ingress.yaml
+++ b/bitnami/minio/templates/ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "minio.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "minio.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.ingress.certManager }}

--- a/bitnami/minio/templates/networkpolicy.yaml
+++ b/bitnami/minio/templates/networkpolicy.yaml
@@ -3,6 +3,7 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: {{ include "minio.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "minio.labels" . | nindent 4 }}
 spec:
   podSelector:

--- a/bitnami/minio/templates/pvc-standalone.yaml
+++ b/bitnami/minio/templates/pvc-standalone.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ include "minio.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "minio.labels" . | nindent 4 }}
 spec:
   accessModes:

--- a/bitnami/minio/templates/secrets.yaml
+++ b/bitnami/minio/templates/secrets.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "minio.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "minio.labels" . | nindent 4 }}
 type: Opaque
 data:

--- a/bitnami/minio/templates/service.yaml
+++ b/bitnami/minio/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "minio.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "minio.labels" . | nindent 4 }}
   {{- if .Values.service.annotations }}
   annotations: {{- include "minio.tplValue" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}

--- a/bitnami/minio/templates/serviceaccount.yml
+++ b/bitnami/minio/templates/serviceaccount.yml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "minio.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "minio.labels" . | nindent 4 }}
 secrets:
   - name: {{ include "minio.fullname" . }}

--- a/bitnami/minio/templates/statefulset.yaml
+++ b/bitnami/minio/templates/statefulset.yaml
@@ -5,6 +5,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "minio.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "minio.labels" . | nindent 4 }}
 spec:
   selector:

--- a/bitnami/minio/templates/svc-headless.yaml
+++ b/bitnami/minio/templates/svc-headless.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "minio.fullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "minio.labels" . | nindent 4 }}
 spec:
   type: ClusterIP

--- a/bitnami/minio/templates/tls-secrets.yaml
+++ b/bitnami/minio/templates/tls-secrets.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .name }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "minio.labels" $ | nindent 4 }}
 type: kubernetes.io/tls
 data:

--- a/bitnami/minio/values-production.yaml
+++ b/bitnami/minio/values-production.yaml
@@ -19,7 +19,7 @@ global:
 image:
   registry: docker.io
   repository: bitnami/minio
-  tag: 2020.3.25-debian-10-r13
+  tag: 2020.3.25-debian-10-r14
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/minio/values.yaml
+++ b/bitnami/minio/values.yaml
@@ -19,7 +19,7 @@ global:
 image:
   registry: docker.io
   repository: bitnami/minio
-  tag: 2020.3.25-debian-10-r13
+  tag: 2020.3.25-debian-10-r14
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This PR adds `.Release.Namespace` to objects meta for minio chart. Related to discussion in [this issue](https://github.com/bitnami/charts/issues/2006).

**Benefits**

Ability to use the helm chart when having declarative definition of all cluster objects rendered using `helm template`, for example in tools like Spinnaker.

**Possible drawbacks**

I don't see any, it will work as previously for `helm install`.

**Applicable issues**

#2006 

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
