### PR TITLE
[bitnami/jasperreports] Add nodeSelector and tolerations to deployment.

### DIFF
--- a/bitnami/jasperreports/Chart.yaml
+++ b/bitnami/jasperreports/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: jasperreports
-version: 7.0.14
+version: 7.0.15
 appVersion: 7.2.0
 description: The JasperReports server can be used as a stand-alone or embedded reporting
   and BI server that offers web-based reporting, analytic tools and visualization,

--- a/bitnami/jasperreports/README.md
+++ b/bitnami/jasperreports/README.md
@@ -72,6 +72,8 @@ The following table lists the configurable parameters of the JasperReports chart
 | `smtpPassword`                   | SMTP password                                | `nil`                                                    |
 | `smtpProtocol`                   | SMTP protocol [`ssl`, `none`]                | `nil`                                                    |
 | `allowEmptyPassword`             | Allow DB blank passwords                     | `yes`                                                    |
+| `nodeSelector`                   | Node labels for pod assignment               | `{}`                                                     |
+| `tolerations`                    | List of node taints to tolerate              | `[]`                                                     |
 | `ingress.enabled`                | Enable ingress controller resource           | `false`                                                  |
 | `ingress.annotations`            | Ingress annotations                          | `[]`                                                     |
 | `ingress.certManager`            | Add annotations for cert-manager             | `false`                                                  |

--- a/bitnami/jasperreports/templates/deployment.yaml
+++ b/bitnami/jasperreports/templates/deployment.yaml
@@ -19,6 +19,12 @@ spec:
         chart: "{{ template "jasperreports.chart" . }}"
         release: {{ .Release.Name | quote }}
     spec:
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end -}}
+      {{- with .Values.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}
 {{- include "jasperreports.imagePullSecrets" . | indent 6 }}
       containers:
       - name: {{ template "jasperreports.fullname" . }}

--- a/bitnami/jasperreports/values.yaml
+++ b/bitnami/jasperreports/values.yaml
@@ -55,6 +55,16 @@ jasperreportsEmail: user@example.com
 ## ref: https://github.com/bitnami/bitnami-docker-jasperreports#environment-variables
 allowEmptyPassword: "yes"
 
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+
+## Tolerations for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+
 ##
 ## External database configuration
 ##


### PR DESCRIPTION
**Description of the change**

Add nodeSelector and tolerations in deployment.

**Benefits**

Jasperreports need lot of CPU and Memory when running compare to other microservices. It might be a good options to put a dedicated server or nodes pool for reporting use.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
