### PR TITLE
[bitnami/nginx] Provide mechanisms to mount a custom static site

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx
-version: 5.1.15
+version: 5.2.0
 appVersion: 1.17.10
 description: Chart for the nginx server
 keywords:

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -49,58 +49,70 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the NGINX Open Source chart and their default values.
 
-| Parameter                              | Description                                                                                 | Default                                                      |
-| -------------------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| `global.imageRegistry`                 | Global Docker image registry                                                                | `nil`                                                        |
-| `global.imagePullSecrets`              | Global Docker registry secret names as an array                                             | `[]` (does not add image pull secrets to deployed pods)      |
-| `image.registry`                       | NGINX image registry                                                                        | `docker.io`                                                  |
-| `image.repository`                     | NGINX Image name                                                                            | `bitnami/nginx`                                              |
-| `image.tag`                            | NGINX Image tag                                                                             | `{TAG_NAME}`                                                 |
-| `image.pullPolicy`                     | NGINX image pull policy                                                                     | `IfNotPresent`                                               |
-| `image.pullSecrets`                    | Specify docker-registry secret names as an array                                            | `[]` (does not add image pull secrets to deployed pods)      |
-| `nameOverride`                         | String to partially override nginx.fullname template                                        | `nil`                                                        |
-| `fullnameOverride`                     | String to fully override nginx.fullname template                                            | `nil`                                                        |
-| `serverBlock`                          | Custom NGINX server block                                                                   | `nil`                                                        |
-| `replicaCount`                         | Number of replicas to deploy                                                                | `1`                                                          |
-| `podAnnotations`                       | Pod annotations                                                                             | `{}`                                                         |
-| `affinity`                             | Map of node/pod affinities                                                                  | `{}` (The value is evaluated as a template)                  |
-| `nodeSelector`                         | Node labels for pod assignment                                                              | `{}` (The value is evaluated as a template)                  |
-| `tolerations`                          | Tolerations for pod assignment                                                              | `[]` (The value is evaluated as a template)                  |
-| `resources`                            | Resource requests/limit                                                                     | `{}`                                                         |
-| `livenessProbe`                        | Deployment Liveness Probe                                                                   | See `values.yaml`                                            |
-| `readinessProbe`                       | Deployment Readiness Probe                                                                  | See `values.yaml`                                            |
-| `service.type`                         | Kubernetes Service type                                                                     | `LoadBalancer`                                               |
-| `service.port`                         | Service HTTP port                                                                           | `80`                                                         |
-| `service.httpsPort`                    | Service HTTPS port                                                                          | `443`                                                        |
-| `service.nodePorts.http`               | Kubernetes http node port                                                                   | `""`                                                         |
-| `service.nodePorts.https`              | Kubernetes https node port                                                                  | `""`                                                         |
-| `service.externalTrafficPolicy`        | Enable client source IP preservation                                                        | `Cluster`                                                    |
-| `service.loadBalancerIP`               | LoadBalancer service IP address                                                             | `""`                                                         |
-| `service.annotations`                  | Service annotations                                                                         | `{}`                                                         |
-| `ingress.enabled`                      | Enable ingress controller resource                                                          | `false`                                                      |
-| `ingress.certManager`                  | Add annotations for cert-manager                                                            | `false`                                                      |
-| `ingress.selectors`                    | Ingress selectors for labelSelector option                                                  | `[]`                                                         |
-| `ingress.annotations`                  | Ingress annotations                                                                         | `[]`                                                         |
-| `ingress.hosts[0].name`                | Hostname to your NGINX installation                                                         | `nginx.local`                                                |
-| `ingress.hosts[0].path`                | Path within the url structure                                                               | `/`                                                          |
-| `ingress.tls[0].hosts[0]`              | TLS hosts                                                                                   | `nginx.local`                                                |
-| `ingress.tls[0].secretName`            | TLS Secret (certificates)                                                                   | `nginx.local-tls`                                            |
-| `ingress.secrets[0].name`              | TLS Secret Name                                                                             | `nil`                                                        |
-| `ingress.secrets[0].certificate`       | TLS Secret Certificate                                                                      | `nil`                                                        |
-| `ingress.secrets[0].key`               | TLS Secret Key                                                                              | `nil`                                                        |
-| `metrics.enabled`                      | Start a side-car prometheus exporter                                                        | `false`                                                      |
-| `metrics.image.registry`               | NGINX Prometheus exporter image registry                                                    | `docker.io`                                                  |
-| `metrics.image.repository`             | NGINX Prometheus exporter image name                                                        | `bitnami/nginx-exporter`                                     |
-| `metrics.image.tag`                    | NGINX Prometheus exporter image tag                                                         | `{TAG_NAME}`                                                 |
-| `metrics.image.pullPolicy`             | NGINX Prometheus exporter image pull policy                                                 | `IfNotPresent`                                               |
-| `metrics.image.pullSecrets`            | Specify docker-registry secret names as an array                                            | `[]` (does not add image pull secrets to deployed pods)      |
-| `metrics.podAnnotations`               | Additional annotations for NGINX Prometheus exporter pod(s)                                 | `{prometheus.io/scrape: "true", prometheus.io/port: "9113"}` |
-| `metrics.resources`                    | NGINX Prometheus exporter resource requests/limit                                           | `{}`                                                         |
-| `metrics.serviceMonitor.enabled`       | Creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`) | `false`                                                      |
-| `metrics.serviceMonitor.namespace`     | Namespace in which Prometheus is running                                                    | `nil`                                                        |
-| `metrics.serviceMonitor.interval`      | Interval at which metrics should be scraped.                                                | `nil` (Prometheus Operator default value)                    |
-| `metrics.serviceMonitor.scrapeTimeout` | Timeout after which the scrape is ended                                                     | `nil` (Prometheus Operator default value)                    |
-| `metrics.serviceMonitor.selector`      | Prometheus instance selector labels                                                         | `nil`                                                        |
+| Parameter                                  | Description                                                                                 | Default                                                      |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `global.imageRegistry`                     | Global Docker image registry                                                                | `nil`                                                        |
+| `global.imagePullSecrets`                  | Global Docker registry secret names as an array                                             | `[]` (does not add image pull secrets to deployed pods)      |
+| `image.registry`                           | NGINX image registry                                                                        | `docker.io`                                                  |
+| `image.repository`                         | NGINX Image name                                                                            | `bitnami/nginx`                                              |
+| `image.tag`                                | NGINX Image tag                                                                             | `{TAG_NAME}`                                                 |
+| `image.pullPolicy`                         | NGINX image pull policy                                                                     | `IfNotPresent`                                               |
+| `image.pullSecrets`                        | Specify docker-registry secret names as an array                                            | `[]` (does not add image pull secrets to deployed pods)      |
+| `nameOverride`                             | String to partially override nginx.fullname template                                        | `nil`                                                        |
+| `fullnameOverride`                         | String to fully override nginx.fullname template                                            | `nil`                                                        |
+| `staticSiteConfigmap`                      | Name of existing ConfigMap with the server static content                                   | `nil`                                                        |
+| `staticSitePVC`                            | Name of existing PVC with the server static content                                         | `nil`                                                        |
+| `cloneStaticSiteFromGit.enabled`           | Get the server static content from a git repository                                         | `false`                                                      |
+| `cloneStaticSiteFromGit.image.registry`    | Git image registry                                                                          | `docker.io`                                                  |
+| `cloneStaticSiteFromGit.image.repository`  | Git image name                                                                              | `bitnami/git`                                                |
+| `cloneStaticSiteFromGit.image.tag`         | Git image tag                                                                               | `{TAG_NAME}`                                                 |
+| `cloneStaticSiteFromGit.image.pullPolicy`  | Git image pull policy                                                                       | `Always`                                                     |
+| `cloneStaticSiteFromGit.image.pullSecrets` | Specify docker-registry secret names as an array                                            | `[]` (does not add image pull secrets to deployed pods)      |
+| `cloneStaticSiteFromGit.repository`        | Repository to clone static content from                                                     | `nil`                                                        |
+| `cloneStaticSiteFromGit.branch`            | Branch inside the git repository                                                            | `nil`                                                        |
+| `cloneStaticSiteFromGit.interval`          | Interval for sidecar container pull from the repository                                     | `60`                                                         |
+| `serverBlock`                              | Custom NGINX server block                                                                   | `nil`                                                        |
+| `existingServerBlockConfigmap`             | Name of existing PVC with custom NGINX server block                                         | `nil`                                                        |
+| `replicaCount`                             | Number of replicas to deploy                                                                | `1`                                                          |
+| `podAnnotations`                           | Pod annotations                                                                             | `{}`                                                         |
+| `affinity`                                 | Map of node/pod affinities                                                                  | `{}` (The value is evaluated as a template)                  |
+| `nodeSelector`                             | Node labels for pod assignment                                                              | `{}` (The value is evaluated as a template)                  |
+| `tolerations`                              | Tolerations for pod assignment                                                              | `[]` (The value is evaluated as a template)                  |
+| `resources`                                | Resource requests/limit                                                                     | `{}`                                                         |
+| `livenessProbe`                            | Deployment Liveness Probe                                                                   | See `values.yaml`                                            |
+| `readinessProbe`                           | Deployment Readiness Probe                                                                  | See `values.yaml`                                            |
+| `service.type`                             | Kubernetes Service type                                                                     | `LoadBalancer`                                               |
+| `service.port`                             | Service HTTP port                                                                           | `80`                                                         |
+| `service.httpsPort`                        | Service HTTPS port                                                                          | `443`                                                        |
+| `service.nodePorts.http`                   | Kubernetes http node port                                                                   | `""`                                                         |
+| `service.nodePorts.https`                  | Kubernetes https node port                                                                  | `""`                                                         |
+| `service.externalTrafficPolicy`            | Enable client source IP preservation                                                        | `Cluster`                                                    |
+| `service.loadBalancerIP`                   | LoadBalancer service IP address                                                             | `""`                                                         |
+| `service.annotations`                      | Service annotations                                                                         | `{}`                                                         |
+| `ingress.enabled`                          | Enable ingress controller resource                                                          | `false`                                                      |
+| `ingress.certManager`                      | Add annotations for cert-manager                                                            | `false`                                                      |
+| `ingress.selectors`                        | Ingress selectors for labelSelector option                                                  | `[]`                                                         |
+| `ingress.annotations`                      | Ingress annotations                                                                         | `[]`                                                         |
+| `ingress.hosts[0].name`                    | Hostname to your NGINX installation                                                         | `nginx.local`                                                |
+| `ingress.hosts[0].path`                    | Path within the url structure                                                               | `/`                                                          |
+| `ingress.tls[0].hosts[0]`                  | TLS hosts                                                                                   | `nginx.local`                                                |
+| `ingress.tls[0].secretName`                | TLS Secret (certificates)                                                                   | `nginx.local-tls`                                            |
+| `ingress.secrets[0].name`                  | TLS Secret Name                                                                             | `nil`                                                        |
+| `ingress.secrets[0].certificate`           | TLS Secret Certificate                                                                      | `nil`                                                        |
+| `ingress.secrets[0].key`                   | TLS Secret Key                                                                              | `nil`                                                        |
+| `metrics.enabled`                          | Start a side-car prometheus exporter                                                        | `false`                                                      |
+| `metrics.image.registry`                   | NGINX Prometheus exporter image registry                                                    | `docker.io`                                                  |
+| `metrics.image.repository`                 | NGINX Prometheus exporter image name                                                        | `bitnami/nginx-exporter`                                     |
+| `metrics.image.tag`                        | NGINX Prometheus exporter image tag                                                         | `{TAG_NAME}`                                                 |
+| `metrics.image.pullPolicy`                 | NGINX Prometheus exporter image pull policy                                                 | `IfNotPresent`                                               |
+| `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                                            | `[]` (does not add image pull secrets to deployed pods)      |
+| `metrics.podAnnotations`                   | Additional annotations for NGINX Prometheus exporter pod(s)                                 | `{prometheus.io/scrape: "true", prometheus.io/port: "9113"}` |
+| `metrics.resources`                        | NGINX Prometheus exporter resource requests/limit                                           | `{}`                                                         |
+| `metrics.serviceMonitor.enabled`           | Creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`) | `false`                                                      |
+| `metrics.serviceMonitor.namespace`         | Namespace in which Prometheus is running                                                    | `nil`                                                        |
+| `metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped.                                                | `nil` (Prometheus Operator default value)                    |
+| `metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                                     | `nil` (Prometheus Operator default value)                    |
+| `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                         | `nil`                                                        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -128,12 +140,27 @@ It is strongly recommended to use immutable tags in a production environment. Th
 
 Bitnami will release a new chart updating its containers if a new version of the main container, significant changes, or critical vulnerabilities exist.
 
