### PR TITLE
[bitnami/thanos] provide Objstore config via secret

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
-version: 0.4.4
+version: 0.5.0

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
-version: 0.4.3
+version: 0.4.4

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -100,9 +100,8 @@ The following tables lists the configurable parameters of the Thanos chart and t
 | `fullnameOverride`              | String to fully override thanos.fullname               | `nil`                                                   |
 | `clusterDomain`                 | Default Kubernetes cluster domain                      | `cluster.local`                                         |
 | `objstoreConfig`                | Objstore configuration                                 | `nil`                                                   |
-| `existingObjstoreConfigmap`     | Name of existing ConfigMap with Objstore configuration | `nil`                                                   |
-| `existingObjstoreSecret.name`   | Name of existing secret with Objstore configuration    | `nil`                                                   |
-| `existingObjstoreSecret.items`  | List of secrets keys to paths                          | `[]`                                                    |
+| `existingObjstoreSecret`        | Name of existing secret with Objstore configuration    | `nil`                                                   |
+| `existingObjstoreSecretItems`   | List of Secret Keys and Paths                          | `[]`                                                    |
 
 ### Thanos Querier parameters
 
@@ -431,7 +430,7 @@ This helm chart supports using custom Objstore configuration.
 
 You can specify the Objstore configuration using the `objstoreConfig` parameter.
 
-In addition, you can also set an external ConfigMap with the configuration file. This is done by setting the `existingObjstoreConfigmap` parameter. Note that this will override the previous option.
+In addition, you can also set an external Secret with the configuration file. This is done by setting the `existingObjstoreSecret` parameter. Note that this will override the previous option. If needed you can also provide a custom Secret Key with `existingObjstoreSecretItems`, please be aware that the Path of your Secret should be `objstore.yml`.
 
 ### Using custom Querier Service Discovery configuration
 

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -115,7 +115,7 @@ The following tables lists the configurable parameters of the Thanos chart and t
 | `querier.stores`                           | Store APIs to connect with Thanos Querier                      | `[]`                            |
 | `querier.sdConfig`                         | Service Discovery configuration                                | `nil`                           |
 | `querier.existingSDConfigmap`              | Name of existing ConfigMap with Ruler configuration            | `nil`                           |
-| `querier.extraFlags`                       | Extra Flags to passed to Thanos Compactor                      | `{}`                            |
+| `querier.extraFlags`                       | Extra Flags to passed to Thanos Querier                        | `{}`                            |
 | `querier.replicaCount`                     | Number of Thanos Querier replicas to deploy                    | `1`                             |
 | `querier.strategyType`                     | Deployment Strategy Type                                       | `RollingUpdate`                 |
 | `querier.affinity`                         | Affinity for pod assignment                                    | `{}` (evaluated as a template)  |
@@ -157,7 +157,7 @@ The following tables lists the configurable parameters of the Thanos chart and t
 | `bucketweb.logLevel`                         | Thanos Bucket Web log level                                    | `info`                         |
 | `bucketweb.refresh`                          | Refresh interval to download metadata from remote storage      | `30m`                          |
 | `bucketweb.timeout`                          | Timeout to download metadata from remote storage               | `5m`                           |
-| `bucketweb.extraFlags`                       | Extra Flags to passed to Thanos Compactor                      | `{}`                           |
+| `bucketweb.extraFlags`                       | Extra Flags to passed to Thanos Bucket Web                     | `{}`                           |
 | `bucketweb.replicaCount`                     | Number of Thanos Bucket Web replicas to deploy                 | `1`                            |
 | `bucketweb.strategyType`                     | Deployment Strategy Type                                       | `RollingUpdate`                |
 | `bucketweb.affinity`                         | Affinity for pod assignment                                    | `{}` (evaluated as a template) |

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -101,6 +101,7 @@ The following tables lists the configurable parameters of the Thanos chart and t
 | `clusterDomain`             | Default Kubernetes cluster domain                      | `cluster.local`                                         |
 | `objstoreConfig`            | Objstore configuration                                 | `nil`                                                   |
 | `existingObjstoreConfigmap` | Name of existing ConfigMap with Objstore configuration | `nil`                                                   |
