### PR TITLE
[bitnami/consul] Use static node name on Consul replicas

### DIFF
--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: consul
-version: 7.0.14
+version: 7.0.15
 appVersion: 1.7.3
 description: Highly available and distributed service discovery and key-value store designed with support for the modern data center to make distributed systems and configuration easy.
 home: https://www.consul.io/

--- a/bitnami/consul/templates/statefulset.yaml
+++ b/bitnami/consul/templates/statefulset.yaml
@@ -92,6 +92,10 @@ spec:
             {{- $clusterDomain := .Values.clusterDomain }}
             - name: BITNAMI_DEBUG
               value: {{ ternary "true" "false" .Values.image.debug | quote }}
+            - name: CONSUL_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: CONSUL_RETRY_JOIN
               value: {{ printf "%s-0.%s.%s.svc.%s" $consulFullName $consulHeadlessSvcName .Release.Namespace $clusterDomain | quote }}
             - name: CONSUL_DISABLE_KEYRING_FILE

--- a/bitnami/consul/values-production.yaml
+++ b/bitnami/consul/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/consul
-  tag: 1.7.3-debian-10-r0
+  tag: 1.7.3-debian-10-r1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/consul/values.yaml
+++ b/bitnami/consul/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/consul
-  tag: 1.7.3-debian-10-r0
+  tag: 1.7.3-debian-10-r1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

This PR ensures each Consul node has a static name, so it's not dynamically changed when the pod is deleted, causing the pod to "crashloopback".

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/2487

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)