### PR TITLE
[bitnami/external-dns:] Follow Helm rbac best practices

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 2.24.1
+version: 3.0.0
 appVersion: 0.7.1
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/bitnami/external-dns/README.md
+++ b/bitnami/external-dns/README.md
@@ -180,10 +180,10 @@ The following table lists the configurable parameters of the external-dns chart 
 | `service.loadBalancerIP`            | IP address to assign to load balancer (if supported)                                                     | `""`                                                        |
 | `service.loadBalancerSourceRanges`  | List of IP CIDRs allowed access to load balancer (if supported)                                          | `[]`                                                        |
 | `service.annotations`               | Annotations to add to service                                                                            | `{}`                                                        |
+| `serviceAccount.create`             | Determine whether a Service Account should be created or it should reuse a exiting one.                  | `true`                                                      |
+| `serviceAccount.name`               | ServiceAccount to use. A name is generated using the external-dns.fullname template if it is not set     | `nil`                                                       |
+| `serviceAccount.annotations`        | Additional Service Account annotations                                                                   | `{}`                                                        |
 | `rbac.create`                       | Weather to create & use RBAC resources or not                                                            | `true`                                                      |
-| `rbac.serviceAccountCreate`         | Determine whether a Service Account should be created or it should reuse a exiting one.                  | `true`                                                      |
-| `rbac.serviceAccountName`           | ServiceAccount to use. A name is generated using the external-dns.fullname template if it is not set     | `nil`                                                       |
-| `rbac.serviceAccountAnnotations`    | Additional Service Account annotations                                                                   | `{}`                                                        |
 | `rbac.apiVersion`                   | Version of the RBAC API                                                                                  | `v1beta1`                                                   |
 | `rbac.pspEnabled`                   | PodSecurityPolicy                                                                                        | `false`                                                     |
 | `resources`                         | CPU/Memory resource requests/limits.                                                                     | `{}`                                                        |
@@ -261,6 +261,14 @@ $ helm install my-release \
 ```
 
 ## Upgrading
+
+### To 3.0.0
+
+- The parameters below are renamed:
+  - `rbac.serviceAccountCreate` -> `serviceAccount.create`
+  - `rbac.serviceAccountName` -> `serviceAccount.name`
+  - `rbac.serviceAccountAnnotations` -> `serviceAccount.annotation`
+- It is now possible to create serviceAccount, clusterRole and clusterRoleBinding manually and give the serviceAccount to the chart.
 
 ### To 2.0.0
 

--- a/bitnami/external-dns/templates/_helpers.tpl
+++ b/bitnami/external-dns/templates/_helpers.tpl
@@ -578,9 +578,9 @@ external-dns: ovh.applicationSecret
 Return the ExternalDNS service account name
 */}}
 {{- define "external-dns.serviceAccountName" -}}
-{{- if .Values.rbac.serviceAccountName -}}
-    {{- printf "%s" (tpl .Values.rbac.serviceAccountName . ) -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "external-dns.fullname" .) .Values.serviceAccount.name }}
 {{- else -}}
-    {{- printf "%s" (include "external-dns.fullname" . ) -}}
+    {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -34,9 +34,7 @@ spec:
       {{- with .Values.tolerations }}
       tolerations: {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
-      {{- if .Values.rbac.create }}
       serviceAccountName: {{ template "external-dns.serviceAccountName" . }}
-      {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}

--- a/bitnami/external-dns/templates/serviceaccount.yaml
+++ b/bitnami/external-dns/templates/serviceaccount.yaml
@@ -1,10 +1,10 @@
-{{- if and .Values.rbac.create .Values.rbac.serviceAccountCreate -}}
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "external-dns.serviceAccountName" . }}
   labels: {{ include "external-dns.labels" . | nindent 4 }}
-  {{- if .Values.rbac.serviceAccountAnnotations }}
-  annotations: {{ toYaml .Values.rbac.serviceAccountAnnotations | nindent 4 }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/bitnami/external-dns/values-production.yaml
+++ b/bitnami/external-dns/values-production.yaml
@@ -448,24 +448,23 @@ service:
   ##
   annotations: {}
 
-## RBAC parameteres
+## ServiceAccount parameters
+## https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  create: true
+  ## Service Account for pods
+  ##
+  name:
+  ## Annotations for the Service Account
+  ##
+  annotations: {}
+
+## RBAC parameteres (clusterRole and clusterRoleBinding)
 ## https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 ##
 rbac:
   create: true
-  ## Determine whether a Service Account should be created
-  ## or reuse a exiting one
-  ##
-  serviceAccountCreate: true
-
-  ## Service Account for pods
-  ## https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-  ##
-  serviceAccountName:
-
-  ## Annotations for the Service Account
-  ##
-  serviceAccountAnnotations: {}
   ## RBAC API version
   ##
   apiVersion: v1beta1

--- a/bitnami/external-dns/values-production.yaml
+++ b/bitnami/external-dns/values-production.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/external-dns
-  tag: 0.7.1-debian-10-r54
+  tag: 0.7.1-debian-10-r56
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/external-dns/values.yaml
+++ b/bitnami/external-dns/values.yaml
@@ -447,24 +447,23 @@ service:
   ##
   annotations: {}
 
+## ServiceAccount parameters
+## https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  create: true
+  ## Service Account for pods
+  ##
+  name:
+  ## Annotations for the Service Account
+  ##
+  annotations: {}
+
 ## RBAC parameteres
 ## https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 ##
 rbac:
   create: true
-  ## Determine whether a Service Account should be created
-  ## or reuse a exiting one
-  ##
-  serviceAccountCreate: true
-
-  ## Service Account for pods
-  ## https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-  ##
-  serviceAccountName:
-
-  ## Annotations for the Service Account
-  ##
-  serviceAccountAnnotations: {}
   ## RBAC API version
   ##
   apiVersion: v1beta1

--- a/bitnami/external-dns/values.yaml
+++ b/bitnami/external-dns/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/external-dns
-  tag: 0.7.1-debian-10-r54
+  tag: 0.7.1-debian-10-r56
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
bitnami/external-dns : Follow Helm rbac best practices (https://helm.sh/docs/chart_best_practices/rbac/).
Enables the use of custom serviceAccount with custom clusteRole and clusterRoleBinding.

**Benefits**

  - Enables the use of custom serviceAccount with custom clusteRole and clusterRoleBinding (was not possible).
  - Follow Helm best practices (https://helm.sh/docs/chart_best_practices/rbac/).

**Possible drawbacks**

Changes in variables names : breaking changes

**Applicable issues**

Not known

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