+| `existingObjstoreSecret`    | Name of existing secret with Objstore configuration    | `nil`                                                   |
 
 ### Thanos Querier parameters
 

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -89,19 +89,20 @@ The following tables lists the configurable parameters of the Thanos chart and t
 
 ### Common parameters
 
-| Parameter                   | Description                                            | Default                                                 |
-|-----------------------------|--------------------------------------------------------|---------------------------------------------------------|
-| `image.registry`            | Thanos image registry                                  | `docker.io`                                             |
-| `image.repository`          | Thanos image name                                      | `bitnami/thanos`                                        |
-| `image.tag`                 | Thanos image tag                                       | `{TAG_NAME}`                                            |
-| `image.pullPolicy`          | Thanos image pull policy                               | `IfNotPresent`                                          |
-| `image.pullSecrets`         | Specify docker-registry secret names as an array       | `[]` (does not add image pull secrets to deployed pods) |
-| `nameOverride`              | String to partially override thanos.fullname           | `nil`                                                   |
-| `fullnameOverride`          | String to fully override thanos.fullname               | `nil`                                                   |
-| `clusterDomain`             | Default Kubernetes cluster domain                      | `cluster.local`                                         |
-| `objstoreConfig`            | Objstore configuration                                 | `nil`                                                   |
-| `existingObjstoreConfigmap` | Name of existing ConfigMap with Objstore configuration | `nil`                                                   |
-| `existingObjstoreSecret`    | Name of existing secret with Objstore configuration    | `nil`                                                   |
+| Parameter                       | Description                                            | Default                                                 |
+|---------------------------------|--------------------------------------------------------|---------------------------------------------------------|
+| `image.registry`                | Thanos image registry                                  | `docker.io`                                             |
+| `image.repository`              | Thanos image name                                      | `bitnami/thanos`                                        |
+| `image.tag`                     | Thanos image tag                                       | `{TAG_NAME}`                                            |
+| `image.pullPolicy`              | Thanos image pull policy                               | `IfNotPresent`                                          |
+| `image.pullSecrets`             | Specify docker-registry secret names as an array       | `[]` (does not add image pull secrets to deployed pods) |
+| `nameOverride`                  | String to partially override thanos.fullname           | `nil`                                                   |
+| `fullnameOverride`              | String to fully override thanos.fullname               | `nil`                                                   |
+| `clusterDomain`                 | Default Kubernetes cluster domain                      | `cluster.local`                                         |
+| `objstoreConfig`                | Objstore configuration                                 | `nil`                                                   |
+| `existingObjstoreConfigmap`     | Name of existing ConfigMap with Objstore configuration | `nil`                                                   |
+| `existingObjstoreSecret.name`   | Name of existing secret with Objstore configuration    | `nil`                                                   |
+| `existingObjstoreSecret.items`  | List of secrets keys to paths                          | `[]`                                                    |
 
 ### Thanos Querier parameters
 

--- a/bitnami/thanos/requirements.lock
+++ b/bitnami/thanos/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: minio
   repository: https://charts.bitnami.com/bitnami
-  version: 3.3.2
-digest: sha256:35da63f789a26ffbf9edbc40a45db4b38762cde2c276e093a7b04ccd2f725616
-generated: "2020-04-15T18:21:11.869657918Z"
+  version: 3.3.3
+digest: sha256:88c8ffe6821e60a849996561752507bd93367e211898a1a589ab12d22ac06006
+generated: "2020-04-21T11:46:26.943195571Z"

