### PR TITLE
[bitnami/elasticsearch] Istio showing Passthrough traffic among Elastic Pods

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: elasticsearch
-version: 12.0.2
+version: 12.1.0
 appVersion: 7.6.2
 description: A highly scalable open-source full-text search and analytics engine
 keywords:

--- a/bitnami/elasticsearch/templates/coordinating-deploy.yaml
+++ b/bitnami/elasticsearch/templates/coordinating-deploy.yaml
@@ -22,6 +22,9 @@ spec:
         app.kubernetes.io/component: coordinating-only
         ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
         app: coordinating-only
+        {{- if .Values.coordinating.podLabels }}
+        {{- include "elasticsearch.tplValue" (dict "value" .Values.coordinating.podLabels "context" $) | nindent 8 }}
+        {{- end }}
       {{- with .Values.coordinating.podAnnotations }}
       annotations: {{- toYaml . | nindent 10 }}
       {{- end }}

--- a/bitnami/elasticsearch/templates/coordinating-svc.yaml
+++ b/bitnami/elasticsearch/templates/coordinating-svc.yaml
@@ -20,5 +20,7 @@ spec:
       {{- else if eq .Values.coordinating.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    - name: tcp-transport
+      port: 9300
   selector: {{- include "elasticsearch.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: coordinating-only

--- a/bitnami/elasticsearch/templates/cronjob.yaml
+++ b/bitnami/elasticsearch/templates/cronjob.yaml
@@ -27,6 +27,9 @@ spec:
         app.kubernetes.io/component: curator
         ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
         app: curator
+        {{- if .Values.curator.podLabels }}
+        {{- include "elasticsearch.tplValue" (dict "value" .Values.curator.podLabels "context" $) | nindent 8 }}
+        {{- end }}
     spec:
       template:
         metadata:

--- a/bitnami/elasticsearch/templates/data-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/data-statefulset.yaml
@@ -109,6 +109,8 @@ spec:
             - name: ELASTICSEARCH_NODE_TYPE
               value: "data"
           ports:
+            - name: http
+              containerPort: 9200
             - name: transport
               containerPort: 9300
           {{- if .Values.data.livenessProbe.enabled }}

--- a/bitnami/elasticsearch/templates/data-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/data-statefulset.yaml
@@ -27,6 +27,9 @@ spec:
         app.kubernetes.io/component: data
         ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
         app: data
+        {{- if .Values.data.podLabels }}
+        {{- include "elasticsearch.tplValue" (dict "value" .Values.data.podLabels "context" $) | nindent 8 }}
+        {{- end }}
       {{- with .Values.data.podAnnotations }}
       annotations: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/bitnami/elasticsearch/templates/data-svc.yaml
+++ b/bitnami/elasticsearch/templates/data-svc.yaml
@@ -8,6 +8,9 @@ spec:
   type: ClusterIP
   publishNotReadyAddresses: true
   ports:
+    - name: http
+      port: 9200
+      targetPort: http
     - name: tcp-transport
       port: 9300
       targetPort: transport

--- a/bitnami/elasticsearch/templates/ingest-deploy.yaml
+++ b/bitnami/elasticsearch/templates/ingest-deploy.yaml
@@ -79,6 +79,8 @@ spec:
             - name: ELASTICSEARCH_NODE_TYPE
               value: "ingest"
           ports:
+            - name: http
+              containerPort: 9200
             - name: transport
               containerPort: 9300
           {{- if .Values.ingest.livenessProbe.enabled }}

--- a/bitnami/elasticsearch/templates/ingest-deploy.yaml
+++ b/bitnami/elasticsearch/templates/ingest-deploy.yaml
@@ -18,6 +18,9 @@ spec:
         app.kubernetes.io/component: ingest
         ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
         app: ingest
+        {{- if .Values.ingest.podLabels }}
+        {{- include "elasticsearch.tplValue" (dict "value" .Values.ingest.podLabels "context" $) | nindent 8 }}
+        {{- end }}
       {{- with .Values.ingest.podAnnotations }}
       annotations: {{- toYaml . | nindent 10 }}
       {{- end }}

--- a/bitnami/elasticsearch/templates/ingest-svc.yaml
+++ b/bitnami/elasticsearch/templates/ingest-svc.yaml
@@ -13,6 +13,9 @@ spec:
   {{- end }}
   publishNotReadyAddresses: true
   ports:
+    - name: http
+      port: 9200
+      targetPort: http
     - name: tcp-transport
       port: {{ .Values.ingest.service.port }}
       targetPort: transport

--- a/bitnami/elasticsearch/templates/master-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/master-statefulset.yaml
@@ -112,6 +112,8 @@ spec:
             - name: ELASTICSEARCH_NODE_TYPE
               value: "master"
           ports:
+            - name: http
+              containerPort: 9200
             - name: transport
               containerPort: 9300
           {{- if .Values.master.livenessProbe.enabled }}

--- a/bitnami/elasticsearch/templates/master-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/master-statefulset.yaml
@@ -24,6 +24,9 @@ spec:
         app.kubernetes.io/component: master
         ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
         app: master
+        {{- if .Values.master.podLabels }}
+        {{- include "elasticsearch.tplValue" (dict "value" .Values.master.podLabels "context" $) | nindent 8 }}
+        {{- end }}
       {{- with .Values.master.podAnnotations }}
       annotations: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/bitnami/elasticsearch/templates/master-svc.yaml
+++ b/bitnami/elasticsearch/templates/master-svc.yaml
@@ -12,6 +12,9 @@ spec:
   {{- end }}
   publishNotReadyAddresses: true
   ports:
+    - name: http
+      port: 9200
+      targetPort: http
     - name: tcp-transport
       port: {{ .Values.master.service.port }}
       targetPort: transport

--- a/bitnami/elasticsearch/templates/metrics-deploy.yaml
+++ b/bitnami/elasticsearch/templates/metrics-deploy.yaml
@@ -18,6 +18,9 @@ spec:
         app.kubernetes.io/component: metrics
         ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
         app: metrics
+        {{- if .Values.metrics.podLabels }}
+        {{- include "elasticsearch.tplValue" (dict "value" .Values.metrics.podLabels "context" $) | nindent 8 }}
+        {{- end }}
       {{- with .Values.metrics.podAnnotations }}
       annotations: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/bitnami/elasticsearch/values-production.yaml
+++ b/bitnami/elasticsearch/values-production.yaml
@@ -19,7 +19,7 @@ global:
 image:
   registry: docker.io
   repository: bitnami/elasticsearch
-  tag: 7.6.2-debian-10-r40
+  tag: 7.6.2-debian-10-r42
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -564,7 +564,7 @@ curator:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch-curator
-    tag: 5.8.1-debian-10-r104
+    tag: 5.8.1-debian-10-r105
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -732,7 +732,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch-exporter
-    tag: 1.1.0-debian-10-r103
+    tag: 1.1.0-debian-10-r104
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/elasticsearch/values-production.yaml
+++ b/bitnami/elasticsearch/values-production.yaml
@@ -19,7 +19,7 @@ global:
 image:
   registry: docker.io
   repository: bitnami/elasticsearch
-  tag: 7.6.2-debian-10-r42
+  tag: 7.6.2-debian-10-r43
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/elasticsearch/values-production.yaml
+++ b/bitnami/elasticsearch/values-production.yaml
@@ -148,6 +148,10 @@ master:
   ## Provide annotations for master-eligible pods.
   ##
   podAnnotations: {}
+  
+  ## Extra labels to add to Pod
+  podLabels: {}
+  
   ## Pod Security Context for master-eligible pods.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
@@ -272,6 +276,10 @@ coordinating:
   ## Provide annotations for the coordinating-only pods.
   ##
   podAnnotations: {}
+  
+  ## Extra labels to add to Pod
+  podLabels: {}
+  
   ## Pod Security Context for coordinating-only pods.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
@@ -371,6 +379,10 @@ data:
   ## Provide annotations for the data pods.
   ##
   podAnnotations: {}
+  
+  ## Extra labels to add to Pod
+  podLabels: {}
+  
   ## Pod Security Context for data pods.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
@@ -468,6 +480,10 @@ ingest:
   ## Provide annotations for the ingest pods.
   ##
   podAnnotations: {}
+  
+  ## Extra labels to add to Pod
+  podLabels: {}
+  
   ## Pod Security Context for ingest pods.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
@@ -567,6 +583,9 @@ curator:
     jobRestartPolicy: Never
 
   podAnnotations: {}
+  
+  ## Extra labels to add to Pod
+  podLabels: {}
 
   rbac:
     # Specifies whether RBAC should be enabled
@@ -752,6 +771,9 @@ metrics:
   podAnnotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "8080"
+    
+  ## Extra labels to add to Pod
+  podLabels: {}
 
   ## Prometheus Operator ServiceMonitor configuration
   ##

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -19,7 +19,7 @@ global:
 image:
   registry: docker.io
   repository: bitnami/elasticsearch
-  tag: 7.6.2-debian-10-r40
+  tag: 7.6.2-debian-10-r42
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -564,7 +564,7 @@ curator:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch-curator
-    tag: 5.8.1-debian-10-r104
+    tag: 5.8.1-debian-10-r105
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -732,7 +732,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch-exporter
-    tag: 1.1.0-debian-10-r103
+    tag: 1.1.0-debian-10-r104
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -148,6 +148,10 @@ master:
   ## Provide annotations for master-eligible pods.
   ##
   podAnnotations: {}
+  
+  ## Extra labels to add to Pod
+  podLabels: {}
+  
   ## Pod Security Context for master-eligible pods.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
@@ -272,6 +276,10 @@ coordinating:
   ## Provide annotations for the coordinating-only pods.
   ##
   podAnnotations: {}
+  
+  ## Extra labels to add to Pod
+  podLabels: {}
+  
   ## Pod Security Context for coordinating-only pods.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
@@ -371,6 +379,10 @@ data:
   ## Provide annotations for the data pods.
   ##
   podAnnotations: {}
+  
+  ## Extra labels to add to Pod
+  podLabels: {}
+  
   ## Pod Security Context for data pods.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
@@ -468,6 +480,10 @@ ingest:
   ## Provide annotations for the ingest pods.
   ##
   podAnnotations: {}
+  
+  ## Extra labels to add to Pod
+  podLabels: {}
+  
   ## Pod Security Context for ingest pods.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
@@ -567,6 +583,9 @@ curator:
     jobRestartPolicy: Never
 
   podAnnotations: {}
+  
+  ## Extra labels to add to Pod
+  podLabels: {}  
 
   rbac:
     # Specifies whether RBAC should be enabled
@@ -752,6 +771,9 @@ metrics:
   podAnnotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "8080"
+    
+  ## Extra labels to add to Pod
+  podLabels: {}
 
   ## Prometheus Operator ServiceMonitor configuration
   ##

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -19,7 +19,7 @@ global:
 image:
   registry: docker.io
   repository: bitnami/elasticsearch
-  tag: 7.6.2-debian-10-r42
+  tag: 7.6.2-debian-10-r43
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
**Description of the change**

Removes the Passthrough cluster among Elastic pods

**Benefits**

Enhance Istio compatibility

**Possible drawbacks**

None

**Applicable issues**

  - fixes #2539

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ X] Variables are documented in the README.md
- [ X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

