### PR TITLE
[bitnami/wordpress] Mount configmap as wp-config.php

### DIFF
--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -85,6 +85,16 @@ The following table lists the configurable parameters of the WordPress chart and
 | `wordpressBlogName`                       | Blog name                                                                             | `User's Blog!`                                               |
 | `wordpressTablePrefix`                    | Table prefix                                                                          | `wp_`                                                        |
 | `wordpressScheme`                         | Scheme to generate application URLs [`http`, `https`]                                 | `http`                                                       |
+| `wordpressAuthKey`                        | Auth key                                                                              | _random 64 character long alphanumeric string_               |
+| `wordpressSecureAuthKey`                  | Secure auth key                                                                       | _random 64 character long alphanumeric string_               |
+| `wordpressLoggedInKey`                    | Logged in key                                                                         | _random 64 character long alphanumeric string_               |
+| `wordpressNonceKey`                       | Nonce key                                                                             | _random 64 character long alphanumeric string_               |
+| `wordpressAuthSalt`                       | Auth salt                                                                             | _random 64 character long alphanumeric string_               |
+| `wordpressSecureAuthSalt`                 | Secure auth salt                                                                      | _random 64 character long alphanumeric string_               |
+| `wordpressLoggedInSalt`                   | Logged in salt                                                                        | _random 64 character long alphanumeric string_               |
+| `wordpressNonceSalt`                      | Nonce salt                                                                            | _random 64 character long alphanumeric string_               |
+| `wordpressConfigDefine`                   | Define key-value pairs to append in wp-config.php                                     | `{}`                                                         |
+| `wordpressConfigBlock`                    | Raw string to append in wp-config.php                                                 | `""`                                                         |
 | `allowEmptyPassword`                      | Allow DB blank passwords                                                              | `true`                                                       |
 | `allowOverrideNone`                       | Set Apache AllowOverride directive to None                                            | `false`                                                      |
 | `htaccessPersistenceEnabled`              | Make `.htaccess` persistence so that it can be customized. [See](#disabling-htaccess) | `false`                                                      |

--- a/bitnami/wordpress/templates/configmap.yaml
+++ b/bitnami/wordpress/templates/configmap.yaml
@@ -1,0 +1,135 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "wordpress.fullname" . }}
+  labels: {{- include "wordpress.labels" . | nindent 4 }}
+data:
+  wp-config.php: |-
+    <?php
+    /**
+     * DO NOT edit the this file directly as any changes will be
+     * overwritten when upgrading wordpress from helm. Please set
+     * the values using helm install.
+     *
+     * The base configuration for WordPress
+     *
+     * The wp-config.php creation script uses this file during the
+     * installation. You don't have to use the web site, you can
+     * copy this file to "wp-config.php" and fill in the values.
+     *
+     * This file contains the following configurations:
+     *
+     * * MySQL settings
+     * * Secret keys
+     * * Database table prefix
+     * * ABSPATH
+     *
+     * @link https://wordpress.org/support/article/editing-wp-config-php/
+     *
+     * @package WordPress
+     */
+    
+    // ** MySQL settings - You can get this info from your web host ** //
+    /** The name of the database for WordPress */
+    define( 'DB_NAME', getenv('WORDPRESS_DATABASE_NAME') );
+    
+    /** MySQL database username */
+    define( 'DB_USER', getenv('WORDPRESS_DATABASE_USER') );
+    
+    /** MySQL database password */
+    define( 'DB_PASSWORD', getenv('WORDPRESS_DATABASE_PASSWORD') );
+    
+    /** MySQL hostname */
+    define( 'DB_HOST', getenv('MARIADB_HOST') . ':' . getenv('MARIADB_PORT_NUMBER') );
+    
+    /** Database Charset to use in creating database tables. */
+    define( 'DB_CHARSET', 'utf8' );
+    
+    /** The Database Collate type. Don't change this if in doubt. */
+    define( 'DB_COLLATE', '' );
+    
+    /**#@+
+     * Authentication Unique Keys and Salts.
+     *
+     * Change these to different unique phrases!
+     * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
+     * You can change these at any point in time to invalidate all existing cookies. This will force all users to have to log in again.
+     *
+     * @since 2.6.0
+     */
+    define( 'AUTH_KEY',         getenv('WORDPRESS_AUTH_KEY') );
+    define( 'SECURE_AUTH_KEY',  getenv('WORDPRESS_SECURE_AUTH_KEY') );
+    define( 'LOGGED_IN_KEY',    getenv('WORDPRESS_LOGGED_IN_KEY') );
+    define( 'NONCE_KEY',        getenv('WORDPRESS_NONCE_KEY') );
+    define( 'AUTH_SALT',        getenv('WORDPRESS_AUTH_SALT') );
+    define( 'SECURE_AUTH_SALT', getenv('WORDPRESS_SECURE_AUTH_SALT') );
+    define( 'LOGGED_IN_SALT',   getenv('WORDPRESS_LOGGED_IN_SALT') );
+    define( 'NONCE_SALT',       getenv('WORDPRESS_NONCE_SALT') );
+    
+    /**#@-*/
+    
+    /**
+     * WordPress Database Table prefix.
+     *
+     * You can have multiple installations in one database if you give each
+     * a unique prefix. Only numbers, letters, and underscores please!
+     */
+    $table_prefix = getenv('WORDPRESS_TABLE_PREFIX');
+    
+    /**
+     * For developers: WordPress debugging mode.
+     *
+     * Change this to true to enable the display of notices during development.
+     * It is strongly recommended that plugin and theme developers use WP_DEBUG
+     * in their development environments.
+     *
+     * For information on other constants that can be used for debugging,
+     * visit the documentation.
+     *
+     * @link https://wordpress.org/support/article/debugging-in-wordpress/
+     */
+    define( 'WP_DEBUG', false );
+    
+    define('WP_PLUGIN_DIR', '/bitnami/wordpress' . '/wp-content/plugins');
+
+    {{- range $key, $value := .Values.wordpressConfigDefine }}
+    define('{{ $key }}', {{ $value }} );
+    {{- end }}
+    {{ .Values.wordpressConfigBlock }}
+
+    /* That's all, stop editing! Happy publishing. */
+    
+    
+    if ( defined( 'WP_CLI' ) ) {
+      $_SERVER['HTTP_HOST'] = '127.0.0.1';
+    }
+    
+    define('WP_SITEURL', getenv('WORDPRESS_SCHEME') . '://' . $_SERVER['HTTP_HOST'] . '/');
+    define('WP_HOME', getenv('WORDPRESS_SCHEME') . '://' . $_SERVER['HTTP_HOST'] . '/');
+    define('FS_METHOD', 'direct');
+    /** Absolute path to the WordPress directory. */
+    
+    if ( ! defined( 'ABSPATH' ) ) {
+            define('ABSPATH', '/opt/bitnami/wordpress' . '/');
+    }
+    
+    /** Sets up WordPress vars and included files. */
+    require_once ABSPATH . 'wp-settings.php';
+    
+    define('WP_TEMP_DIR', '/opt/bitnami/wordpress/tmp');
+    
+    if ( !defined( 'WP_CLI' ) ) {
+    //  Disable pingback.ping xmlrpc method to prevent WordPress from participating in DDoS attacks
+    //  More info at: https://wiki.bitnami.com/Applications/Bitnami_WordPress#XMLRPC_and_Pingback
+    
+    // remove x-pingback HTTP header
+    add_filter("wp_headers", function($headers) {
+                unset($headers["X-Pingback"]);
+                return $headers;
+               });
+    // disable pingbacks
+    add_filter( "xmlrpc_methods", function( $methods ) {
+                 unset( $methods["pingback.ping"] );
+                 return $methods;
+               });
+    }

