### PR TITLE
[bitnami/external-dns] azure secrets set in env by secretKeyRef

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.20.11
+version: 2.20.12
 appVersion: 0.7.1
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/bitnami/external-dns/templates/_helpers.tpl
+++ b/bitnami/external-dns/templates/_helpers.tpl
@@ -118,6 +118,8 @@ Return true if a secret object should be created
     {{- true -}}
 {{- else if and (eq .Values.provider "azure") (or (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId .Values.azure.aadClientId .Values.azure.aadClientSecret (not .Values.azure.useManagedIdentityExtension)) (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId .Values.azure.useManagedIdentityExtension)) (not .Values.azure.secretName) -}}
     {{- true -}}
+{{- else if and (eq .Values.provider "azure-private-dns") (or (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId .Values.azure.aadClientId .Values.azure.aadClientSecret (not .Values.azure.useManagedIdentityExtension)) (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId .Values.azure.useManagedIdentityExtension)) (not .Values.azure.secretName) -}}
+    {{- true -}}
 {{- else if and (eq .Values.provider "cloudflare") (or .Values.cloudflare.apiToken .Values.cloudflare.apiKey) (not .Values.cloudflare.secretName) -}}
     {{- true -}}
 {{- else if and (eq .Values.provider "designate") (or .Values.designate.username .Values.designate.password) -}}
@@ -144,7 +146,7 @@ Return the name of the Secret used to store the passwords
 {{- define "external-dns.secretName" -}}
 {{- if and (eq .Values.provider "aws") .Values.aws.credentials.secretName }}
 {{- .Values.aws.credentials.secretName }}
-{{- else if and (eq .Values.provider "azure") .Values.azure.secretName }}
+{{- else if and (or (eq .Values.provider "azure") (eq .Values.provider "azure-private-dns")) .Values.azure.secretName }}
 {{- .Values.azure.secretName }}
 {{- else if and (eq .Values.provider "cloudflare") .Values.cloudflare.secretName }}
 {{- .Values.cloudflare.secretName }}
@@ -326,9 +328,9 @@ Validate values of Azure DNS:
 - must provide the Azure Resource Group when provider is "azure"
 */}}
 {{- define "external-dns.validateValues.azure.resourceGroup" -}}
-{{- if and (eq .Values.provider "azure") (not .Values.azure.resourceGroup) -}}
+{{- if and (or (eq .Values.provider "azure") (eq .Values.provider "azure-private-dns")) (not .Values.azure.resourceGroup) -}}
 external-dns: azure.resourceGroup
-    You must provide the Azure Resource Group when provider="azure".
+    You must provide the Azure Resource Group when provider="azure" or provider="azure-private-dns".
     Please set the resourceGroup parameter (--set azure.resourceGroup="xxxx")
 {{- end -}}
 {{- end -}}
@@ -338,9 +340,9 @@ Validate values of Azure DNS:
 - must provide the Azure Tenant ID when provider is "azure" and secretName is not set
 */}}
 {{- define "external-dns.validateValues.azure.tenantId" -}}
-{{- if and (eq .Values.provider "azure") (not .Values.azure.tenantId) (not .Values.azure.secretName) -}}
+{{- if and (or (eq .Values.provider "azure") (eq .Values.provider "azure-private-dns")) (not .Values.azure.tenantId) (not .Values.azure.secretName) -}}
 external-dns: azure.tenantId
-    You must provide the Azure Tenant ID when provider="azure".
+    You must provide the Azure Tenant ID when provider="azure" or provider="azure-private-dns".
     Please set the tenantId parameter (--set azure.tenantId="xxxx")
 {{- end -}}
 {{- end -}}
@@ -350,9 +352,9 @@ Validate values of Azure DNS:
 - must provide the Azure Subscription ID when provider is "azure" and secretName is not set
 */}}
 {{- define "external-dns.validateValues.azure.subscriptionId" -}}
-{{- if and (eq .Values.provider "azure") (not .Values.azure.subscriptionId) (not .Values.azure.secretName) -}}
+{{- if and (or (eq .Values.provider "azure") (eq .Values.provider "azure-private-dns")) (not .Values.azure.subscriptionId) (not .Values.azure.secretName) -}}
 external-dns: azure.subscriptionId
