### PR TITLE
[bitnami/mongodb] improve network policy to include internal traffic

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb
-version: 7.14.1
+version: 7.14.2
 appVersion: 4.2.6
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -168,6 +168,7 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `metrics.image.tag`                                | MongoDB exporter image tag                                                                                                                                | `{TAG_NAME}`                                             |
 | `metrics.image.pullPolicy`                         | Image pull policy                                                                                                                                         | `Always`                                                 |
 | `metrics.image.pullSecrets`                        | Specify docker-registry secret names as an array                                                                                                          | `[]` (does not add image pull secrets to deployed pods)  |
+| `metrics.port`                                    | The port the metrics are listening on | `9216` |
 | `metrics.podAnnotations.prometheus.io/scrape`      | Additional annotations for Metrics exporter pod                                                                                                           | `true`                                                   |
 | `metrics.podAnnotations.prometheus.io/port`        | Additional annotations for Metrics exporter pod                                                                                                           | `"9216"`                                                 |
 | `metrics.extraArgs`                                | String with extra arguments for the MongoDB Exporter                                                                                                      | ``                                                       |
@@ -190,6 +191,8 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `metrics.readinessProbe.timeoutSeconds`            | Timeout for Readiness Check of Prometheus metrics exporter                                                                                                | `1`                                                      |
 | `metrics.readinessProbe.failureThreshold`          | Failure Threshold for Readiness Check of Prometheus metrics exporter                                                                                      | `3`                                                      |
 | `metrics.readinessProbe.successThreshold`          | Success Threshold for Readiness Check of Prometheus metrics exporter                                                                                      | `1`                                                      |
+| `networkPolicy.enabled`              | Enable NetworkPolicy                                                                                                                                      | `false`                                                      |
+| `networkPolicy.allowExternal`        | Don't require client label for connections                                                                                                                | `true`                                                       |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/bitnami/mongodb/templates/networkpolicy.yaml
+++ b/bitnami/mongodb/templates/networkpolicy.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.networkPolicy.enabled }}
+kind: NetworkPolicy
+{{- if .Values.global.networkPolicy }}
+apiVersion: {{ .Values.global.networkPolicy.apiVersion . | default "networking.k8s.io/v1" }}
+{{- else }}
+apiVersion: networking.k8s.io/v1
+{{- end }}
+metadata:
+  name: {{ template "mongodb.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "mongodb.name" . }}
+    chart: {{ template "mongodb.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "mongodb.name" . }}
+      release: {{ .Release.Name | quote }}
+  ingress:
+    # Allow inbound connections
+    - ports:
+      - port: {{ .Values.service.port }}
+      {{- if not .Values.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels:
+              {{ template "mongodb.fullname" . }}-client: "true"
+      {{- end }}
+    - from:
+      - podSelector:
+          matchLabels:
+            app: "{{ template "mongodb.name" . }}"
+    {{- if .Values.metrics.enabled }}
+    # Allow prometheus scrapes for metrics
+    - ports:
+      - port: {{ .Values.metrics.port }}
+      from:
+      - podSelector:
+          matchLabels:
+            app: "{{ template "mongodb.fullname" . }}"
+    {{- end }}
+{{- end }}

--- a/bitnami/mongodb/values-production.yaml
+++ b/bitnami/mongodb/values-production.yaml
@@ -449,6 +449,8 @@ configmap:
 metrics:
   enabled: true
 
+  port: 9216
+
   image:
     registry: docker.io
     repository: bitnami/mongodb-exporter
@@ -519,3 +521,18 @@ metrics:
       ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Prometheus Rules to work with
       ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
       additionalLabels: {}
+
+## Network policies
+## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+##
+networkPolicy:
+  ## Specifies whether a NetworkPolicy should be created
+  ##
+  enabled: false
+
+  ## The Policy model to apply. When set to false, only pods with the correct
+  ## client label will have network access to the port Mongo is listening
+  ## on. When true, Mongo will accept connections from any source
+  ## (with the correct destination port).
+  ##
+  allowExternal: true

--- a/bitnami/mongodb/values.schema.json
+++ b/bitnami/mongodb/values.schema.json
@@ -142,6 +142,23 @@
           }
         }
       }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Enable Network Policy",
+          "description": "Create a Network Policy to control the access to the Mongo Service",
+          "form": true
+        },
+        "allowExternal": {
+          "type": "boolean",
+          "title": "Don't require client label for connections",
+          "description": "Whether external services can access the Mongo Service on it's exposed ports",
+          "form": true
+        }
+      }
     }
   }
 }

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -326,7 +326,7 @@ persistence:
   # storageClass: "-"
   # storageClassSecondary: "-"
   accessModes:
-    - ReadWriteOnce
+  - ReadWriteOnce
   size: 8Gi
   annotations: {}
 
@@ -353,15 +353,15 @@ ingress:
   ## The list of hostnames to be covered with this ingress record.
   ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
   hosts:
-    - name: mongodb.local
-      path: /
+  - name: mongodb.local
+    path: /
 
   ## The tls configuration for the ingress
   ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
   tls:
-    - hosts:
-        - mongodb.local
-      secretName: mongodb.local-tls
+  - hosts:
+    - mongodb.local
+    secretName: mongodb.local-tls
 
   secrets:
   ## If you're providing your own certificates, please use this to add the certificates as secrets
@@ -454,6 +454,8 @@ configmap:
 metrics:
   enabled: false
 
+  port: 9216
+
   image:
     registry: docker.io
     repository: bitnami/mongodb-exporter
@@ -524,3 +526,18 @@ metrics:
       ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Prometheus Rules to work with
       ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
       additionalLabels: {}
+
+## Network policies
+## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+##
+networkPolicy:
+  ## Specifies whether a NetworkPolicy should be created
+  ##
+  enabled: false
+
+  ## The Policy model to apply. When set to false, only pods with the correct
+  ## client label will have network access to the port Mongo is listening
+  ## on. When true, Mongo will accept connections from any source
+  ## (with the correct destination port).
+  ##
+  allowExternal: true


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Add Network Policy for Mongo services to allow the cluster connectivity to support a denied network policy between services, only allowed is using the `mongodb-client` labels on the service.

**Benefits**

Ability to support a deny all default network policy so that services can be provided access based on need.

**Possible drawbacks**

If configured incorrectly, the cluster sets may not work with denying the network traffic

**Applicable issues**


**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
