### PR TITLE
[bitnami/thanos] Adds support to add annotations to Service Accounts

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
-version: 0.2.2
+version: 0.3.0

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -137,6 +137,7 @@ The following tables lists the configurable parameters of the Thanos chart and t
 | `querier.service.loadBalancerIP`           | loadBalancerIP if service type is `LoadBalancer`               | `nil`                           |
 | `querier.service.loadBalancerSourceRanges` | Address that are allowed when service is LoadBalancer          | `[]`                            |
 | `querier.service.annotations`              | Annotations for Thanos Querier service                         | `{}`                            |
+| `querier.serviceAccount.annotations`       | Annotations for Thanos Querier Service Account                 | `{}`                            |
 | `querier.autoscaling.enabled`              | Enable autoscaling for Thanos Querier                          | `false`                         |
 | `querier.autoscaling.minReplicas`          | Minimum number of Thanos Querier replicas                      | `nil`                           |
 | `querier.autoscaling.maxReplicas`          | Maximum number of Thanos Querier replicas                      | `nil`                           |
@@ -174,6 +175,7 @@ The following tables lists the configurable parameters of the Thanos chart and t
 | `bucketweb.service.loadBalancerIP`           | loadBalancerIP if service type is `LoadBalancer`               | `nil`                          |
 | `bucketweb.service.loadBalancerSourceRanges` | Address that are allowed when service is LoadBalancer          | `[]`                           |
 | `bucketweb.service.annotations`              | Annotations for Thanos Bucket Web service                      | `{}`                           |
+| `bucketweb.serviceAccount.annotations`       | Annotations for Thanos Bucket Web Service Account              | `{}`                           |
 | `bucketweb.pdb.create`                       | Enable/disable a Pod Disruption Budget creation                | `false`                        |
 | `bucketweb.pdb.minAvailable`                 | Minimum number/percentage of pods that should remain scheduled | `1`                            |
 | `bucketweb.pdb.maxUnavailable`               | Maximum number/percentage of pods that may be made unavailable | `nil`                          |
@@ -207,6 +209,7 @@ The following tables lists the configurable parameters of the Thanos chart and t
 | `compactor.service.loadBalancerIP`           | loadBalancerIP if service type is `LoadBalancer`               | `nil`                          |
 | `compactor.service.loadBalancerSourceRanges` | Address that are allowed when service is LoadBalancer          | `[]`                           |
 | `compactor.service.annotations`              | Annotations for Thanos Compactor service                       | `{}`                           |
+| `compactor.serviceAccount.annotations`       | Annotations for Thanos Compactor Service Account               | `{}`                           |
 | `compactor.persistence.enabled`              | Enable data persistence                                        | `true`                         |
 | `compactor.persistence.existingClaim`        | Use a existing PVC which must be created manually before bound | `nil`                          |
 | `compactor.persistence.storageClass`         | Specify the `storageClass` used to provision the volume        | `nil`                          |
@@ -241,6 +244,7 @@ The following tables lists the configurable parameters of the Thanos chart and t
 | `storegateway.service.loadBalancerIP`           | loadBalancerIP if service type is `LoadBalancer`               | `nil`                          |
 | `storegateway.service.loadBalancerSourceRanges` | Address that are allowed when service is LoadBalancer          | `[]`                           |
 | `storegateway.service.annotations`              | Annotations for Thanos Store Gateway service                   | `{}`                           |
+| `storegateway.serviceAccount.annotations`       | Annotations for Thanos Store Gateway Service Account           | `{}`                           |
 | `storegateway.persistence.enabled`              | Enable data persistence                                        | `true`                         |
 | `storegateway.persistence.existingClaim`        | Use a existing PVC which must be created manually before bound | `nil`                          |
 | `storegateway.persistence.storageClass`         | Specify the `storageClass` used to provision the volume        | `nil`                          |
@@ -284,6 +288,7 @@ The following tables lists the configurable parameters of the Thanos chart and t
 | `ruler.service.loadBalancerIP`           | loadBalancerIP if service type is `LoadBalancer`               | `nil`                          |
 | `ruler.service.loadBalancerSourceRanges` | Address that are allowed when service is LoadBalancer          | `[]`                           |
 | `ruler.service.annotations`              | Annotations for Thanos Ruler service                           | `{}`                           |
+| `ruler.serviceAccount.annotations`       | Annotations for Thanos Ruler Service Account                   | `{}`                           |
 | `ruler.persistence.enabled`              | Enable data persistence                                        | `true`                         |
 | `ruler.persistence.existingClaim`        | Use a existing PVC which must be created manually before bound | `nil`                          |
 | `ruler.persistence.storageClass`         | Specify the `storageClass` used to provision the volume        | `nil`                          |

