### PR TITLE
[bitnami/airflow] Do not hardcode service port to 8080

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: airflow
-version: 6.1.7
+version: 6.1.8
 appVersion: 1.10.10
 description: Apache Airflow is a platform to programmatically author, schedule and monitor workflows.
 keywords:

--- a/bitnami/airflow/requirements.lock
+++ b/bitnami/airflow/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 8.9.1
+  version: 8.9.2
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 10.6.10
-digest: sha256:2f17f4dcf955dddf64d9257b51f476ba064932e51578994008cef73d286d341d
-generated: "2020-04-22T08:09:02.114896758Z"
+digest: sha256:20fb1556cc84d55530139163bcbf91b2f0034476237dfe11ced895b77751a9b6
+generated: "2020-04-23T09:26:17.160293075Z"

--- a/bitnami/airflow/templates/NOTES.txt
+++ b/bitnami/airflow/templates/NOTES.txt
@@ -1,15 +1,58 @@
+{{- if not .Values.airflow.baseUrl -}}
+###############################################################################
+### ERROR: You did not provide an external URL in your 'helm install' call ###
+###############################################################################
+
+This deployment will be incomplete until you configure Airflow with a resolvable
+host. To configure Airflow with the URL of your service:
+
+{{- if .Values.ingress.enabled }}
+
+1. Get the Airflow URL indicated on the Ingress Rule and associate it to your cluster external IP:
+
+   export CLUSTER_IP=$(minikube ip) # On Minikube. Use: `kubectl cluster-info` on others K8s clusters
+   export HOSTNAME=$(kubectl get ingress --namespace {{ .Release.Namespace }} {{ template "airflow.fullname" . }} -o jsonpath='{.spec.rules[0].host}')
+   echo "Airflow URL: http://$HOSTNAME/"
+   echo "$CLUSTER_IP  $HOSTNAME" | sudo tee -a /etc/hosts
+
+{{- else }}
+1. Get the Airflow URL by running:
+
+  {{- if contains "NodePort" .Values.service.type }}
+
+   export APP_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+   export APP_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "airflow.fullname" . }})
+
+  {{- else if contains "ClusterIP" .Values.service.type }}
+
+  export APP_HOST=127.0.0.1
+  export APP_PORT=8080
+
+  {{- else if contains "LoadBalancer" .Values.service.type }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "airflow.fullname" . }}'
+
+  export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "airflow.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+  export APP_PORT=80
+  {{- end }}
+  export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "airflow.secretName" . }} -o jsonpath="{.data.airflow-password}" | base64 --decode)
+  export APP_DATABASE_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "airflow.postgresql.secretName" . }} -o jsonpath="{.data.postgresql-password}" | base64 --decode)
+  export APP_REDIS_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "airflow.redis.secretName" . }} -o jsonpath="{.data.redis-password}" | base64 --decode)
+
+{{- end }}
+2. Complete your Airflow deployment by running:
+
+  helm upgrade {{ .Release.Name }} bitnami/{{ .Chart.Name }} \
+    --set service.type={{ .Values.service.type }},airflow.baseUrl=http://$APP_HOST:$APP_PORT,airflow.auth.password=$APP_PASSWORD,postgresql.postgresqlPassword=$APP_DATABASE_PASSWORD,redis.password=$APP_REDIS_PASSWORD{{- if .Values.global }}{{- if .Values.global.imagePullSecrets }},global.imagePullSecrets={{ .Values.global.imagePullSecrets }}{{- end }}{{- end }}
+
+{{- else -}}
+
 1. Get the Airflow URL by running:
 
 {{- if .Values.ingress.enabled }}
 
-  {{- if .Values.ingress.hostname }}
-      - http://{{ .Values.ingress.hostname }}
-  {{- end }}
-  {{- range $host := .Values.ingress.hosts }}
-    {{- range .paths }}
-      - http://{{ $host.name }}{{ . }}
-    {{- end }}
-  {{- end }}
+  echo URL  : {{ .Values.airflow.baseUrl }}
 
 {{- else if eq .Values.service.type "ClusterIP" }}
 
@@ -31,6 +74,8 @@
 
   echo User:    {{ .Values.airflow.auth.username }}
   echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "airflow.secretName" . }} -o jsonpath="{.data.airflow-password}" | base64 --decode)
+
+{{- end  }}
 
 {{ include "airflow.validateValues" . }}
 {{ include "airflow.checkRollingTags" . }}

--- a/bitnami/airflow/templates/NOTES.txt
+++ b/bitnami/airflow/templates/NOTES.txt
@@ -1,58 +1,15 @@
-{{- if not .Values.airflow.baseUrl -}}
-###############################################################################
-### ERROR: You did not provide an external URL in your 'helm install' call ###
-###############################################################################
-
-This deployment will be incomplete until you configure Airflow with a resolvable
-host. To configure Airflow with the URL of your service:
+1. Get the Airflow URL by running:
 
 {{- if .Values.ingress.enabled }}
 
