### PR TITLE
[bitnami/redis] update failovertimeout regarding the docs

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 10.6.13
+version: 10.6.14
 appVersion: 6.0.1
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/bitnami/redis/values-production.yaml
+++ b/bitnami/redis/values-production.yaml
@@ -76,7 +76,7 @@ sentinel:
   initialCheckTimeout: 5
   quorum: 2
   downAfterMilliseconds: 60000
-  failoverTimeout: 18000
+  failoverTimeout: 180000
   parallelSyncs: 1
   port: 26379
   ## Additional Redis configuration for the sentinel nodes

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -76,7 +76,7 @@ sentinel:
   initialCheckTimeout: 5
   quorum: 2
   downAfterMilliseconds: 60000
-  failoverTimeout: 18000
+  failoverTimeout: 180000
   parallelSyncs: 1
   port: 26379
   ## Additional Redis configuration for the sentinel nodes


### PR DESCRIPTION
**Description of the change**

Regarding sentinel docs, failover is recommended to be thrice the value of downAfterMilliseconds

**Benefits**

Better failover behavior.

**Possible drawbacks**

N/A

**Applicable issues**

  - fixes #2575

**Additional information**

N/A

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
