### PR TITLE
[bitnami/postgresql] Fix typo

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 8.9.4
+version: 8.9.5
 appVersion: 11.7.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/bitnami/postgresql/values-production.yaml
+++ b/bitnami/postgresql/values-production.yaml
@@ -426,7 +426,7 @@ resources:
 
 ## Add annotations to all the deployed resources
 ##
-commonAnnotiations: {}
+commonAnnotations: {}
 
 networkPolicy:
   ## Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.

--- a/bitnami/postgresql/values.yaml
+++ b/bitnami/postgresql/values.yaml
@@ -432,7 +432,7 @@ resources:
 
 ## Add annotations to all the deployed resources
 ##
-commonAnnotiations: {}
+commonAnnotations: {}
 
 networkPolicy:
   ## Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.


### PR DESCRIPTION
**Description of the change**

Hey dudes! Here's a quick drive-by to fix a spelling error in the postgresql chart, affecting `commonAnnotations`

**Benefits**

`commonAnnotations` will work as intended

**Possible drawbacks**

Somebody will 🤦 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