--- a/bitnami/thanos/requirements.lock
+++ b/bitnami/thanos/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: minio
   repository: https://charts.bitnami.com/bitnami
-  version: 3.0.15
-digest: sha256:d71181145675bf94b876db2c64d5a0b6cf9c07a0805191744114a39a8d19985b
-generated: "2020-03-20T10:46:40.290701039Z"
+  version: 3.2.2
+digest: sha256:70959650a9bf1cf0b58ad64446e2b0c885ab3b146efb6f2654a73df1d75d1b2e
+generated: "2020-04-07T06:54:29.475849217Z"

--- a/bitnami/thanos/templates/bucketweb/serviceaccount.yaml
+++ b/bitnami/thanos/templates/bucketweb/serviceaccount.yaml
@@ -1,4 +1,3 @@
-  
 {{- if .Values.bucketweb.enabled -}}
 apiVersion: v1
 kind: ServiceAccount
@@ -6,4 +5,8 @@ metadata:
   name: {{ include "thanos.fullname" . }}-bucketweb
   labels: {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: bucketweb
+  {{- if .Values.bucketweb.serviceAccount.annotations }}
+  annotations:
+    {{- include "thanos.tplValue" ( dict "value" .Values.bucketweb.serviceAccount.annotations "context" $) | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/compactor/serviceaccount.yaml
+++ b/bitnami/thanos/templates/compactor/serviceaccount.yaml
@@ -1,4 +1,3 @@
-  
 {{- if .Values.compactor.enabled -}}
 apiVersion: v1
 kind: ServiceAccount
@@ -6,4 +5,8 @@ metadata:
   name: {{ include "thanos.fullname" . }}-compactor
   labels: {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: compactor
+  {{- if .Values.compactor.serviceAccount.annotations }}
+  annotations:
+    {{- include "thanos.tplValue" ( dict "value" .Values.compactor.serviceAccount.annotations "context" $) | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/querier/serviceaccount.yaml
+++ b/bitnami/thanos/templates/querier/serviceaccount.yaml
@@ -1,4 +1,3 @@
-  
 {{- if .Values.querier.enabled -}}
 apiVersion: v1
 kind: ServiceAccount
@@ -6,4 +5,8 @@ metadata:
   name: {{ include "thanos.fullname" . }}-querier
   labels: {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: querier
+  {{- if .Values.querier.serviceAccount.annotations }}
+  annotations:
+    {{ include "thanos.tplValue" ( dict "value" .Values.querier.serviceAccount.annotations "context" $) | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/ruler/serviceaccount.yaml
+++ b/bitnami/thanos/templates/ruler/serviceaccount.yaml
@@ -1,4 +1,4 @@
-  
+
 {{- if .Values.ruler.enabled -}}
 apiVersion: v1
 kind: ServiceAccount
@@ -6,4 +6,8 @@ metadata:
   name: {{ include "thanos.fullname" . }}-ruler
   labels: {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: ruler
+  {{- if .Values.ruler.serviceAccount.annotations }}
+  annotations:
+    {{- include "thanos.tplValue" ( dict "value" .Values.ruler.serviceAccount.annotations "context" $) | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/storegateway/serviceaccount.yaml
+++ b/bitnami/thanos/templates/storegateway/serviceaccount.yaml
@@ -1,4 +1,3 @@
-  
 {{- if .Values.storegateway.enabled -}}
 apiVersion: v1
 kind: ServiceAccount
@@ -6,4 +5,8 @@ metadata:
   name: {{ include "thanos.fullname" . }}-storegateway
   labels: {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: storegateway
+  {{- if .Values.storegateway.serviceAccount.annotations }}
+  annotations:
+    {{- include "thanos.tplValue" ( dict "value" .Values.storegateway.serviceAccount.annotations "context" $) | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/bitnami/thanos/values-production.yaml
+++ b/bitnami/thanos/values-production.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/thanos
-  tag: 0.11.0-scratch-r8
+  tag: 0.11.0-scratch-r10
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##

--- a/bitnami/thanos/values-production.yaml
+++ b/bitnami/thanos/values-production.yaml
@@ -57,6 +57,11 @@ querier:
   ##
   logLevel: info
 
+  ## Provide any additional annotations which may be required
+  ##
+  serviceAccount:
+    annotations: {}
+
   ## Labels to treat as a replica indicator along which data is deduplicated
   ##
   replicaLabel: replica
@@ -65,14 +70,14 @@ querier:
   ##
   dnsDiscovery:
     enabled: true
-    ## Sidecars service name to discover them using DNS discovery 
+    ## Sidecars service name to discover them using DNS discovery
     ## Evaluated as a template.
     # sidecarsService: "{{ .Release.Name }}-prometheus-thanos"
     ##
     ## Sidecars namespace to discover them using DNS discovery
     ## Evaluated as a template.
     # sidecarsNamespace: "{{ .Release.Namespace }}"
-  
+
   ## Statically configure store APIs to connect with Thanos Querier
   ##
   stores: []
@@ -126,7 +131,7 @@ querier:
     enabled: true
     fsGroup: 1001
     runAsUser: 1001
-  
+
   ## Thanos Querier containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
@@ -141,7 +146,7 @@ querier:
     requests: {}
     #   cpu: 100m
     #   memory: 128Mi
-  
+
   ## Thanos Querier pods' liveness and readiness probes. Evaluated as a template.
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   ##
@@ -231,6 +236,11 @@ bucketweb:
   ##
   logLevel: info
 
+  ## Provide any additional annotations which may be required
+  ##
+  serviceAccount:
+    annotations: {}
+
   ## Refresh interval to download metadata from remote storage
   ##
   refresh: 30m
@@ -278,7 +288,7 @@ bucketweb:
     enabled: true
     fsGroup: 1001
     runAsUser: 1001
-  
+
   ## Thanos Bucket Web containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
@@ -366,12 +376,17 @@ compactor:
   ##
   logLevel: info
 
+  ## Provide any additional annotations which may be required
+  ##
+  serviceAccount:
+    annotations: {}
+
   ## Resolution and Retention flags
   ##
   retentionResolutionRaw: 30d
   retentionResolution5m: 30d
   retentionResolution1h: 10y
-  
+
   ## Minimum age of fresh (non-compacted) blocks
   ## before they are being processed
   ##
@@ -412,7 +427,7 @@ compactor:
     enabled: true
     fsGroup: 1001
     runAsUser: 1001
-  
+
   ## Thanos Compactor containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
@@ -427,7 +442,7 @@ compactor:
     requests: {}
     #   cpu: 100m
     #   memory: 128Mi
-  
+
   ## Thanos Compactor pods' liveness and readiness probes. Evaluated as a template.
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   ##
@@ -512,6 +527,11 @@ storegateway:
   ##
   logLevel: info
 
+  ## Provide any additional annotations which may be required
+  ##
+  serviceAccount:
+    annotations: {}
+
   ## Extra Flags to passed to Thanos Store Gateway
   ##
   extraFlags: {}
@@ -551,7 +571,7 @@ storegateway:
     enabled: true
     fsGroup: 1001
     runAsUser: 1001
-  
+
   ## Thanos Store Gateway containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
@@ -566,7 +586,7 @@ storegateway:
     requests: {}
     #   cpu: 100m
     #   memory: 128Mi
-  
+
   ## Thanos Store Gateway pods' liveness and readiness probes. Evaluated as a template.
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   ##
@@ -671,6 +691,11 @@ ruler:
   ##
   logLevel: info
 
+  ## Provide any additional annotations which may be required
+  ##
+  serviceAccount:
+    annotations: {}
+
   ## Dinamically configure Querier APIs using DNS discovery
   ##
   dnsDiscovery:
@@ -679,24 +704,24 @@ ruler:
   ## Alermanager URLs array
   ##
   alertmanagers: []
-  
+
   ## The default evaluation interval to use
   ##
   evalInterval: 1m
 
   ## Used to set the 'ruler_cluster' label
   ##
-  # clusterName: 
+  # clusterName:
 
   ## Extra Flags to passed to Thanos Ruler
   ##
   extraFlags: {}
-  
+
   ## Ruler Configuration
   ## Specify content for ruler.yml
   ##
   # config:
-  
+
   ## ConfigMap with Ruler Configuration
   ## NOTE: This will override ruler.config
   ##
@@ -737,7 +762,7 @@ ruler:
     enabled: true
     fsGroup: 1001
     runAsUser: 1001
-  
+
   ## Thanos Ruler containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
@@ -752,7 +777,7 @@ ruler:
     requests: {}
     #   cpu: 100m
     #   memory: 128Mi
-  
+
   ## Thanos Ruler pods' liveness and readiness probes. Evaluated as a template.
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   ##
@@ -850,7 +875,7 @@ ruler:
 ##
 metrics:
   enabled: true
-  
+
   ## Prometheus Operator ServiceMonitor configuration
   ##
   serviceMonitor:

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/thanos
-  tag: 0.11.0-scratch-r8
+  tag: 0.11.0-scratch-r10
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -57,15 +57,20 @@ querier:
   ##
   logLevel: info
 
+  ## Provide any additional annotations which may be required
+  ##
+  serviceAccount:
+    annotations: {}
+
   ## Labels to treat as a replica indicator along which data is deduplicated
   ##
   replicaLabel: replica
-  
+
   ## Dynamically configure store APIs using DNS discovery
   ##
   dnsDiscovery:
     enabled: true
-    ## Sidecars service name to discover them using DNS discovery 
+    ## Sidecars service name to discover them using DNS discovery
     ## Evaluated as a template.
     # sidecarsService: "{{ .Release.Name }}-prometheus-thanos"
     ##
@@ -126,7 +131,7 @@ querier:
     enabled: true
     fsGroup: 1001
     runAsUser: 1001
-  
+
   ## Thanos Querier containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
@@ -141,7 +146,7 @@ querier:
     requests: {}
     #   cpu: 100m
     #   memory: 128Mi
-  
+
   ## Thanos Querier pods' liveness and readiness probes. Evaluated as a template.
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   ##
@@ -231,6 +236,11 @@ bucketweb:
   ##
   logLevel: info
 
+  ## Provide any additional annotations which may be required
+  ##
+  serviceAccount:
+    annotations: {}
+
   ## Refresh interval to download metadata from remote storage
   ##
   refresh: 30m
@@ -278,7 +288,7 @@ bucketweb:
     enabled: true
     fsGroup: 1001
     runAsUser: 1001
-  
+
   ## Thanos Bucket Web containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
@@ -366,12 +376,17 @@ compactor:
   ##
   logLevel: info
 
+  ## Provide any additional annotations which may be required
+  ##
+  serviceAccount:
+    annotations: {}
+
   ## Resolution and Retention flags
   ##
   retentionResolutionRaw: 30d
   retentionResolution5m: 30d
   retentionResolution1h: 10y
-  
+
   ## Minimum age of fresh (non-compacted) blocks
   ## before they are being processed
   ##
@@ -412,7 +427,7 @@ compactor:
     enabled: true
     fsGroup: 1001
     runAsUser: 1001
-  
+
   ## Thanos Compactor containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
@@ -427,7 +442,7 @@ compactor:
     requests: {}
     #   cpu: 100m
     #   memory: 128Mi
-  
+
   ## Thanos Compactor pods' liveness and readiness probes. Evaluated as a template.
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   ##
@@ -512,6 +527,11 @@ storegateway:
   ##
   logLevel: info
 
+  ## Provide any additional annotations which may be required
+  ##
+  serviceAccount:
+    annotations: {}
+
   ## Extra Flags to passed to Thanos Store Gateway
   ##
   extraFlags: {}
@@ -551,7 +571,7 @@ storegateway:
     enabled: true
     fsGroup: 1001
     runAsUser: 1001
-  
+
   ## Thanos Store Gateway containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
@@ -566,7 +586,7 @@ storegateway:
     requests: {}
     #   cpu: 100m
     #   memory: 128Mi
-  
+
   ## Thanos Store Gateway pods' liveness and readiness probes. Evaluated as a template.
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   ##
@@ -671,6 +691,11 @@ ruler:
   ##
   logLevel: info
 
+  ## Provide any additional annotations which may be required
+  ##
+  serviceAccount:
+    annotations: {}
+
   ## Dinamically configure Querier APIs using DNS discovery
   ##
   dnsDiscovery:
@@ -679,24 +704,24 @@ ruler:
   ## Alermanager URLs array
   ##
   alertmanagers: []
-  
+
   ## The default evaluation interval to use
   ##
   evalInterval: 1m
 
   ## Used to set the 'ruler_cluster' label
   ##
-  # clusterName: 
+  # clusterName:
 
   ## Extra Flags to passed to Thanos Ruler
   ##
   extraFlags: {}
-  
+
   ## Ruler Configuration
   ## Specify content for ruler.yml
   ##
   # config:
-  
+
   ## ConfigMap with Ruler Configuration
   ## NOTE: This will override ruler.config
   ##
@@ -737,7 +762,7 @@ ruler:
     enabled: true
     fsGroup: 1001
     runAsUser: 1001
-  
+
   ## Thanos Ruler containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
@@ -752,7 +777,7 @@ ruler:
     requests: {}
     #   cpu: 100m
     #   memory: 128Mi
-  
+
   ## Thanos Ruler pods' liveness and readiness probes. Evaluated as a template.
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   ##
@@ -850,7 +875,7 @@ ruler:
 ##
 metrics:
   enabled: false
-  
+
   ## Prometheus Operator ServiceMonitor configuration
   ##
   serviceMonitor:


### PR DESCRIPTION
**Description of the change**

Adds support to add annotations to Service Accounts

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Add the ability to use [Amazon IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
