### PR TITLE
[bitnami/postgresql] Avoid using 'deepCopy' since it's not supported in Helm old versions

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 8.7.2
+version: 8.7.3
 appVersion: 11.7.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/bitnami/postgresql/templates/svc-read.yaml
+++ b/bitnami/postgresql/templates/svc-read.yaml
@@ -1,5 +1,10 @@
 {{- if .Values.replication.enabled }}
-{{- $service := merge (deepCopy .Values.slave.service) (deepCopy .Values.service) -}}
+{{- $serviceAnnotations := coalesce .Values.slave.service.annotations .Values.service.annotations -}}
+{{- $serviceType := coalesce .Values.slave.service.type .Values.service.type -}}
+{{- $serviceLoadBalancerIP := coalesce .Values.slave.service.loadBalancerIP .Values.service.loadBalancerIP -}}
+{{- $serviceLoadBalancerSourceRanges := coalesce .Values.slave.service.loadBalancerSourceRanges .Values.service.loadBalancerSourceRanges -}}
+{{- $serviceClusterIP := coalesce .Values.slave.service.clusterIP .Values.service.clusterIP -}}
+{{- $serviceNodePort := coalesce .Values.slave.service.nodePort .Values.service.nodePort -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -9,26 +14,26 @@ metadata:
     chart: {{ template "postgresql.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-  {{- if $service.annotations }}
-  annotations: {{- include "postgresql.tplValue" (dict "value" $service.annotations "context" $) | nindent 4 }}
+  {{- if $serviceAnnotations }}
+  annotations: {{- include "postgresql.tplValue" (dict "value" $serviceAnnotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ $service.type }}
-  {{- if and $service.loadBalancerIP (eq $service.type "LoadBalancer") }}
-  loadBalancerIP: {{ $service.loadBalancerIP }}
+  type: {{ $serviceType }}
+  {{- if and $serviceLoadBalancerIP (eq $serviceType "LoadBalancer") }}
+  loadBalancerIP: {{ $serviceLoadBalancerIP }}
   {{- end }}
-  {{- if and (eq $service.type "LoadBalancer") $service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges: {{- include "postgresql.tplValue" (dict "value" $service.loadBalancerSourceRanges "context" $) | nindent 4 }}
+  {{- if and (eq $serviceType "LoadBalancer") $serviceLoadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- include "postgresql.tplValue" (dict "value" $serviceLoadBalancerSourceRanges "context" $) | nindent 4 }}
   {{- end }}
-  {{- if and (eq $service.type "ClusterIP") $service.clusterIP }}
-  clusterIP: {{ $service.clusterIP }}
+  {{- if and (eq $serviceType "ClusterIP") $serviceClusterIP }}
+  clusterIP: {{ $serviceClusterIP }}
   {{- end }}
   ports:
     - name: tcp-postgresql
       port:  {{ template "postgresql.port" . }}
       targetPort: tcp-postgresql
-      {{- if $service.nodePort }}
-      nodePort: {{ $service.nodePort }}
+      {{- if $serviceNodePort }}
+      nodePort: {{ $serviceNodePort }}
       {{- end }}
   selector:
     app: {{ template "postgresql.name" . }}

--- a/bitnami/postgresql/templates/svc.yaml
+++ b/bitnami/postgresql/templates/svc.yaml
@@ -1,4 +1,9 @@
-{{- $service := merge (deepCopy .Values.master.service) (deepCopy .Values.service) -}}
+{{- $serviceAnnotations := coalesce .Values.master.service.annotations .Values.service.annotations -}}
+{{- $serviceType := coalesce .Values.master.service.type .Values.service.type -}}
+{{- $serviceLoadBalancerIP := coalesce .Values.master.service.loadBalancerIP .Values.service.loadBalancerIP -}}
+{{- $serviceLoadBalancerSourceRanges := coalesce .Values.master.service.loadBalancerSourceRanges .Values.service.loadBalancerSourceRanges -}}
+{{- $serviceClusterIP := coalesce .Values.master.service.clusterIP .Values.service.clusterIP -}}
+{{- $serviceNodePort := coalesce .Values.master.service.nodePort .Values.service.nodePort -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,26 +13,26 @@ metadata:
     chart: {{ template "postgresql.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-  {{- if $service.annotations }}
-  annotations: {{- include "postgresql.tplValue" (dict "value" $service.annotations "context" $) | nindent 4 }}
+  {{- if $serviceAnnotations }}
+  annotations: {{- include "postgresql.tplValue" (dict "value" $serviceAnnotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ $service.type }}
-  {{- if and $service.loadBalancerIP (eq $service.type "LoadBalancer") }}
-  loadBalancerIP: {{ $service.loadBalancerIP }}
+  type: {{ $serviceType }}
+  {{- if and $serviceLoadBalancerIP (eq $serviceType "LoadBalancer") }}
+  loadBalancerIP: {{ $serviceLoadBalancerIP }}
   {{- end }}
-  {{- if and (eq $service.type "LoadBalancer") $service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges: {{- include "postgresql.tplValue" (dict "value" $service.loadBalancerSourceRanges "context" $) | nindent 4 }}
+  {{- if and (eq $serviceType "LoadBalancer") $serviceLoadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- include "postgresql.tplValue" (dict "value" $serviceLoadBalancerSourceRanges "context" $) | nindent 4 }}
   {{- end }}
-  {{- if and (eq $service.type "ClusterIP") $service.clusterIP }}
-  clusterIP: {{ $service.clusterIP }}
+  {{- if and (eq $serviceType "ClusterIP") $serviceClusterIP }}
+  clusterIP: {{ $serviceClusterIP }}
   {{- end }}
   ports:
     - name: tcp-postgresql
       port: {{ template "postgresql.port" . }}
       targetPort: tcp-postgresql
-      {{- if $service.nodePort }}
-      nodePort: {{ $service.nodePort }}
+      {{- if $serviceNodePort }}
+      nodePort: {{ $serviceNodePort }}
       {{- end }}
   selector:
     app: {{ template "postgresql.name" . }}

--- a/bitnami/postgresql/values-production.yaml
+++ b/bitnami/postgresql/values-production.yaml
@@ -15,7 +15,7 @@ global:
 image:
   registry: docker.io
   repository: bitnami/postgresql
-  tag: 11.7.0-debian-10-r63
+  tag: 11.7.0-debian-10-r65
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -497,7 +497,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/postgres-exporter
-    tag: 0.8.0-debian-10-r70
+    tag: 0.8.0-debian-10-r72
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/postgresql/values.yaml
+++ b/bitnami/postgresql/values.yaml
@@ -15,7 +15,7 @@ global:
 image:
   registry: docker.io
   repository: bitnami/postgresql
-  tag: 11.7.0-debian-10-r63
+  tag: 11.7.0-debian-10-r65
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -503,7 +503,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/postgres-exporter
-    tag: 0.8.0-debian-10-r70
+    tag: 0.8.0-debian-10-r72
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

`deepCopy` is a function that was introduced in Helm 2.16. There are still many users using old version of Helm and we should try to avoid this kind of functions, or clearly state in the README.m that it's necessary 2.16+ to use this chart.

This PR reverts the use of this function in favor of `coalesce` that was introduced 3 years ago.

**Benefits**

Users can use Helm 2.11+

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/2266

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
