### PR TITLE
[bitnami/phabricator] fix ingress in phabricator chart with tls

### DIFF
--- a/bitnami/phabricator/Chart.yaml
+++ b/bitnami/phabricator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: phabricator
-version: 9.1.0
+version: 9.1.1
 appVersion: 2020.7.0
 description: Collection of open source web applications that help software companies build better software.
 keywords:

--- a/bitnami/phabricator/templates/ingress.yaml
+++ b/bitnami/phabricator/templates/ingress.yaml
@@ -26,14 +26,14 @@ spec:
     {{- range .Values.ingress.hosts }}
     {{- if .tls }}
     - hosts:
-    {{- if .tlsHosts }}
-    {{- range $host := .tlsHosts }}
+      {{- if .tlsHosts }}
+      {{- range $host := .tlsHosts }}
       - {{ $host }}
+      {{- end }}
+      {{- else }}
+      - {{ .name }}
+      {{- end }}
+      secretName: {{ .tlsSecret }}
     {{- end }}
-  {{- else }}
-    - {{ .name }}
-  {{- end }}
-    secretName: {{ .tlsSecret }}
-  {{- end }}
   {{- end }}
 {{- end }}

--- a/bitnami/phabricator/values.yaml
+++ b/bitnami/phabricator/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/phabricator
-  tag: 2020.7.0-debian-10-r60
+  tag: 2020.7.0-debian-10-r65
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -251,7 +251,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.8.0-debian-10-r18
+    tag: 0.8.0-debian-10-r22
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**

Fix ingress in chart with tls

**Benefits**

It works with tls.

**Possible drawbacks**

Crashing "feature" when setting "tls: true" no longer works.

**Applicable issues**


**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