-    You must provide the Azure Subscription ID when provider="azure".
+    You must provide the Azure Subscription ID when provider="azure" or provider="azure-private-dns".
     Please set the subscriptionId parameter (--set azure.subscriptionId="xxxx")
 {{- end -}}
 {{- end -}}
@@ -362,9 +364,9 @@ Validate values of Azure DNS:
 - must not provide the Azure AAD Client ID when provider is "azure", secretName is not set and MSI is enabled
 */}}
 {{- define "external-dns.validateValues.azure.useManagedIdentityExtensionAadClientId" -}}
-{{- if and (eq .Values.provider "azure") (not .Values.azure.secretName) .Values.azure.aadClientId .Values.azure.useManagedIdentityExtension -}}
-external-dns: azure.seManagedIdentityExtension
-    You must not provide the Azure AAD Client ID when provider="azure" and useManagedIdentityExtension is "true".
+{{- if and (or (eq .Values.provider "azure") (eq .Values.provider "azure-private-dns")) (not .Values.azure.secretName) .Values.azure.aadClientId .Values.azure.useManagedIdentityExtension -}}
+external-dns: azure.useManagedIdentityExtension
+    You must not provide the Azure AAD Client ID when provider="azure" or provider="azure-private-dns" and useManagedIdentityExtension is "true".
     Please unset the aadClientId parameter (--set azure.aadClientId="xxxx")
 {{- end -}}
 {{- end -}}
@@ -374,9 +376,9 @@ Validate values of Azure DNS:
 - must not provide the Azure AAD Client Secret when provider is "azure", secretName is not set and MSI is enabled
 */}}
 {{- define "external-dns.validateValues.azure.useManagedIdentityExtensionAadClientSecret" -}}
-{{- if and (eq .Values.provider "azure") (not .Values.azure.secretName) .Values.azure.aadClientSecret .Values.azure.useManagedIdentityExtension -}}
-external-dns: azure.seManagedIdentityExtension
-    You must not provide the Azure AAD Client Secret when provider="azure" and useManagedIdentityExtension is "true".
+{{- if and (or (eq .Values.provider "azure") (eq .Values.provider "azure-private-dns")) (not .Values.azure.secretName) .Values.azure.aadClientSecret .Values.azure.useManagedIdentityExtension -}}
+external-dns: azure.useManagedIdentityExtension
+    You must not provide the Azure AAD Client Secret when provider="azure" or provider="azure-private-dns" and useManagedIdentityExtension is "true".
     Please unset set the aadClientSecret parameter (--set azure.aadClientSecret="xxxx")
 {{- end -}}
 {{- end -}}
@@ -386,9 +388,9 @@ Validate values of Azure DNS:
 - must provide the Azure AAD Client ID when provider is "azure", secretName is not set and MSI is disabled
 */}}
 {{- define "external-dns.validateValues.azure.aadClientId" -}}
-{{- if and (eq .Values.provider "azure") (not .Values.azure.secretName) (not .Values.azure.aadClientId) (not .Values.azure.useManagedIdentityExtension) -}}
-external-dns: azure.seManagedIdentityExtension
-    You must provide the Azure AAD Client ID when provider="azure" and useManagedIdentityExtension is not set.
+{{- if and (or (eq .Values.provider "azure") (eq .Values.provider "azure-private-dns")) (not .Values.azure.secretName) (not .Values.azure.aadClientId) (not .Values.azure.useManagedIdentityExtension) -}}
+external-dns: azure.useManagedIdentityExtension
+    You must provide the Azure AAD Client ID when provider="azure" or provider="azure-private-dns" and useManagedIdentityExtension is not set.
     Please set the aadClientId parameter (--set azure.aadClientId="xxxx").
 {{- end -}}
 {{- end -}}
@@ -398,10 +400,10 @@ Validate values of Azure DNS:
 - must provide the Azure AAD Client Secret when provider is "azure", secretName is not set and MSI is disabled
 */}}
 {{- define "external-dns.validateValues.azure.aadClientSecret" -}}
