### PR TITLE
[bitnami/rabbitmq] Add a selector to persistentVolumeClaims to be able to target an existing persistentVolume

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 6.22.0
+version: 6.23.0
 appVersion: 3.8.3
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/bitnami/rabbitmq/README.md
+++ b/bitnami/rabbitmq/README.md
@@ -108,6 +108,7 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 | `schedulerName`                              | Name of the k8s service (other than default)     | `nil`                                                   |
 | `persistence.storageClass`                   | Storage class of backing PVC                     | `nil` (uses alpha storage class annotation)             |
 | `persistence.existingClaim`                  | RabbitMQ data Persistent Volume existing claim name, evaluated as a template |  ""                         |
+| `persistence.selector`                       | Selector to match an existing Persistent Volume  | `nil`                                                   |
 | `persistence.accessMode`                     | Use volume as ReadOnly or ReadWrite              | `ReadWriteOnce`                                         |
 | `persistence.size`                           | Size of data volume                              | `8Gi`                                                   |
 | `persistence.path`                           | Mount path of the data volume                    | `/opt/bitnami/rabbitmq/var/lib/rabbitmq`                |

--- a/bitnami/rabbitmq/templates/statefulset.yaml
+++ b/bitnami/rabbitmq/templates/statefulset.yaml
@@ -376,4 +376,10 @@ spec:
             requests:
               storage: {{ .Values.persistence.size | quote }}
         {{ include "rabbitmq.storageClass" . }}
+        {{- if .Values.persistence.selector }}
+        selector:
+          {{- with .Values.persistence.selector -}}
+          {{ toYaml . | nindent 10 }}
+          {{- end -}}
+        {{- end -}}
   {{- end }}

--- a/bitnami/rabbitmq/values-production.yaml
+++ b/bitnami/rabbitmq/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/rabbitmq
-  tag: 3.8.3-debian-10-r29
+  tag: 3.8.3-debian-10-r31
 
   ## set to true if you would like to see extra information on logs
   ## it turns BASH and NAMI debugging in minideb
@@ -411,7 +411,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/rabbitmq-exporter
-    tag: 0.29.0-debian-10-r65
+    tag: 0.29.0-debian-10-r66
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/rabbitmq/values-production.yaml
+++ b/bitnami/rabbitmq/values-production.yaml
@@ -263,6 +263,10 @@ persistence:
   ##   GKE, AWS & OpenStack)
   ##
   # storageClass: "-"
+  ## selector can be used to match an existing PersistentVolume
+  # selector:
+  #   matchLabels:
+  #     app: my-app
   accessMode: ReadWriteOnce
 
   ## Existing PersistentVolumeClaims

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/rabbitmq
-  tag: 3.8.3-debian-10-r29
+  tag: 3.8.3-debian-10-r31
 
   ## set to true if you would like to see extra information on logs
   ## it turns BASH and NAMI debugging in minideb
@@ -394,7 +394,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/rabbitmq-exporter
-    tag: 0.29.0-debian-10-r65
+    tag: 0.29.0-debian-10-r66
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -270,6 +270,10 @@ persistence:
   ##   GKE, AWS & OpenStack)
   ##
   # storageClass: "-"
+  ## selector can be used to match an existing PersistentVolume
+  # selector:
+  #   matchLabels:
+  #     app: my-app
   accessMode: ReadWriteOnce
 
   ## Existing PersistentVolumeClaims


### PR DESCRIPTION
**Description of the change**

Add a selector to persistentVolumeClaims to be able to target an existing persistentVolume

**Benefits**

Target a specific existing PVC

**Possible drawbacks**

**Applicable issues**

**Additional information**

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files