### PR TITLE
 [bitnami/mariadb-galera]Rename the enviroment vars used for TLS accordingly with the container

### DIFF
--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb-galera
-version: 1.1.3
+version: 2.0.0
 appVersion: 10.4.12
 description: MariaDB Galera is a multi-master database cluster solution for synchronous replication and high availability.
 keywords:

--- a/bitnami/mariadb-galera/README.md
+++ b/bitnami/mariadb-galera/README.md
@@ -106,11 +106,11 @@ The following table lists the configurable parameters of the MariaDB Galera char
 | `ldap.nss_initgroups_ignoreusers`    | LDAP ignored users                                                                                                                                          | `root,nslcd`                                                      |
 | `ldap.scope`                         | LDAP search scope                                                                                                                                           | `nil`                                                             |
 | `ldap.tls_reqcert`                   | LDAP TLS check on server certificates                                                                                                                       | `nil`                                                             |
-| `tls.rt.enabled`                     | Enable TLS support for replication traffic                                                                                                                  | `false`                                                           |
-| `tls.rt.certificatesSecret`          | Name of the secret that contains the certificates                                                                                                           | `nil`                                                             |
-| `tls.rt.certFilename`                | Certificate filename                                                                                                                                        | `nil`                                                             |
-| `tls.rt.certKeyFilename`             | Certificate key filename                                                                                                                                    | `nil`                                                             |
-| `tls.rt.certCAFilename`              | CA Certificate filename                                                                                                                                     | `nil`                                                             |
+| `tls.enabled`                        | Enable TLS support for replication traffic                                                                                                                  | `false`                                                           |
+| `tls.certificatesSecret`             | Name of the secret that contains the certificates                                                                                                           | `nil`                                                             |
+| `tls.certFilename`                   | Certificate filename                                                                                                                                        | `nil`                                                             |
+| `tls.certKeyFilename`                | Certificate key filename                                                                                                                                    | `nil`                                                             |
+| `tls.certCAFilename`                 | CA Certificate filename                                                                                                                                     | `nil`                                                             |
 | `mariadbConfiguration`               | Configuration for the MariaDB server                                                                                                                        | `_default values in the values.yaml file_`                        |
 | `configurationConfigMap`             | ConfigMap with the MariaDB configuration files (Note: Overrides `mariadbConfiguration`). The value is evaluated as a template.                              | `nil`                                                             |
 | `initdbScripts`                      | Dictionary of initdb scripts                                                                                                                                | `nil`                                                             |
@@ -266,32 +266,32 @@ CREATE USER 'bitnami'@'localhost' IDENTIFIED VIA pam USING 'mariadb';
 
 With the above example, when the `bitnami` user attempts to login to the MariaDB server, he/she will be authenticated against the LDAP server.
 
-### TLS for Replication Traffic
+### Securing traffic using TLS
 
-TLS support for replication traffic can be enabled in the chart by specifying the `tls.rt.` parameters while creating a release. The following parameters should be configured to properly enable the TLS support for replication traffic in the chart:
+TLS support can be enabled in the chart by specifying the `tls.` parameters while creating a release. The following parameters should be configured to properly enable the TLS support in the chart:
 
-- `tls.rt.enabled`: Enable TLS support for replication traffic. Defaults to `false`
-- `tls.rt.certificatesSecret`: Name of the secret that contains the certificates. No defaults.
-- `tls.rt.certFilename`: Certificate filename. No defaults.
-- `tls.rt.certKeyFilename`: Certificate key filename. No defaults.
-- `tls.rt.certCAFilename`: CA Certificate filename. No defaults.
+- `tls.enabled`: Enable TLS support. Defaults to `false`
+- `tls.certificatesSecret`: Name of the secret that contains the certificates. No defaults.
+- `tls.certFilename`: Certificate filename. No defaults.
+- `tls.certKeyFilename`: Certificate key filename. No defaults.
+- `tls.certCAFilename`: CA Certificate filename. No defaults.
 
 For example:
 
 First, create the secret with the cetificates files:
 
 ```console
-kubectl create secret generic certificates-tls-rt-secret --from-file=./cert.pem --from-file=./cert.key --from-file=./ca.pem
+kubectl create secret generic certificates-tls-secret --from-file=./cert.pem --from-file=./cert.key --from-file=./ca.pem
 ```
 
 Then, use the following parameters:
 
 ```console
-tls.rt.enabled="true"
-tls.rt.certificatesSecret="certificates-tls-rt-secret"
-tls.rt.certFilename="cert.pem"
-tls.rt.certKeyFilename="cert.key"
-tls.rt.certCAFilename="ca.pem"
+tls.enabled="true"
+tls.certificatesSecret="certificates-tls-secret"
+tls.certFilename="cert.pem"
+tls.certKeyFilename="cert.key"
+tls.certCAFilename="ca.pem"
 ```
 
 ### Initialize a fresh instance

