### PR TITLE
[bitnami/harbor] - Set updateStrategy for RWO mounts

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: harbor
-version: 5.0.10
+version: 5.0.11
 appVersion: 1.10.2
 description: Harbor is an an open source trusted cloud native registry project that stores, signs, and scans content
 keywords:

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: harbor
-version: 5.0.11
+version: 5.1.0
 appVersion: 1.10.2
 description: Harbor is an an open source trusted cloud native registry project that stores, signs, and scans content
 keywords:

--- a/bitnami/harbor/README.md
+++ b/bitnami/harbor/README.md
@@ -167,6 +167,7 @@ The following table lists the configurable parameters of the Harbor chart and th
 | `jobserviceImage.pullSecrets`                                               | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
 | `jobserviceImage.debug`                                                     | Specify if debug logs should be enabled      | `false`     |
 | `jobservice.replicas`                                                       | The replica count                            | `1`         |
+| `jobservice.updateStrategy.type`                                            | The update strategy for deployments with persistent volumes: RollingUpdate or Recreate. Set it as Recreate when RWM for volumes isn't supported | `RollingUpdate` 
 | `jobservice.maxJobWorkers`                                                  | The max job workers                          | `10`        |
 | `jobservice.jobLogger`                                                      | The logger for jobs: `file`, `database` or `stdout` | `file`      |
 | `jobservice.resources`                                                      | The [resources] to allocate for container    | undefined   |
@@ -197,6 +198,7 @@ The following table lists the configurable parameters of the Harbor chart and th
 | `registry.controller.livenessProbe`                                         | Liveness probe configuration for Registryctl | `Check values.yaml file` |
 | `registry.controller.readinessProbe`                                        | Readines probe configuration for Registryctl | `Check values.yaml file` |
 | `registry.replicas`                                                         | The replica count                            | `1`         |
+| `registry.updateStrategy.type`                                              | The update strategy for deployments with persistent volumes: RollingUpdate or Recreate. Set it as Recreate when RWM for volumes isn't supported | `RollingUpdate` 
 | `registry.nodeSelector`                                                     | Node labels for pod assignment               | `{}` (The value is evaluated as a template) |
 | `registry.tolerations`                                                      | Tolerations for pod assignment               | `[]` (The value is evaluated as a template) |
 | `registry.affinity`                                                         | Node/Pod affinities                          | `{}` (The value is evaluated as a template) |
@@ -210,6 +212,7 @@ The following table lists the configurable parameters of the Harbor chart and th
 | `chartMuseumImage.debug`                                                    | Specify if debug logs should be enabled      | `false`     |
 | `chartmuseum.enabled`                                                       | Enable ChartMuseum                           | `true`      |
 | `chartmuseum.replicas`                                                      | Number of ChartMuseum replicas               | `1`         |
+| `chartmuseum.updateStrategy.type`                                           | The update strategy for deployments with persistent volumes: RollingUpdate or Recreate. Set it as Recreate when RWM for volumes isn't supported | `RollingUpdate` 
 | `chartmuseum.port`                                                          | ChartMuseum listen port                      | `8080`      |
 | `chartmuseum.useRedisCache`                                                 | Specify if ChartMuseum will use redis cache  | `true`      |
 | `chartmuseum.absoluteUrl`                                                   | Specify an absolute URL for ChartMuseum registry | `false`     |

--- a/bitnami/harbor/requirements.lock
+++ b/bitnami/harbor/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 8.9.1
+  version: 8.9.2
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 10.6.10
-digest: sha256:2f17f4dcf955dddf64d9257b51f476ba064932e51578994008cef73d286d341d
-generated: "2020-04-22T08:07:42.708724552Z"
+digest: sha256:20fb1556cc84d55530139163bcbf91b2f0034476237dfe11ced895b77751a9b6
+generated: "2020-04-23T16:31:02.706769353Z"

