### PR TITLE
[bitnami/elasticsearch] Fix broken indentation of cronjob annotations

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: elasticsearch
-version: 11.0.16
+version: 11.0.17
 appVersion: 7.6.2
 description: A highly scalable open-source full-text search and analytics engine
 keywords:

--- a/bitnami/elasticsearch/templates/cronjob.yaml
+++ b/bitnami/elasticsearch/templates/cronjob.yaml
@@ -6,7 +6,7 @@ metadata:
   labels: {{- include "elasticsearch.labels" . | nindent 4 }}
     role: curator
   {{- if .Values.curator.cronjob.annotations }}
-  annotations: {{- toYaml .Values.curator.cronjob.annotations | indent 4 }}
+  annotations: {{- toYaml .Values.curator.cronjob.annotations | nindent 4 }}
   {{- end }}
 spec:
   schedule: "{{ .Values.curator.cronjob.schedule }}"

--- a/bitnami/elasticsearch/values-production.yaml
+++ b/bitnami/elasticsearch/values-production.yaml
@@ -19,7 +19,7 @@ global:
 image:
   registry: docker.io
   repository: bitnami/elasticsearch
-  tag: 7.6.2-debian-10-r3
+  tag: 7.6.2-debian-10-r11
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -548,7 +548,7 @@ curator:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch-curator
-    tag: 5.8.1-debian-10-r65
+    tag: 5.8.1-debian-10-r73
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -713,7 +713,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch-exporter
-    tag: 1.1.0-debian-10-r64
+    tag: 1.1.0-debian-10-r72
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -19,7 +19,7 @@ global:
 image:
   registry: docker.io
   repository: bitnami/elasticsearch
-  tag: 7.6.2-debian-10-r3
+  tag: 7.6.2-debian-10-r11
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -548,7 +548,7 @@ curator:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch-curator
-    tag: 5.8.1-debian-10-r65
+    tag: 5.8.1-debian-10-r73
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -713,7 +713,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch-exporter
-    tag: 1.1.0-debian-10-r64
+    tag: 1.1.0-debian-10-r72
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Fixes an error in the Elasticsearch curator cronjob.yaml template, which prevents user from specifying annotations for the cronjob

**Benefits**

Allows user to annotate his cronjobs

**Possible drawbacks**

None

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
