### PR TITLE
[bitnami/redis]: Fix container name

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 10.6.0
+version: 10.6.1
 appVersion: 5.0.8
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/bitnami/redis/templates/redis-master-statefulset.yaml
+++ b/bitnami/redis/templates/redis-master-statefulset.yaml
@@ -68,7 +68,7 @@ spec:
       schedulerName: "{{ .Values.master.schedulerName }}"
       {{- end }}
       containers:
-      - name: {{ template "redis.fullname" . }}
+      - name: {{ template "redis.name" . }}
         image: "{{ template "redis.image" . }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         {{- if .Values.securityContext.enabled }}

--- a/bitnami/redis/templates/redis-slave-statefulset.yaml
+++ b/bitnami/redis/templates/redis-slave-statefulset.yaml
@@ -74,7 +74,7 @@ spec:
 {{ tpl (toYaml .) $ | indent 8 }}
     {{- end }}
       containers:
-      - name: {{ template "redis.fullname" . }}
+      - name: {{ template "redis.name" . }}
         image: {{ template "redis.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         {{- if .Values.securityContext.enabled }}

--- a/bitnami/redis/values-production.yaml
+++ b/bitnami/redis/values-production.yaml
@@ -18,7 +18,7 @@ image:
   ## Bitnami Redis image tag
   ## ref: https://github.com/bitnami/bitnami-docker-redis#supported-tags-and-respective-dockerfile-links
   ##
-  tag: 5.0.8-debian-10-r21
+  tag: 5.0.8-debian-10-r26
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -60,7 +60,7 @@ sentinel:
     ## Bitnami Redis image tag
     ## ref: https://github.com/bitnami/bitnami-docker-redis-sentinel#supported-tags-and-respective-dockerfile-links
     ##
-    tag: 5.0.8-debian-10-r17
+    tag: 5.0.8-debian-10-r21
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -480,7 +480,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/redis-exporter
-    tag: 1.5.2-debian-10-r13
+    tag: 1.5.2-debian-10-r17
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -18,7 +18,7 @@ image:
   ## Bitnami Redis image tag
   ## ref: https://github.com/bitnami/bitnami-docker-redis#supported-tags-and-respective-dockerfile-links
   ##
-  tag: 5.0.8-debian-10-r21
+  tag: 5.0.8-debian-10-r26
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -60,7 +60,7 @@ sentinel:
     ## Bitnami Redis image tag
     ## ref: https://github.com/bitnami/bitnami-docker-redis-sentinel#supported-tags-and-respective-dockerfile-links
     ##
-    tag: 5.0.8-debian-10-r17
+    tag: 5.0.8-debian-10-r21
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -480,7 +480,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/redis-exporter
-    tag: 1.5.2-debian-10-r13
+    tag: 1.5.2-debian-10-r17
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**

Fix redis container name

**Benefits**

I use redis chart in a chart dependency and redis container name include his release name. It is complicated to find all redis containers logs based on container name for example.

Best practise seems to only use Chart Name or static values in this field.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files