+### Deploying your custom web application
+
+The NGINX chart allows you to deploy a custom web application using one of the following methods:
+
+- Cloning from a git repository: Set `cloneStaticSiteFromGit.enabled` to `true` and set the repository and branch using the `cloneStaticSiteFromGit.repository` and  `cloneStaticSiteFromGit.branch` parameters. A sidecar will also pull the latest changes in an interval set by `cloneStaticSitesFromGit.interval`.
+- Providing a ConfigMap: Set the `staticSiteConfigMap` value to mount a ConfigMap in the NGINX html folder.
+- Using an existing PVC: Set the `staticSitePVC` value to mount an PersistentVolumeClaim with the static site content.
+
+You can deploy a example web application using git deploying the chart with the following parameters:
+
+```console
+cloneStaticSiteFromGit.enabled=true
+cloneStaticSiteFromGit.repository=https://github.com/mdn/beginner-html-site-styled.git
+cloneStaticSiteFromGit.branch=master
+```
+
 ### Providing a custom server block
 
-You can use the `serverBlock` value to provide a custom server block for NGINX to use.
-To do this, create a values files with your server block and install the chart using it:
+This helm chart supports using custom custom server block for NGINX to use.
 
-_custom-server-block.yaml_
+You can use the `serverBlock` value to provide a custom server block for NGINX to use. To do this, create a values files with your server block and install the chart using it:
 
 ```yaml
 serverBlock: |-
@@ -146,6 +173,8 @@ serverBlock: |-
 ```
 
 > Warning: The above example is not compatible with enabling Prometheus metrics since it affects the `/status` endpoint.
