### PR TITLE
[bitnami/prometheus-operator] Mount Prometheus data volume into Thanos sidecar

### DIFF
--- a/bitnami/prometheus-operator/Chart.yaml
+++ b/bitnami/prometheus-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.39.0
 description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 name: prometheus-operator
-version: 0.17.0
+version: 0.17.1
 keywords:
   - prometheus
   - alertmanager

--- a/bitnami/prometheus-operator/requirements.lock
+++ b/bitnami/prometheus-operator/requirements.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.2.13
 - name: kube-state-metrics
   repository: https://charts.bitnami.com/bitnami
-  version: 0.2.1
-digest: sha256:5ae800ac83341163dd0652ca2d744aae8947c77b97cf8e35790ce092ef01f6a2
-generated: "2020-05-05T16:11:17.396711266Z"
+  version: 0.2.2
+digest: sha256:2115a39520dc2ffdba5dd0f51178b34167aa2b8df9915e1c5d5a7e78bc37eef0
+generated: "2020-05-19T15:03:18.57636418Z"

--- a/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -172,6 +172,7 @@ spec:
         - --prometheus.url=http://localhost:9090
         - --grpc-address=0.0.0.0:10901
         - --http-address=0.0.0.0:10902
+        - --tsdb.path=/prometheus/
         {{- if .Values.prometheus.thanos.objectStorageConfig }}
         - --objstore.config=$(OBJSTORE_CONFIG)
         {{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -102,8 +102,7 @@ spec:
   {{- end }}
   {{- if .Values.prometheus.storageSpec }}
   storage: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.storageSpec "context" $) | nindent 4 }}
-  {{- else }}
-  {{- if .Values.prometheus.persistence.enabled }}
+  {{- else if .Values.prometheus.persistence.enabled }}
   storage:
     volumeClaimTemplate:
       spec:
@@ -115,7 +114,6 @@ spec:
           requests:
             storage: {{ .Values.prometheus.persistence.size | quote }}
         {{- include "prometheus-operator.prometheus.storageClass" . | nindent 8 }}
-  {{- end }}
   {{- end }}
   {{- if .Values.prometheus.podMetadata }}
   podMetadata: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.podMetadata "context" $) | nindent 4 }}
@@ -195,6 +193,10 @@ spec:
         - name: http
           containerPort: 10902
           protocol: TCP
+      volumeMounts:
+        - mountPath: /prometheus
+          name: prometheus-{{ template "prometheus-operator.prometheus.fullname" . }}-db
+          subPath: prometheus-db
     {{- end }}
     {{- if .Values.prometheus.containers }}
     {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.containers "context" $) | nindent 4 }}

--- a/bitnami/prometheus-operator/values-production.yaml
+++ b/bitnami/prometheus-operator/values-production.yaml
@@ -42,7 +42,7 @@ operator:
   image:
     registry: docker.io
     repository: bitnami/prometheus-operator
-    tag: 0.39.0-debian-10-r3
+    tag: 0.39.0-debian-10-r8
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -208,7 +208,7 @@ operator:
     image:
       registry: docker.io
       repository: bitnami/configmap-reload
-      tag: 0.3.0-debian-10-r110
+      tag: 0.3.0-debian-10-r113
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -239,7 +239,7 @@ prometheus:
   image:
     registry: docker.io
     repository: bitnami/prometheus
-    tag: 2.18.1-debian-10-r4
+    tag: 2.18.1-debian-10-r8
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -633,7 +633,7 @@ alertmanager:
   image:
     registry: docker.io
     repository: bitnami/alertmanager
-    tag: 0.20.0-debian-10-r110
+    tag: 0.20.0-debian-10-r115
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/bitnami/prometheus-operator/values.yaml
+++ b/bitnami/prometheus-operator/values.yaml
@@ -42,7 +42,7 @@ operator:
   image:
     registry: docker.io
     repository: bitnami/prometheus-operator
-    tag: 0.39.0-debian-10-r3
+    tag: 0.39.0-debian-10-r8
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -208,7 +208,7 @@ operator:
     image:
       registry: docker.io
       repository: bitnami/configmap-reload
-      tag: 0.3.0-debian-10-r110
+      tag: 0.3.0-debian-10-r113
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -239,7 +239,7 @@ prometheus:
   image:
     registry: docker.io
     repository: bitnami/prometheus
-    tag: 2.18.1-debian-10-r4
+    tag: 2.18.1-debian-10-r8
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -639,7 +639,7 @@ alertmanager:
   image:
     registry: docker.io
     repository: bitnami/alertmanager
-    tag: 0.20.0-debian-10-r110
+    tag: 0.20.0-debian-10-r115
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

**Description of the change**

When configuring the Thanos sidecar to also upload data to object storage, it needs access to the Prometheus data volume.

This PR ensures the Prometheus data volume is mounted in the sidecar container whenever this sidecar is enabled.

**Benefits**

The sidecar can be configured to upload data to object storage.

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/2251

**Additional information**

You can test these changes installing the Minio chart and the Prometheus Operator chart as described below:

```console
$ helm install minio bitnami/minio -n monitoring --set accessKey.password=minio --set secretKey.password=minio123 --set defaultBuckets="thanos"
$ cat > thanos.yaml << 'EOF'
type: s3
config:
  bucket: thanos
  endpoint: minio.monitoring.svc.cluster.local:9000
  access_key: minio
  secret_key: minio123
  insecure: true
EOF
$ kubectl create secret generic thanos-objstore-config --from-file=./thanos.yaml -n monitoring
$ cat > values.yaml << 'EOF'
prometheus:
  disableCompaction: true
  thanos:
    create: true
    objectStorageConfig:
      secretName: thanos-objstore-config
      secretKey: thanos.yaml
  replicaCount: 2
  retention: 15d
  storageSpec:
    volumeClaimTemplate:
      spec:
        accessModes:
          - ReadWriteOnce
        resources:
          requests:
            storage: 50Gi
alertmanager:
  enabled: false
$ helm install prometheus-operator -f values.yaml --namespace monitoring bitnami/prometheus-operator 
```

Test everything is okey:

```console
$ kubectl get pods prometheus-prometheus-operator-prometheus-0 -o yaml -n monitoring
(...)
  - args:
    - sidecar
    - --prometheus.url=http://localhost:9090
    - --grpc-address=0.0.0.0:10901
    - --http-address=0.0.0.0:10902
    - --tsdb.path=/prometheus/
    - --objstore.config=$(OBJSTORE_CONFIG)
    env:
    - name: OBJSTORE_CONFIG
      valueFrom:
        secretKeyRef:
          key: thanos.yaml
          name: thanos-objstore-config
    (...)
    volumeMounts:
    - mountPath: /prometheus
      name: prometheus-prometheus-operator-prometheus-db
      subPath: prometheus-db
(...)
  volumes:
  - name: prometheus-prometheus-operator-prometheus-db
    persistentVolumeClaim:
      claimName: prometheus-prometheus-operator-prometheus-db-prometheus-prometheus-operator-prometheus-0
(...)
$ kubectl logs prometheus-prometheus-operator-prometheus-0 -c thanos-sidecar -n monitoring
(...)
level=info ts=2020-05-19T09:39:47.217783559Z caller=sidecar.go:220 msg="successfully loaded prometheus external labels" external_labels="{prometheus=\"monitoring/prometheus-operator-prometheus\", prometheus_replica=\"prometheus-prometheus-operator-prometheus-0\"}"
level=info ts=2020-05-19T09:39:47.217840081Z caller=intrumentation.go:48 msg="changing probe status" status=ready
```

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

