### PR TITLE
[bitnami/kube-state-metrics] Additional relabeling options in ServiceMonitor

### DIFF
--- a/bitnami/kube-state-metrics/Chart.yaml
+++ b/bitnami/kube-state-metrics/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.9.5
 description: kube-state-metrics is a simple service that listens to the Kubernetes API server and generates metrics about the state of the objects.
 name: kube-state-metrics
-version: 0.1.19
+version: 0.1.20
 keywords:
   - prometheus
   - kube-state-metrics

--- a/bitnami/kube-state-metrics/Chart.yaml
+++ b/bitnami/kube-state-metrics/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.9.5
 description: kube-state-metrics is a simple service that listens to the Kubernetes API server and generates metrics about the state of the objects.
 name: kube-state-metrics
-version: 0.1.20
+version: 0.2.0
 keywords:
   - prometheus
   - kube-state-metrics

--- a/bitnami/kube-state-metrics/README.md
+++ b/bitnami/kube-state-metrics/README.md
@@ -133,6 +133,8 @@ The following table lists the configurable parameters of the kube-state-metrics 
 | `serviceMonitor.interval`               | Scrape interval (use by default, falling back to Prometheus' default)                                         | `nil`                                                      |
 | `serviceMonitor.jobLabel`               | The name of the label on the target service to use as the job name in prometheus.                             | `nil`                                                      |
 | `serviceMonitor.selector`               | ServiceMonitor selector labels                                                                                | `[]`                                                       |
+| `serviceMonitor.honorLabels`            | Honor metrics labels                                                                                          | `false`                                                       |
+| `serviceMonitor.relabelings`            | ServiceMonitor relabelings                                                                                    | `[]`                                                       |
 | `serviceMonitor.metricRelabelings`      | ServiceMonitor metricRelabelings                                                                              | `[]`                                                       |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example the following command sets the `replicas` of the kube-state-metrics Pods to `2`.

--- a/bitnami/kube-state-metrics/templates/servicemonitor.yaml
+++ b/bitnami/kube-state-metrics/templates/servicemonitor.yaml
@@ -24,6 +24,12 @@ spec:
       {{- if .Values.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
       {{- end }}
+      {{- if .Values.serviceMonitor.honorLabels }}
+      honorLabels: true
+      {{- end }}
+      {{- if .Values.serviceMonitor.relabelings }}
+      relabelings: {{- include "kube-state-metrics.tplValue" ( dict "value" .Values.serviceMonitor.relabelings "context" $) | nindent 8 }}
+      {{- end }}
       {{- if .Values.serviceMonitor.metricRelabelings }}
       metricRelabelings: {{- include "kube-state-metrics.tplValue" ( dict "value" .Values.serviceMonitor.metricRelabelings "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/kube-state-metrics/templates/servicemonitor.yaml
+++ b/bitnami/kube-state-metrics/templates/servicemonitor.yaml
@@ -24,8 +24,8 @@ spec:
       {{- if .Values.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
       {{- end }}
-      {{- if .Values.serviceMonitor.honorLabels }}
-      honorLabels: true
+      {{- if hasKey .Values.serviceMonitor "honorLabels" }}
+      honorLabels: {{ .Values.serviceMonitor.honorLabels }}
       {{- end }}
       {{- if .Values.serviceMonitor.relabelings }}
       relabelings: {{- include "kube-state-metrics.tplValue" ( dict "value" .Values.serviceMonitor.relabelings "context" $) | nindent 8 }}

--- a/bitnami/kube-state-metrics/values-production.yaml
+++ b/bitnami/kube-state-metrics/values-production.yaml
@@ -244,6 +244,16 @@ serviceMonitor:
   # selector:
   #   prometheus: my-prometheus
 
+  ## Honor metric labels
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+  ##
+  # honorLabels: false
+
+  ## Relabeling (before scrape)
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+  ##
+  # relabelings: []
+
   ## Metric relabeling
   ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
   ##

--- a/bitnami/kube-state-metrics/values-production.yaml
+++ b/bitnami/kube-state-metrics/values-production.yaml
@@ -51,7 +51,7 @@ serviceAccount:
 image:
   registry: docker.io
   repository: bitnami/kube-state-metrics
-  tag: 1.9.5-debian-10-r61
+  tag: 1.9.5-debian-10-r66
 
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/bitnami/kube-state-metrics/values.yaml
+++ b/bitnami/kube-state-metrics/values.yaml
@@ -244,6 +244,16 @@ serviceMonitor:
   # selector:
   #   prometheus: my-prometheus
 
+  ## Honor metric labels
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+  ##
+  # honorLabels: false
+
+  ## Relabeling (before scrape)
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+  ##
+  # relabelings: []
+
   ## Metric relabeling
   ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
   ##

--- a/bitnami/kube-state-metrics/values.yaml
+++ b/bitnami/kube-state-metrics/values.yaml
@@ -51,7 +51,7 @@ serviceAccount:
 image:
   registry: docker.io
   repository: bitnami/kube-state-metrics
-  tag: 1.9.5-debian-10-r61
+  tag: 1.9.5-debian-10-r66
 
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
**Description of the change**

Allows to set `serviceMonitor.honorLabels` and `serviceMonitor.relabelings` values to achieve additional control over metric relabeling in kube-state-metrics ServiceMonitor.
Both are disabled by default so as not to break anything that relies on current behavior.

**Benefits**

This change makes it possible to have more precise control over how metrics are relabeled and how label name conflicts (specifically those between labels from kube-state-metrics itself and labels from service discovery) are handled by Prometheus. Enabling `serviceMonitor.honorLabels`, for example, makes the [KubeGraf Grafana plugin](https://grafana.com/grafana/plugins/devopsprodigy-kubegraf-app) work out-of-the-box because it expects the `pod` and `namespace` labels to contain actual pod and namespace names.

**Possible drawbacks**

**Applicable issues**

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
