### PR TITLE
[bitnami/nginx] Horizontal Pod Autoscaler

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx
-version: 5.3.1
+version: 5.4.0
 appVersion: 1.17.10
 description: Chart for the nginx server
 keywords:

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -127,7 +127,7 @@ The following tables lists the configurable parameters of the NGINX Open Source 
 | `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                         | `nil`                                                        |
 | `autoscaling.enabled`                      | Enable autoscaling for NGINX deployment                                                     | `false`                                                      |
 | `autoscaling.minReplicas`                  | Minimum number of replicas to scale back                                                    | `nil`                                                        |
-| `autoscaling.maxReplicas`                  | Maximum number of replicas to sacle out                                                     | `nil`                                                        |
+| `autoscaling.maxReplicas`                  | Maximum number of replicas to scale out                                                     | `nil`                                                        |
 | `autoscaling.targetCPU`                    | Target CPU utilization percentage                                                           | `nil`                                                        |
 | `autoscaling.targetMemory`                 | Target Memory utilization percentage                                                        | `nil`                                                        |
 

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -125,6 +125,11 @@ The following tables lists the configurable parameters of the NGINX Open Source 
 | `metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped.                                                | `nil` (Prometheus Operator default value)                    |
 | `metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                                     | `nil` (Prometheus Operator default value)                    |
 | `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                         | `nil`                                                        |
+| `autoscaling.enabled`                      | Enable autoscaling for NGINX deployment                                                     | `false`                                                      |
+| `autoscaling.minReplicas`                  | Minimum number of replicas to scale back                                                    | `nil`                                                        |
+| `autoscaling.maxReplicas`                  | Maximum number of replicas to sacle out                                                     | `nil`                                                        |
+| `autoscaling.targetCPU`                    | Target CPU utilization percentage                                                           | `nil`                                                        |
+| `autoscaling.targetMemory`                 | Target Memory utilization percentage                                                        | `nil`                                                        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/nginx/templates/hpa.yaml
+++ b/bitnami/nginx/templates/hpa.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "nginx.fullname" . }}
+  labels: {{- include "nginx.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "nginx.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPU }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPU }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemory }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemory  }}
+    {{- end }}
+{{- end }}

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/nginx
-  tag: 1.17.10-debian-10-r33
+  tag: 1.17.10-debian-10-r40
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -54,7 +54,7 @@ cloneStaticSiteFromGit:
   image:
     registry: docker.io
     repository: bitnami/git
-    tag: 2.26.2-debian-10-r1
+    tag: 2.26.2-debian-10-r26
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -298,7 +298,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/nginx-exporter
-    tag: 0.7.0-debian-10-r21
+    tag: 0.7.0-debian-10-r28
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -364,3 +364,12 @@ metrics:
     ##
     # selector:
     #   prometheus: my-prometheus
+
+## Autoscaling parameters
+##
+autoscaling:
+  enabled: false
+  # minReplicas: 1
+  # maxReplicas: 10
+  # targetCPU: 50
+  # targetMemory: 50


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Added Horizontal Pod Autoscaler 

**Benefits**
This will automatically scales the number of pods in a NGINX deployment

**Possible drawbacks**
Nil

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)