### PR TITLE
[bitnami/mongodb-sharded] improve network policy to include internal traffic

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb-sharded
-version: 1.3.1
+version: 1.3.2
 appVersion: 4.2.6
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications. Sharded topology.
 keywords:

--- a/bitnami/mongodb-sharded/README.md
+++ b/bitnami/mongodb-sharded/README.md
@@ -265,8 +265,11 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `metrics.readinessProbe.successThreshold`     | Success Threshold for Readiness Check of Prometheus metrics exporter                                                                                      | `1`                                                      |
 | `metrics.serviceMonitor.enabled`              | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.kafka.enabled` or `metrics.jmx.enabled` to be `true`)                     | `false`                                                  |
 | `metrics.serviceMonitor.namespace`            | Namespace which Prometheus is running in                                                                                                                  | `monitoring`                                             |
+| `metrics.port`                                    | The port the metrics are listening on | `9216` |
 | `metrics.serviceMonitor.interval`             | How frequently to scrape metrics (use by default, falling back to Prometheus' default)                                                                    | `nil`                                                    |
 | `metrics.serviceMonitor.selector`             | Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install                                                | `{ prometheus: kube-prometheus }`                        |
+| `networkPolicy.enabled`              | Enable NetworkPolicy                                                                                                                                      | `false`                                                      |
+| `networkPolicy.allowExternal`        | Don't require client label for connections                                                                                                                | `true`                                                       |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/mongodb-sharded/templates/networkpolicy.yaml
+++ b/bitnami/mongodb-sharded/templates/networkpolicy.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.networkPolicy.enabled }}
+kind: NetworkPolicy
+{{- if .Values.global.networkPolicy }}
+apiVersion: {{ .Values.global.networkPolicy.apiVersion . | default "networking.k8s.io/v1" }}
+{{- else }}
+apiVersion: networking.k8s.io/v1
+{{- end }}
+metadata:
+  name: {{ template "mongodb-sharded.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "mongodb-sharded.name" . }}
+    helm.sh/chart: {{ template "mongodb-sharded.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "mongodb-sharded.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  ingress:
+    # Allow inbound connections
+    - ports:
+      - port: {{ .Values.service.port }}
+      {{- if not .Values.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels:
+              {{ template "mongodb-sharded.fullname" . }}-client: "true"
+      {{- end }}
+    - from:
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/name: "{{ template "mongodb-sharded.name" . }}"
+    {{- if .Values.metrics.enabled }}
+    # Allow prometheus scrapes for metrics
+    - ports:
+      - port: {{ .Values.metrics.port }}
+      from:
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/name: "{{ template "mongodb-sharded.fullname" . }}"
+    {{- end }}
+{{- end }}

--- a/bitnami/mongodb-sharded/values-production.yaml
+++ b/bitnami/mongodb-sharded/values-production.yaml
@@ -734,6 +734,8 @@ readinessProbe:
 metrics:
   enabled: true
 
+  port: 9216
+
   image:
     registry: docker.io
     repository: bitnami/mongodb-exporter
@@ -788,3 +790,18 @@ metrics:
     ## [Kube Prometheus Selector Label](https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#exporters)
     selector:
       prometheus: kube-prometheus
+
+## Network policies
+## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+##
+networkPolicy:
+  ## Specifies whether a NetworkPolicy should be created
+  ##
+  enabled: false
+
+  ## The Policy model to apply. When set to false, only pods with the correct
+  ## client label will have network access to the port Mongo is listening
+  ## on. When true, Mongo will accept connections from any source
+  ## (with the correct destination port).
+  ##
+  allowExternal: true

--- a/bitnami/mongodb-sharded/values.yaml
+++ b/bitnami/mongodb-sharded/values.yaml
@@ -293,7 +293,7 @@ shardsvr:
     ##
     # storageClass: "-"
     accessModes:
-      - ReadWriteOnce
+    - ReadWriteOnce
     ## PersistentVolumeClaim size
     ##
     size: 8Gi
@@ -423,7 +423,7 @@ configsvr:
     ##
     # storageClass: "-"
     accessModes:
-      - ReadWriteOnce
+    - ReadWriteOnce
     ## PersistentVolumeClaim size
     ##
     size: 8Gi
@@ -718,6 +718,8 @@ readinessProbe:
 metrics:
   enabled: false
 
+  port: 9216
+
   image:
     registry: docker.io
     repository: bitnami/mongodb-exporter
@@ -772,3 +774,18 @@ metrics:
     ## [Kube Prometheus Selector Label](https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#exporters)
     selector:
       prometheus: kube-prometheus
+
+## Network policies
+## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+##
+networkPolicy:
+  ## Specifies whether a NetworkPolicy should be created
+  ##
+  enabled: false
+
+  ## The Policy model to apply. When set to false, only pods with the correct
+  ## client label will have network access to the port Mongo is listening
+  ## on. When true, Mongo will accept connections from any source
+  ## (with the correct destination port).
+  ##
+  allowExternal: true


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Add Network Policy for RabbitMQ services to allow the cluster connectivity to support a denied network policy between services, only allowed is using the `mongodb-sharded-client` labels on the service.

**Benefits**

Ability to support a deny all default network policy so that services can be provided access based on need.

**Possible drawbacks**

If configured incorrectly, the cluster sets may not work with denying the network traffic

**Applicable issues**


**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
