### PR TITLE
[bitnami/common]: add initial functions

### DIFF
--- a/bitnami/common/.helmignore
+++ b/bitnami/common/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -1,11 +1,18 @@
 apiVersion: v1
 name: common
-description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
 version: 0.1.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application.
 appVersion: 0.1.0
+description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
+keywords:
+  - common
+  - helper
+  - template
+  - function
+  - bitnami
+icon: https://bitnami.com/downloads/logos/bitnami-mark.png
+sources:
+  - https://github.com/bitnami/charts
+maintainers:
+  - name: Bitnami
+    email: containers@bitnami.com
+engine: gotpl

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+name: common
+description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 0.1.0

--- a/bitnami/common/README.md
+++ b/bitnami/common/README.md
@@ -1,0 +1,159 @@
+# Bitnami Common Library Chart
+
+A [Helm Library Chart](https://helm.sh/docs/topics/library_charts/#helm) for grouping common logic between bitnami charts.
+
+## TL;DR;
+
+```yaml
+dependencies:
+- name: common
+  version: 0.1.0
+  repository: https://charts.bitnami.com/bitnami
+```
+
+```bash
+$ helm dependency update
+```
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "common.names.fullname" . }}
+data:
+  myvalue: "Hello World"
+```
+## Introduction
+
+This chart provide a common template helpers which can be used to develop new charts using [Helm](https://helm.sh) package manager.
+
+Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters. This Helm chart has been tested on top of [Bitnami Kubernetes Production Runtime](https://kubeprod.io/) (BKPR). Deploy BKPR to get automated TLS certificates, logging and monitoring for your applications.
+
+## Prerequisites
+
+- Kubernetes 1.12+
+- Helm 2.16+ or Helm 3.0-beta3+
+- PV provisioner support in the underlying infrastructure
+- ReadWriteMany volumes for deployment scaling
+
+## Helpers
+
+The following table lists the helpers available in the library which are scoped in different sections.
+
+**Names**
+| Helper identifier                           | Description                                                | Expected Input                                                                                                                                           |
+|---------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `common.names.name`                         | Expand the name of the chart or use `.Values.nameOverride` | `.` Chart context                                                                                                                                        |
+| `common.names.chart`                        | Chart name plus version                                    | `.` Chart context                                                                                                                                        |
+| `common.names.fullname`                     | Create a default fully qualified app name.                 | `.` Chart context                                                                                                                                        |
+
+**Images**
+| Helper identifier                           | Description                                                | Expected Input                                                                                                                                           |
+|---------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `common.images.image`                       | Return the proper and full image name                      | `dict "imageRoot" .Values.path.to.the.image "global" $`, see [ImageRoot](#imageRoot) for the structure.                                                  |
+| `common.images.pullSecrets`                 | Return the proper Docker Image Registry Secret Names       | `dict "images" (list .Values.path.to.the.image1, .Values.path.to.the.image2) "global" $`                                                                 |
+
+**Labels**
+| Helper identifier                           | Description                                                | Expected Input                                                                                                                                           |
+|---------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `common.labels.standard`                    | Return Kubernetes standard labels                          | `.` Chart context                                                                                                                                        |
+| `common.labels.matchLabels`                 | Return the proper Docker Image Registry Secret Names       | `.` Chart context                                                                                                                                        |
+
+**Storage**
+| Helper identifier                           | Description                                                | Expected Input                                                                                                                                           |
+|---------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `common.storage.class`                      | Return the proper Storage Class                            | `dict "persistence" .Values.path.to.the.persistence "global" $`, see [Persistence](#persistence) for the structure.                                      |
+
+**TplValues**
+| Helper identifier                           | Description                                                | Expected Input                                                                                                                                           |
+|---------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `common.tplvalues.render`                   | Renders a value that contains template                     | `dict "value" .Values.path.to.the.Value "context" $`, value is the value should rendered as template, context frecuently is the chart context `$` or `.` |
+
+**Capabilities**
+| Helper identifier                           | Description                                                | Expected Input                                                                                                                                           |
+|---------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `common.capabilities.deployment.apiVersion` | Return the appropriate apiVersion for deployment.          | `.` Chart context                                                                                                                                        |
+
+
+## Special input schemas
+
+### ImageRoot
+
+```yaml
+registry: 
+  type: string
+  description: Docker registry where the image is located
+  example: docker.io
+
+repository:
+  type: string
+  description: Repository and image name
+  example: bitnami/nginx
+
+tag:
+  type: string
+  description: image tag
+  example: 1.16.1-debian-10-r63
+
+pullPolicy:
+  type: string
+  description: Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+
+pullSecrets:
+  type: array
+  items:
+    type: string
+  description: Optionally specify an array of imagePullSecrets.
+
+debug:
+  type: boolean
+  description: Set to true if you would like to see extra information on logs
+  example: false
+
+## An instance would be:
+# registry: docker.io
+# repository: bitnami/nginx
+# tag: 1.16.1-debian-10-r63
+# pullPolicy: IfNotPresent
+# debug: false
+```
+
+### Persistence
+
+```yaml
+enabled:
+  type: boolean
+  description: Whether enable persistence.
+  example: true
+
+storageClass:
+  type: string
+  description: Ghost data Persistent Volume Storage Class, If set to "-", storageClassName: "" which disables dynamic provisioning.
+  example: "-"
+ 
+accessMode:
+  type: string
+  description: Access mode for the Persistent Volume Storage.
+  example: ReadWriteOnce
+
+size:
+  type: string
+  description: Size the Persistent Volume Storage.
+  example: 8Gi
+
+path:
+  type: string
+  description: Path to be persisted.
+  example: /bitnami
+
+## An instance would be:
+# enabled: true
+# storageClass: "-"
+# accessMode: ReadWriteOnce
+# size: 8Gi
+# path: /bitnami
+```
+
+## Notable changes
+
+N/A

--- a/bitnami/common/README.md
+++ b/bitnami/common/README.md
@@ -6,9 +6,9 @@ A [Helm Library Chart](https://helm.sh/docs/topics/library_charts/#helm) for gro
 
 ```yaml
 dependencies:
