### PR TITLE
[bitnami/consul] fix: indention of consul parameter localConfig

### DIFF
--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: consul
-version: 7.0.8
+version: 7.0.9
 appVersion: 1.7.2
 description: Highly available and distributed service discovery and key-value store designed with support for the modern data center to make distributed systems and configuration easy.
 home: https://www.consul.io/

--- a/bitnami/consul/templates/statefulset.yaml
+++ b/bitnami/consul/templates/statefulset.yaml
@@ -115,7 +115,8 @@ spec:
             {{- end }}
             {{- if .Values.localConfig }}
             - name: CONSUL_LOCAL_CONFIG
-              value: |- {{- .Values.localConfig | nindent 12 }}
+              value: |-
+                {{- .Values.localConfig | nindent 16 }}
             {{- end }}
             - name: CONSUL_UI
               value: "{{ .Values.ui.service.enabled }}"

--- a/bitnami/consul/values-production.yaml
+++ b/bitnami/consul/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/consul
-  tag: 1.7.2-debian-10-r9
+  tag: 1.7.2-debian-10-r29
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -330,7 +330,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/consul-exporter
-    tag: 0.6.0-debian-10-r57
+    tag: 0.6.0-debian-10-r77
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/consul/values.yaml
+++ b/bitnami/consul/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/consul
-  tag: 1.7.2-debian-10-r9
+  tag: 1.7.2-debian-10-r29
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -330,7 +330,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/consul-exporter
-    tag: 0.6.0-debian-10-r57
+    tag: 0.6.0-debian-10-r77
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**

This PR fixes the indention of the localConfig parameter as it is not working as expected using the documented config variable:

The chart is currently templating the following:

**input tests**
```yaml
# test1 as described in values.yaml
localConfig: |-
  {
    "disable_host_node_id": "true"
  }

# test2
localConfig: '{ "disable_host_node_id": "true" }'
```

**outputs**
```yaml

# test 1
            - name: CONSUL_LOCAL_CONFIG
              value: |-
            {
              "disable_host_node_id": "true"
            }

# test 2
            - name: CONSUL_LOCAL_CONFIG
              value: |-
            { "disable_host_node_id": "true" }
```
**Benefits**

localConfig can be used

**Possible drawbacks**

If someone managed to work around the issue, it will possibly break.

**Applicable issues**


**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
