### PR TITLE
[bitnami/prometheus-operator] Fix custom alerting endpoints

### DIFF
--- a/bitnami/prometheus-operator/Chart.yaml
+++ b/bitnami/prometheus-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.38.1
 description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 name: prometheus-operator
-version: 0.16.0
+version: 0.16.1
 keywords:
   - prometheus
   - alertmanager

--- a/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -15,7 +15,7 @@ spec:
   alerting:
     alertmanagers:
     {{- if .Values.prometheus.alertingEndpoints }}
-    {{ include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.alertingEndpoints "context" $) | indent 6 }}
+    {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.alertingEndpoints "context" $) | nindent 6 }}
     {{- else if .Values.alertmanager.enabled }}
       - namespace: {{ .Release.Namespace }}
         name: {{ template "prometheus-operator.alertmanager.fullname" . }}

--- a/bitnami/prometheus-operator/values-production.yaml
+++ b/bitnami/prometheus-operator/values-production.yaml
@@ -42,7 +42,7 @@ operator:
   image:
     registry: docker.io
     repository: bitnami/prometheus-operator
-    tag: 0.38.1-debian-10-r21
+    tag: 0.38.1-debian-10-r22
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -208,7 +208,7 @@ operator:
     image:
       registry: docker.io
       repository: bitnami/configmap-reload
-      tag: 0.3.0-debian-10-r102
+      tag: 0.3.0-debian-10-r103
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -239,7 +239,7 @@ prometheus:
   image:
     registry: docker.io
     repository: bitnami/prometheus
-    tag: 2.17.2-debian-10-r14
+    tag: 2.18.0-debian-10-r0
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/bitnami/prometheus-operator/values.yaml
+++ b/bitnami/prometheus-operator/values.yaml
@@ -42,7 +42,7 @@ operator:
   image:
     registry: docker.io
     repository: bitnami/prometheus-operator
-    tag: 0.38.1-debian-10-r21
+    tag: 0.38.1-debian-10-r22
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -208,7 +208,7 @@ operator:
     image:
       registry: docker.io
       repository: bitnami/configmap-reload
-      tag: 0.3.0-debian-10-r102
+      tag: 0.3.0-debian-10-r103
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -239,7 +239,7 @@ prometheus:
   image:
     registry: docker.io
     repository: bitnami/prometheus
-    tag: 2.17.2-debian-10-r14
+    tag: 2.18.0-debian-10-r0
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION
**Description of the change**

Small fix on prometheus template

**Benefits**

The template rendered custom alert endpoints with wrong indentation, like:
```yaml
  alerting:
    alertmanagers:
          - name: metrics-kube-prometheus-op-alertmanager
        namespace: metrics
        pathPrefix: /
        port: http
``` 

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
