### PR TITLE
[bitnami/wordpress] Fix wrong instructions for Upgrading -> v9.0.0

### DIFF
--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -419,7 +419,7 @@ See the [Parameters](#parameters) section to configure the PVC or to disable per
 
 ### To 9.0.0
 
-The [Bitnami WordPress](https://github.com/bitnami/bitnami-docker-wordpress) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Apache daemon was started as the `daemon` user. From now on, both the container and the Apache daemon run as user `1001`. You can revert this behavior by setting the parameters `securityContext.runAsUser`, and `securityContext.fsGroup` to `root`.
+The [Bitnami WordPress](https://github.com/bitnami/bitnami-docker-wordpress) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Apache daemon was started as the `daemon` user. From now on, both the container and the Apache daemon run as user `1001`. You can revert this behavior by setting the parameters `securityContext.runAsUser`, and `securityContext.fsGroup` to `0`.
 Chart labels and Ingress configuration were also adapted to follow the Helm charts best practices.
 
 Consequences:


### PR DESCRIPTION
Closes #2446

**Description of the change**

Fixes a mistake in upgrade instructions for WordPress chart, for v9.0.0.

This paragraph:

> The Bitnami WordPress image was migrated to a "non-root" user approach. Previously the container ran as the root user and the Apache daemon was started as the daemon user. From now on, both the container and the Apache daemon run as user `1001`. You can revert this behavior by setting the parameters `securityContext.runAsUser`, and `securityContext.fsGroup` to `root`. Chart labels and Ingress configuration were also adapted to follow the Helm charts best practices.

Here, `root` should actually be `0`.

**Benefits**

Fewer grey hairs for users

**Possible drawbacks**

None.

**Applicable issues**

  - #2446

**Additional information**

idk what is needed so feel free to edit (or wipe) this section.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