-{{- if and (eq .Values.provider "azure") (not .Values.azure.secretName) (not .Values.azure.aadClientSecret) (not .Values.azure.useManagedIdentityExtension) -}}
-external-dns: azure.seManagedIdentityExtension
-    You must provide the Azure AAD Client Secret when provider="azure" and useManagedIdentityExtension is not set.
-    Please set set the aadClientSecret parameter (--set azure.aadClientSecret="xxxx")
+{{- if and (or (eq .Values.provider "azure") (eq .Values.provider "azure-private-dns")) (not .Values.azure.secretName) (not .Values.azure.aadClientSecret) (not .Values.azure.useManagedIdentityExtension) -}}
+external-dns: azure.useManagedIdentityExtension
+    You must provide the Azure AAD Client Secret when provider="azure" or provider="azure-private-dns" and useManagedIdentityExtension is not set.
+    Please set the aadClientSecret parameter (--set azure.aadClientSecret="xxxx")
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/external-dns/templates/_helpers.tpl
+++ b/bitnami/external-dns/templates/_helpers.tpl
@@ -207,6 +207,9 @@ Compile all warnings into a single message, and call fail.
 {{- $messages := append $messages (include "external-dns.validateValues.azure.useManagedIdentityExtensionAadClientSecret" .) -}}
 {{- $messages := append $messages (include "external-dns.validateValues.azure.aadClientId" .) -}}
 {{- $messages := append $messages (include "external-dns.validateValues.azure.aadClientSecret" .) -}}
+{{- $messages := append $messages (include "external-dns.validateValues.azurePrivateDns.resourceGroup" .) -}}
+{{- $messages := append $messages (include "external-dns.validateValues.azurePrivateDns.aadClientId" .) -}}
+{{- $messages := append $messages (include "external-dns.validateValues.azurePrivateDns.aadClientSecret" .) -}}
 {{- $messages := append $messages (include "external-dns.validateValues.transip.account" .) -}}
 {{- $messages := append $messages (include "external-dns.validateValues.transip.apiKey" .) -}}
 {{- $messages := without $messages "" -}}
@@ -340,7 +343,7 @@ Validate values of Azure private DNS:
 - must provide the Azure Resource Group when provider is "azure-private-dns"
 - azure-private-dns provider does not use azure.json so secretName takes no effect
 */}}
-{{- define "external-dns.validateValues.azure.resourceGroup" -}}
+{{- define "external-dns.validateValues.azurePrivateDns.resourceGroup" -}}
 {{- if and (eq .Values.provider "azure-private-dns") (not .Values.azure.resourceGroup) -}}
 external-dns: azure.resourceGroup
     You must provide the Azure Resource Group when provider="azure" or provider="azure-private-dns".
@@ -401,9 +404,21 @@ Validate values of Azure DNS:
 - must provide the Azure AAD Client ID when provider is "azure", secretName is not set and MSI is disabled
 */}}
 {{- define "external-dns.validateValues.azure.aadClientId" -}}
-{{- if and (or (eq .Values.provider "azure") (eq .Values.provider "azure-private-dns")) (not .Values.azure.secretName) (not .Values.azure.aadClientId) (not .Values.azure.useManagedIdentityExtension) -}}
+{{- if and (eq .Values.provider "azure") (not .Values.azure.secretName) (not .Values.azure.aadClientId) (not .Values.azure.useManagedIdentityExtension) -}}
 external-dns: azure.useManagedIdentityExtension
-    You must provide the Azure AAD Client ID when provider="azure" or provider="azure-private-dns" and useManagedIdentityExtension is not set.
+    You must provide the Azure AAD Client ID when provider="azure" and useManagedIdentityExtension is not set.
+    Please set the aadClientId parameter (--set azure.aadClientId="xxxx").
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate values of Azure private DNS:
+- must provide the Azure AAD Client ID when provider is "azure-private-dns" and MSI is disabled
+*/}}
+{{- define "external-dns.validateValues.azurePrivateDns.aadClientId" -}}
+{{- if and (eq .Values.provider "azure-private-dns") (not .Values.azure.aadClientId) (not .Values.azure.useManagedIdentityExtension) -}}
+external-dns: azure.useManagedIdentityExtension
+    You must provide the Azure AAD Client ID when provider="azure-private-dns" and useManagedIdentityExtension is not set.
     Please set the aadClientId parameter (--set azure.aadClientId="xxxx").
 {{- end -}}
 {{- end -}}
