### PR TITLE
[bitnami/magento] Bump major version due to a new major in a dependency

### DIFF
--- a/bitnami/magento/Chart.yaml
+++ b/bitnami/magento/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: magento
-version: 12.1.2
+version: 13.0.0
 appVersion: 2.3.5
 description: A feature-rich flexible e-commerce solution. It includes transaction options, multi-store functionality, loyalty programs, product categorization and shopper filtering, promotion rules, and more.
 keywords:

--- a/bitnami/magento/README.md
+++ b/bitnami/magento/README.md
@@ -210,6 +210,10 @@ The [Bitnami Magento](https://github.com/bitnami/bitnami-docker-magento) image s
 
 ## Notable changes
 
+### 13.0.0
+
+This version includes a new major version of the ElasticSearch chart bundled as dependency. You can find the release notes of the new ElasticSearch major version in [this section](https://github.com/bitnami/charts/tree/master/bitnami/elasticsearch#1200) of the ES README.
+
 ### 9.0.0
 
 This version enabled by default an initContainer that modify some kernel settings to meet the Elasticsearch requirements.

--- a/bitnami/magento/README.md
+++ b/bitnami/magento/README.md
@@ -212,7 +212,9 @@ The [Bitnami Magento](https://github.com/bitnami/bitnami-docker-magento) image s
 
 ### 13.0.0
 
-This version includes a new major version of the ElasticSearch chart bundled as dependency. You can find the release notes of the new ElasticSearch major version in [this section](https://github.com/bitnami/charts/tree/master/bitnami/elasticsearch#1200) of the ES README.
+Several changes were introduced that can break backwards compatibilty:
+- This version includes a new major version of the ElasticSearch chart bundled as dependency. You can find the release notes of the new ElasticSearch major version in [this section](https://github.com/bitnami/charts/tree/master/bitnami/elasticsearch#1200) of the ES README.
+- Labels are adapted to follow the Helm charts best practices.
 
 ### 9.0.0
 

--- a/bitnami/magento/requirements.lock
+++ b/bitnami/magento/requirements.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 7.3.21
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
-  version: 11.0.20
-digest: sha256:c8d4211df185057b15280557594df0dcfdbf583d804801876bd2da9ef0213ab2
-generated: "2020-04-29T11:44:09.051477719Z"
+  version: 12.0.1
+digest: sha256:80c24e19477cc49bb09a473130350e9410bfddcee4431ec20fc618776997d04b
+generated: "2020-04-30T14:11:11.27030324Z"

--- a/bitnami/magento/requirements.lock
+++ b/bitnami/magento/requirements.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 7.3.21
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
-  version: 12.0.1
-digest: sha256:80c24e19477cc49bb09a473130350e9410bfddcee4431ec20fc618776997d04b
-generated: "2020-04-30T14:11:11.27030324Z"
+  version: 11.0.20
+digest: sha256:c8d4211df185057b15280557594df0dcfdbf583d804801876bd2da9ef0213ab2
+generated: "2020-04-29T11:44:09.051477719Z"

--- a/bitnami/magento/requirements.lock
+++ b/bitnami/magento/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 7.3.21
+  version: 7.4.1
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
-  version: 11.0.20
-digest: sha256:c8d4211df185057b15280557594df0dcfdbf583d804801876bd2da9ef0213ab2
-generated: "2020-04-29T11:44:09.051477719Z"
+  version: 12.0.2
+digest: sha256:ddce83af36160415764acc82a451b1ca392c60280ea5df3ab62ff96da55a249d
+generated: "2020-05-08T10:05:58.100744343Z"

--- a/bitnami/magento/requirements.yaml
+++ b/bitnami/magento/requirements.yaml
@@ -4,6 +4,6 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: mariadb.enabled
   - name: elasticsearch
-    version: 11.x.x
+    version: 12.x.x
     repository: https://charts.bitnami.com/bitnami
     condition: elasticsearch.enabled

--- a/bitnami/magento/templates/apache-pvc.yaml
+++ b/bitnami/magento/templates/apache-pvc.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 metadata:
   name: {{ template "magento.fullname" . }}-apache
   labels:
-    app: {{ template "magento.fullname" . }}
-    chart: {{ template "magento.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "magento.fullname" . }}
+    helm.sh/chart: {{ template "magento.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 spec:
   accessModes:
     - {{ .Values.persistence.apache.accessMode | quote }}

--- a/bitnami/magento/templates/deployment.yaml
+++ b/bitnami/magento/templates/deployment.yaml
@@ -4,23 +4,23 @@ kind: Deployment
 metadata:
   name: {{ template "magento.fullname" . }}
   labels:
-    app: {{ template "magento.fullname" . }}
-    chart: {{ template "magento.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "magento.fullname" . }}
+    helm.sh/chart: {{ template "magento.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 spec:
   selector:
     matchLabels:
-      app: {{ template "magento.fullname" . }}
-      release: "{{ .Release.Name }}"
+      app.kubernetes.io/name: {{ template "magento.fullname" . }}
+      app.kubernetes.io/instance: "{{ .Release.Name }}"
   strategy:
     type: {{ .Values.updateStrategy }}
   template:
     metadata:
       labels:
-        app: {{ template "magento.fullname" . }}
-        chart: {{ template "magento.chart" . }}
-        release: "{{ .Release.Name }}"
+        app.kubernetes.io/name: {{ template "magento.fullname" . }}
+        helm.sh/chart: {{ template "magento.chart" . }}
+        app.kubernetes.io/instance: "{{ .Release.Name }}"
 {{- if or .Values.podAnnotations .Values.metrics.enabled }}
       annotations:
   {{- if .Values.podAnnotations }}

--- a/bitnami/magento/templates/externaldb-secrets.yaml
+++ b/bitnami/magento/templates/externaldb-secrets.yaml
@@ -4,10 +4,10 @@ kind: Secret
 metadata:
   name: {{ template "magento.fullname" . }}-externaldb
   labels:
-    app: {{ template "magento.fullname" . }}
-    chart: {{ template "magento.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "magento.fullname" . }}
+    helm.sh/chart: {{ template "magento.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 type: Opaque
 data:
   db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}

--- a/bitnami/magento/templates/ingress.yaml
+++ b/bitnami/magento/templates/ingress.yaml
@@ -4,10 +4,10 @@ kind: Ingress
 metadata:
   name: {{ template "magento.fullname" . }}
   labels:
-    app: "{{ template "magento.fullname" . }}"
-    chart: "{{ template "magento.chart" . }}"
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ template "magento.fullname" . }}
+    helm.sh/chart: {{ template "magento.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
   annotations:
     {{- if .Values.ingress.certManager }}
     kubernetes.io/tls-acme: "true"

--- a/bitnami/magento/templates/magento-pvc.yaml
+++ b/bitnami/magento/templates/magento-pvc.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 metadata:
   name: {{ template "magento.fullname" . }}-magento
   labels:
-    app: {{ template "magento.fullname" . }}
-    chart: {{ template "magento.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "magento.fullname" . }}
+    helm.sh/chart: {{ template "magento.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 spec:
   accessModes:
     - {{ .Values.persistence.magento.accessMode | quote }}

--- a/bitnami/magento/templates/secrets.yaml
+++ b/bitnami/magento/templates/secrets.yaml
@@ -3,10 +3,10 @@ kind: Secret
 metadata:
   name: {{ template "magento.fullname" . }}
   labels:
-    app: {{ template "magento.fullname" . }}
-    chart: {{ template "magento.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "magento.fullname" . }}
+    helm.sh/chart: {{ template "magento.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 type: Opaque
 data:
   magento-password: "{{ b64enc (include "magento.password" .) }}"

--- a/bitnami/magento/templates/svc.yaml
+++ b/bitnami/magento/templates/svc.yaml
@@ -3,10 +3,10 @@ kind: Service
 metadata:
   name: {{ template "magento.fullname" . }}
   labels:
-    app: {{ template "magento.fullname" . }}
-    chart: {{ template "magento.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "magento.fullname" . }}
+    helm.sh/chart: {{ template "magento.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 spec:
   type: {{ .Values.service.type }}
   {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}
@@ -23,4 +23,4 @@ spec:
       nodePort: {{ .Values.service.nodePorts.http }}
       {{- end }}
   selector:
-    app: {{ template "magento.fullname" . }}
+    app.kubernetes.io/name: {{ template "magento.fullname" . }}

--- a/bitnami/magento/values-production.yaml
+++ b/bitnami/magento/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/magento
-  tag: 2.3.5-debian-10-r7
+  tag: 2.3.5-debian-10-r14
   ## Set to true if you would like to see extra information on logs
   ## It turns BASH and NAMI debugging in minideb
   ## ref:  https://github.com/bitnami/minideb-extras/#turn-on-bash-debugging
@@ -183,7 +183,7 @@ elasticsearch:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch
-    tag: 6.8.8-debian-10-r34
+    tag: 6.8.8-debian-10-r42
   ## Enable to perform the sysctl operation
   sysctlImage:
     enabled: true
@@ -347,7 +347,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.8.0-debian-10-r30
+    tag: 0.8.0-debian-10-r37
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/magento/values.yaml
+++ b/bitnami/magento/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/magento
-  tag: 2.3.5-debian-10-r7
+  tag: 2.3.5-debian-10-r14
   ## Set to true if you would like to see extra information on logs
   ## It turns BASH and NAMI debugging in minideb
   ## ref:  https://github.com/bitnami/minideb-extras/#turn-on-bash-debugging
@@ -183,7 +183,7 @@ elasticsearch:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch
-    tag: 6.8.8-debian-10-r34
+    tag: 6.8.8-debian-10-r42
   ## Enable to perform the sysctl operation
   sysctlImage:
     enabled: true
@@ -347,7 +347,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.8.0-debian-10-r30
+    tag: 0.8.0-debian-10-r37
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**

ElasticSearch chart bundled as dependency receive a new major version, we need to also bump the major version of Magento in order to use the latest ES.