### PR TITLE
[bitnami/mongodb-sharded] allow non-root access to sharded system

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb-sharded
-version: 1.3.1
+version: 1.3.2
 appVersion: 4.2.6
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications. Sharded topology.
 keywords:

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
@@ -107,6 +107,17 @@ spec:
                 secretKeyRef:
                   name: {{ include "mongodb-sharded.secret" . }}
                   key: mongodb-root-password
+            {{- if and $.Values.mongodbUsername $.Values.mongodbDatabase }}
+            - name: MONGODB_DATABASE
+              value: {{ $.Values.mongodbDatabase | quote }}
+            - name: MONGODB_USERNAME
+              value: {{ $.Values.mongodbUsername | quote }}
+            - name: MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mongodb-sharded.secret" $ }}
+                  key: mongodb-password
+            {{- end }}
             - name: MONGODB_REPLICA_SET_KEY
               valueFrom:
                 secretKeyRef:

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-deployment.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-deployment.yaml
@@ -70,6 +70,17 @@ spec:
                 secretKeyRef:
                   name: {{ include "mongodb-sharded.secret" . }}
                   key: mongodb-root-password
+            {{- if and $.Values.mongodbUsername $.Values.mongodbDatabase }}
+            - name: MONGODB_DATABASE
+              value: {{ $.Values.mongodbDatabase | quote }}
+            - name: MONGODB_USERNAME
+              value: {{ $.Values.mongodbUsername | quote }}
+            - name: MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mongodb-sharded.secret" $ }}
+                  key: mongodb-password
+            {{- end }}
             - name: MONGODB_REPLICA_SET_KEY
               valueFrom:
                 secretKeyRef:

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
@@ -204,6 +204,17 @@ spec:
                 secretKeyRef:
                   name: {{ include "mongodb-sharded.secret" $ }}
                   key: mongodb-root-password
+            {{- if and $.Values.mongodbUsername $.Values.mongodbDatabase }}
+            - name: MONGODB_DATABASE
+              value: {{ $.Values.mongodbDatabase | quote }}
+            - name: MONGODB_USERNAME
+              value: {{ $.Values.mongodbUsername | quote }}
+            - name: MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mongodb-sharded.secret" $ }}
+                  key: mongodb-password
+            {{- end }}
           {{- end }}
           command:
             - sh

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -112,6 +112,17 @@ spec:
                 secretKeyRef:
                   name: {{ include "mongodb-sharded.secret" $ }}
                   key: mongodb-root-password
+            {{- if and $.Values.mongodbUsername $.Values.mongodbDatabase }}
+            - name: MONGODB_DATABASE
+              value: {{ $.Values.mongodbDatabase | quote }}
+            - name: MONGODB_USERNAME
+              value: {{ $.Values.mongodbUsername | quote }}
+            - name: MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mongodb-sharded.secret" $ }}
+                  key: mongodb-password
+            {{- end }}
             - name: MONGODB_REPLICA_SET_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Allows the sharded cluster to provide a default database and non-root user for data access.

**Benefits**

Allows a service to only use a specific non-root user and generate an authDB for that specific application

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