@@ -425,7 +440,7 @@ Validate values of Azure Private DNS:
 - must provide the Azure AAD Client Secret when provider is "azure" and MSI is disabled
 - azure-private-dns provider does not use azure.json so secretName takes no effect
 */}}
-{{- define "external-dns.validateValues.azure.aadClientSecret" -}}
+{{- define "external-dns.validateValues.azurePrivateDns.aadClientSecret" -}}
 {{- if and (eq .Values.provider "azure-private-dns") (not .Values.azure.aadClientSecret) (not .Values.azure.useManagedIdentityExtension) -}}
 external-dns: azure.useManagedIdentityExtension
     You must provide the Azure AAD Client Secret when provider="azure-private-dns" and useManagedIdentityExtension is not set.

--- a/bitnami/external-dns/templates/_helpers.tpl
+++ b/bitnami/external-dns/templates/_helpers.tpl
@@ -146,7 +146,7 @@ Return the name of the Secret used to store the passwords
 {{- define "external-dns.secretName" -}}
 {{- if and (eq .Values.provider "aws") .Values.aws.credentials.secretName }}
 {{- .Values.aws.credentials.secretName }}
-{{- else if and (eq .Values.provider "azure") .Values.azure.secretName }}
+{{- else if and (or (eq .Values.provider "azure") (eq .Values.provider "azure-private-dns")) .Values.azure.secretName }}
 {{- .Values.azure.secretName }}
 {{- else if and (eq .Values.provider "cloudflare") .Values.cloudflare.secretName }}
 {{- .Values.cloudflare.secretName }}

--- a/bitnami/external-dns/templates/_helpers.tpl
+++ b/bitnami/external-dns/templates/_helpers.tpl
@@ -367,7 +367,7 @@ Validate values of Azure DNS:
 {{- if and (or (eq .Values.provider "azure") (eq .Values.provider "azure-private-dns")) (not .Values.azure.secretName) .Values.azure.aadClientId .Values.azure.useManagedIdentityExtension -}}
 external-dns: azure.useManagedIdentityExtension
     You must not provide the Azure AAD Client ID when provider="azure" or provider="azure-private-dns" and useManagedIdentityExtension is "true".
-    Please unset the aadClientId parameter (--set azure.aadClientId="xxxx")
+    Please unset the aadClientId parameter (--set azure.aadClientId="")
 {{- end -}}
 {{- end -}}
 
@@ -379,7 +379,7 @@ Validate values of Azure DNS:
 {{- if and (or (eq .Values.provider "azure") (eq .Values.provider "azure-private-dns")) (not .Values.azure.secretName) .Values.azure.aadClientSecret .Values.azure.useManagedIdentityExtension -}}
 external-dns: azure.useManagedIdentityExtension
     You must not provide the Azure AAD Client Secret when provider="azure" or provider="azure-private-dns" and useManagedIdentityExtension is "true".
-    Please unset set the aadClientSecret parameter (--set azure.aadClientSecret="xxxx")
+    Please unset the aadClientSecret parameter (--set azure.aadClientSecret="")
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/external-dns/templates/_helpers.tpl
+++ b/bitnami/external-dns/templates/_helpers.tpl
@@ -346,7 +346,7 @@ Validate values of Azure private DNS:
 {{- define "external-dns.validateValues.azurePrivateDns.resourceGroup" -}}
 {{- if and (eq .Values.provider "azure-private-dns") (not .Values.azure.resourceGroup) -}}
 external-dns: azure.resourceGroup
