### PR TITLE
[bitnami/mariadb] Add seconds_behind readinessProbe #2360

### DIFF
--- a/bitnami/mariadb/README.md
+++ b/bitnami/mariadb/README.md
@@ -156,6 +156,8 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `slave.livenessProbe.successThreshold`      | Minimum consecutive successes for the probe (slave) | `1`                                                               |
 | `slave.livenessProbe.failureThreshold`      | Minimum consecutive failures for the probe (slave)  | `3`                                                               |
 | `slave.readinessProbe.enabled`              | Turn on and off readiness probe (slave)             | `true`                                                            |
+| `slave.readinessProbe.type`                 | Select the type of readiness probe (slave)         | `status`                                                            |
+| `slave.readinessProbe.typeSecondsBehind` | Number of seconds behind master to count as ready  for the seconds_behind readiness check (slave) | `true`                                                            |
 | `slave.readinessProbe.initialDelaySeconds`  | Delay before readiness probe is initiated (slave)   | `45`                                                              |
 | `slave.readinessProbe.periodSeconds`        | How often to perform the probe (slave)              | `10`                                                              |
 | `slave.readinessProbe.timeoutSeconds`       | When the probe times out (slave)                    | `1`                                                               |

--- a/bitnami/mariadb/templates/slave-statefulset.yaml
+++ b/bitnami/mariadb/templates/slave-statefulset.yaml
@@ -167,6 +167,7 @@ spec:
             failureThreshold: {{ .Values.slave.livenessProbe.failureThreshold }}
           {{- end }}
           {{- if .Values.slave.readinessProbe.enabled }}
+            {{- if (eq .Values.slave.readinessProbe.type "status") }}
           readinessProbe:
             exec:
               command:
@@ -178,6 +179,23 @@ spec:
                       password_aux=$(cat $MARIADB_MASTER_ROOT_PASSWORD_FILE)
                   fi
                   mysqladmin status -uroot -p$password_aux
+            {{- end }}
+            {{- if (eq .Values.slave.readinessProbe.type "seconds_behind") }}
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - |
+                  set -e
+                  password_aux="${MARIADB_MASTER_ROOT_PASSWORD:-}"
+                  if [ -f "${MARIADB_MASTER_ROOT_PASSWORD_FILE:-}" ]; then
+                      password_aux=$(cat $MARIADB_MASTER_ROOT_PASSWORD_FILE)
+                  fi
+                  seconds_behind=$(mysql -e "show slave status\G" -uroot -p$password_aux | grep "Seconds_Behind_Master" | awk '{print $2}')
+                  seconds_behind=${seconds_behind%.*}
+                  if [[ ${seconds_behind} =~ ^-?[0-9]+$ && {{ .Values.slave.readinessProbe.typeSecondsBehind }} -gt ${seconds_behind} ]]; then exit 0; else exit 1; fi
+            {{- end }}
             initialDelaySeconds: {{ .Values.slave.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.slave.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.slave.readinessProbe.timeoutSeconds }}

--- a/bitnami/mariadb/values-production.yaml
+++ b/bitnami/mariadb/values-production.yaml
@@ -434,6 +434,10 @@ slave:
     failureThreshold: 3
   readinessProbe:
     enabled: true
+    # "status" or "seconds_behind"
+    type: status
+    # Number of seconds behind for the seconds_behind readiness check
+    # typeSecondsBehind: 60
     initialDelaySeconds: 45
     ##
     ## Default Kubernetes values

--- a/bitnami/mariadb/values.yaml
+++ b/bitnami/mariadb/values.yaml
@@ -435,6 +435,10 @@ slave:
     failureThreshold: 3
   readinessProbe:
     enabled: true
+    # "status" or "seconds_behind"
+    type: status
+    # Number of seconds behind for the seconds_behind readiness check
+    # typeSecondsBehind: 60
     initialDelaySeconds: 45
     ##
     ## Default Kubernetes values


### PR DESCRIPTION
**Description of the change**

Add a readinessProbe that checks the number of seconds a replica is lagged behind the master.

**Benefits**

This allows you to increase the replica count and have the replica catch up to a desired lag before being pooled as part of the service.

**Possible drawbacks**

Seconds_behind_master may not be the perfect measure of this, but it is "pretty good"

**Applicable issues**

  - fixes #2360

**Additional information**

This could probably also be done in the mysql chart?

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