--- a/bitnami/wordpress/templates/deployment.yaml
+++ b/bitnami/wordpress/templates/deployment.yaml
@@ -97,6 +97,46 @@ spec:
               value: {{ .Values.wordpressTablePrefix | quote }}
             - name: WORDPRESS_SCHEME
               value: {{ .Values.wordpressScheme | quote }}
+            - name: WORDPRESS_AUTH_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wordpress.fullname" . }}
+                  key: auth_key
+            - name: WORDPRESS_SECURE_AUTH_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wordpress.fullname" . }}
+                  key: secure_auth_key
+            - name: WORDPRESS_LOGGED_IN_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wordpress.fullname" . }}
+                  key: logged_in_key
+            - name: WORDPRESS_NONCE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wordpress.fullname" . }}
+                  key: nonce_key
+            - name: WORDPRESS_AUTH_SALT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wordpress.fullname" . }}
+                  key: auth_salt
+            - name: WORDPRESS_SECURE_AUTH_SALT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wordpress.fullname" . }}
+                  key: secure_auth_salt
+            - name: WORDPRESS_LOGGED_IN_SALT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wordpress.fullname" . }}
+                  key: logged_in_salt
+            - name: WORDPRESS_NONCE_SALT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wordpress.fullname" . }}
+                  key: nonce_salt
             {{- if .Values.smtpHost }}
             - name: SMTP_HOST
               value: {{ .Values.smtpHost | quote }}