+
+In addition, you can also set an external ConfigMap with the configuration file. This is done by setting the `existingServerBlockConfigmap` parameter. Note that this will override the previous option.
 
 ## Upgrading
 

--- a/bitnami/nginx/templates/NOTES.txt
+++ b/bitnami/nginx/templates/NOTES.txt
@@ -35,9 +35,5 @@ Get the NGINX URL:
 
 {{- end }}
 
-{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
-
-WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
-+info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
-
-{{- end }}
+{{- include "nginx.validateValues" . }}
+{{- include "nginx.checkRollingTags" . }}

--- a/bitnami/nginx/templates/_helpers.tpl
+++ b/bitnami/nginx/templates/_helpers.tpl
@@ -182,7 +182,6 @@ Return true if a static site should be mounted in the NGINX container
 {{- define "nginx.useStaticSite" -}}
 {{- if or .Values.cloneStaticSiteFromGit.enabled .Values.staticSiteConfigmap .Values.staticSitePVC }}
     {- true -}}
-{{- else -}}
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/nginx/templates/_helpers.tpl
+++ b/bitnami/nginx/templates/_helpers.tpl
@@ -72,6 +72,29 @@ Also, we can't use a single if because lazy evaluation is not an option
 {{- end -}}
 
 {{/*
+Return the proper Git image name
+*/}}
+{{- define "cloneStaticSiteFromGit.image" -}}
+{{- $registryName := .Values.cloneStaticSiteFromGit.image.registry -}}
+{{- $repositoryName := .Values.cloneStaticSiteFromGit.image.repository -}}
+{{- $tag := .Values.cloneStaticSiteFromGit.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the proper image name (for the metrics image)
 */}}
 {{- define "nginx.metrics.image" -}}