--- a/bitnami/thanos/templates/_helpers.tpl
+++ b/bitnami/thanos/templates/_helpers.tpl
@@ -144,21 +144,21 @@ imagePullSecrets:
 {{- end -}}
 
 {{/*
-Return the Thanos Objstore configuration configmap.
+Return the Thanos Objstore configuration secret.
 */}}
-{{- define "thanos.objstoreConfigmapName" -}}
-{{- if .Values.existingObjstoreConfigmap -}}
-    {{- printf "%s" (tpl .Values.existingObjstoreConfigmap $) -}}
+{{- define "thanos.objstoreSecretName" -}}
+{{- if .Values.existingObjstoreSecret -}}
+    {{- printf "%s" (tpl .Values.existingObjstoreSecret $) -}}
 {{- else -}}
-    {{- printf "%s-objstore-configmap" (include "thanos.fullname" .) -}}
+    {{- printf "%s-objstore-secret" (include "thanos.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 
 {{/*
-Return true if a configmap object should be created
+Return true if a secret object should be created
 */}}
-{{- define "thanos.createObjstoreConfigmap" -}}
-{{- if and .Values.objstoreConfig (not .Values.existingObjstoreConfigmap) }}
+{{- define "thanos.createObjstoreSecret" -}}
+{{- if and .Values.objstoreConfig (not .Values.existingObjstoreSecret) }}
     {- true -}}
 {{- else -}}
 {{- end -}}
@@ -363,15 +363,14 @@ Compile all warnings into a single message, and call fail.
 
 {{/* Validate values of Thanos - Objstore configuration */}}
 {{- define "thanos.validateValues.objstore" -}}
-{{- if and (or .Values.bucketweb.enabled .Values.compactor.enabled .Values.ruler.enabled .Values.storegateway.enabled) (not (include "thanos.createObjstoreConfigmap" .)) (not .Values.existingObjstoreConfigmap) ( not .Values.existingObjstoreSecret) -}}
+{{- if and (or .Values.bucketweb.enabled .Values.compactor.enabled .Values.ruler.enabled .Values.storegateway.enabled) (not (include "thanos.createObjstoreSecret" .)) ( not .Values.existingObjstoreSecret) -}}
 thanos: objstore configuration
     When enabling Bucket Web, Compactor, Ruler or Store Gateway component,
     you must provide a valid objstore configuration.
     There are three alternatives to provide it:
       1) Provide it using the 'objstoreConfig' parameter
-      2) Provide it using an existing Configmap and using the 'existingObjstoreConfigmap' parameter
+      2) Provide it using an existing Secret and using the 'existingObjstoreSecret' parameter
       3) Put your objstore.yml under the 'files/conf/' directory
-      4) Provide it using an existing Secret and using the 'existingObjstoreSecret' parameters
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/thanos/templates/_helpers.tpl
+++ b/bitnami/thanos/templates/_helpers.tpl
@@ -363,7 +363,7 @@ Compile all warnings into a single message, and call fail.
 
 {{/* Validate values of Thanos - Objstore configuration */}}
 {{- define "thanos.validateValues.objstore" -}}
-{{- if and (or .Values.bucketweb.enabled .Values.compactor.enabled .Values.ruler.enabled .Values.storegateway.enabled) (not (include "thanos.createObjstoreConfigmap" .)) (not .Values.existingObjstoreConfigmap) -}}
+{{- if and (or .Values.bucketweb.enabled .Values.compactor.enabled .Values.ruler.enabled .Values.storegateway.enabled) (not (include "thanos.createObjstoreConfigmap" .)) (not .Values.existingObjstoreConfigmap) ( not .Values.existingObjstoreSecret) -}}
 thanos: objstore configuration
     When enabling Bucket Web, Compactor, Ruler or Store Gateway component,
     you must provide a valid objstore configuration.

