### PR TITLE
[bitnami/external-dns] support vinyldns configuration

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.21.2
+version: 2.22.0
 appVersion: 0.7.1
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/bitnami/external-dns/README.md
+++ b/bitnami/external-dns/README.md
@@ -136,6 +136,9 @@ The following table lists the configurable parameters of the external-dns chart 
 | `pdns.apiKey`                       | When using the PowerDNS provider, specify the API key of the server.                                     | `""`                                                        |
 | `transip.account`                   | When using the TransIP provider, specify the account name.                                               | `""`                                                        |
 | `transip.apiKey`                    | When using the TransIP provider, specify the API key to use.                                             | `""`                                                        |
+| `vinyldns.host`                     | When using the VinylDNS provider, specify the VinylDNS API host.                                         | `""`                                                        |
+| `vinyldns.accessKey`                | When using the VinylDNS provider, specify the Access Key to use.                                         | `""`                                                        |
+| `vinyldns.secretKey`                | When using the VinylDNS provider, specify the Secret key to use.                                         | `""`                                                        |
 | `annotationFilter`                  | Filter sources managed by external-dns via annotation using label selector (optional)                    | `""`                                                        |
 | `domainFilters`                     | Limit possible target zones by domain suffixes (optional)                                                | `[]`                                                        |
 | `zoneIdFilters`                     | Limit possible target zones by zone id (optional)                                                        | `[]`                                                        |

--- a/bitnami/external-dns/templates/_helpers.tpl
+++ b/bitnami/external-dns/templates/_helpers.tpl
@@ -138,6 +138,8 @@ Return true if a secret object should be created
     {{- true -}}
 {{- else if and (eq .Values.provider "ovh") .Values.ovh.consumerKey -}}
     {{- true -}}
+{{- else if and (eq .Values.provider "vinyldns") (or .Values.vinyldns.secretKey .Values.vinyldns.accessKey) -}}
+    {{- true -}}
 {{- else -}}
 {{- end -}}
 {{- end -}}

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -386,6 +386,27 @@ spec:
                   name: {{ template "external-dns.secretName" . }}
                   key: pdns_api_key
             {{- end }}
+            {{- if eq .Values.provider "vinyldns" }}
+            # VinylDNS environment variables
+            {{- if .Values.vinyldns.host }}
+            - name: VINYLDNS_HOST
+              value: {{ .Values.vinyldns.host }}
+            {{- end }}
+            {{- if .Values.vinyldns.accessKey }}
+            - name: VINYLDNS_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "external-dns.secretName" . }}
+                  key: vinyldns-access-key
+            {{- end }}
+            {{- if .Values.vinyldns.secretKey }}
+            - name: VINYLDNS_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "external-dns.secretName" . }}
+                  key: vinyldns-secret-key
+            {{- end }}
+            {{- end }}
             {{- if .Values.extraEnv }}
             # Extra environment variables
             {{- toYaml .Values.extraEnv | nindent 12 }}

--- a/bitnami/external-dns/templates/secret.yaml
+++ b/bitnami/external-dns/templates/secret.yaml
@@ -57,5 +57,9 @@ data:
   ovh_consumer_key: {{ .Values.ovh.consumerKey | b64enc | quote }}
   ovh_application_key: {{ .Values.ovh.applicationKey | b64enc | quote }}
   ovh_application_secret: {{ .Values.ovh.applicationSecret | b64enc | quote }}
-  {{- end }}  
+  {{- end }}
+  {{- if eq .Values.provider "vinyldns" }}
+  vinyldns-access-key: {{ .Values.vinyldns.accessKey | b64enc | quote }}
+  vinyldns-secret-key: {{ .Values.vinyldns.secretKey | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/bitnami/external-dns/values-production.yaml
+++ b/bitnami/external-dns/values-production.yaml
@@ -301,6 +301,13 @@ transip:
   ## API key that is authorised for the account
   apiKey: ""
 
+## VinylDNS configuration to be set via arguments/env. variables
+##
+vinyldns:
+  host: ""
+  accessKey: ""
+  secretKey: ""
+
 ## Limit possible target zones by domain suffixes (optional)
 ##
 domainFilters: []

--- a/bitnami/external-dns/values-production.yaml
+++ b/bitnami/external-dns/values-production.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/external-dns
-  tag: 0.7.1-debian-10-r27
+  tag: 0.7.1-debian-10-r34
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/external-dns/values.yaml
+++ b/bitnami/external-dns/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/external-dns
-  tag: 0.7.1-debian-10-r27
+  tag: 0.7.1-debian-10-r34
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/external-dns/values.yaml
+++ b/bitnami/external-dns/values.yaml
@@ -300,6 +300,13 @@ transip:
   ## API key that is authorised for the account
   apiKey: ""
 
+## VinylDNS configuration to be set via arguments/env. variables
+##
+vinyldns:
+  host: ""
+  accessKey: ""
+  secretKey: ""
+
 ## Limit possible target zones by domain suffixes (optional)
 ##
 domainFilters: []


### PR DESCRIPTION
**Description of the change**

Add to the external-dns chart parameters for [configuring VinylDNS authentication](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/vinyldns.md):
- `vinyldns.host`
- `vinyldns.accessKey`
-`vinyldns.secretKey,

**Benefits**

Users will be able to deploy the external-dns chart for use with VinylDNS.

**Possible drawbacks**

None
**Applicable issues**

None

**Additional information**

None

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
