### PR TITLE
[bitnami/elasticsearch] Fix gateway configuration based on node number

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: elasticsearch
-version: 12.0.1
+version: 12.0.2
 appVersion: 7.6.2
 description: A highly scalable open-source full-text search and analytics engine
 keywords:

--- a/bitnami/elasticsearch/requirements.lock
+++ b/bitnami/elasticsearch/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kibana
   repository: https://charts.bitnami.com/bitnami
-  version: 5.0.16
-digest: sha256:707f1bd5825d859bddf8159fdab2fbdf74c7177f6cd68905f46bdc3b2acc580a
-generated: "2020-04-24T07:01:30.568520074Z"
+  version: 5.1.0
+digest: sha256:2dd5f285a8c17e9ed9ad97182a8b7444a538ec1420b9ba7c694bb24f638a8c9b
+generated: "2020-05-08T08:06:59.735625234Z"

--- a/bitnami/elasticsearch/templates/coordinating-deploy.yaml
+++ b/bitnami/elasticsearch/templates/coordinating-deploy.yaml
@@ -71,6 +71,8 @@ spec:
               value: {{ .Values.name | quote }}
             - name: ELASTICSEARCH_CLUSTER_HOSTS
               value: {{ include "elasticsearch.hosts" . | quote }}
+            - name: ELASTICSEARCH_TOTAL_NODES
+              value: {{ add .Values.master.replicas .Values.data.replicas | quote }}
             {{- if .Values.plugins }}
             - name: ELASTICSEARCH_PLUGINS
               value: {{ .Values.plugins | quote }}

--- a/bitnami/elasticsearch/templates/data-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/data-statefulset.yaml
@@ -96,6 +96,8 @@ spec:
               value: {{ .Values.name | quote }}
             - name: ELASTICSEARCH_CLUSTER_HOSTS
               value: {{ include "elasticsearch.hosts" . | quote }}
+            - name: ELASTICSEARCH_TOTAL_NODES
+              value: {{ add .Values.master.replicas .Values.data.replicas | quote }}
             {{- if .Values.plugins }}
             - name: ELASTICSEARCH_PLUGINS
               value: {{ .Values.plugins | quote }}

--- a/bitnami/elasticsearch/templates/ingest-deploy.yaml
+++ b/bitnami/elasticsearch/templates/ingest-deploy.yaml
@@ -66,6 +66,8 @@ spec:
               value: {{ .Values.name | quote }}
             - name: ELASTICSEARCH_CLUSTER_HOSTS
               value: {{ include "elasticsearch.hosts" . | quote }}
+            - name: ELASTICSEARCH_TOTAL_NODES
+              value: {{ add .Values.master.replicas .Values.data.replicas | quote }}
             {{- if .Values.plugins }}
             - name: ELASTICSEARCH_PLUGINS
               value: {{ .Values.plugins | quote }}

--- a/bitnami/elasticsearch/templates/master-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/master-statefulset.yaml
@@ -93,6 +93,8 @@ spec:
               value: {{ .Values.name | quote }}
             - name: ELASTICSEARCH_CLUSTER_HOSTS
               value: {{ include "elasticsearch.hosts" . | quote }}
+            - name: ELASTICSEARCH_TOTAL_NODES
+              value: {{ add .Values.master.replicas .Values.data.replicas | quote }}
             - name: ELASTICSEARCH_CLUSTER_MASTER_HOSTS
               {{- $elasticsearchMasterFullname := include "elasticsearch.master.fullname" . }}
               {{- $replicas := int .Values.master.replicas }}

--- a/bitnami/elasticsearch/values-production.yaml
+++ b/bitnami/elasticsearch/values-production.yaml
@@ -19,7 +19,7 @@ global:
 image:
   registry: docker.io
   repository: bitnami/elasticsearch
-  tag: 7.6.2-debian-10-r30
+  tag: 7.6.2-debian-10-r40
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -548,7 +548,7 @@ curator:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch-curator
-    tag: 5.8.1-debian-10-r91
+    tag: 5.8.1-debian-10-r104
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -713,7 +713,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch-exporter
-    tag: 1.1.0-debian-10-r90
+    tag: 1.1.0-debian-10-r103
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -19,7 +19,7 @@ global:
 image:
   registry: docker.io
   repository: bitnami/elasticsearch
-  tag: 7.6.2-debian-10-r30
+  tag: 7.6.2-debian-10-r40
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -548,7 +548,7 @@ curator:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch-curator
-    tag: 5.8.1-debian-10-r91
+    tag: 5.8.1-debian-10-r104
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -713,7 +713,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch-exporter
-    tag: 1.1.0-debian-10-r90
+    tag: 1.1.0-debian-10-r103
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Add `ELASTICSEARCH_TOTAL_NODES` env. variable to configure the gateway section of the config file. Now, there is an issue when the number of nodes (data + master) is smaller than 3.

This PR needs changes in the ES image as well.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files