### PR TITLE
[bitnami/common] add secrets and warnings helpers

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: common
-version: 0.1.1
+version: 0.2.0
 appVersion: 0.1.0
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 keywords:

--- a/bitnami/common/README.md
+++ b/bitnami/common/README.md
@@ -40,38 +40,49 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 The following table lists the helpers available in the library which are scoped in different sections.
 
 **Names**
-| Helper identifier                           | Description                                                | Expected Input                                                                                                                                           |
-|---------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `common.names.name`                         | Expand the name of the chart or use `.Values.nameOverride` | `.` Chart context                                                                                                                                        |
-| `common.names.fullname`                     | Create a default fully qualified app name.                 | `.` Chart context                                                                                                                                        |
-| `common.names.chart`                        | Chart name plus version                                    | `.` Chart context                                                                                                                                        |
+| Helper identifier                           | Description                                                | Expected Input                                                                                                                                                 |
+|---------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `common.names.name`                         | Expand the name of the chart or use `.Values.nameOverride` | `.` Chart context                                                                                                                                              |
+| `common.names.fullname`                     | Create a default fully qualified app name.                 | `.` Chart context                                                                                                                                              |
+| `common.names.chart`                        | Chart name plus version                                    | `.` Chart context                                                                                                                                              |
 
 **Images**