@@ -170,6 +210,9 @@ spec:
             - mountPath: /bitnami/wordpress
               name: wordpress-data
               subPath: wordpress
+            - mountPath: /bitnami/wordpress/wp-config.php
+              name: wp-config
+              subPath: wp-config.php
             {{- if and .Values.allowOverrideNone .Values.customHTAccessCM }}
             - mountPath: /htaccess
               name: custom-htaccess
@@ -226,6 +269,10 @@ spec:
           {{- else }}
           emptyDir: {}
           {{ end }}
+        - name: wp-config
+          configMap:
+            name: {{ template "wordpress.fullname" . }}
+            defaultMode: 0440
         {{- if .Values.extraVolumes }}
         {{- include "wordpress.tplValue" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}

--- a/bitnami/wordpress/templates/secrets.yaml
+++ b/bitnami/wordpress/templates/secrets.yaml
@@ -13,3 +13,43 @@ data:
   {{- if .Values.smtpPassword }}
   smtp-password: {{ .Values.smtpPassword | b64enc | quote }}
   {{- end }}
+  {{- if .Values.wordpressAuthKey }}
+  auth_key: {{ .Values.wordpressAuthKey | b64enc | quote }}
+  {{- else }}
+  auth_key: {{ randAlphaNum 64 | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.wordpressSecureAuthKey }}
+  secure_auth_key: {{ .Values.wordpressSecureAuthKey | b64enc | quote }}
+  {{- else }}
+  secure_auth_key: {{ randAlphaNum 64 | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.wordpressLoggedInKey }}
+  logged_in_key: {{ .Values.wordpressLoggedInKey | b64enc | quote }}
+  {{- else }}
+  logged_in_key: {{ randAlphaNum 64 | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.wordpressNonceKey }}
+  nonce_key: {{ .Values.wordpressNonceKey | b64enc | quote }}
+  {{- else }}
+  nonce_key: {{ randAlphaNum 64 | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.wordpressAuthSalt }}
+  auth_salt: {{ .Values.wordpressAuthSalt | b64enc | quote }}
+  {{- else }}
+  auth_salt: {{ randAlphaNum 64 | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.wordpressSecureAuthSalt }}
+  secure_auth_salt: {{ .Values.wordpressSecureAuthSalt | b64enc | quote }}
+  {{- else }}
+  secure_auth_salt: {{ randAlphaNum 64 | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.wordpressLoggedInSalt }}
+  logged_in_salt: {{ .Values.wordpressLoggedInSalt | b64enc | quote }}
+  {{- else }}
+  logged_in_salt: {{ randAlphaNum 64 | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.wordpressNonceSalt }}
+  nonce_salt: {{ .Values.wordpressNonceSalt | b64enc | quote }}
+  {{- else }}
+  nonce_salt: {{ randAlphaNum 64 | b64enc | quote }}
+  {{- end }}

--- a/bitnami/wordpress/values-production.yaml
+++ b/bitnami/wordpress/values-production.yaml
@@ -84,6 +84,68 @@ wordpressScheme: http
 ##
 wordpressSkipInstall: false
 
+## Application auth key
+## Defaults to a random 64-character alphanumeric string if not set
+## ref: https://wordpress.org/support/article/editing-wp-config-php/
+##
+# wordpressAuthKey:
+
+## Application secure auth key
+## Defaults to a random 64-character alphanumeric string if not set
+## ref: https://wordpress.org/support/article/editing-wp-config-php/
+##
+# wordpressSecureAuthKey:
+
+## Application logged in key
+## Defaults to a random 64-character alphanumeric string if not set
+## ref: https://wordpress.org/support/article/editing-wp-config-php/
+##
+# wordpressLoggedInKey:
+
+## Application nonce key
+## Defaults to a random 64-character alphanumeric string if not set
+## ref: https://wordpress.org/support/article/editing-wp-config-php/
+##
+# wordpressNonceKey:
+
+## Application auth salt
+## Defaults to a random 64-character alphanumeric string if not set
+## ref: https://wordpress.org/support/article/editing-wp-config-php/
+##
+# wordpressAuthSalt:
+
+## Application secure auth salt
+## Defaults to a random 64-character alphanumeric string if not set
+## ref: https://wordpress.org/support/article/editing-wp-config-php/
+##
+# wordpressSecureAuthSalt:
+
+## Application logged in salte
+## Defaults to a random 64-character alphanumeric string if not set
+## ref: https://wordpress.org/support/article/editing-wp-config-php/
+##
+# wordpressLoggedInSalt:
+
+## Application nonce salt
+## Defaults to a random 64-character alphanumeric string if not set
+## ref: https://wordpress.org/support/article/editing-wp-config-php/
+##
+# wordpressNonceSalt:
+
+## A map of key-value pairs wrapped in define method to append in wp-config.php
+## ref: https://wordpress.org/support/article/editing-wp-config-php/
+## Example:
+## wordpressConfigDefine:
+##  WP_HTTP_BLOCK_EXTERNAL: true
+##  WP_ACCESSIBLE_HOSTS: "'api.wordpress.org,*.github.com'"
+##  EMPTY_TRASH_DAYS: 30
+wordpressConfigDefine: {}
+
+## Raw string to append in wp-config.php
+## ref: https://wordpress.org/support/article/editing-wp-config-php/
+##
+wordpressConfigBlock: ""
+
 ## Set up update strategy for wordpress installation. Set to Recreate if you use persistent volume that cannot be mounted by more than one pods to makesure the pods is destroyed first.
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
 ## Example:

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -84,6 +84,68 @@ wordpressScheme: http
 ##
 wordpressSkipInstall: false
 
+## Application auth key
+## Defaults to a random 64-character alphanumeric string if not set
+## ref: https://wordpress.org/support/article/editing-wp-config-php/
+##
+# wordpressAuthKey:
+
+## Application secure auth key
+## Defaults to a random 64-character alphanumeric string if not set
+## ref: https://wordpress.org/support/article/editing-wp-config-php/
+##
+# wordpressSecureAuthKey:
+
+## Application logged in key
+## Defaults to a random 64-character alphanumeric string if not set
+## ref: https://wordpress.org/support/article/editing-wp-config-php/
+##
+# wordpressLoggedInKey:
+
+## Application nonce key
+## Defaults to a random 64-character alphanumeric string if not set
+## ref: https://wordpress.org/support/article/editing-wp-config-php/
+##
+# wordpressNonceKey:
+
+## Application auth salt
+## Defaults to a random 64-character alphanumeric string if not set
+## ref: https://wordpress.org/support/article/editing-wp-config-php/
+##
+# wordpressAuthSalt:
+
+## Application secure auth salt
+## Defaults to a random 64-character alphanumeric string if not set
+## ref: https://wordpress.org/support/article/editing-wp-config-php/
+##
+# wordpressSecureAuthSalt:
+
+## Application logged in salte
+## Defaults to a random 64-character alphanumeric string if not set
+## ref: https://wordpress.org/support/article/editing-wp-config-php/
+##
+# wordpressLoggedInSalt:
+
+## Application nonce salt
+## Defaults to a random 64-character alphanumeric string if not set
+## ref: https://wordpress.org/support/article/editing-wp-config-php/
+##
+# wordpressNonceSalt:
+
+## A map of key-value pairs wrapped in define method to append in wp-config.php
+## ref: https://wordpress.org/support/article/editing-wp-config-php/
+## Example:
+## wordpressConfigDefine:
+##  WP_HTTP_BLOCK_EXTERNAL: true
+##  WP_ACCESSIBLE_HOSTS: "'api.wordpress.org,*.github.com'"
+##  EMPTY_TRASH_DAYS: 30
+wordpressConfigDefine: {}
+
+## Raw string to append in wp-config.php
+## ref: https://wordpress.org/support/article/editing-wp-config-php/
+##
+wordpressConfigBlock: ""
+
 ## Set up update strategy for wordpress installation. Set to Recreate if you use persistent volume that cannot be mounted by more than one pods to makesure the pods is destroyed first.
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
 ## Example:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
As described in https://github.com/bitnami/charts/issues/2473
We generate a config map using a .yaml template defining a wp-config.php key with the value containing the actual configs. And mount this config map key in /bitnami/worpress/wp-config.php.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
Changes are in sync between helm and wp-config.php

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**
Bitnami Wordpress image needs to be changed for this to work as the image fails to chmod wp-config.php
<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #2473

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
