### PR TITLE
bitnami/rabbitMQ

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 6.25.4
+version: 6.25.5
 appVersion: 3.8.3
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/bitnami/rabbitmq/templates/secrets.yaml
+++ b/bitnami/rabbitmq/templates/secrets.yaml
@@ -1,4 +1,4 @@
-{{- if or (not .Values.rabbitmq.existingErlangSecret) (not .Values.rabbitmq.existingPasswordSecret) }}
+{{- if or (not .Values.rabbitmq.existingErlangSecret) (not .Values.rabbitmq.existingPasswordSecret) (not .Release.IsUpgrade ) }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION

**Description of the change**
Add one liner to detect that we are upgrading and not touch the secret.

**Benefits**
We don't need to ever know or read the secret to upgrade rabbit, the chart is smart enough not to render the resource if it's an upgrade.

**Possible drawbacks**
May prevent users from rotating secrets via `upgrade` with helm.

**Applicable issues**
  - fixes #2371

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