-| Helper identifier                           | Description                                                | Expected Input                                                                                                                                           |
-|---------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `common.images.image`                       | Return the proper and full image name                      | `dict "imageRoot" .Values.path.to.the.image "global" $`, see [ImageRoot](#imageRoot) for the structure.                                                  |
-| `common.images.pullSecrets`                 | Return the proper Docker Image Registry Secret Names       | `dict "images" (list .Values.path.to.the.image1, .Values.path.to.the.image2) "global" $`                                                                 |
+| Helper identifier                           | Description                                                | Expected Input                                                                                                                                                 |
+|---------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `common.images.image`                       | Return the proper and full image name                      | `dict "imageRoot" .Values.path.to.the.image "global" $`, see [ImageRoot](#imageroot) for the structure.                                                        |
+| `common.images.pullSecrets`                 | Return the proper Docker Image Registry Secret Names       | `dict "images" (list .Values.path.to.the.image1, .Values.path.to.the.image2) "global" $`                                                                       |
 
 **Labels**
-| Helper identifier                           | Description                                                | Expected Input                                                                                                                                           |
-|---------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `common.labels.standard`                    | Return Kubernetes standard labels                          | `.` Chart context                                                                                                                                        |
-| `common.labels.matchLabels`                 | Return the proper Docker Image Registry Secret Names       | `.` Chart context                                                                                                                                        |
+| Helper identifier                           | Description                                                | Expected Input                                                                                                                                                 |
+|---------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `common.labels.standard`                    | Return Kubernetes standard labels                          | `.` Chart context                                                                                                                                              |
+| `common.labels.matchLabels`                 | Return the proper Docker Image Registry Secret Names       | `.` Chart context                                                                                                                                              |
 
 **Storage**
-| Helper identifier                           | Description                                                | Expected Input                                                                                                                                           |
-|---------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `common.storage.class`                      | Return the proper Storage Class                            | `dict "persistence" .Values.path.to.the.persistence "global" $`, see [Persistence](#persistence) for the structure.                                      |
+| Helper identifier                           | Description                                                | Expected Input                                                                                                                                                 |
+|---------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `common.storage.class`                      | Return the proper Storage Class                            | `dict "persistence" .Values.path.to.the.persistence "global" $`, see [Persistence](#persistence) for the structure.                                            |
 
 **TplValues**
-| Helper identifier                           | Description                                                | Expected Input                                                                                                                                           |
-|---------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `common.tplvalues.render`                   | Renders a value that contains template                     | `dict "value" .Values.path.to.the.Value "context" $`, value is the value should rendered as template, context frecuently is the chart context `$` or `.` |
+| Helper identifier                           | Description                                                | Expected Input                                                                                                                                                 |
+|---------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `common.tplvalues.render`                   | Renders a value that contains template                     | `dict "value" .Values.path.to.the.Value "context" $`, value is the value should rendered as template, context frecuently is the chart context `$` or `.`       |
 
 **Capabilities**
-| Helper identifier                           | Description                                                | Expected Input                                                                                                                                           |
-|---------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `common.capabilities.deployment.apiVersion` | Return the appropriate apiVersion for deployment.          | `.` Chart context                                                                                                                                        |
+| Helper identifier                           | Description                                                | Expected Input                                                                                                                                                 |
+|---------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `common.capabilities.deployment.apiVersion` | Return the appropriate apiVersion for deployment.          | `.` Chart context                                                                                                                                              |
+
+**Warnings**
+| Helper identifier                           | Description                                                | Expected Input                                                                                                                                                 |
+|---------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `common.warnings.rollingTag`                | Warning about using rolling tag.                           | `ImageRoot` see [ImageRoot](#imageroot) for the structure.                                                                                                     |
+
+**Secrets**
+| Helper identifier                           | Description                                                | Expected Input                                                                                                                                                 |
+|---------------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `common.secrets.name`                       | Generate the name of the secret.                           | `dict "existingSecret" .Values.path.to.the.existingSecret "defaultNameSuffix" "mySuffix" "context" $` see [ExistingSecret](#existingsecret) for the structure. |
+| `common.secrets.key`                        | Generate secret key.                                       | `dict "existingSecret" .Values.path.to.the.existingSecret "key" "keyName"` see [ExistingSecret](#existingsecret) for the structure.                            |
 
 ## Special input schemas
 
@@ -150,6 +161,22 @@ path:
 # accessMode: ReadWriteOnce
 # size: 8Gi
 # path: /bitnami
+```
+
+### ExistingSecret
+```yaml
+name:
+  type: string
+  description: Name of the existing secret.
+  example: mySecret
+keyMapping:
+  description: Mapping between the expected key name and the name of the key in the existing secret.
+  type: object
+
+## An instance would be:
+# name: mySecret
+# keyMapping:
+#   password: myPasswordKey
 ```
 
 ## Notable changes

--- a/bitnami/common/README.md
+++ b/bitnami/common/README.md
@@ -179,6 +179,41 @@ keyMapping:
 #   password: myPasswordKey
 ```
 
+**Example of use**
+
+When we store sensitive data for a deployment in a secret, some times we want to give to users the possiblity of using theirs existing secrets.
+
+```yaml
+# templates/secret.yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  labels:
+    app: {{ include "common.names.fullname" . }}
+type: Opaque
+data:
+  password: {{ .Values.password | b64enc | quote }}
+
+# templates/dpl.yaml
+---
+...
+      env:
+        - name: PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "common.secrets.name" (dict "existingSecret" .Values.existingSecret "context" $) }}
+              key: {{ include "common.secrets.key" (dict "existingSecret" .Values.existingSecret "key" "password") }}
+...
+
+# values.yaml
+---
+name: mySecret
+keyMapping:
+  password: myPasswordKey
+```
+
 ## Notable changes
 
 N/A

--- a/bitnami/common/templates/_secrets.tpl
+++ b/bitnami/common/templates/_secrets.tpl
@@ -1,0 +1,36 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Generate secret name.
+Usage:
+{{ include "common.secrets.name" (dict "existingSecret" .Values.path.to.the.existingSecret "defaultNameSuffix" "mySuffix" "context" $) }}
+Params:
+defaultNameSuffix - optional is used only if we have several secrets in the same deployment.
+*/}}
+{{- define "common.secrets.name" -}}
+{{- $name := (include "common.names.fullname" .context) -}}
+
+{{- if .defaultNameSuffix -}}
+{{- $name = cat $name .defaultNameSuffix -}}
+{{- end -}}
+
+{{- with .existingSecret -}}
+{{- $name = .name -}}
+{{- end -}}
+
+{{- printf "%s" $name -}}
+{{- end -}}
+
+{{/*
+Generate secret key.
+Usage:
+{{ include "common.secrets.key" (dict "existingSecret" .Values.path.to.the.existingSecret "key" "keyName") }}
+*/}}
+{{- define "common.secrets.key" -}}
+{{- $key := .key -}}
+
+{{- with .existingSecret -}}
+{{- $key = get .keyMapping $.key -}}
+{{- end -}}
+
+{{- printf "%s" $key -}}
+{{- end -}}

--- a/bitnami/common/templates/_secrets.tpl
+++ b/bitnami/common/templates/_secrets.tpl
@@ -1,10 +1,15 @@
 {{/* vim: set filetype=mustache: */}}
 {{/*
 Generate secret name.
+
 Usage:
 {{ include "common.secrets.name" (dict "existingSecret" .Values.path.to.the.existingSecret "defaultNameSuffix" "mySuffix" "context" $) }}
+
 Params:
-defaultNameSuffix - optional is used only if we have several secrets in the same deployment.
+  - existingSecret - ExistingSecret - Optional. The path to the existing secrets in the values.yaml given by the user
+    to be used istead of the default one. +info: https://github.com/bitnami/charts/tree/master/bitnami/common#existingsecret
+  - defaultNameSuffix - String - Optional. It is used only if we have several secrets in the same deployment.
+  - context - Dict - Required. The context for the template evaluation.
 */}}
 {{- define "common.secrets.name" -}}
 {{- $name := (include "common.names.fullname" .context) -}}
@@ -22,8 +27,14 @@ defaultNameSuffix - optional is used only if we have several secrets in the same
 
 {{/*
 Generate secret key.
+
 Usage:
 {{ include "common.secrets.key" (dict "existingSecret" .Values.path.to.the.existingSecret "key" "keyName") }}
+
+Params:
+  - existingSecret - ExistingSecret - Optional. The path to the existing secrets in the values.yaml given by the user
+    to be used istead of the default one. +info: https://github.com/bitnami/charts/tree/master/bitnami/common#existingsecret
+  - key - String - Required. Name of the key in the secret.
 */}}
 {{- define "common.secrets.key" -}}
 {{- $key := .key -}}

--- a/bitnami/common/templates/_warnings.tpl
+++ b/bitnami/common/templates/_warnings.tpl
@@ -1,0 +1,14 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Warning about using rolling tag.
+Usage:
+{{ include "common.warnings.rollingTag" .Values.path.to.the.imageRoot }}
+*/}}
+{{- define "common.warnings.rollingTag" -}}
+
+{{- if and (contains "bitnami/" .repository) (not (.tag | toString | regexFind "-r\\d+$|sha256:")) }}
+WARNING: Rolling tag detected ({{ .repository }}:{{ .tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
++info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
+{{- end }}
+
+{{- end -}}


### PR DESCRIPTION
**Description of the change**

Adding secrets and warnings helpers.

**Benefits**

We will be able to reuse some helpers for secret, existingSecrets and rolling tag warning.

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

