### PR TITLE
 [bitnami/redis bitnami/redis-cluster] Only scrape metrics from the metrics service

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis-cluster
-version: 2.0.4
+version: 2.0.2
 appVersion: 5.0.8
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis-cluster
-version: 2.0.1
+version: 2.0.4
 appVersion: 5.0.8
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/bitnami/redis-cluster/templates/metrics-prometheus.yaml
+++ b/bitnami/redis-cluster/templates/metrics-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     {{- end }}
   selector:
     matchLabels: {{- include "redis-cluster.matchLabels" . | nindent 6 }}
+    app.kubernetes.io/component: "metrics"
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/bitnami/redis-cluster/templates/metrics-svc.yaml
+++ b/bitnami/redis-cluster/templates/metrics-svc.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- if .Values.metrics.service.labels -}}
     {{- toYaml .Values.metrics.service.labels | nindent 4 }}
     {{- end -}}
+    app.kubernetes.io/component: "metrics"
   {{- if .Values.metrics.service.annotations }}
   annotations: {{- toYaml .Values.metrics.service.annotations | nindent 4 }}
   {{- end }}

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 10.6.7
+version: 10.6.9
 appVersion: 5.0.8
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 10.6.9
+version: 10.6.8
 appVersion: 5.0.8
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/bitnami/redis/templates/metrics-prometheus.yaml
+++ b/bitnami/redis/templates/metrics-prometheus.yaml
@@ -26,6 +26,7 @@ spec:
     matchLabels:
       app: {{ template "redis.name" . }}
       release: {{ .Release.Name }}
+      app.kubernetes.io/component: "metrics"
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/bitnami/redis/templates/metrics-svc.yaml
+++ b/bitnami/redis/templates/metrics-svc.yaml
@@ -9,6 +9,7 @@ metadata:
     chart: {{ template "redis.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: "metrics"
     {{- if .Values.metrics.service.labels -}}
     {{ toYaml .Values.metrics.service.labels | nindent 4 }}
     {{- end -}}

--- a/bitnami/redis/values-production.yaml
+++ b/bitnami/redis/values-production.yaml
@@ -18,7 +18,7 @@ image:
   ## Bitnami Redis image tag
   ## ref: https://github.com/bitnami/bitnami-docker-redis#supported-tags-and-respective-dockerfile-links
   ##
-  tag: 5.0.8-debian-10-r42
+  tag: 5.0.8-debian-10-r44
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -60,7 +60,7 @@ sentinel:
     ## Bitnami Redis image tag
     ## ref: https://github.com/bitnami/bitnami-docker-redis-sentinel#supported-tags-and-respective-dockerfile-links
     ##
-    tag: 5.0.8-debian-10-r34
+    tag: 5.0.8-debian-10-r36
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -480,7 +480,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/redis-exporter
-    tag: 1.5.3-debian-10-r0
+    tag: 1.5.3-debian-10-r1
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -18,7 +18,7 @@ image:
   ## Bitnami Redis image tag
   ## ref: https://github.com/bitnami/bitnami-docker-redis#supported-tags-and-respective-dockerfile-links
   ##
-  tag: 5.0.8-debian-10-r42
+  tag: 5.0.8-debian-10-r44
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -60,7 +60,7 @@ sentinel:
     ## Bitnami Redis image tag
     ## ref: https://github.com/bitnami/bitnami-docker-redis-sentinel#supported-tags-and-respective-dockerfile-links
     ##
-    tag: 5.0.8-debian-10-r34
+    tag: 5.0.8-debian-10-r36
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -526,7 +526,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/redis-exporter
-    tag: 1.5.3-debian-10-r0
+    tag: 1.5.3-debian-10-r1
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

Adds the `app.kubernetes.io/component: "metrics"` label ([from K8s best practices](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/)) to the metrics service and configures the `ServiceMonitor` to select based on it.

**Benefits**

<!-- What benefits will be realized by the code change? -->
Currently, all Redis services match the labels searched for by the `ServiceMonitor`, so Prometheus tries to scrape from all of them even though only the metrics service has the correct ports. This ensures that only the metrics service is scraped. 

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
Perhaps if people were doing something with the `app.kubernetes.io/component` label in `.Values.metrics.service.labels`, there could be a conflict.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - N/A

**Additional information**

Happy to combine with the following PRs into one, if that makes things easier:
- https://github.com/bitnami/charts/pull/2348
- https://github.com/bitnami/charts/pull/2334

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
