### PR TITLE
[bitnami/nginx-ingress-controller] Fix for proxyheaders-configmap.yaml: error converting YAML to JSON

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress-controller
-version: 5.3.12
+version: 5.3.13
 appVersion: 0.30.0
 description: Chart for the nginx Ingress controller
 keywords:

--- a/bitnami/nginx-ingress-controller/templates/proxyheaders-configmap.yaml
+++ b/bitnami/nginx-ingress-controller/templates/proxyheaders-configmap.yaml
@@ -9,6 +9,6 @@ data:
 {{- if .Values.proxySetHeaders }}
 {{ toYaml .Values.proxySetHeaders | indent 2 }}
 {{- else if and .Values.headers (not .Values.proxySetHeaders) }}
-{{- toYaml .Values.headers | indent 2 }}
+{{ toYaml .Values.headers | indent 2 }}
 {{- end }}
 {{- end }}

--- a/bitnami/nginx-ingress-controller/templates/proxyheaders-configmap.yaml
+++ b/bitnami/nginx-ingress-controller/templates/proxyheaders-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     component: {{ .Values.name }}
 data:
 {{- if .Values.proxySetHeaders }}
-{{- toYaml .Values.proxySetHeaders | indent 2 }}
+{{ toYaml .Values.proxySetHeaders | indent 2 }}
 {{- else if and .Values.headers (not .Values.proxySetHeaders) }}
 {{- toYaml .Values.headers | indent 2 }}
 {{- end }}

--- a/bitnami/nginx-ingress-controller/values-production.yaml
+++ b/bitnami/nginx-ingress-controller/values-production.yaml
@@ -15,7 +15,7 @@ name: controller
 image:
   registry: docker.io
   repository: bitnami/nginx-ingress-controller
-  tag: 0.30.0-debian-10-r43
+  tag: 0.30.0-debian-10-r52
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -370,7 +370,7 @@ defaultBackend:
   image:
     registry: docker.io
     repository: bitnami/nginx
-    tag: 1.16.1-debian-10-r70
+    tag: 1.16.1-debian-10-r78
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/nginx-ingress-controller/values.yaml
+++ b/bitnami/nginx-ingress-controller/values.yaml
@@ -15,7 +15,7 @@ name: controller
 image:
   registry: docker.io
   repository: bitnami/nginx-ingress-controller
-  tag: 0.30.0-debian-10-r43
+  tag: 0.30.0-debian-10-r52
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -370,7 +370,7 @@ defaultBackend:
   image:
     registry: docker.io
     repository: bitnami/nginx
-    tag: 1.16.1-debian-10-r70
+    tag: 1.16.1-debian-10-r78
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Remove leading dash in `proxyheaders-configmap.yaml` causing invalid yaml to be rendered 

**Benefits**

No more error when `proxySetHeaders` is set to a non-empty map.

**Possible drawbacks**

None.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #2226

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files