### PR TITLE
[bitnami/ghost] add support for existing PVCs

### DIFF
--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ghost
-version: 9.1.16
+version: 9.2.0
 appVersion: 3.12.1
 description: A simple, powerful publishing platform that allows you to share your stories with the world
 keywords:

--- a/bitnami/ghost/README.md
+++ b/bitnami/ghost/README.md
@@ -124,6 +124,7 @@ The following table lists the configurable parameters of the Ghost chart and the
 | `mariadb.db.user`                   | MariaDB Database user to create                               | `bn_ghost`                                               |
 | `mariadb.db.password`               | MariaDB Password for user                                     | _random 10 character long alphanumeric string_           |
 | `persistence.enabled`               | Enable persistence using PVC                                  | `true`                                                   |
+| `persistence.existingClaim`         | Use an existing PVC                                           | `""`
 | `persistence.storageClass`          | PVC Storage Class for Ghost volume                            | `nil` (uses alpha storage annotation)                    |
 | `persistence.accessMode`            | PVC Access Mode for Ghost volume                              | `ReadWriteOnce`                                          |
 | `persistence.size`                  | PVC Storage Request for Ghost volume                          | `8Gi`                                                    |

--- a/bitnami/ghost/templates/deployment.yaml
+++ b/bitnami/ghost/templates/deployment.yaml
@@ -176,8 +176,13 @@ spec:
       volumes:
       - name: ghost-data
       {{- if .Values.persistence.enabled }}
+        {{- if .Values.persistence.existingClaim }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.existingClaim }}
+        {{- else }}
         persistentVolumeClaim:
           claimName: {{ template "ghost.fullname" . }}
+        {{- end }}
       {{- else }}
         emptyDir: {}
       {{- end }}

--- a/bitnami/ghost/templates/pvc.yaml
+++ b/bitnami/ghost/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.enabled -}}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/bitnami/ghost/values.yaml
+++ b/bitnami/ghost/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/ghost
-  tag: 3.12.1-debian-10-r0
+  tag: 3.12.1-debian-10-r16
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
**Description of the change**
This PR adds support for using existing PVCs with Ghost.

**Benefits**
This makes it easier to reinstall Ghost without using data, and to take advantage of
backups created with the `VolumeSnapshot` API.

**Possible drawbacks**
A little added complexity

**Applicable issues**
none

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