--- a/bitnami/mariadb-galera/templates/_helpers.tpl
+++ b/bitnami/mariadb-galera/templates/_helpers.tpl
@@ -234,22 +234,22 @@ mariadb-galera: LDAP
 {{/*
 Return the path to the cert file.
 */}}
-{{- define "mariadb-galera.tlsRTCert" -}}
-{{- printf "/bitnami/mariadb/cert/%s" .Values.tls.rt.certFilename -}}
+{{- define "mariadb-galera.tlsCert" -}}
+{{- printf "/bitnami/mariadb/cert/%s" .Values.tls.certFilename -}}
 {{- end -}}
 
 {{/*
 Return the path to the cert key file.
 */}}
-{{- define "mariadb-galera.tlsRTCertKey" -}}
-{{- printf "/bitnami/mariadb/cert/%s" .Values.tls.rt.certKeyFilename -}}
+{{- define "mariadb-galera.tlsCertKey" -}}
+{{- printf "/bitnami/mariadb/cert/%s" .Values.tls.certKeyFilename -}}
 {{- end -}}
 
 {{/*
 Return the path to the CA cert file.
 */}}
-{{- define "mariadb-galera.tlsRTCACert" -}}
-{{- printf "/bitnami/mariadb/cert/%s" .Values.tls.rt.certCAFilename -}}
+{{- define "mariadb-galera.tlsCACert" -}}
+{{- printf "/bitnami/mariadb/cert/%s" .Values.tls.certCAFilename -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/mariadb-galera/templates/statefulset.yaml
+++ b/bitnami/mariadb-galera/templates/statefulset.yaml
@@ -128,15 +128,15 @@ spec:
             - name: MARIADB_EXTRA_FLAGS
               value: {{ .Values.extraFlags | quote }}
             {{- end }}
-            - name:  MARIADB_ENABLE_TLS_RT
-              value: {{ ternary "yes" "no" .Values.tls.rt.enabled | quote }}
-            {{- if .Values.tls.rt.enabled }}
-            - name:  MARIADB_TLS_RT_CERT
-              value: {{ template "mariadb-galera.tlsRTCert" . }}
-            - name:  MARIADB_TLS_RT_KEY
-              value: {{ template "mariadb-galera.tlsRTCertKey" . }}
-            - name:  MARIADB_TLS_RT_CA
-              value: {{ template "mariadb-galera.tlsRTCACert" . }}
+            - name:  MARIADB_ENABLE_TLS
+              value: {{ ternary "yes" "no" .Values.tls.enabled | quote }}
+            {{- if .Values.tls.enabled }}
+            - name:  MARIADB_TLS_CERT_FILE
+              value: {{ template "mariadb-galera.tlsCert" . }}
+            - name:  MARIADB_TLS_KEY_FILE
+              value: {{ template "mariadb-galera.tlsCertKey" . }}
+            - name:  MARIADB_TLS_CA_FILE
+              value: {{ template "mariadb-galera.tlsCACert" . }}
             {{- end }}
           ports:
             - name: mysql
@@ -196,8 +196,8 @@ spec:
             {{- if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
-            {{- if .Values.tls.rt.enabled }}
-            - name: mariadb-galera-rt-certificates
+            {{- if .Values.tls.enabled }}
+            - name: mariadb-galera-certificates
               mountPath: /bitnami/mariadb/certs/
               readOnly: true
             {{- end }}
@@ -243,10 +243,10 @@ spec:
         {{- include "mariadb-galera.tplValue" (dict "value" .Values.extraContainers "context" $) | nindent 8 }}
         {{- end }}
       volumes:
-        {{- if .Values.tls.rt.enabled }}
-        - name: mariadb-galera-rt-certificates
+        {{- if .Values.tls.enabled }}
+        - name: mariadb-galera-certificates
           secret:
-            secretName: {{ required "A secret containing the ertificates for the TLS replication traffic is required when TLS RT in enabled" .Values.tls.rt.certificatesSecret }}
+            secretName: {{ required "A secret containing the certificates for the TLS traffic is required when TLS in enabled" .Values.tls.certificatesSecret }}
             defaultMode: 256
         {{- end }}
         {{- if or (.Files.Glob "files/my.cnf") .Values.mariadbConfiguration .Values.configurationConfigMap }}

--- a/bitnami/mariadb-galera/values-production.yaml
+++ b/bitnami/mariadb-galera/values-production.yaml
@@ -179,27 +179,24 @@ ldap:
   scope:
   tls_reqcert:
 
-## TSL configuration
+## TLS configuration
 ##
-tsl:
-  ## Replicaction traffic
+tls:
+  ## Enable TLS
   ##
-  rt:
-    ## Enable TSL for replication traffic
-    ##
-    enabled: false
-    ## Name of the secret that contains the certificates
-    ##
-    # certificatesSecret:
-    ## Certificate filename
-    ##
-    # certFilename:
-    ## Certificate Key filename
-    ##
-    # certKeyFilename:
-    ## CA Certificate filename
-    ##
-    # certCAFilename:
+  enabled: false
+  ## Name of the secret that contains the certificates
+  ##
+  # certificatesSecret:
+  ## Certificate filename
+  ##
+  # certFilename:
+  ## Certificate Key filename
+  ##
+  # certKeyFilename:
+  ## CA Certificate filename
+  ##
+  # certCAFilename:
 
 ## Configure MariaDB with a custom my.cnf file
 ## ref: https://mysql.com/kb/en/mysql/configuring-mysql-with-mycnf/#example-of-configuration-file

--- a/bitnami/mariadb-galera/values.yaml
+++ b/bitnami/mariadb-galera/values.yaml
@@ -181,24 +181,21 @@ ldap:
 ## TLS configuration
 ##
 tls:
-  ## Replicaction traffic
+  ## Enable TLS
   ##
-  rt:
-    ## Enable TLS for replication traffic
-    ##
-    enabled: false
-    ## Name of the secret that contains the certificates
-    ##
-    # certificatesSecret:
-    ## Certificate filename
-    ##
-    # certFilename:
-    ## Certificate Key filename
-    ##
-    # certKeyFilename:
-    ## CA Certificate filename
-    ##
-    # certCAFilename:
+  enabled: false
+  ## Name of the secret that contains the certificates
+  ##
+  # certificatesSecret:
+  ## Certificate filename
+  ##
+  # certFilename:
+  ## Certificate Key filename
+  ##
+  # certKeyFilename:
+  ## CA Certificate filename
+  ##
+  # certCAFilename:
 
 ## Configure MariaDB with a custom my.cnf file
 ## ref: https://mysql.com/kb/en/mysql/configuring-mysql-with-mycnf/#example-of-configuration-file


### PR DESCRIPTION
Description of the change
Renames the parameter for TLS usage, they are general and not only replication traffic related.
Also documents in the REAMDE how to use TLS in the client

Benefits
Use TLS for replication and clients

Possible drawbacks
Parameter renaming of the previous version

Checklist

Chart version bumped in Chart.yaml according to semver.
Variables are documented in the README.md
Title of the PR starts with chart name (e.g. [bitnami/chart])
If the chart contains a values-production.yaml apart from values.yaml, ensure that you implement the changes in both files