-1. Get the Airflow URL indicated on the Ingress Rule and associate it to your cluster external IP:
-
-   export CLUSTER_IP=$(minikube ip) # On Minikube. Use: `kubectl cluster-info` on others K8s clusters
-   export HOSTNAME=$(kubectl get ingress --namespace {{ .Release.Namespace }} {{ template "airflow.fullname" . }} -o jsonpath='{.spec.rules[0].host}')
-   echo "Airflow URL: http://$HOSTNAME/"
-   echo "$CLUSTER_IP  $HOSTNAME" | sudo tee -a /etc/hosts
-
-{{- else }}
-1. Get the Airflow URL by running:
-
-  {{- if contains "NodePort" .Values.service.type }}
-
-   export APP_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-   export APP_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "airflow.fullname" . }})
-
-  {{- else if contains "ClusterIP" .Values.service.type }}
-
-  export APP_HOST=127.0.0.1
-  export APP_PORT=8080
-
-  {{- else if contains "LoadBalancer" .Values.service.type }}
-
-  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "airflow.fullname" . }}'
-
-  export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "airflow.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
-  export APP_PORT=80
+  {{- if .Values.ingress.hostname }}
+      - http://{{ .Values.ingress.hostname }}
   {{- end }}
-  export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "airflow.secretName" . }} -o jsonpath="{.data.airflow-password}" | base64 --decode)
-  export APP_DATABASE_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "airflow.postgresql.secretName" . }} -o jsonpath="{.data.postgresql-password}" | base64 --decode)
-  export APP_REDIS_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "airflow.redis.secretName" . }} -o jsonpath="{.data.redis-password}" | base64 --decode)
-
-{{- end }}
-2. Complete your Airflow deployment by running:
-
-  helm upgrade {{ .Release.Name }} bitnami/{{ .Chart.Name }} \
-    --set service.type={{ .Values.service.type }},airflow.baseUrl=http://$APP_HOST:$APP_PORT,airflow.auth.password=$APP_PASSWORD,postgresql.postgresqlPassword=$APP_DATABASE_PASSWORD,redis.password=$APP_REDIS_PASSWORD{{- if .Values.global }}{{- if .Values.global.imagePullSecrets }},global.imagePullSecrets={{ .Values.global.imagePullSecrets }}{{- end }}{{- end }}
-
-{{- else -}}
-
-1. Get the Airflow URL by running:
-
-{{- if .Values.ingress.enabled }}
-
-  echo URL  : {{ .Values.airflow.baseUrl }}
+  {{- range $host := .Values.ingress.hosts }}
+    {{- range .paths }}
+      - http://{{ $host.name }}{{ . }}
+    {{- end }}
+  {{- end }}
 
 {{- else if eq .Values.service.type "ClusterIP" }}
 
@@ -74,8 +31,6 @@ host. To configure Airflow with the URL of your service:
 
   echo User:    {{ .Values.airflow.auth.username }}
   echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "airflow.secretName" . }} -o jsonpath="{.data.airflow-password}" | base64 --decode)
-
-{{- end  }}
 
 {{ include "airflow.validateValues" . }}
 {{ include "airflow.checkRollingTags" . }}

--- a/bitnami/airflow/templates/deployment-scheduler.yaml
+++ b/bitnami/airflow/templates/deployment-scheduler.yaml
@@ -168,6 +168,8 @@ spec:
                   key: airflow-fernetKey
             - name: AIRFLOW_WEBSERVER_HOST
               value: {{ template "airflow.fullname" . }}
+            - name: AIRFLOW_WEBSERVER_PORT_NUMBER
+              value: {{ .Values.service.port | quote }}
             - name: AIRFLOW_LOAD_EXAMPLES
               {{- if .Values.airflow.loadExamples }}
               value: "yes"