-    You must provide the Azure Resource Group when provider="azure" or provider="azure-private-dns".
+    You must provide the Azure Resource Group when provider="azure-private-dns".
     Please set the resourceGroup parameter (--set azure.resourceGroup="xxxx")
 {{- end -}}
 {{- end -}}

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -225,13 +225,17 @@ spec:
             - name: AZURE_TENANT_ID
               value: {{ .Values.azure.tenantId }}
             {{- end }}
-            {{- if .Values.azure.aadClientId }}
-            - name: AZURE_CLIENT_ID
-              value: {{ .Values.azure.aadClientId }}
-            {{- end }}
-            {{- if .Values.azure.aadClientSecret }}
+            {{- if or .Values.azure.aadClientId .Values.azure.aadClientSecret }}
             - name: AZURE_CLIENT_SECRET
-              value: {{ .Values.azure.aadClientSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "external-dns.secretName" . }}
+                  key: azure_aad_client_secret
+            - name: AZURE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "external-dns.secretName" . }}
+                  key: azure_aad_client_id
             {{- end }}
             {{- end }}
             {{- if eq .Values.provider "cloudflare" }}
@@ -381,7 +385,7 @@ spec:
               mountPath: {{ .Values.aws.credentials.mountPath }}
               readOnly: true
             {{- end }}
-            {{- if eq .Values.provider "azure" }}
+            {{- if or (eq .Values.provider "azure") (eq .Values.provider "azure-private-dns") }}
             # Azure mountPath(s)
             - name: azure-config-file
               {{- if or .Values.azure.secretName (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId) }}
@@ -433,7 +437,7 @@ spec:
           secret:
             secretName: {{ template "external-dns.secretName" . }}
         {{- end }}
-        {{- if eq .Values.provider "azure" }}
+        {{- if or (eq .Values.provider "azure") (eq .Values.provider "azure-private-dns") }}
         # Azure volume(s)
         - name: azure-config-file
           {{- if or .Values.azure.secretName (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId) }}

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -385,7 +385,7 @@ spec:
               mountPath: {{ .Values.aws.credentials.mountPath }}
               readOnly: true
             {{- end }}
-            {{- if or (eq .Values.provider "azure") }}
+            {{- if eq .Values.provider "azure" }}
             # Azure mountPath(s)
             - name: azure-config-file
               {{- if or .Values.azure.secretName (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId) }}
@@ -437,7 +437,7 @@ spec:
           secret:
             secretName: {{ template "external-dns.secretName" . }}
         {{- end }}
-        {{- if or (eq .Values.provider "azure") }}
+        {{- if eq .Values.provider "azure" }}
         # Azure volume(s)
         - name: azure-config-file
           {{- if or .Values.azure.secretName (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId) }}

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -385,7 +385,7 @@ spec:
               mountPath: {{ .Values.aws.credentials.mountPath }}
               readOnly: true
             {{- end }}
-            {{- if or (eq .Values.provider "azure") (eq .Values.provider "azure-private-dns") }}
+            {{- if or (eq .Values.provider "azure") }}
             # Azure mountPath(s)
             - name: azure-config-file
               {{- if or .Values.azure.secretName (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId) }}
@@ -437,7 +437,7 @@ spec:
           secret:
             secretName: {{ template "external-dns.secretName" . }}
         {{- end }}
-        {{- if or (eq .Values.provider "azure") (eq .Values.provider "azure-private-dns") }}
+        {{- if or (eq .Values.provider "azure") }}
         # Azure volume(s)
         - name: azure-config-file
           {{- if or .Values.azure.secretName (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId) }}

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -133,11 +133,13 @@ spec:
             {{- if and (kindIs "bool" .Values.aws.evaluateTargetHealth) (not .Values.aws.evaluateTargetHealth) }}
             - --no-aws-evaluate-target-health
             {{- end }}
-            {{- if or (eq .Values.provider "azure") (eq .Values.provider "azure-private-dns") }}
+            {{- if or (and (eq .Values.provider "azure") (not .Values.azure.secretName)) (eq .Values.provider "azure-private-dns") }}
             # Azure Arguments
             {{- if .Values.azure.resourceGroup }}
             - --azure-resource-group={{ .Values.azure.resourceGroup }}
             {{- end }}
