### PR TITLE
[bitnami/redis-cluster] Fix metrics loadBalancerIP spacing

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis-cluster
-version: 2.0.3
+version: 2.0.4
 appVersion: 5.0.8
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/bitnami/redis-cluster/templates/metrics-svc.yaml
+++ b/bitnami/redis-cluster/templates/metrics-svc.yaml
@@ -13,10 +13,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.metrics.service.type }}
-  {{- if eq .Values.metrics.service.type "LoadBalancer" }} {{ if .Values.metrics.service.loadBalancerIP }}
+  {{- if and (eq .Values.metrics.service.type "LoadBalancer") .Values.metrics.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.metrics.service.loadBalancerIP }}
-  {{ end -}}
-  {{- end -}}
+  {{- end }}
   ports:
     - name: metrics
       port: 9121

--- a/bitnami/redis-cluster/values-production.yaml
+++ b/bitnami/redis-cluster/values-production.yaml
@@ -18,7 +18,7 @@ image:
   ## Bitnami Redis image tag
   ## ref: https://github.com/bitnami/bitnami-docker-redis#supported-tags-and-respective-dockerfile-links
   ##
-  tag: 5.0.8-debian-10-r6
+  tag: 5.0.8-debian-10-r9
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -305,7 +305,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/redis-exporter
-    tag: 1.5.3-debian-10-r2
+    tag: 1.5.3-debian-10-r5
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/redis-cluster/values.yaml
+++ b/bitnami/redis-cluster/values.yaml
@@ -18,7 +18,7 @@ image:
   ## Bitnami Redis image tag
   ## ref: https://github.com/bitnami/bitnami-docker-redis#supported-tags-and-respective-dockerfile-links
   ##
-  tag: 5.0.8-debian-10-r6
+  tag: 5.0.8-debian-10-r9
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -305,7 +305,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/redis-exporter
-    tag: 1.5.3-debian-10-r2
+    tag: 1.5.3-debian-10-r5
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Fix the spacing of `loadBalancerIP` and condensed the logic a bit. Before, setting the `metrics.enabled` would produce an error message like:

`Error: YAML parse error on redis-cluster/templates/metrics-svc.yaml: error converting YAML to JSON: yaml: line 14: mapping values are not allowed in this context`

and output like:

```yaml
# Source: redis-cluster/templates/metrics-svc.yaml

apiVersion: v1
kind: Service
metadata:
  name: redis-redis-cluster-metrics
  labels:
    app.kubernetes.io/name: redis-cluster
    helm.sh/chart: redis-cluster-2.0.1
    app.kubernetes.io/instance: redis
    app.kubernetes.io/managed-by: Tiller  
spec:
  type: ClusterIPports: # NOTE: see the squashing of these keys
    - name: metrics
      port: 9121
      targetPort: http-metrics
  selector:
    app.kubernetes.io/name: redis-cluster
    app.kubernetes.io/instance: redis
```

**Benefits**

Metrics service can now be enabled.

**Possible drawbacks**

None, fully backward compatible.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
N/A

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
