### PR TITLE
[bitnami/node-exporter] Add the ability to specify the ServiceMonitor relabelings

### DIFF
--- a/bitnami/node-exporter/Chart.yaml
+++ b/bitnami/node-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.18.1
 description: Prometheus exporter for hardware and OS metrics exposed by UNIX kernels, with pluggable metric collectors.
 name: node-exporter
-version: 0.2.8
+version: 0.2.9
 keywords:
   - prometheus
   - node-exporter

--- a/bitnami/node-exporter/README.md
+++ b/bitnami/node-exporter/README.md
@@ -110,6 +110,7 @@ The following table lists the configurable parameters of the Node Exporter chart
 | `serviceMonitor.interval`            | Scrape interval (use by default, falling back to Prometheus' default)                                    | `nil`                                                                     |
 | `serviceMonitor.jobLabel`            | The name of the label on the target service to use as the job name in prometheus.                        | `nil`                                                                     |
 | `serviceMonitor.selector`            | ServiceMonitor selector labels                                                                           | `[]`                                                                      |
+| `serviceMonitor.relabelings`         | ServiceMonitor relabelings                                                                               | `[]`                                                                      |
 | `serviceMonitor.metricRelabelings`   | ServiceMonitor metricRelabelings                                                                         | `[]`                                                                      |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example the following command sets the `minReadySeconds` of the Node Exporter Pods to `120` seconds.

--- a/bitnami/node-exporter/templates/servicemonitor.yaml
+++ b/bitnami/node-exporter/templates/servicemonitor.yaml
@@ -24,6 +24,9 @@ spec:
       {{- if .Values.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
       {{- end }}
+      {{- if .Values.serviceMonitor.relabelings }}
+      relabelings: {{- include "node-exporter.tplValue" ( dict "value" .Values.serviceMonitor.relabelings "context" $) | nindent 8 }}
+      {{- end }}
       {{- if .Values.serviceMonitor.metricRelabelings }}
       metricRelabelings: {{- include "node-exporter.tplValue" ( dict "value" .Values.serviceMonitor.metricRelabelings "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/node-exporter/values.yaml
+++ b/bitnami/node-exporter/values.yaml
@@ -222,7 +222,12 @@ serviceMonitor:
   # selector:
   #   prometheus: my-prometheus
 
-  ## Metric relabeling
+  ## RelabelConfigs to apply to samples before scraping
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+  ##
+  # relabelings: []
+
+  ## MetricRelabelConfigs to apply to samples before ingestion
   ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
   ##
   # metricRelabelings: []

--- a/bitnami/node-exporter/values.yaml
+++ b/bitnami/node-exporter/values.yaml
@@ -50,7 +50,7 @@ serviceAccount:
 image:
   registry: docker.io
   repository: bitnami/node-exporter
-  tag: 0.18.1-debian-10-r56
+  tag: 0.18.1-debian-10-r74
 
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
This allows the user to apply pre-scraping relabeling

It's just forwarding a .Values array to the ServiceMonitor template.

- [ x ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ x ] Variables are documented in the README.md
- [ x ] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