+            {{- end }}
+            {{- if eq .Values.provider "azure-private-dns" }}
             {{- if .Values.azure.subscriptionId }}
             - --azure-subscription-id={{ .Values.azure.subscriptionId }}
             {{- end }}
@@ -225,7 +227,7 @@ spec:
             - name: AZURE_TENANT_ID
               value: {{ .Values.azure.tenantId }}
             {{- end }}
-            {{- if or .Values.azure.aadClientId .Values.azure.aadClientSecret }}
+            {{- if or .Values.azure.aadClientId .Values.azure.aadClientSecret .Values.azure.secretName }}
             - name: AZURE_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/bitnami/external-dns/templates/secret.yaml
+++ b/bitnami/external-dns/templates/secret.yaml
@@ -12,8 +12,13 @@ data:
   config: {{ include "external-dns.aws-config" . | b64enc | quote }}
   {{- end }}
   {{- end }}
-  {{- if eq .Values.provider "azure" }}
+  {{- if or (eq .Values.provider "azure") (eq .Values.provider "azure-private-dns") }}
+  {{- if .Values.azure.secretName }}
   azure.json: {{ include "external-dns.azure-credentials" . | b64enc | quote }}
+  {{- else }}
+  azure_aad_client_id: {{ .Values.azure.aadClientId | b64enc | quote }}
+  azure_aad_client_secret: {{ .Values.azure.aadClientSecret | b64enc | quote }}
+  {{- end }}
   {{- end }}
   {{- if eq .Values.provider "google" }}
   credentials.json: {{ .Values.google.serviceAccountKey | b64enc | quote }}

--- a/bitnami/external-dns/templates/secret.yaml
+++ b/bitnami/external-dns/templates/secret.yaml
@@ -12,13 +12,12 @@ data:
   config: {{ include "external-dns.aws-config" . | b64enc | quote }}
   {{- end }}
   {{- end }}
-  {{- if or (eq .Values.provider "azure") (eq .Values.provider "azure-private-dns") }}
-  {{- if .Values.azure.secretName }}
+  {{- if eq .Values.provider "azure" }}
   azure.json: {{ include "external-dns.azure-credentials" . | b64enc | quote }}
-  {{- else }}
+  {{- end }}
+  {{- if eq .Values.provider "azure-private-dns"}}
   azure_aad_client_id: {{ .Values.azure.aadClientId | b64enc | quote }}
   azure_aad_client_secret: {{ .Values.azure.aadClientSecret | b64enc | quote }}
-  {{- end }}
   {{- end }}
   {{- if eq .Values.provider "google" }}
   credentials.json: {{ .Values.google.serviceAccountKey | b64enc | quote }}

--- a/bitnami/external-dns/values-production.yaml
+++ b/bitnami/external-dns/values-production.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/external-dns
-  tag: 0.7.1-debian-10-r2
+  tag: 0.7.1-debian-10-r12
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/external-dns/values.yaml
+++ b/bitnami/external-dns/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/external-dns
-  tag: 0.7.1-debian-10-r2
+  tag: 0.7.1-debian-10-r12
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
**Description of the change**
* bugfix of Azure credential variables being set in plaintext environment variables in the deployment template. Store these values in a secret and reference by name & key
* combine `azure` and `azure-private-dns` provider validation & conditionals where they use the same values throughout
* add separate validation for `azure-private-dns` since it only works through env vars and not an `azure.json` configuration file

**Benefits**
* credentials that were in the clear in the deployment environment variables now reference the generated secret by name & key instead of plaintext
* expanding Helm validation for `azure` provider is now applied for the `azure-private-dns` provider where the two providers reuse the same values

**Possible drawbacks**
I'll be testing these changes against an Azure private DNS only so may need a hand validating this against public Azure DNS zones. Have not validated if there's broken compatibility with the `azure.secretName` value and its handling in the deployment template. Need to test this on a live cluster.

**Applicable issues**
  - fixes #2221 

**Additional information**
In the event that there are true semantic differences between these providers, a split is warranted in the current azure Values. Probably best to do that sooner rather than later since they are different APIs on the cloud provider and they may diverge in terms of feature set or functionality. 

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