--- a/bitnami/harbor/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/bitnami/harbor/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -7,6 +7,9 @@ metadata:
     app.kubernetes.io/component: chartmuseum
 spec:
   replicas: {{ .Values.chartmuseum.replicas }}
+  {{- if .Values.chartmuseum.strategy }}
+  strategy: {{- toYaml .Values.chartmuseum.strategy | nindent 4 }}
+  {{- end }}  
   selector:
     matchLabels: {{- include "harbor.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: chartmuseum

--- a/bitnami/harbor/templates/jobservice/jobservice-dpl.yaml
+++ b/bitnami/harbor/templates/jobservice/jobservice-dpl.yaml
@@ -6,6 +6,9 @@ metadata:
     app.kubernetes.io/component: jobservice
 spec:
   replicas: {{ .Values.jobservice.replicas }}
+  {{- if .Values.jobservice.strategy }}
+  strategy: {{- toYaml .Values.jobservice.strategy | nindent 4 }}
+  {{- end }}  
   selector:
     matchLabels: {{- include "harbor.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: jobservice

--- a/bitnami/harbor/templates/registry/registry-dpl.yaml
+++ b/bitnami/harbor/templates/registry/registry-dpl.yaml
@@ -6,6 +6,9 @@ metadata:
     app.kubernetes.io/component: registry
 spec:
   replicas: {{ .Values.registry.replicas }}
+  {{- if .Values.registry.strategy }}
+  strategy: {{- toYaml .Values.registry.strategy | nindent 4 }}
+  {{- end }}  
   selector:
     matchLabels: {{- include "harbor.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: registry

--- a/bitnami/harbor/values-production.yaml
+++ b/bitnami/harbor/values-production.yaml
@@ -14,7 +14,7 @@
 coreImage:
   registry: docker.io
   repository: bitnami/harbor-core
-  tag: 1.10.2-debian-10-r13
+  tag: 1.10.2-debian-10-r14
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -38,7 +38,7 @@ coreImage:
 portalImage:
   registry: docker.io
   repository: bitnami/harbor-portal
-  tag: 1.10.2-debian-10-r13
+  tag: 1.10.2-debian-10-r15
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -62,7 +62,7 @@ portalImage:
 jobserviceImage:
   registry: docker.io
   repository: bitnami/harbor-jobservice
-  tag: 1.10.2-debian-10-r13
+  tag: 1.10.2-debian-10-r14
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -86,7 +86,7 @@ jobserviceImage:
 chartMuseumImage:
   registry: docker.io
   repository: bitnami/chartmuseum
-  tag: 0.12.0-debian-10-r26
+  tag: 0.12.0-debian-10-r28
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -110,7 +110,7 @@ chartMuseumImage:
 registryImage:
   registry: docker.io
   repository: bitnami/harbor-registry
-  tag: 1.10.2-debian-10-r13
+  tag: 1.10.2-debian-10-r14
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -134,7 +134,7 @@ registryImage:
 registryctlImage:
   registry: docker.io
   repository: bitnami/harbor-registryctl
-  tag: 1.10.2-debian-10-r13
+  tag: 1.10.2-debian-10-r14
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -158,7 +158,7 @@ registryctlImage:
 clairImage:
   registry: docker.io
   repository: bitnami/harbor-clair
-  tag: 1.10.2-debian-10-r13
+  tag: 1.10.2-debian-10-r14
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -182,7 +182,7 @@ clairImage:
 clairAdapterImage:
   registry: docker.io
   repository: bitnami/harbor-adapter-clair
-  tag: 1.0.2-debian-10-r8
+  tag: 1.0.2-debian-10-r9
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -206,7 +206,7 @@ clairAdapterImage:
 notaryServerImage:
   registry: docker.io
   repository: bitnami/harbor-notary-server
-  tag: 1.10.2-debian-10-r13
+  tag: 1.10.2-debian-10-r14
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -230,7 +230,7 @@ notaryServerImage:
 notarySignerImage:
   registry: docker.io
   repository: bitnami/harbor-notary-signer
-  tag: 1.10.2-debian-10-r13
+  tag: 1.10.2-debian-10-r14
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -254,7 +254,7 @@ notarySignerImage:
 nginxImage:
   registry: docker.io
   repository: bitnami/nginx
-  tag: 1.16.1-debian-10-r94
+  tag: 1.16.1-debian-10-r95
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/harbor/values-production.yaml
+++ b/bitnami/harbor/values-production.yaml
@@ -805,6 +805,12 @@ core:
 ## Harbor Jobservice parameters
 ##
 jobservice:
+  ## Update strategy - only really applicable for deployments with RWO PVs attached
+  ## If replicas = 1, an update can get "stuck", as the previous pod remains attached to the 
+  ## PV, and the "incoming" pod can never start. Changing the strategy to "Recreate" will 
+  ## terminate the single previous pod, so that the new, incoming pod can attach to the PV
+  updateStrategy:
+    type: RollingUpdate   
   replicas: 1
   maxJobWorkers: 10
   # The logger for jobs: "file", "database" or "stdout"
@@ -870,6 +876,12 @@ jobservice:
 
 registry:
   replicas: 1
+  ## Update strategy - only really applicable for deployments with RWO PVs attached
+  ## If replicas = 1, an update can get "stuck", as the previous pod remains attached to the 
+  ## PV, and the "incoming" pod can never start. Changing the strategy to "Recreate" will 
+  ## terminate the single previous pod, so that the new, incoming pod can attach to the PV
+  updateStrategy:
+    type: RollingUpdate     
   ## Harbor Registry parameters
   ##
   registry:
@@ -971,6 +983,12 @@ registry:
 ##
 chartmuseum:
   enabled: true
+  ## Update strategy - only really applicable for deployments with RWO PVs attached
+  ## If replicas = 1, an update can get "stuck", as the previous pod remains attached to the 
+  ## PV, and the "incoming" pod can never start. Changing the strategy to "Recreate" will 
+  ## terminate the single previous pod, so that the new, incoming pod can attach to the PV
+  updateStrategy:
+    type: RollingUpdate   
   replicas: 1
   port: 8080
 

--- a/bitnami/harbor/values.yaml
+++ b/bitnami/harbor/values.yaml
@@ -14,7 +14,7 @@
 coreImage:
   registry: docker.io
   repository: bitnami/harbor-core
-  tag: 1.10.2-debian-10-r13
+  tag: 1.10.2-debian-10-r14
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -38,7 +38,7 @@ coreImage:
 portalImage:
   registry: docker.io
   repository: bitnami/harbor-portal
-  tag: 1.10.2-debian-10-r13
+  tag: 1.10.2-debian-10-r15
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -62,7 +62,7 @@ portalImage:
 jobserviceImage:
   registry: docker.io
   repository: bitnami/harbor-jobservice
-  tag: 1.10.2-debian-10-r13
+  tag: 1.10.2-debian-10-r14
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -86,7 +86,7 @@ jobserviceImage:
 chartMuseumImage:
   registry: docker.io
   repository: bitnami/chartmuseum
-  tag: 0.12.0-debian-10-r26
+  tag: 0.12.0-debian-10-r28
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -110,7 +110,7 @@ chartMuseumImage:
 registryImage:
   registry: docker.io
   repository: bitnami/harbor-registry
-  tag: 1.10.2-debian-10-r13
+  tag: 1.10.2-debian-10-r14
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -134,7 +134,7 @@ registryImage:
 registryctlImage:
   registry: docker.io
   repository: bitnami/harbor-registryctl
-  tag: 1.10.2-debian-10-r13
+  tag: 1.10.2-debian-10-r14
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -158,7 +158,7 @@ registryctlImage:
 clairImage:
   registry: docker.io
   repository: bitnami/harbor-clair
-  tag: 1.10.2-debian-10-r13
+  tag: 1.10.2-debian-10-r14
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -182,7 +182,7 @@ clairImage:
 clairAdapterImage:
   registry: docker.io
   repository: bitnami/harbor-adapter-clair
-  tag: 1.0.2-debian-10-r8
+  tag: 1.0.2-debian-10-r9
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -206,7 +206,7 @@ clairAdapterImage:
 notaryServerImage:
   registry: docker.io
   repository: bitnami/harbor-notary-server
-  tag: 1.10.2-debian-10-r13
+  tag: 1.10.2-debian-10-r14
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -230,7 +230,7 @@ notaryServerImage:
 notarySignerImage:
   registry: docker.io
   repository: bitnami/harbor-notary-signer
-  tag: 1.10.2-debian-10-r13
+  tag: 1.10.2-debian-10-r14
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -254,7 +254,7 @@ notarySignerImage:
 nginxImage:
   registry: docker.io
   repository: bitnami/nginx
-  tag: 1.16.1-debian-10-r94
+  tag: 1.16.1-debian-10-r95
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/harbor/values.yaml
+++ b/bitnami/harbor/values.yaml
@@ -806,6 +806,12 @@ core:
 ##
 jobservice:
   replicas: 1
+  ## Update strategy - only really applicable for deployments with RWO PVs attached
+  ## If replicas = 1, an update can get "stuck", as the previous pod remains attached to the 
+  ## PV, and the "incoming" pod can never start. Changing the strategy to "Recreate" will 
+  ## terminate the single previous pod, so that the new, incoming pod can attach to the PV
+  updateStrategy:
+    type: RollingUpdate   
   maxJobWorkers: 10
   # The logger for jobs: "file", "database" or "stdout"
   jobLogger: file
@@ -870,6 +876,12 @@ jobservice:
 
 registry:
   replicas: 1
+  ## Update strategy - only really applicable for deployments with RWO PVs attached
+  ## If replicas = 1, an update can get "stuck", as the previous pod remains attached to the 
+  ## PV, and the "incoming" pod can never start. Changing the strategy to "Recreate" will 
+  ## terminate the single previous pod, so that the new, incoming pod can attach to the PV
+  updateStrategy:
+    type: RollingUpdate   
   ## Harbor Registry parameters
   ##
   registry:
@@ -971,7 +983,15 @@ registry:
 ##
 chartmuseum:
   enabled: true
+
   replicas: 1
+  ## Update strategy - only really applicable for deployments with RWO PVs attached
+  ## If replicas = 1, an update can get "stuck", as the previous pod remains attached to the 
+  ## PV, and the "incoming" pod can never start. Changing the strategy to "Recreate" will 
+  ## terminate the single previous pod, so that the new, incoming pod can attach to the PV
+  updateStrategy:
+    type: RollingUpdate 
+
   port: 8080
 
   ## Set the use of the Redis cache.


### PR DESCRIPTION
Hi guys,

This is a repeat of https://github.com/bitnami/charts/pull/1953, which went stale because I missed the email. https://github.com/bitnami/charts/pull/1953 was, in turn, a retry of https://github.com/bitnami/charts/pull/1926, in which I messed up the rebase. Hopefully, 3rd-time lucky!

**Description of the change**

Unlike the official helm chart, this chart doesn't currently allow the user to set an updateStrategy for the deployments (chartmuseum, registry, jobservice) which would usually be attached to storage in RWO mode. In this event, an update (i.e., via helm upgrade) will fail, since the old instance of a pod will not detach from its storage, preventing the new instance of a pod from replacing it.

This change ports the updateStrategy.type value from the official helm chart for the chartmuseum, jobservice, and registry deployments.

The PR additionally fixes an error re the replicas for notary service/signer, which failed local CI when preparing this PR.

**Benefits**

Users can choose (non-default) to set the updateStrategy to "Recreate", so that helm updates on RWO/1-replica deployments succeed.
**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
