### PR TITLE
[bitnami/rabbitmq] extraVolumeMounts new line fix

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 6.25.7
+version: 6.25.8
 appVersion: 3.8.3
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/bitnami/rabbitmq/templates/statefulset.yaml
+++ b/bitnami/rabbitmq/templates/statefulset.yaml
@@ -106,7 +106,7 @@ spec:
           {{- end }}
           volumeMounts:
             {{- if .Values.extraVolumeMounts }}
-            {{- toYaml .Values.extraVolumeMounts | indent 12 }}
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
             - name: config-volume
               mountPath: /opt/bitnami/rabbitmq/conf

--- a/bitnami/rabbitmq/values-production.yaml
+++ b/bitnami/rabbitmq/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/rabbitmq
-  tag: 3.8.3-debian-10-r68
+  tag: 3.8.3-debian-10-r71
 
   ## set to true if you would like to see extra information on logs
   ## it turns BASH and NAMI debugging in minideb

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/rabbitmq
-  tag: 3.8.3-debian-10-r68
+  tag: 3.8.3-debian-10-r71
 
   ## set to true if you would like to see extra information on logs
   ## it turns BASH and NAMI debugging in minideb


### PR DESCRIPTION
**Description of the change**

Changed `indent` by `nindent` as needed for extraVolumeMounts to be output correctly.

**Possible drawbacks**

none

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #2532

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
