### PR TITLE
[bitnami/nginx] Adding health ingress.

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx
-version: 5.2.4
+version: 5.2.5
 appVersion: 1.17.10
 description: Chart for the nginx server
 keywords:

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx
-version: 5.3.4
+version: 5.3.0
 appVersion: 1.17.10
 description: Chart for the nginx server
 keywords:

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx
-version: 5.2.5
+version: 5.3.4
 appVersion: 1.17.10
 description: Chart for the nginx server
 keywords:

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -100,6 +100,17 @@ The following tables lists the configurable parameters of the NGINX Open Source 
 | `ingress.secrets[0].name`                  | TLS Secret Name                                                                             | `nil`                                                        |
 | `ingress.secrets[0].certificate`           | TLS Secret Certificate                                                                      | `nil`                                                        |
 | `ingress.secrets[0].key`                   | TLS Secret Key                                                                              | `nil`                                                        |
+| `healthIngress.enabled`                    | Enable health ingress controller resource                                                   | `false`                                                      |
+| `healthIngress.certManager`                | Add annotations for cert-manager                                                            | `false`                                                      |
+| `healthIngress.selectors`                  | Health Ingress selectors for labelSelector option                                           | `[]`                                                         |
+| `healthIngress.annotations`                | Health Ingress annotations                                                                  | `[]`                                                         |
+| `healthIngress.hosts[0].name`              | Hostname to your NGINX installation                                                         | `nginx.local`                                                |
+| `healthIngress.hosts[0].path`              | Path within the url structure                                                               | `/`                                                          |
+| `healthIngress.tls[0].hosts[0]`            | TLS hosts                                                                                   | `nginx.local`                                                |
+| `healthIngress.tls[0].secretName`          | TLS Secret (certificates)                                                                   | `nginx.local-tls`                                            |
+| `healthIngress.secrets[0].name`            | TLS Secret Name                                                                             | `nil`                                                        |
+| `healthIngress.secrets[0].certificate`     | TLS Secret Certificate                                                                      | `nil`                                                        |
+| `healthIngress.secrets[0].key`             | TLS Secret Key                                                                              | `nil`                                                        |
 | `metrics.enabled`                          | Start a side-car prometheus exporter                                                        | `false`                                                      |
 | `metrics.image.registry`                   | NGINX Prometheus exporter image registry                                                    | `docker.io`                                                  |
 | `metrics.image.repository`                 | NGINX Prometheus exporter image name                                                        | `bitnami/nginx-exporter`                                     |

--- a/bitnami/nginx/templates/health-ingress.yaml
+++ b/bitnami/nginx/templates/health-ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.healthIngress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ include "nginx.fullname" . }}-health
+  labels: {{- include "nginx.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.healthIngress.certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- range $key, $value := .Values.healthIngress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- if .Values.healthIngress.hostname }}
+    - host: {{ .Values.healthIngress.hostname }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: "{{ template "nginx.fullname" $ }}"
+              servicePort: http
+    {{- end }}
+    {{- range .Values.healthIngress.hosts }}
+    - host: {{ .name }}
+      http:
+        paths:
+          - path: {{ default "/" .path }}
+            backend:
+              serviceName: "{{ template "nginx.fullname" $ }}"
+              servicePort: http
+    {{- end }}
+  {{- if .Values.healthIngress.tls }}
+  tls: {{- toYaml .Values.healthIngress.tls | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/nginx
-  tag: 1.17.10-debian-10-r11
+  tag: 1.17.10-debian-10-r28
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -294,7 +294,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/nginx-exporter
-    tag: 0.6.0-debian-10-r63
+    tag: 0.7.0-debian-10-r17
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -232,6 +232,43 @@ ingress:
         - example.local
       secretName: example.local-tls
 
+
+healthIngress:
+  ## Set to true to enable health ingress record generation
+  ##
+  enabled: false
+
+  ## Set this to true in order to add the corresponding annotations for cert-manager
+  ##
+  certManager: false
+
+  ## When the health ingress is enabled, a host pointing to this will be created
+  ##
+  hostname: example.local
+
+  ## Health Ingress annotations done as key:value pairs
+  ## For a full list of possible ingress annotations, please see
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ##
+  ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+  annotations: {}
+  #  kubernetes.io/ingress.class: nginx
+
+  ## The list of additional hostnames to be covered with this health ingress record.
+  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+  ## hosts:
+  ## - name: example.local
+  ##   path: /
+
+  ## The tls configuration for the health ingress
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ##
+  tls:
+    - hosts:
+        - example.local
+      secretName: example.local-tls
+
   secrets:
   ## If you're providing your own certificates, please use this to add the certificates as secrets
   ## key and certificate should start with -----BEGIN CERTIFICATE----- or


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Adding a separate health ingress for checking the health status of the application and it will be use for traffic manager.

**Benefits**

Create separate health ingress for the application.

**Possible drawbacks**

No drawbacks

**Additional information**

We can't use the same ingress which is available now for the health status also. Since i want to use the ingress annotation `nginx.ingress.kubernetes.io/rewrite-target: /health/status` which is going to use only for ingress health host and not for the application host. So created a separate health ingress.
**Note**: Exactly used the same existing ingress copy as a new health ingress

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)