### PR TITLE
[bitnami/fluentd] Remove template fragments from example ConfigMap in README

### DIFF
--- a/bitnami/fluentd/README.md
+++ b/bitnami/fluentd/README.md
@@ -214,7 +214,7 @@ data:
     # input plugin that exports metrics
     <source>
       @type prometheus
-      port {{ .Values.metrics.service.port }}
+      port 24231
     </source>
 
     # input plugin that collects metrics from MonitorAgent
@@ -232,7 +232,6 @@ data:
         host ${hostname}
       </labels>
     </source>
-    {{- end }}
 
     # Ignore fluentd own events
     <match fluent.**>
@@ -243,7 +242,7 @@ data:
     <source>
       @type forward
       bind 0.0.0.0
-      port {{ .Values.aggregator.port }}
+      port 24224
     </source>
 
     # HTTP input for the liveness and readiness probes


### PR DESCRIPTION
**Description of the change**

This PR closes #2389 

**Benefits**

Users dont get errors when using the example ConfigMap for their setups.

**Possible drawbacks**

None.

**Checklist**
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
