### PR TITLE
[bitnami/cassandra] Allow to specify maxUnavailable pods

### DIFF
--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cassandra
-version: 5.3.3
+version: 5.4.0
 appVersion: 3.11.6
 description: Apache Cassandra is a free and open-source distributed database management system designed to handle large amounts of data across many commodity servers, providing high availability with no single point of failure. Cassandra offers robust support for clusters spanning multiple datacenters, with asynchronous masterless replication allowing low latency operations for all clients.
 keywords:

--- a/bitnami/cassandra/README.md
+++ b/bitnami/cassandra/README.md
@@ -92,8 +92,9 @@ The following tables lists the configurable parameters of the cassandra chart an
 | `cluster.rack`                       | Rack name                                                                                                                                                 | `rack1`                                                      |
 | `cluster.enableRPC`                  | Enable Thrift RPC endpoint                                                                                                                                | `true`                                                       |
 | `cluster.enableUDF'                  | Enable CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS                                                                                                            | `false`                                                      |
-| `cluster.pdbEnabled`                 | Enable the creation of a Pod Disruption Budget to ensure a minimun number of pods are running.                                                            |               `true`                                                      |
-| `cluster.minimumAvailable`           | Minimum number of instances that must be available in the cluster (used of PodDisruptionBudget) Needs `cluster.pdbEnabled=true`                           | `1`                                                          |
+| `cluster.pdbEnabled`                 | Enable the creation of a Pod Disruption Budget to ensure a minimun number of pods are running.                                                            | `true`                                                       |
+| `cluster.minAvailable`               | Minimum number of instances that must be available in the cluster (used of PodDisruptionBudget) Needs `cluster.pdbEnabled=true`                           | `nil`                                                        |
+| `cluster.maxUnavailable`             | Maximum number of instances that can be unavailable in the cluster (used of PodDisruptionBudget) Needs `cluster.pdbEnabled=true`                          | `nil`                                                        |
 | `cluster.internodeEncryption`        | Set internode encryption. NOTE: A value different from 'none' requires setting `tlsEncryptionSecretName`                                                  | `none`                                                       |
 | `cluster.clientEncryption`           | Set client-server encryption. NOTE: A value different from 'false' requires setting `tlsEncryptionSecretName`                                             | `false`                                                      |
 | `cluster.jvm.extraOpts`              | Set the value for Java Virtual Machine extra optinos (JVM_EXTRA_OPTS)                                                                                     | `nil`                                                        |
@@ -257,6 +258,10 @@ As an alternative, this chart supports using an initContainer to change the owne
 You can enable this initContainer by setting `volumePermissions.enabled` to `true`.
 
 ## Upgrade
+
+### 5.4.0
+
+The `minimumAvailable` option has been renamed to `minAvailable` for consistency with other charts. This is not a breaking change as `minimumAvailable` never worked before because of an error in chart templates.
 
 ### 5.0.0
 

--- a/bitnami/cassandra/templates/pdb.yaml
+++ b/bitnami/cassandra/templates/pdb.yaml
@@ -7,9 +7,10 @@ metadata:
 spec:
   selector:
     matchLabels: {{- include "cassandra.matchLabels" . | nindent 6 }}
-  {{- if .Values.minAvailable }}
-  minAvailable: {{ .Values.cluster.minimumAvailable }}
-  {{- else }}
-  maxUnavailable: 1
+  {{- if .Values.cluster.minAvailable }}
+  minAvailable: {{ .Values.cluster.minAvailable }}
+  {{- end }}
+  {{- if .Values.cluster.maxUnavailable }}
+  maxUnavailable: {{ .Values.cluster.maxUnavailable }}
   {{- end }}
 {{- end }}

--- a/bitnami/cassandra/values-production.yaml
+++ b/bitnami/cassandra/values-production.yaml
@@ -17,7 +17,7 @@ image:
   ## Bitnami Cassandra image tag
   ## ref: https://github.com/bitnami/bitnami-docker-cassandra#supported-tags-and-respective-dockerfile-links
   ##
-  tag: 3.11.6-debian-10-r72
+  tag: 3.11.6-debian-10-r82
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -291,7 +291,7 @@ metrics:
     registry: docker.io
     pullPolicy: IfNotPresent
     repository: bitnami/cassandra-exporter
-    tag: 2.3.4-debian-10-r50
+    tag: 2.3.4-debian-10-r63
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/bitnami/cassandra/values-production.yaml
+++ b/bitnami/cassandra/values-production.yaml
@@ -172,7 +172,7 @@ cluster:
   minAvailable: 2
   ## Maximum number of cluster nodes that may not be running. Needs pdbEnabled=true
   ##
-  maxUnavailable: 1
+  # maxUnavailable: 1
   ## Encryption values. NOTE: They require tlsEncryptionSecretName
   ##
   internodeEncryption: none

--- a/bitnami/cassandra/values-production.yaml
+++ b/bitnami/cassandra/values-production.yaml
@@ -167,9 +167,12 @@ cluster:
   ## Enable the creation of the Pod Disruption Budget
   ##
   pdbEnabled: true
-  ## Minimun number of cluster nodes that will be running. Needs pdbEnabled=true
+  ## Minimum number of cluster nodes that will be running. Needs pdbEnabled=true
   ##
-  minimumAvailable: 2
+  minAvailable: 2
+  ## Maximum number of cluster nodes that may not be running. Needs pdbEnabled=true
+  ##
+  # maxUnavailable: 1
   ## Encryption values. NOTE: They require tlsEncryptionSecretName
   ##
   internodeEncryption: none

--- a/bitnami/cassandra/values-production.yaml
+++ b/bitnami/cassandra/values-production.yaml
@@ -172,7 +172,7 @@ cluster:
   minAvailable: 2
   ## Maximum number of cluster nodes that may not be running. Needs pdbEnabled=true
   ##
-  # maxUnavailable: 1
+  maxUnavailable: 1
   ## Encryption values. NOTE: They require tlsEncryptionSecretName
   ##
   internodeEncryption: none

--- a/bitnami/cassandra/values.yaml
+++ b/bitnami/cassandra/values.yaml
@@ -17,7 +17,7 @@ image:
   ## Bitnami Cassandra image tag
   ## ref: https://github.com/bitnami/bitnami-docker-cassandra#supported-tags-and-respective-dockerfile-links
   ##
-  tag: 3.11.6-debian-10-r72
+  tag: 3.11.6-debian-10-r82
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -291,7 +291,7 @@ metrics:
     registry: docker.io
     pullPolicy: IfNotPresent
     repository: bitnami/cassandra-exporter
-    tag: 2.3.4-debian-10-r50
+    tag: 2.3.4-debian-10-r63
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/bitnami/cassandra/values.yaml
+++ b/bitnami/cassandra/values.yaml
@@ -172,7 +172,7 @@ cluster:
   minAvailable: 1
   ## Maximum number of cluster nodes that may not be running. Needs pdbEnabled=true.
   ##
-  # maxUnavailable: 1
+  maxUnavailable: 1
   ## Encryption values. NOTE: They require tlsEncryptionSecretName
   ##
   internodeEncryption: none

--- a/bitnami/cassandra/values.yaml
+++ b/bitnami/cassandra/values.yaml
@@ -172,7 +172,7 @@ cluster:
   minAvailable: 1
   ## Maximum number of cluster nodes that may not be running. Needs pdbEnabled=true.
   ##
-  maxUnavailable: 1
+  # maxUnavailable: 1
   ## Encryption values. NOTE: They require tlsEncryptionSecretName
   ##
   internodeEncryption: none

--- a/bitnami/cassandra/values.yaml
+++ b/bitnami/cassandra/values.yaml
@@ -167,9 +167,12 @@ cluster:
   ## Enable the creation of the Pod Disruption Budget
   ##
   pdbEnabled: true
-  ## Minimun number of cluster nodes that will be running. Needs pdbEnabled=true
+  ## Minimum number of cluster nodes that will be running. Needs pdbEnabled=true
   ##
-  minimumAvailable: 1
+  minAvailable: 1
+  ## Maximum number of cluster nodes that may not be running. Needs pdbEnabled=true.
+  ##
+  # maxUnavailable: 1
   ## Encryption values. NOTE: They require tlsEncryptionSecretName
   ##
   internodeEncryption: none


### PR DESCRIPTION
**Description of the change**

- fixes name of setting that configured minimum disruption budget (minimumAvailable -> minAvailable)
- adds setting that configures maximum disruption budget (maxUnavailable)

**Benefits**

As above

**Possible drawbacks**

No breaking changes

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