--- a/bitnami/thanos/templates/_helpers.tpl
+++ b/bitnami/thanos/templates/_helpers.tpl
@@ -371,6 +371,7 @@ thanos: objstore configuration
       1) Provide it using the 'objstoreConfig' parameter
       2) Provide it using an existing Configmap and using the 'existingObjstoreConfigmap' parameter
       3) Put your objstore.yml under the 'files/conf/' directory
+      4) Provide it using an existing Secret and using the 'existingObjstoreSecret' parameters
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/thanos/templates/bucketweb/deployment.yaml
+++ b/bitnami/thanos/templates/bucketweb/deployment.yaml
@@ -82,6 +82,11 @@ spec:
               subPath: objstore.yml
       volumes:
         - name: objstore-config
+          {{- if .Values.existingObjstoreSecret }}
+          secret:
+            secretName: {{ .Values.existingObjstoreSecret }}
+          {{- else }}
           configMap:
             name: {{ include "thanos.objstoreConfigmapName" . }}
+          {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/bucketweb/deployment.yaml
+++ b/bitnami/thanos/templates/bucketweb/deployment.yaml
@@ -78,13 +78,20 @@ spec:
           {{- end }}
           volumeMounts:
             - name: objstore-config
+              {{- if .Values.existingObjstoreSecret.items }}
+              mountPath: /conf
+              {{- else }}
               mountPath: /conf/objstore.yml
               subPath: objstore.yml
+              {{- end }}
       volumes:
         - name: objstore-config
           {{- if .Values.existingObjstoreSecret }}
           secret:
-            secretName: {{ .Values.existingObjstoreSecret }}
+            secretName: {{ .Values.existingObjstoreSecret.name }}
+            {{- if .Values.existingObjstoreSecret.items }}
+            items: {{- toYaml .Values.existingObjstoreSecret.items | nindent 14 }}
+            {{- end }}
           {{- else }}
           configMap:
             name: {{ include "thanos.objstoreConfigmapName" . }}

--- a/bitnami/thanos/templates/bucketweb/deployment.yaml
+++ b/bitnami/thanos/templates/bucketweb/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       labels: {{- include "thanos.labels" . | nindent 8 }}
         app.kubernetes.io/component: bucketweb
       annotations:
-        checksum/ojbstore-configuration: {{ include (print $.Template.BasePath "/objstore-configmap.yaml") . | sha256sum }}
+        checksum/ojbstore-configuration: {{ include (print $.Template.BasePath "/objstore-secret.yaml") . | sha256sum }}
         {{- if .Values.bucketweb.podAnnotations }}
         {{- include "thanos.tplValue" (dict "value" .Values.bucketweb.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
@@ -78,7 +78,7 @@ spec:
           {{- end }}
           volumeMounts:
             - name: objstore-config
-              {{- if .Values.existingObjstoreSecret.items }}
+              {{- if .Values.existingObjstoreSecretItems }}
               mountPath: /conf
               {{- else }}
               mountPath: /conf/objstore.yml
@@ -86,14 +86,9 @@ spec:
               {{- end }}
       volumes:
         - name: objstore-config
-          {{- if .Values.existingObjstoreSecret }}
           secret:
-            secretName: {{ .Values.existingObjstoreSecret.name }}
-            {{- if .Values.existingObjstoreSecret.items }}
-            items: {{- toYaml .Values.existingObjstoreSecret.items | nindent 14 }}
+            secretName: {{ include "thanos.objstoreSecretName" . }}
+            {{- if .Values.existingObjstoreSecretItems }}
+            items: {{- toYaml .Values.existingObjstoreSecretItems | nindent 14 }}
             {{- end }}
-          {{- else }}
-          configMap:
-            name: {{ include "thanos.objstoreConfigmapName" . }}
-          {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/compactor/deployment.yaml
+++ b/bitnami/thanos/templates/compactor/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       labels: {{- include "thanos.labels" . | nindent 8 }}
         app.kubernetes.io/component: compactor
       annotations:
-        checksum/ojbstore-configuration: {{ include (print $.Template.BasePath "/objstore-configmap.yaml") . | sha256sum }}
+        checksum/ojbstore-configuration: {{ include (print $.Template.BasePath "/objstore-secret.yaml") . | sha256sum }}
         {{- if .Values.compactor.podAnnotations }}
         {{- include "thanos.tplValue" (dict "value" .Values.compactor.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
@@ -97,7 +97,7 @@ spec:
           {{- end }}
           volumeMounts:
             - name: objstore-config
-              {{- if .Values.existingObjstoreSecret.items }}
+              {{- if .Values.existingObjstoreSecretItems }}
               mountPath: /conf
               {{- else }}
               mountPath: /conf/objstore.yml
@@ -107,16 +107,11 @@ spec:
               mountPath: /data
       volumes:
         - name: objstore-config
-          {{- if .Values.existingObjstoreSecret }}
           secret:
-            secretName: {{ .Values.existingObjstoreSecret.name }}
-            {{- if .Values.existingObjstoreSecret.items }}
-            items: {{- toYaml .Values.existingObjstoreSecret.items | nindent 14 }}
+            secretName: {{ include "thanos.objstoreSecretName" . }}
+            {{- if .Values.existingObjstoreSecretItems }}
+            items: {{- toYaml .Values.existingObjstoreSecretItems | nindent 14 }}
             {{- end }}
-          {{- else }}
-          configMap:
-            name: {{ include "thanos.objstoreConfigmapName" . }}
-          {{- end }}
         - name: data
           {{- if .Values.compactor.persistence.enabled }}
           persistentVolumeClaim:

--- a/bitnami/thanos/templates/compactor/deployment.yaml
+++ b/bitnami/thanos/templates/compactor/deployment.yaml
@@ -103,8 +103,13 @@ spec:
               mountPath: /data
       volumes:
         - name: objstore-config
+          {{- if .Values.existingObjstoreSecret }}
+          secret:
+            secretName: {{ .Values.existingObjstoreSecret }}
+          {{- else }}
           configMap:
             name: {{ include "thanos.objstoreConfigmapName" . }}
+          {{- end }}
         - name: data
           {{- if .Values.compactor.persistence.enabled }}
           persistentVolumeClaim:

--- a/bitnami/thanos/templates/compactor/deployment.yaml
+++ b/bitnami/thanos/templates/compactor/deployment.yaml
@@ -97,15 +97,22 @@ spec:
           {{- end }}
           volumeMounts:
             - name: objstore-config
+              {{- if .Values.existingObjstoreSecret.items }}
+              mountPath: /conf
+              {{- else }}
               mountPath: /conf/objstore.yml
               subPath: objstore.yml
+              {{- end }}
             - name: data
               mountPath: /data
       volumes:
         - name: objstore-config
           {{- if .Values.existingObjstoreSecret }}
           secret:
-            secretName: {{ .Values.existingObjstoreSecret }}
+            secretName: {{ .Values.existingObjstoreSecret.name }}
+            {{- if .Values.existingObjstoreSecret.items }}
+            items: {{- toYaml .Values.existingObjstoreSecret.items | nindent 14 }}
+            {{- end }}
           {{- else }}
           configMap:
             name: {{ include "thanos.objstoreConfigmapName" . }}

--- a/bitnami/thanos/templates/objstore-secret.yaml
+++ b/bitnami/thanos/templates/objstore-secret.yaml
@@ -6,5 +6,5 @@ metadata:
   labels: {{- include "thanos.labels" . | nindent 4 }}
 data:
   objstore.yml: |-
-    {{- include "thanos.tplValue" (dict "value" .Values.objstoreConfig "context" $) | nindent 4 }}
+    {{- include "thanos.tplValue" (dict "value" .Values.objstoreConfig "context" $) | b64enc | nindent 4 }}
 {{ end }}

--- a/bitnami/thanos/templates/objstore-secret.yaml
+++ b/bitnami/thanos/templates/objstore-secret.yaml
@@ -1,8 +1,8 @@
-{{- if (include "thanos.createObjstoreConfigmap" .) }}
+{{- if (include "thanos.createObjstoreSecret" .) }}
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
-  name: {{ include "thanos.fullname" . }}-objstore-configmap
+  name: {{ include "thanos.fullname" . }}-objstore-secret
   labels: {{- include "thanos.labels" . | nindent 4 }}
 data:
   objstore.yml: |-

--- a/bitnami/thanos/templates/ruler/statefulset.yaml
+++ b/bitnami/thanos/templates/ruler/statefulset.yaml
@@ -120,8 +120,12 @@ spec:
               mountPath: /conf/ruler.yml
               subPath: ruler.yml
             - name: objstore-config
+              {{- if .Values.existingObjstoreSecret.items }}
+              mountPath: /conf
+              {{- else }}
               mountPath: /conf/objstore.yml
               subPath: objstore.yml
+              {{- end }}
             - name: data
               mountPath: /data
       volumes:
@@ -131,7 +135,10 @@ spec:
         - name: objstore-config
           {{- if .Values.existingObjstoreSecret }}
           secret:
-            secretName: {{ .Values.existingObjstoreSecret }}
+            secretName: {{ .Values.existingObjstoreSecret.name }}
+            {{- if .Values.existingObjstoreSecret.items }}
+            items: {{- toYaml .Values.existingObjstoreSecret.items | nindent 14 }}
+            {{- end }}
           {{- else }}
           configMap:
             name: {{ include "thanos.objstoreConfigmapName" . }}

--- a/bitnami/thanos/templates/ruler/statefulset.yaml
+++ b/bitnami/thanos/templates/ruler/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
       labels: {{- include "thanos.labels" . | nindent 8 }}
         app.kubernetes.io/component: ruler
       annotations:
-        checksum/ojbstore-configuration: {{ include (print $.Template.BasePath "/objstore-configmap.yaml") . | sha256sum }}
+        checksum/ojbstore-configuration: {{ include (print $.Template.BasePath "/objstore-secret.yaml") . | sha256sum }}
         checksum/ruler-configuration: {{ include (print $.Template.BasePath "/ruler/configmap.yaml") . | sha256sum }}
         {{- if .Values.ruler.podAnnotations }}
         {{- include "thanos.tplValue" (dict "value" .Values.ruler.podAnnotations "context" $) | nindent 8 }}
@@ -120,7 +120,7 @@ spec:
               mountPath: /conf/ruler.yml
               subPath: ruler.yml
             - name: objstore-config
-              {{- if .Values.existingObjstoreSecret.items }}
+              {{- if .Values.existingObjstoreSecretItems }}
               mountPath: /conf
               {{- else }}
               mountPath: /conf/objstore.yml
@@ -133,16 +133,11 @@ spec:
           configMap:
             name: {{ include "thanos.ruler.configmapName" . }}
         - name: objstore-config
-          {{- if .Values.existingObjstoreSecret }}
           secret:
-            secretName: {{ .Values.existingObjstoreSecret.name }}
-            {{- if .Values.existingObjstoreSecret.items }}
-            items: {{- toYaml .Values.existingObjstoreSecret.items | nindent 14 }}
+            secretName: {{ include "thanos.objstoreSecretName" . }}
+            {{- if .Values.existingObjstoreSecretItems }}
+            items: {{- toYaml .Values.existingObjstoreSecretItems | nindent 14 }}
             {{- end }}
-          {{- else }}
-          configMap:
-            name: {{ include "thanos.objstoreConfigmapName" . }}
-          {{- end }}
   {{- if and .Values.ruler.persistence.enabled .Values.ruler.persistence.existingClaim }}
         - name: data
           persistentVolumeClaim:

--- a/bitnami/thanos/templates/ruler/statefulset.yaml
+++ b/bitnami/thanos/templates/ruler/statefulset.yaml
@@ -129,8 +129,13 @@ spec:
           configMap:
             name: {{ include "thanos.ruler.configmapName" . }}
         - name: objstore-config
+          {{- if .Values.existingObjstoreSecret }}
+          secret:
+            secretName: {{ .Values.existingObjstoreSecret }}
+          {{- else }}
           configMap:
             name: {{ include "thanos.objstoreConfigmapName" . }}
+          {{- end }}
   {{- if and .Values.ruler.persistence.enabled .Values.ruler.persistence.existingClaim }}
         - name: data
           persistentVolumeClaim:

--- a/bitnami/thanos/templates/storegateway/statefulset.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset.yaml
@@ -104,8 +104,13 @@ spec:
               mountPath: /data
       volumes:
         - name: objstore-config
+          {{- if .Values.existingObjstoreSecret }}
+          secret:
+            secretName: {{ .Values.existingObjstoreSecret }}
+          {{- else }}
           configMap:
             name: {{ include "thanos.objstoreConfigmapName" . }}
+          {{- end }}
   {{- if and .Values.storegateway.persistence.enabled .Values.storegateway.persistence.existingClaim }}
         - name: data
           persistentVolumeClaim:

--- a/bitnami/thanos/templates/storegateway/statefulset.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset.yaml
@@ -98,15 +98,22 @@ spec:
           {{- end }}
           volumeMounts:
             - name: objstore-config
+              {{- if .Values.existingObjstoreSecret.items }}
+              mountPath: /conf
+              {{- else }}
               mountPath: /conf/objstore.yml
               subPath: objstore.yml
+              {{- end }}
             - name: data
               mountPath: /data
       volumes:
         - name: objstore-config
           {{- if .Values.existingObjstoreSecret }}
           secret:
-            secretName: {{ .Values.existingObjstoreSecret }}
+            secretName: {{ .Values.existingObjstoreSecret.name }}
+            {{- if .Values.existingObjstoreSecret.items }}
+            items: {{- toYaml .Values.existingObjstoreSecret.items | nindent 14 }}
+            {{- end }}
           {{- else }}
           configMap:
             name: {{ include "thanos.objstoreConfigmapName" . }}

--- a/bitnami/thanos/templates/storegateway/statefulset.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
       labels: {{- include "thanos.labels" . | nindent 8 }}
         app.kubernetes.io/component: storegateway
       annotations:
-        checksum/ojbstore-configuration: {{ include (print $.Template.BasePath "/objstore-configmap.yaml") . | sha256sum }}
+        checksum/ojbstore-configuration: {{ include (print $.Template.BasePath "/objstore-secret.yaml") . | sha256sum }}
         {{- if .Values.storegateway.podAnnotations }}
         {{- include "thanos.tplValue" (dict "value" .Values.storegateway.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
@@ -98,7 +98,7 @@ spec:
           {{- end }}
           volumeMounts:
             - name: objstore-config
-              {{- if .Values.existingObjstoreSecret.items }}
+              {{- if .Values.existingObjstoreSecretItems }}
               mountPath: /conf
               {{- else }}
               mountPath: /conf/objstore.yml
@@ -108,16 +108,11 @@ spec:
               mountPath: /data
       volumes:
         - name: objstore-config
-          {{- if .Values.existingObjstoreSecret }}
           secret:
-            secretName: {{ .Values.existingObjstoreSecret.name }}
-            {{- if .Values.existingObjstoreSecret.items }}
-            items: {{- toYaml .Values.existingObjstoreSecret.items | nindent 14 }}
+            secretName: {{ include "thanos.objstoreSecretName" . }}
+            {{- if .Values.existingObjstoreSecretItems }}
+            items: {{- toYaml .Values.existingObjstoreSecretItems | nindent 14 }}
             {{- end }}
-          {{- else }}
-          configMap:
-            name: {{ include "thanos.objstoreConfigmapName" . }}
-          {{- end }}
   {{- if and .Values.storegateway.persistence.enabled .Values.storegateway.persistence.existingClaim }}
         - name: data
           persistentVolumeClaim:

--- a/bitnami/thanos/values-production.yaml
+++ b/bitnami/thanos/values-production.yaml
@@ -51,6 +51,8 @@ clusterDomain: cluster.local
 ## Note: This will override objstoreConfig
 ##
 # existingObjstoreSecret:
+#   name:
+#   items: []
 
 ## Thanos Querier parameters
 ##

--- a/bitnami/thanos/values-production.yaml
+++ b/bitnami/thanos/values-production.yaml
@@ -47,6 +47,11 @@ clusterDomain: cluster.local
 ##
 # existingObjstoreConfigmap:
 
+## Secret with Objstore Configuration
+## Note: This will override objstoreConfig
+##
+# existingObjstoreSecret:
+
 ## Thanos Querier parameters
 ##
 querier:
@@ -930,12 +935,10 @@ metrics:
     ## Namespace in which Prometheus is running
     ##
     # namespace: monitoring
-
     ## Interval at which metrics should be scraped.
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
     ##
     # interval: 10s
-
     ## Timeout after which the scrape is ended
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
     ##

--- a/bitnami/thanos/values-production.yaml
+++ b/bitnami/thanos/values-production.yaml
@@ -42,17 +42,12 @@ clusterDomain: cluster.local
 ##
 # objstoreConfig:
 
-## ConfigMap with Objstore Configuration
-## NOTE: This will override objstoreConfig
-##
-# existingObjstoreConfigmap:
-
 ## Secret with Objstore Configuration
 ## Note: This will override objstoreConfig
 ##
 # existingObjstoreSecret:
-#   name:
-#   items: []
+##  optional item list for specifying a custom Secret key. If so, path should be objstore.yml
+# existingObjstoreSecretItems: []
 
 ## Thanos Querier parameters
 ##

--- a/bitnami/thanos/values-production.yaml
+++ b/bitnami/thanos/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/thanos
-  tag: 0.12.0-scratch-r5
+  tag: 0.12.0-scratch-r6
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -51,6 +51,8 @@ clusterDomain: cluster.local
 ## Note: This will override objstoreConfig
 ##
 # existingObjstoreSecret:
+#   name:
+#   items: []
 
 ## Thanos Querier parameters
 ##

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -47,6 +47,11 @@ clusterDomain: cluster.local
 ##
 # existingObjstoreConfigmap:
 
+## Secret with Objstore Configuration
+## Note: This will override objstoreConfig
+##
+# existingObjstoreSecret:
+
 ## Thanos Querier parameters
 ##
 querier:

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -42,17 +42,12 @@ clusterDomain: cluster.local
 ##
 # objstoreConfig:
 
-## ConfigMap with Objstore Configuration
-## NOTE: This will override objstoreConfig
-##
-# existingObjstoreConfigmap:
-
 ## Secret with Objstore Configuration
 ## Note: This will override objstoreConfig
 ##
 # existingObjstoreSecret:
-#   name:
-#   items: []
+##  optional item list for specifying a custom Secret key. If so, path should be objstore.yml
+# existingObjstoreSecretItems: []
 
 ## Thanos Querier parameters
 ##

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/thanos
-  tag: 0.12.0-scratch-r5
+  tag: 0.12.0-scratch-r6
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

With this change it is possible to provide the Objstore configuration via a existing secret. It also has the capability to provide keys for you secret, this way we can expand the functionality with for example Tracing config.

Also fixed some typos in the Readme.md

**Benefits**

Keep the configuration and password to your Objstore private.

**Possible drawbacks**

Still expects that you name the path of your secret (existingObjstoreSecret.items) objstore.yaml for the objstore config.

**Applicable issues**

  - fixes #2353

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