@@ -109,23 +132,83 @@ imagePullSecrets:
 {{- range .Values.global.imagePullSecrets }}
   - name: {{ . }}
 {{- end }}
-{{- else if or .Values.image.pullSecrets .Values.metrics.image.pullSecrets }}
+{{- else if or .Values.image.pullSecrets .Values.metrics.image.pullSecrets .Values.cloneStaticSiteFromGit.image.pullSecrets }}
 imagePullSecrets:
 {{- range .Values.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.cloneStaticSiteFromGit.image.pullSecrets }}
   - name: {{ . }}
 {{- end }}
 {{- range .Values.metrics.image.pullSecrets }}
   - name: {{ . }}
 {{- end }}
 {{- end -}}
-{{- else if or .Values.image.pullSecrets .Values.metrics.image.pullSecrets }}
+{{- else if or .Values.image.pullSecrets .Values.metrics.image.pullSecrets .Values.cloneStaticSiteFromGit.image.pullSecrets }}
 imagePullSecrets:
 {{- range .Values.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.cloneStaticSiteFromGit.image.pullSecrets }}
   - name: {{ . }}
 {{- end }}
 {{- range .Values.metrics.image.pullSecrets }}
   - name: {{ . }}
 {{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Check if there are rolling tags in the images
+*/}}
+{{- define "nginx.checkRollingTags" -}}
+{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
+WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
++info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
+{{- end }}
+{{- if and (contains "bitnami/" .Values.cloneStaticSiteFromGit.image.repository) (not (.Values.cloneStaticSiteFromGit.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
+WARNING: Rolling tag detected ({{ .Values.cloneStaticSiteFromGit.image.repository }}:{{ .Values.cloneStaticSiteFromGit.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
++info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
+{{- end }}
+{{- if and (contains "bitnami/" .Values.metrics.image.repository) (not (.Values.metrics.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
+WARNING: Rolling tag detected ({{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
++info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
+{{- end }}
+{{- end -}}
+
+{{/*
+Return true if a static site should be mounted in the NGINX container
+*/}}
+{{- define "nginx.useStaticSite" -}}
+{{- if or .Values.cloneStaticSiteFromGit.enabled .Values.staticSiteConfigmap .Values.staticSitePVC }}
+    {- true -}}
+{{- else -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the volume to use to mount the static site in the NGINX container
+*/}}
+{{- define "nginx.staticSiteVolume" -}}
+{{- if .Values.cloneStaticSiteFromGit.enabled }}
+emptyDir: {}
+{{- else if .Values.staticSiteConfigmap }}
+configMap:
+  name: {{ .Values.staticSiteConfigmap }}
+{{- else if .Values.staticSitePVC }}
+persistentVolumeClaim:
+  claimName: {{ .Values.staticSitePVC }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Return the custom NGINX server block configmap.
+*/}}
+{{- define "nginx.serverBlockConfigmapName" -}}
+{{- if .Values.existingServerBlockConfigmap -}}
+    {{- printf "%s" (tpl .Values.existingServerBlockConfigmap $) -}}
+{{- else -}}
+    {{- printf "%s-server-block" (include "nginx.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 
@@ -140,4 +223,27 @@ Usage:
     {{- else }}
         {{- tpl (.value | toYaml) .context }}
     {{- end }}
+{{- end -}}
+
+{{/*
+Compile all warnings into a single message, and call fail.
+*/}}
+{{- define "nginx.validateValues" -}}
+{{- $messages := list -}}
+{{- $messages := append $messages (include "nginx.validateValues.cloneStaticSiteFromGit" .) -}}
+{{- $messages := without $messages "" -}}
+{{- $message := join "\n" $messages -}}
+
+{{- if $message -}}
+{{-   printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Validate values of NGINX - Clone StaticSite from Git configuration */}}
+{{- define "nginx.validateValues.cloneStaticSiteFromGit" -}}
+{{- if and .Values.cloneStaticSiteFromGit.enabled (or (not .Values.cloneStaticSiteFromGit.repository) (not .Values.cloneStaticSiteFromGit.branch)) -}}
+nginx: cloneStaticSiteFromGit
+    When enabling cloing a static site from a Git repository, both the Git repository and the Git branch must be provided.
+    Please provide them by setting the `cloneStaticSiteFromGit.repository` and `cloneStaticSiteFromGit.branch` parameters.
+{{- end -}}
 {{- end -}}

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
         {{- if and .Values.metrics.enabled .Values.metrics.podAnnotations }}
         {{- include "nginx.tplValue" ( dict "value" .Values.metrics.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
+        {{- if and .Values.serverBlock (not .Values.existingServerBlockConfigmap) }}
+        checksum/server-block-configuration: {{ include (print $.Template.BasePath "/server-block-configmap.yaml") . | sha256sum }}
+        {{- end }}
       {{- end }}
     spec:
 {{- include "nginx.imagePullSecrets" . | indent 6 }}
@@ -30,7 +33,37 @@ spec:
       {{- if .Values.tolerations }}
       tolerations: {{- include "nginx.tplValue" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.cloneStaticSiteFromGit.enabled }}
+      initContainers:
+        - name: git-clone-repository
+          image: {{ include "cloneStaticSiteFromGit.image" . }}
+          imagePullPolicy: {{ .Values.cloneStaticSiteFromGit.image.pullPolicy | quote }}
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              git clone {{ .Values.cloneStaticSiteFromGit.repository }} --branch {{ .Values.cloneStaticSiteFromGit.branch }} /app
+          volumeMounts:
+            - name: staticsite
+              mountPath: /app
       containers:
+        - name: git-repo-syncer
+          image: {{ include "cloneStaticSiteFromGit.image" . }}
+          imagePullPolicy: {{ .Values.cloneStaticSiteFromGit.image.pullPolicy | quote }}
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              while true; do
+                  cd /app && git pull origin {{ .Values.cloneStaticSiteFromGit.branch }}
+                  sleep {{ .Values.cloneStaticSiteFromGit.interval }}
+              done
+          volumeMounts:
+            - name: staticsite
+              mountPath: /app
+      {{- else }}
+      containers:
+      {{- end }}
         - name: nginx
           image: {{ template "nginx.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
@@ -46,10 +79,16 @@ spec:
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
-          {{- if .Values.serverBlock }}
+          {{- if or .Values.serverBlock .Values.existingServerBlockConfigmap (include "nginx.useStaticSite" .) }}
           volumeMounts:
+            {{- if or .Values.serverBlock .Values.existingServerBlockConfigmap }}
             - name: nginx-server-block
               mountPath: /opt/bitnami/nginx/conf/server_blocks
+            {{- end }}
+            {{- if (include "nginx.useStaticSite" .) }}
+            - name: staticsite
+              mountPath: /app
+            {{- end }}
           {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
@@ -75,9 +114,15 @@ spec:
           resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
           {{- end }}
         {{- end }}
-      {{- if .Values.serverBlock }}
+      {{- if or .Values.serverBlock .Values.existingServerBlockConfigmap (include "nginx.useStaticSite" .) }}
       volumes:
+        {{- if or .Values.serverBlock .Values.existingServerBlockConfigmap }}
         - name: nginx-server-block
           configMap:
-            name: {{ template "nginx.fullname" . }}
+            name: {{ include "nginx.serverBlockConfigmapName" . }}
+        {{- end }}
+        {{- if (include "nginx.useStaticSite" .) }}
+        - name: staticsite
+          {{- include "nginx.staticSiteVolume" . | nindent 10 }}
+        {{- end }}
       {{- end }}

--- a/bitnami/nginx/templates/server-block-configmap.yaml
+++ b/bitnami/nginx/templates/server-block-configmap.yaml
@@ -1,10 +1,10 @@
-{{- if .Values.serverBlock -}}
+{{- if and .Values.serverBlock (not .Values.existingServerBlockConfigmap) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "nginx.fullname" . }}
+  name: {{ template "nginx.fullname" . }}-server-block
   labels: {{- include "nginx.labels" . | nindent 4 }}
 data:
   server-block.conf: |-
 {{ .Values.serverBlock | indent 4 }}
-{{- end -}}
+{{- end }}

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/nginx
-  tag: 1.17.10-debian-10-r0
+  tag: 1.17.10-debian-10-r1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -257,7 +257,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/nginx-exporter
-    tag: 0.6.0-debian-10-r55
+    tag: 0.6.0-debian-10-r56
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -34,6 +34,48 @@ image:
 ##
 # fullnameOverride:
 
+## Name of existing ConfigMap with the server static site content
+##
+# staticSiteConfigmap
+
+## Name of existing PVC with the server static site content
+## NOTE: This will override staticSiteConfigmap
+##
+# staticSitePVC
+
+## Get the server static content from a git repository
+## NOTE: This will override staticSiteConfigmap and staticSitePVC
+##
+cloneStaticSiteFromGit:
+  enabled: false
+  ## Bitnami Git image version
+  ## ref: https://hub.docker.com/r/bitnami/git/tags/
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/git
+    tag: 2.26.0-debian-10-r18
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+  ## Repository to clone static content from
+  ##
+  # repository:
+  ## Branch inside the git repository	 
+  ##
+  # branch:
+  ## Interval for sidecar container pull from the repository
+  ##
+  interval: 60
+
 ## Custom server block to be added to NGINX configuration
 ## PHP-FPM example server block:
 ## serverBlock: |-
@@ -51,6 +93,11 @@ image:
 ##   }
 ##
 # serverBlock:
+
+## ConfigMap with custom server block to be added to NGINX configuration
+## NOTE: This will override serverBlock
+##
+# existingServerBlockConfigmap:
 
 ## Number of replicas to deploy
 ##


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

This PR adds several mechanisms to mount a custom static site to NGINX.

**Benefits**

User have a way to automatically server a custom static site using the NGXIN chart.

**Possible drawbacks**

None

**Applicable issues**

- fixes https://github.com/bitnami/charts/issues/2301

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

