### PR TITLE
[bitnami/logstash] Fixbug/issue 2553 - chart should take configured values from vars input/output/filter in values.yaml in values.yaml

### DIFF
--- a/bitnami/logstash/.helmignore
+++ b/bitnami/logstash/.helmignore
@@ -19,3 +19,4 @@
 .project
 .idea/
 *.tmproj
+files/conf/README.md

--- a/bitnami/logstash/Chart.yaml
+++ b/bitnami/logstash/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
 name: logstash
 sources:
   - https://github.com/bitnami/bitnami-docker-logstash
-version: 0.2.18
+version: 0.2.19

--- a/bitnami/logstash/values-production.yaml
+++ b/bitnami/logstash/values-production.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/logstash
-  tag: 7.6.2-debian-10-r21
+  tag: 7.6.2-debian-10-r38
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -285,7 +285,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/logstash-exporter
-    tag: 0.1.2-debian-10-r86
+    tag: 0.1.2-debian-10-r106
     ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##

--- a/bitnami/logstash/values.yaml
+++ b/bitnami/logstash/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/logstash
-  tag: 7.6.2-debian-10-r21
+  tag: 7.6.2-debian-10-r38
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -285,7 +285,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/logstash-exporter
-    tag: 0.1.2-debian-10-r86
+    tag: 0.1.2-debian-10-r106
     ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##


### PR DESCRIPTION
**Description of the change**

In chart `logstash`, add the file `files/conf/README.md` to `.helmignore`.

**Benefits**

Help chart `logstash` take the configured values in sections input/output/filter.

**Applicable issues**

  - fixes #2553 

**Additional information**

This is a very simple fix by adding REAMDE.md to `.helmignore` which help helm stop including unwanted files to chart instance.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
