### PR TITLE
[bitnami/rabbitmq] improve network policy to include internal traffic

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 6.25.11
+version: 6.25.12
 appVersion: 3.8.3
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/bitnami/rabbitmq/templates/networkpolicy.yaml
+++ b/bitnami/rabbitmq/templates/networkpolicy.yaml
@@ -27,6 +27,10 @@ spec:
         - podSelector:
             matchLabels:
               {{ template "rabbitmq.fullname" . }}-client: "true"
+        - podSelector:
+            matchLabels:
+              app: {{ template "rabbitmq.name" . }}
+              release: {{ .Release.Name }}
         {{- with .Values.networkPolicy.additionalRules }}
 {{ toYaml . | indent 8 }}
         {{- end }}

--- a/bitnami/rabbitmq/values-production.yaml
+++ b/bitnami/rabbitmq/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/rabbitmq
-  tag: 3.8.3-debian-10-r79
+  tag: 3.8.3-debian-10-r84
 
   ## set to true if you would like to see extra information on logs
   ## it turns BASH and NAMI debugging in minideb

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/rabbitmq
-  tag: 3.8.3-debian-10-r79
+  tag: 3.8.3-debian-10-r84
 
   ## set to true if you would like to see extra information on logs
   ## it turns BASH and NAMI debugging in minideb

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -236,7 +236,7 @@ service:
   ## Service annotations
   ## Example:
   ## annotations:
-  ##   service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0  
+  ##   service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
   ##
   annotations: {}
 
@@ -355,7 +355,7 @@ tolerations: {}
 ## Pod Disruption Budget configuration
 ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
 ## Example:
-## podDisruptionBudget:   
+## podDisruptionBudget:
 ##    maxUnavailable: 1
 ##    minAvailable: 1
 ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Add Network Policy for RabbitMQ services to allow the cluster connectivity to support a denied network policy between services, only allowed is using the `rabbitmq-client` labels on the service.

**Benefits**

Ability to support a deny all default network policy so that services can be provided access based on need.

**Possible drawbacks**

If configured incorrectly, the cluster sets may not work with denying the network traffic

**Applicable issues**


**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
