### PR TITLE
[bitnami/zookeeper] fix() typo

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zookeeper
-version: 5.14.1
+version: 5.14.2
 appVersion: 3.6.1
 description: A centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services for distributed applications.
 keywords:

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -162,7 +162,7 @@ spec:
               value: {{ .Values.service.tls.client_keystore_path | quote }}
             - name: ZOO_TLS_CLIENT_KEYSTORE_PASSWORD
               value: {{ .Values.service.tls.client_keystore_password | quote }}
-            - name: ZOO_TLS_CLIENT_TRUSTTORE_FILE
+            - name: ZOO_TLS_CLIENT_TRUSTSTORE_FILE
               value: {{ .Values.service.tls.client_truststore_path | quote }}
             - name: ZOO_TLS_CLIENT_TRUSTSTORE_PASSWORD
               value: {{ .Values.service.tls.client_truststore_password | quote }}
@@ -174,7 +174,7 @@ spec:
               value: {{ .Values.service.tls.quorum_keystore_path | quote }}
             - name: ZOO_TLS_QUORUM_KEYSTORE_PASSWORD
               value: {{ .Values.service.tls.quorum_keystore_password | quote }}
-            - name: ZOO_TLS_QUORUM_TRUSTTORE_FILE
+            - name: ZOO_TLS_QUORUM_TRUSTSTORE_FILE
               value: {{ .Values.service.tls.quorum_truststore_path | quote }}
             - name: ZOO_TLS_QUORUM_TRUSTSTORE_PASSWORD
               value: {{ .Values.service.tls.quorum_truststore_password | quote }}

--- a/bitnami/zookeeper/values-production.yaml
+++ b/bitnami/zookeeper/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/zookeeper
-  tag: 3.6.1-debian-10-r0
+  tag: 3.6.1-debian-10-r1
   
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/zookeeper
-  tag: 3.6.1-debian-10-r0
+  tag: 3.6.1-debian-10-r1
   
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This is fix for TRUSTTORE typo

**Benefits**

TLS is not working with this typo. This will fix it

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
