### PR TITLE
[bitnami/mongodb-sharded] Add metrics exporter for shard arbiter

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb-sharded
-version: 1.2.1
+version: 1.3.0
 appVersion: 4.2.6
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications. Sharded topology.
 keywords:

--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb-sharded
-version: 1.2.0
+version: 1.2.1
 appVersion: 4.2.6
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications. Sharded topology.
 keywords:

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
@@ -185,6 +185,67 @@ spec:
               {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.arbiter.extraVolumeMounts "context" $ ) | nindent 12 }}
             {{- end }}
           resources: {{- toYaml $.Values.shardsvr.arbiter.resources | nindent 12 }}
+        {{- if $.Values.metrics.enabled }}
+        - name: metrics
+          image: {{ include "mongodb-sharded.metrics.image" $ }}
+          imagePullPolicy: {{ $.Values.metrics.image.pullPolicy | quote }}
+          {{- if $.Values.securityContext.enabled }}
+          securityContext:
+            runAsNonRoot: {{ $.Values.securityContext.runAsNonRoot }}
+            runAsUser: {{ $.Values.securityContext.runAsUser }}
+          {{- end }}
+          env:
+          {{- if $.Values.usePasswordFile }}
+            - name: MONGODB_ROOT_PASSWORD_FILE
+              value: "/bitnami/mongodb/secrets/mongodb-root-password"
+          {{- else }}
+            - name: MONGODB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mongodb-sharded.secret" $ }}
+                  key: mongodb-root-password
+          {{- end }}
+          command:
+            - sh
+            - -ec
+            - |-
+              #!/bin/sh
+              {{- if $.Values.usePasswordFile }}
+              export MONGODB_ROOT_PASSWORD="$(< "${MONGODB_ROOT_PASSWORD_FILE}")"
+              {{- end }}
+              /bin/mongodb_exporter --mongodb.uri mongodb://root:`echo $MONGODB_ROOT_PASSWORD | sed -r "s/@/%40/g;s/:/%3A/g"`@localhost:{{ $.Values.service.port }}/admin {{ $.Values.metrics.extraArgs }}
+          {{- if $.Values.usePasswordFile }}
+          volumeMounts:
+            - name: secrets
+              mountPath: /bitnami/mongodb/secrets/
+          {{- end }}
+          ports:
+            - name: metrics
+              containerPort: 9216
+          {{- if $.Values.metrics.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: {{ $.Values.metrics.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ $.Values.metrics.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ $.Values.metrics.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ $.Values.metrics.livenessProbe.failureThreshold }}
+            successThreshold: {{ $.Values.metrics.livenessProbe.successThreshold }}
+          {{- end }}
+          {{- if $.Values.metrics.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: {{ $.Values.metrics.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ $.Values.metrics.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ $.Values.metrics.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ $.Values.metrics.readinessProbe.failureThreshold }}
+            successThreshold: {{ $.Values.metrics.readinessProbe.successThreshold }}
+          {{- end }}
+          resources: {{ toYaml $.Values.metrics.resources | nindent 12 }}
+        {{- end }}
         {{- with $.Values.shardsvr.arbiter.sidecars }}
         {{- include "mongodb-sharded.tplValue" ( dict "value" . "context" $ ) | nindent 8}}
         {{- end }}


### PR DESCRIPTION
**Description of the change**

Adds metric exporter for shard arbiter pods.

**Benefits**

This seems to have been missed as the Prometheus scraping annotations are there when `metrics.enabled = true` but not the exporter container. This causes Prometheus to mark the arbiter pods as down (ie `up == 0`) and in turn, in our case, sets off an alarm.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