--- a/bitnami/airflow/templates/deployment-web.yaml
+++ b/bitnami/airflow/templates/deployment-web.yaml
@@ -219,9 +219,14 @@ spec:
               containerPort: 8080
         {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
+          {{- if .Values.airflow.baseUrl }}
+            tcpSocket:
+              port: http
+          {{- else }}
             httpGet:
               path: /health
               port: http
+          {{- end }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -230,9 +235,14 @@ spec:
         {{- end }}
         {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
+          {{- if .Values.airflow.baseUrl }}
+            tcpSocket:
+              port: http
+          {{- else }}
             httpGet:
               path: /health
               port: http
+          {{- end }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/bitnami/airflow/templates/statefulset-worker.yaml
+++ b/bitnami/airflow/templates/statefulset-worker.yaml
@@ -173,6 +173,8 @@ spec:
                   key: airflow-fernetKey
             - name: AIRFLOW_WEBSERVER_HOST
               value: {{ template "airflow.fullname" . }}
+            - name: AIRFLOW_WEBSERVER_PORT_NUMBER
+              value: {{ .Values.service.port | quote }}
             {{- if .Values.airflow.extraEnvVars }}
               {{ toYaml .Values.airflow.extraEnvVars | nindent 12 }}
             {{- end }}

--- a/bitnami/airflow/templates/svc.yaml
+++ b/bitnami/airflow/templates/svc.yaml
@@ -20,7 +20,7 @@ spec:
   {{- end }}
   ports:
     - name: http
-      port: 8080
+      port: {{ .Values.service.port }}
       {{- if and .Values.service.nodePort (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) }}
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}

--- a/bitnami/airflow/values-production.yaml
+++ b/bitnami/airflow/values-production.yaml
@@ -382,7 +382,7 @@ postgresql:
   postgresqlUsername: bn_airflow
   # postgresqlPassword:
   postgresqlDatabase: bitnami_airflow
-  #In case of postgresql.enabled = true, allow the usage of existing secrets for postgresql
+  ## In case of postgresql.enabled = true, allow the usage of existing secrets for postgresql
   existingSecret: ""
 
 externalDatabase:
@@ -408,7 +408,7 @@ externalDatabase:
 redis:
   enabled: true
   # password: ""
-  #In case of redis.enabled = true, allow the usage of existing secrets for redis
+  ## In case of redis.enabled = true, allow the usage of existing secrets for redis
   existingSecret: ""
 
 externalRedis:

--- a/bitnami/airflow/values-production.yaml
+++ b/bitnami/airflow/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/airflow
-  tag: 1.10.10-debian-10-r9
+  tag: 1.10.10-debian-10-r11
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -38,7 +38,7 @@ image:
 schedulerImage:
   registry: docker.io
   repository: bitnami/airflow-scheduler
-  tag: 1.10.10-debian-10-r6
+  tag: 1.10.10-debian-10-r7
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -62,7 +62,7 @@ schedulerImage:
 workerImage:
   registry: docker.io
   repository: bitnami/airflow-worker
-  tag: 1.10.10-debian-10-r9
+  tag: 1.10.10-debian-10-r10
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -86,7 +86,7 @@ workerImage:
 git:
   registry: docker.io
   repository: bitnami/git
-  tag: 2.26.2-debian-10-r1
+  tag: 2.26.2-debian-10-r2
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -438,7 +438,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/airflow-exporter
-    tag: 0.20180711.0-debian-10-r85
+    tag: 0.20180711.0-debian-10-r87
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/airflow/values.yaml
+++ b/bitnami/airflow/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/airflow
-  tag: 1.10.10-debian-10-r9
+  tag: 1.10.10-debian-10-r11
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -38,7 +38,7 @@ image:
 schedulerImage:
   registry: docker.io
   repository: bitnami/airflow-scheduler
-  tag: 1.10.10-debian-10-r6
+  tag: 1.10.10-debian-10-r7
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -62,7 +62,7 @@ schedulerImage:
 workerImage:
   registry: docker.io
   repository: bitnami/airflow-worker
-  tag: 1.10.10-debian-10-r9
+  tag: 1.10.10-debian-10-r10
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -86,7 +86,7 @@ workerImage:
 git:
   registry: docker.io
   repository: bitnami/git
-  tag: 2.26.2-debian-10-r1
+  tag: 2.26.2-debian-10-r2
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -439,7 +439,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/airflow-exporter
-    tag: 0.20180711.0-debian-10-r85
+    tag: 0.20180711.0-debian-10-r87
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/airflow/values.yaml
+++ b/bitnami/airflow/values.yaml
@@ -382,7 +382,7 @@ postgresql:
   postgresqlUsername: bn_airflow
   # postgresqlPassword:
   postgresqlDatabase: bitnami_airflow
-  #In case of postgresql.enabled = true, allow the usage of existing secrets for postgresql
+  ## In case of postgresql.enabled = true, allow the usage of existing secrets for postgresql
   existingSecret: ""
 
 externalDatabase:
@@ -407,7 +407,7 @@ externalDatabase:
 ##
 redis:
   enabled: true
-  #In case of redis.enabled = true, allow the usage of existing secrets for redis
+  ## In case of redis.enabled = true, allow the usage of existing secrets for redis
   existingSecret: ""
   # password: ""
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

When using baseUrl, there's the risk that the health check may get redirected to the base url set. In order to avoid that, we change the readinessProbe in the case of baseUrl set to tcpSocket. Apart from that, we also not hardcode the service port to 8080. In order for it to not be a major change, I left it as 8080 the default port.

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
