### PR TITLE
[bitnami/mongodb]: Fix indentation on extraVolumeMounts in deployment-standalone.yaml

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb
-version: 7.10.6
+version: 7.10.7
 appVersion: 4.2.5
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/bitnami/mongodb/templates/deployment-standalone.yaml
+++ b/bitnami/mongodb/templates/deployment-standalone.yaml
@@ -195,7 +195,7 @@ spec:
               subPath: mongodb.conf
             {{- end }}
             {{- if .Values.extraVolumeMounts }}
-  {{ toYaml .Values.extraVolumeMounts | indent 8}}
+  {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
           resources:
   {{- toYaml .Values.resources | nindent 12 }}

--- a/bitnami/mongodb/values-production.yaml
+++ b/bitnami/mongodb/values-production.yaml
@@ -18,7 +18,7 @@ image:
   ## Bitnami MongoDB image tag
   ## ref: https://hub.docker.com/r/bitnami/mongodb/tags/
   ##
-  tag: 4.2.5-debian-10-r35
+  tag: 4.2.5-debian-10-r39
   ## Specify a imagePullPolicy
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -444,7 +444,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mongodb-exporter
-    tag: 0.10.0-debian-10-r63
+    tag: 0.10.0-debian-10-r66
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -18,7 +18,7 @@ image:
   ## Bitnami MongoDB image tag
   ## ref: https://hub.docker.com/r/bitnami/mongodb/tags/
   ##
-  tag: 4.2.5-debian-10-r35
+  tag: 4.2.5-debian-10-r39
   ## Specify a imagePullPolicy
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -446,7 +446,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mongodb-exporter
-    tag: 0.10.0-debian-10-r63
+    tag: 0.10.0-debian-10-r66
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**
This PR Fixes the indentation rendered for the extra volume mounts in the deployment-standalone.yaml file;

The previous implementation would produce a result similar to;
```
          volumeMounts:
            - name: data
              mountPath: /bitnami/mongodb
              subPath:
            - name: config
              mountPath: /opt/bitnami/mongodb/conf/mongodb.conf
              subPath: mongodb.conf
          - mountPath: /volume/mount/path
          name: volume-name
          readOnly: true
```
this is invalid Yaml, and would cause problems during deployment

this fix uses `nindent` to ensure that indentation is considered from column
0, and uses the correct indentation value; producing a value such as;
```
          volumeMounts:
            - name: data
              mountPath: /bitnami/mongodb
              subPath:
            - name: config
              mountPath: /opt/bitnami/mongodb/conf/mongodb.conf
              subPath: mongodb.conf
            - mountPath: /volume/mount/path
              name: volume-name
              readOnly: true
```

**Benefits**
People can actually use extraVolumeMounts now...

**Possible drawbacks**
I don't believe there are any.

**Applicable issues**
Not Sure.. didn't scour your issue backlog to figure this out, if someone wants to tag an issue, be my guest.

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

