### PR TITLE
[bitnami/postgresql-ha] add graceful exit for primary nodes

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql-ha
-version: 3.1.1
+version: 3.2.0
 appVersion: 11.7.0
 description: Chart for PostgreSQL with HA architecture (using Replication Manager (repmgr) and Pgpool).
 keywords:

--- a/bitnami/postgresql-ha/templates/postgresql/hooks-scripts-configmap.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/hooks-scripts-configmap.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-hooks-scripts" (include "postgresql-ha.postgresql" .) }}
+  labels: {{- include "postgresql-ha.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+data:
+  pre-stop.sh: |-
+    #!/bin/bash
+    set -o errexit
+    set -o pipefail
+    set -o nounset
+
+    # Debug section
+    exec 3>&1
+    exec 4>&2
+
+    # Load Libraries
+    . /opt/bitnami/scripts/liblog.sh
+    . /opt/bitnami/scripts/libpostgresql.sh
+    . /opt/bitnami/scripts/librepmgr.sh
+
+    # Auxiliar functions
+    is_new_primary_ready() {
+        return_value=1
+        currenty_primary_node="$(repmgr_get_primary_node)"
+        currenty_primary_host="$(echo $currenty_primary_node | awk '{print $1}')"
+
+        info "$currenty_primary_host != $REPMGR_NODE_NETWORK_NAME"
+        if [[ $(echo $currenty_primary_node | wc -w) -eq 2 ]] && [[ "$currenty_primary_host" != "$REPMGR_NODE_NETWORK_NAME" ]]; then
+            info "New primary detected, leaving the cluster..."
+            return_value=0
+        else
+            info "Waiting for a new primary to be available..."
+        fi
+        return $return_value
+    }
+
+    export MODULE="pre-stop-hook"
+
+    if [[ "${BITNAMI_DEBUG}" == "true" ]]; then
+        info "Bash debug is on"
+    else
+        info "Bash debug is off"
+        exec 1>/dev/null
+        exec 2>/dev/null
+    fi
+
+    # Load PostgreSQL & repmgr environment variables
+    eval "$(repmgr_env)"
+    eval "$(postgresql_env)"
+
+    postgresql_enable_nss_wrapper
+
+    # Prepare env vars for managing roles
+    primary_node="$(repmgr_get_primary_node)"
+    primary_host="$(echo $primary_node | awk '{print $1}')"
+
+    # Stop postgresql for graceful exit.
+    postgresql_stop
+
+    if [[ "$primary_host" == "$REPMGR_NODE_NETWORK_NAME" ]]; then
+        info "Primary node need to wait for a new primary node before leaving the cluster"
+        retry_while is_new_primary_ready 10 5
+    else
+        info "Standby node doesn't need to wait, leaving the cluster."
+    fi

--- a/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
@@ -68,6 +68,11 @@ spec:
       {{- end }}
       containers:
         - name: postgresql
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /pre-stop.sh
           image: {{ include "postgresql-ha.postgresqlImage" . }}
           imagePullPolicy: {{ .Values.postgresqlImage.pullPolicy | quote }}
           {{- if .Values.postgresql.securityContext.enabled }}
@@ -205,6 +210,9 @@ spec:
             - name: data
               mountPath: {{ .Values.persistence.mountPath }}
             {{- end }}
+            - name: hooks-scripts
+              mountPath: /pre-stop.sh
+              subPath: pre-stop.sh
         {{- if .Values.metrics.enabled }}
         - name: metrics
           image: {{ include "postgresql-ha.metricsImage" . }}
@@ -264,6 +272,10 @@ spec:
             {{- end }}
         {{- end }}
       volumes:
+        - name: hooks-scripts
+          configMap:
+            name: {{ printf "%s-hooks-scripts" (include "postgresql-ha.postgresql" .) }}
+            defaultMode: 0755
         {{- if or (.Files.Glob "files/repmgr.conf") (.Files.Glob "files/postgresql.conf") (.Files.Glob "files/pg_hba.conf") .Values.postgresql.repmgrConfiguration .Values.postgresql.configuration .Values.postgresql.pgHbaConfiguration .Values.postgresql.configurationCM }}
         - name: postgresql-config
           configMap:

--- a/bitnami/postgresql-ha/values-production.yaml
+++ b/bitnami/postgresql-ha/values-production.yaml
@@ -244,7 +244,6 @@ postgresql:
   ## ref: https://github.com/bitnami/bitnami-docker-postgresql-repmgr#configuration-file
   ##
   # repmgrConfiguration: |-
-
   ## PostgreSQL configuration
   ## Specify runtime configuration parameters as a dict, using camelCase, e.g.
   ## {"sharedBuffers": "500MB"}
@@ -252,7 +251,6 @@ postgresql:
   ## ref: https://github.com/bitnami/bitnami-docker-postgresql-repmgr#configuration-file
   ##
   # configuration:
-
   ## PostgreSQL client authentication configuration
   ## Specify content for pg_hba.conf
   ## Default: do not create pg_hba.conf
@@ -263,24 +261,20 @@ postgresql:
   #   local all all trust
   #   host all all localhost trust
   #   host mydatabase mysuser 192.168.0.0/24 md5
-
   ## ConfigMap with PostgreSQL configuration
   ## NOTE: This will override repmgrConfiguration, configuration and pgHbaConfiguration
   ##
   # configurationCM:
-
   ## PostgreSQL extended configuration
   ## As above, but _appended_ to the main configuration
   ## Alternatively, you can put your *.conf under the files/conf.d/ directory
   ## ref: https://github.com/bitnami/bitnami-docker-postgresql-repmgr#allow-settings-to-be-loaded-from-files-other-than-the-default-postgresqlconf
   ##
   # extendedConf:
-
   ## ConfigMap with PostgreSQL extended configuration
   ## NOTE: This will override extendedConf
   ##
   # extendedConfCM:
-
   ## initdb scripts
   ## Specify dictionary of scripts to be run at first boot
   ## Alternatively, you can put your scripts under the files/docker-entrypoint-initdb.d directory
@@ -289,12 +283,10 @@ postgresql:
   #   my_init_script.sh: |
   #      #!/bin/sh
   #      echo "Do something."
-
   ## ConfigMap with scripts to be run at first boot
   ## NOTE: This will override initdbScripts
   ##
   # initdbScriptsCM:
-
   ## Secret with scripts to be run at first boot
   ## Note: can be used with initdbScriptsCM or initdbScripts
   ##
@@ -543,18 +535,18 @@ metrics:
     ## [Kube Prometheus Selector Label](https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#exporters)
     selector:
       prometheus: kube-prometheus
-    
+
     ## RelabelConfigs to apply to samples before scraping
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
     ## Value is evalued as a template
     ##
-    # relabelings: []
+    relabelings: []
 
     ## MetricRelabelConfigs to apply to samples before ingestion
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
     ## Value is evalued as a template
     ##
-    # metricRelabelings: []
+    metricRelabelings: []
 
 ## Persistence paramaters
 ##

--- a/bitnami/postgresql-ha/values-production.yaml
+++ b/bitnami/postgresql-ha/values-production.yaml
@@ -29,7 +29,7 @@
 postgresqlImage:
   registry: docker.io
   repository: bitnami/postgresql-repmgr
-  tag: 11.7.0-debian-10-r93
+  tag: 11.7.0-debian-10-r96
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -90,7 +90,7 @@ volumePermissionsImage:
 metricsImage:
   registry: docker.io
   repository: bitnami/postgres-exporter
-  tag: 0.8.0-debian-10-r98
+  tag: 0.8.0-debian-10-r99
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##

--- a/bitnami/postgresql-ha/values.yaml
+++ b/bitnami/postgresql-ha/values.yaml
@@ -533,28 +533,30 @@ metrics:
   ##
   serviceMonitor:
     enabled: false
+
     ## Specify a namespace if needed
     # namespace: monitoring
     # fallback to the prometheus default unless specified
     # interval: 10s
     # scrapeTimeout: 10s
+
     ## Defaults to what's used if you follow CoreOS [Prometheus Install Instructions](https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#tldr)
     ## [Prometheus Selector Label](https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-operator-1)
     ## [Kube Prometheus Selector Label](https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#exporters)
     selector:
       prometheus: kube-prometheus
-    
+
     ## RelabelConfigs to apply to samples before scraping
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
     ## Value is evalued as a template
     ##
-    # relabelings: []
+    relabelings: []
 
     ## MetricRelabelConfigs to apply to samples before ingestion
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
     ## Value is evalued as a template
     ##
-    # metricRelabelings: []
+    metricRelabelings: []
 
 ## Persistence paramaters
 ##

--- a/bitnami/postgresql-ha/values.yaml
+++ b/bitnami/postgresql-ha/values.yaml
@@ -29,7 +29,7 @@
 postgresqlImage:
   registry: docker.io
   repository: bitnami/postgresql-repmgr
-  tag: 11.7.0-debian-10-r93
+  tag: 11.7.0-debian-10-r96
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -90,7 +90,7 @@ volumePermissionsImage:
 metricsImage:
   registry: docker.io
   repository: bitnami/postgres-exporter
-  tag: 0.8.0-debian-10-r98
+  tag: 0.8.0-debian-10-r99
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##


### PR DESCRIPTION
**Description of the change**

This PR adds a graceful exit mechanism for primary nodes in the postgres cluster. Now when a primary node tries to leave the cluster it will wait until any other node promotes to the primary node. 

**Benefits**

Before these changes, when the primary was not the pod 0 (e.g: in a cluster with 3 pods the primary node was pod 1) scale down action bring the cluster to an unrecovered state. Now, We can scale down when the primary node is not the pod 0.

**Possible drawbacks**

N/A

**Applicable issues**

  - fixes #2033 #1934 #2193 #2378

**Additional information**

Steps to reproduce and test.

1. Install the chart

```bash
$ helm install pg --set postgresql.replicaCount=2 --set pgpool.replicaCount=1 \
  bitnami/postgresql-ha
```
2. For a change in the primary role

```bash
$ kubectl delete pod pg-postgresql-ha-postgresql-0
```
3. Wait until new primary is elected

```bash
$ kubectl rollout status sts postgresql-ha-postgresql
```
4. Get data to update the cluster size

```bash
$ export PGPOOL_PASSWORD=$(kubectl get secret pg-postgresql-ha-pgpool -o jsonpath="{.data.admin-password}" | base64 --decode)
$ export POSTGRES_PASSWORD=$(kubectl get secret pg-postgresql-ha-postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode)
$ export REPMGR_PASSWORD=$(kubectl get secret pg-postgresql-ha-postgresql -o jsonpath="{.data.repmgr-password}" | base64 --decode)
```

5. Scale down the cluster

```bash
$ helm upgrade pg \
  --set postgresql.replicaCount=1 \
  --set postgresql.password="$POSTGRES_PASSWORD" \
  --set postgresql.repmgrPassword="$REPMGR_PASSWORD" \
  --set pgpool.replicaCount=1 \
  --set pgpool.adminPassword="$PGPOOL_PASSWORD" \
  bitnami/postgresql-ha
```

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
