### PR TITLE
[bitnami/kibana] Make the Kibana server listen on IPv4 and IPv6

### DIFF
--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kibana
-version: 5.0.15
+version: 5.0.16
 appVersion: 7.6.2
 description: Kibana is an open source, browser based analytics and search dashboard for Elasticsearch.
 keywords:

--- a/bitnami/kibana/templates/configmap.yml
+++ b/bitnami/kibana/templates/configmap.yml
@@ -7,7 +7,7 @@ metadata:
 data:
   kibana.yml: |
     pid.file: /opt/bitnami/kibana/tmp/kibana.pid
-    server.host: 0.0.0.0
+    server.host: "::"
     server.port: 5601
     elasticsearch.hosts: [{{ include "kibana.elasticsearch.url" . }}]
     {{- if .Values.extraConfiguration }}

--- a/bitnami/kibana/values-production.yaml
+++ b/bitnami/kibana/values-production.yaml
@@ -14,7 +14,7 @@ global: {}
 image:
   registry: docker.io
   repository: bitnami/kibana
-  tag: 7.6.2-debian-10-r20
+  tag: 7.6.2-debian-10-r22
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/kibana/values.yaml
+++ b/bitnami/kibana/values.yaml
@@ -14,7 +14,7 @@ global: {}
 image:
   registry: docker.io
   repository: bitnami/kibana
-  tag: 7.6.2-debian-10-r20
+  tag: 7.6.2-debian-10-r22
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
**Description of the change**

This PR closes #2386

This PR will change the default bind address from `0.0.0.0` to `::`.
This will cause kibana to listen by default on IPv4 **and** IPv6.

**Benefits**

The chart would work out of the box for IPv4-only and IPv6 only clusters.

**Possible drawbacks**

None.

**Applicable issues**

This is similar to #2401, #2386 

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