-- name: common
-  version: 0.1.0
-  repository: https://charts.bitnami.com/bitnami
+  - name: common
+    version: 0.1.0
+    repository: https://charts.bitnami.com/bitnami
 ```
 
 ```bash
@@ -23,9 +23,10 @@ metadata:
 data:
   myvalue: "Hello World"
 ```
+
 ## Introduction
 
-This chart provide a common template helpers which can be used to develop new charts using [Helm](https://helm.sh) package manager.
+This chart provides a common template helpers which can be used to develop new charts using [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters. This Helm chart has been tested on top of [Bitnami Kubernetes Production Runtime](https://kubeprod.io/) (BKPR). Deploy BKPR to get automated TLS certificates, logging and monitoring for your applications.
 
@@ -33,8 +34,6 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 
 - Kubernetes 1.12+
 - Helm 2.16+ or Helm 3.0-beta3+
-- PV provisioner support in the underlying infrastructure
-- ReadWriteMany volumes for deployment scaling
 
 ## Helpers
 
@@ -44,8 +43,8 @@ The following table lists the helpers available in the library which are scoped 
 | Helper identifier                           | Description                                                | Expected Input                                                                                                                                           |
 |---------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `common.names.name`                         | Expand the name of the chart or use `.Values.nameOverride` | `.` Chart context                                                                                                                                        |
-| `common.names.chart`                        | Chart name plus version                                    | `.` Chart context                                                                                                                                        |
 | `common.names.fullname`                     | Create a default fully qualified app name.                 | `.` Chart context                                                                                                                                        |
+| `common.names.chart`                        | Chart name plus version                                    | `.` Chart context                                                                                                                                        |
 
 **Images**
 | Helper identifier                           | Description                                                | Expected Input                                                                                                                                           |
@@ -73,7 +72,6 @@ The following table lists the helpers available in the library which are scoped 
 | Helper identifier                           | Description                                                | Expected Input                                                                                                                                           |
 |---------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `common.capabilities.deployment.apiVersion` | Return the appropriate apiVersion for deployment.          | `.` Chart context                                                                                                                                        |
-
 
 ## Special input schemas
 

--- a/bitnami/common/README.md
+++ b/bitnami/common/README.md
@@ -35,7 +35,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 - Kubernetes 1.12+
 - Helm 2.16+ or Helm 3.0-beta3+
 
-## Helpers
+## Parameters
 
 The following table lists the helpers available in the library which are scoped in different sections.
 

--- a/bitnami/common/templates/_capabilities.tpl
+++ b/bitnami/common/templates/_capabilities.tpl
@@ -1,0 +1,11 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Return the appropriate apiVersion for deployment.
+*/}}
+{{- define "common.capabilities.deployment.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/bitnami/common/templates/_images.tpl
+++ b/bitnami/common/templates/_images.tpl
@@ -1,0 +1,38 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Return the proper image name
+{{ include "common.images.image" ( dict "imageRoot" .Values.path.to.the.image "global" $) }}
+*/}}
+{{- define "common.images.image" -}}
+{{- $registryName := .imageRoot.registry -}}
+{{- $repositoryName := .imageRoot.repository -}}
+{{- $tag := .imageRoot.tag | toString -}}
+{{- if .global }}
+    {{- if .global.imageRegistry }}
+     {{- $registryName = .global.imageRegistry -}}
+    {{- end -}}
+{{- end -}}
+{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+{{ include "common.images.pullSecrets" ( dict "images" (list .Values.path.to.the.image1, .Values.path.to.the.image2) "global" $) }}
+*/}}
+{{- define "common.images.pullSecrets" -}}
+{{- if .global }}
+{{- if .global.imagePullSecrets }}
+imagePullSecrets: {{ .global.imagePullSecrets | toYaml | nindent 2 }}
+{{- end }}
+{{- else }}
+{{- $pullSecrets := list }}
+{{- range .images }}
+  {{- if .pullSecrets }}
+    {{- $pullSecrets = concat $pullSecrets .pullSecrets }}
+  {{- end }}
+{{- end }}
+{{- if $pullSecrets }}
+imagePullSecrets: {{ $pullSecrets | toYaml | nindent 2 }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/bitnami/common/templates/_labels.tpl
+++ b/bitnami/common/templates/_labels.tpl
@@ -1,0 +1,18 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Kubernetes standard labels
+*/}}
+{{- define "common.labels.standard" -}}
+app.kubernetes.io/name: {{ include "common.names.name" . }}
+helm.sh/chart: {{ include "common.names.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Labels to use on deploy.spec.selector.matchLabels and svc.spec.selector
+*/}}
+{{- define "common.labels.matchLabels" -}}
+app.kubernetes.io/name: {{ include "common.names.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/bitnami/common/templates/_names.tpl
+++ b/bitnami/common/templates/_names.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "common.names.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "common.names.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "common.names.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/bitnami/common/templates/_storage.tpl
+++ b/bitnami/common/templates/_storage.tpl
@@ -1,0 +1,23 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Return  the proper Storage Class
+{{ include "common.storage.class" ( dict "persistence" .Values.path.to.the.persistence "global" $) }}
+*/}}
+{{- define "common.storage.class" -}}
+
+{{- $storageClass := .persistence.storageClass -}}
+{{- if .global -}}
+    {{- if .global.storageClass -}}
+        {{- $storageClass = .global.storageClass -}}
+    {{- end -}}
+{{- end -}}
+
+{{- if $storageClass -}}
+  {{- if (eq "-" $storageClass) -}}
+      {{- printf "storageClassName: \"\"" -}}
+  {{- else }}
+      {{- printf "storageClassName: %s" $storageClass -}}
+  {{- end -}}
+{{- end -}}
+
+{{- end -}}

--- a/bitnami/common/templates/_tplvalues.tpl
+++ b/bitnami/common/templates/_tplvalues.tpl
@@ -1,0 +1,13 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "common.tplvalues.render" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}


### PR DESCRIPTION
**Description of the change**

Adding bitnami/common with useful common template helpers to be reused as part of the standardization.

**Benefits**

Having clear charts and standardized for common things like affinity, sidecars, images, etc.

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
