### PR TITLE
[bitnami/mongodb] Fix indentation of metrics.resources

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb
-version: 7.10.7
+version: 7.10.8
 appVersion: 4.2.5
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/bitnami/mongodb/templates/deployment-standalone.yaml
+++ b/bitnami/mongodb/templates/deployment-standalone.yaml
@@ -245,7 +245,7 @@ spec:
             successThreshold: {{ .Values.metrics.readinessProbe.successThreshold }}
           {{- end }}
           resources:
-{{ toYaml .Values.metrics.resources | indent 10 }}
+{{ toYaml .Values.metrics.resources | indent 12 }}
 {{- end }}
 {{- if .Values.sidecars }}
 {{ toYaml .Values.sidecars | indent 6 }}

--- a/bitnami/mongodb/values-production.yaml
+++ b/bitnami/mongodb/values-production.yaml
@@ -18,7 +18,7 @@ image:
   ## Bitnami MongoDB image tag
   ## ref: https://hub.docker.com/r/bitnami/mongodb/tags/
   ##
-  tag: 4.2.5-debian-10-r39
+  tag: 4.2.5-debian-10-r42
   ## Specify a imagePullPolicy
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -444,7 +444,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mongodb-exporter
-    tag: 0.10.0-debian-10-r66
+    tag: 0.10.0-debian-10-r69
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -18,7 +18,7 @@ image:
   ## Bitnami MongoDB image tag
   ## ref: https://hub.docker.com/r/bitnami/mongodb/tags/
   ##
-  tag: 4.2.5-debian-10-r39
+  tag: 4.2.5-debian-10-r42
   ## Specify a imagePullPolicy
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -446,7 +446,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mongodb-exporter
-    tag: 0.10.0-debian-10-r66
+    tag: 0.10.0-debian-10-r69
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**
The indentation of `metrics.resources` resulted in invalid yaml and needed to be increased

**Benefits**
Deployments using `metrics.enabled=yes` will succeed

**Possible drawbacks**
None

**Applicable issues**
None

**Additional information**
None

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files