### PR TITLE
[bitnami/wordpress] Allow custom readiness/liveness probes

### DIFF
--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 9.2.5
+version: 9.3.0
 appVersion: 5.4.1
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -119,6 +119,7 @@ The following table lists the configurable parameters of the WordPress chart and
 | `livenessProbe.failureThreshold`          | Minimum consecutive failures for the probe                                            | `6`                                                          |
 | `livenessProbe.successThreshold`          | Minimum consecutive successes for the probe                                           | `1`                                                          |
 | `livenessProbeHeaders`                    | Headers to use for livenessProbe                                                      | `{}`                                                         |
+| `customLivenessProbe`                    | Override default liveness probe (evaluated as a template)                                                     | `{}`                                                         |
 | `readinessProbe.enabled`                  | Enable/disable readinessProbe                                                         | `true`                                                       |
 | `readinessProbe.initialDelaySeconds`      | Delay before readiness probe is initiated                                             | `30`                                                         |
 | `readinessProbe.periodSeconds`            | How often to perform the probe                                                        | `10`                                                         |
@@ -126,6 +127,7 @@ The following table lists the configurable parameters of the WordPress chart and
 | `readinessProbe.failureThreshold`         | Minimum consecutive failures for the probe                                            | `6`                                                          |
 | `readinessProbe.successThreshold`         | Minimum consecutive successes for the probe                                           | `1`                                                          |
 | `readinessProbeHeaders`                   | Headers to use for readinessProbe                                                     | `{}`                                                         |
+| `customReadinessProbe`                    | Override default readiness probe (evaluated as a template)                                                     | `{}`                                                         |
 | `service.annotations`                     | Service annotations                                                                   | `{}` (evaluated as a template)                               |
 | `service.type`                            | Kubernetes Service type                                                               | `LoadBalancer`                                               |
 | `service.port`                            | Service HTTP port                                                                     | `80`                                                         |

--- a/bitnami/wordpress/templates/deployment.yaml
+++ b/bitnami/wordpress/templates/deployment.yaml
@@ -148,6 +148,8 @@ spec:
               {{- if .Values.livenessProbeHeaders }}
               httpHeaders: {{- toYaml .Values.livenessProbeHeaders | nindent 16 }}
               {{- end }}
+          {{- else if .Values.customLivenessProbe }}
+          livenessProbe: {{- include "wordpress.tplValue" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
@@ -165,6 +167,8 @@ spec:
               {{- if .Values.readinessProbeHeaders }}
               httpHeaders: {{- toYaml .Values.readinessProbeHeaders | nindent 16 }}
               {{- end }}
+          {{- else if .Values.customReadinessProbe }}
+          readinessProbe: {{- include "wordpress.tplValue" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
             - mountPath: /bitnami/wordpress

--- a/bitnami/wordpress/values-production.yaml
+++ b/bitnami/wordpress/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/wordpress
-  tag: 5.4.1-debian-10-r15
+  tag: 5.4.1-debian-10-r17
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -444,7 +444,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.8.0-debian-10-r47
+    tag: 0.8.0-debian-10-r49
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/wordpress/values-production.yaml
+++ b/bitnami/wordpress/values-production.yaml
@@ -92,6 +92,7 @@ wordpressSkipInstall: false
 ##  rollingUpdate:
 ##    maxSurge: 25%
 ##    maxUnavailable: 25%
+##
 updateStrategy:
   type: RollingUpdate
 
@@ -111,7 +112,8 @@ allowOverrideNone: true
 ##
 htaccessPersistenceEnabled: false
 
-# ConfigMap with custom wordpress-htaccess.conf file (requires allowOverrideNone to true)
+## ConfigMap with custom wordpress-htaccess.conf file (requires allowOverrideNone to true)
+##
 customHTAccessCM:
 
 ## Use an alternate scheduler, e.g. "stork".
@@ -145,6 +147,7 @@ extraEnv: []
 ##   - name: ca-cert
 ##     subPath: ca_cert
 ##     mountPath: /path/to/ca_cert
+##
 extraVolumeMounts: []
 
 ## Additional volumes
@@ -156,6 +159,7 @@ extraVolumeMounts: []
 ##      items:
 ##        - key: ca-cert
 ##          path: ca_cert
+##
 extraVolumes: []
 
 ## WordPress containers' resource requests and limits
@@ -196,10 +200,12 @@ securityContext:
   runAsUser: 1001
 
 ## Allow health checks to be pointed at the https port
+##
 healthcheckHttps: false
 
 ## WordPress pod extra options for liveness and readiness probes
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+##
 livenessProbe:
   enabled: true
   initialDelaySeconds: 120
@@ -214,6 +220,11 @@ readinessProbe:
   timeoutSeconds: 5
   failureThreshold: 6
   successThreshold: 1
+
+## Custom liveness and readiness probes, it overrides the default one (evaluated as a template)
+##
+customLivenessProbe: {}
+customReadinessProbe: {}
 
 ## If using an HTTPS-terminating load-balancer, the probes may need to behave
 ## like the balancer to prevent HTTP 302 responses. According to the Kubernetes
@@ -253,6 +264,7 @@ service:
   ##   http: <to set explicitly, choose port between 30000-32767>
   ##   https: <to set explicitly, choose port between 30000-32767>
   ##   metrics: <to set explicitly, choose port between 30000-32767>
+  ##
   nodePorts:
     http: ""
     https: ""
@@ -264,6 +276,7 @@ service:
   annotations: {}
   ## Limits which cidr blocks can connect to service's load balancer
   ## Only valid if service.type: LoadBalancer
+  ##
   loadBalancerSourceRanges: []
   ## Extra ports to expose (normally used with the `sidecar` value)
   # extraPorts:
@@ -298,6 +311,7 @@ ingress:
   ## extraHosts:
   ## - name: wordpress.local
   ##   path: /
+  ##
 
   ## The tls configuration for additional hostnames to be covered with this ingress record.
   ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
@@ -305,6 +319,7 @@ ingress:
   ## - hosts:
   ##     - wordpress.local
   ##   secretName: wordpress.local-tls
+  ##
 
   ## If you're providing your own certificates, please use this to add the certificates as secrets
   ## key and certificate should start with -----BEGIN CERTIFICATE----- or
@@ -320,6 +335,7 @@ ingress:
   ## - name: wordpress.local-tls
   ##   key:
   ##   certificate:
+  ##
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
@@ -343,6 +359,7 @@ persistence:
   ## ReadWriteMany PVC, if you dont have a provisioner for this type of storage
   ## We recommend that you install the nfs provisioner and map it to a RWO volume
   ## helm install nfs-server stable/nfs-server-provisioner --set persistence.enabled=true,persistence.size=10Gi
+  ##
   accessMode: ReadWriteMany
   size: 10Gi
 
@@ -353,8 +370,10 @@ persistence:
 ##
 mariadb:
   ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+  ##
   enabled: true
   ## Disable MariaDB replication
+  ##
   replication:
     enabled: false
 
@@ -434,6 +453,7 @@ metrics:
     # pullSecrets:
     #   - myRegistryKeySecretName
   ## Metrics exporter pod Annotation and Labels
+  ##
   podAnnotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9117"
@@ -448,21 +468,26 @@ metrics:
   ## Prometheus Service Monitor
   ## ref: https://github.com/coreos/prometheus-operator
   ##      https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+  ##
   serviceMonitor:
     ## If the operator is installed in your cluster, set to true to create a Service Monitor Entry
+    ##
     enabled: false
     ## Specify the namespace in which the serviceMonitor resource will be created
     # namespace: ""
     ## Specify the interval at which metrics should be scraped
+    ##
     interval: 30s
     ## Specify the timeout after which the scrape is ended
     # scrapeTimeout: 30s
     ## Specify Metric Relabellings to add to the scrape endpoint
     # relabellings:
     ## Specify honorLabels parameter to add the scrape endpoint
+    ##
     honorLabels: false
     ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+    ##
     additionalLabels: {}
 
 ## Add sidecars to the pod.

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -92,6 +92,7 @@ wordpressSkipInstall: false
 ##  rollingUpdate:
 ##    maxSurge: 25%
 ##    maxUnavailable: 25%
+##
 updateStrategy:
   type: RollingUpdate
 
@@ -111,7 +112,8 @@ allowOverrideNone: false
 ##
 htaccessPersistenceEnabled: false
 
-# ConfigMap with custom wordpress-htaccess.conf file (requires allowOverrideNone to true)
+## ConfigMap with custom wordpress-htaccess.conf file (requires allowOverrideNone to true)
+##
 customHTAccessCM:
 
 ## Use an alternate scheduler, e.g. "stork".
@@ -145,6 +147,7 @@ extraEnv: []
 ##   - name: ca-cert
 ##     subPath: ca_cert
 ##     mountPath: /path/to/ca_cert
+##
 extraVolumeMounts: []
 
 ## Additional volumes
@@ -156,6 +159,7 @@ extraVolumeMounts: []
 ##      items:
 ##        - key: ca-cert
 ##          path: ca_cert
+##
 extraVolumes: []
 
 ## WordPress containers' resource requests and limits
@@ -196,10 +200,12 @@ securityContext:
   runAsUser: 1001
 
 ## Allow health checks to be pointed at the https port
+##
 healthcheckHttps: false
 
 ## WordPress pod extra options for liveness and readiness probes
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+##
 livenessProbe:
   enabled: true
   initialDelaySeconds: 120
@@ -214,6 +220,11 @@ readinessProbe:
   timeoutSeconds: 5
   failureThreshold: 6
   successThreshold: 1
+
+## Custom liveness and readiness probes, it overrides the default one (evaluated as a template)
+##
+customLivenessProbe: {}
+customReadinessProbe: {}
 
 ## If using an HTTPS-terminating load-balancer, the probes may need to behave
 ## like the balancer to prevent HTTP 302 responses. According to the Kubernetes
@@ -253,6 +264,7 @@ service:
   ##   http: <to set explicitly, choose port between 30000-32767>
   ##   https: <to set explicitly, choose port between 30000-32767>
   ##   metrics: <to set explicitly, choose port between 30000-32767>
+  ##
   nodePorts:
     http: ""
     https: ""
@@ -264,6 +276,7 @@ service:
   annotations: {}
   ## Limits which cidr blocks can connect to service's load balancer
   ## Only valid if service.type: LoadBalancer
+  ##
   loadBalancerSourceRanges: []
   ## Extra ports to expose (normally used with the `sidecar` value)
   # extraPorts:
@@ -298,6 +311,7 @@ ingress:
   ## extraHosts:
   ## - name: wordpress.local
   ##   path: /
+  ##
 
   ## The tls configuration for additional hostnames to be covered with this ingress record.
   ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
@@ -305,6 +319,7 @@ ingress:
   ## - hosts:
   ##     - wordpress.local
   ##   secretName: wordpress.local-tls
+  ##
 
   ## If you're providing your own certificates, please use this to add the certificates as secrets
   ## key and certificate should start with -----BEGIN CERTIFICATE----- or
@@ -320,6 +335,7 @@ ingress:
   ## - name: wordpress.local-tls
   ##   key:
   ##   certificate:
+  ##
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
@@ -348,8 +364,10 @@ persistence:
 ##
 mariadb:
   ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+  ##
   enabled: true
   ## Disable MariaDB replication
+  ##
   replication:
     enabled: false
 
@@ -429,6 +447,7 @@ metrics:
     # pullSecrets:
     #   - myRegistryKeySecretName
   ## Metrics exporter pod Annotation and Labels
+  ##
   podAnnotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9117"
@@ -443,21 +462,26 @@ metrics:
   ## Prometheus Service Monitor
   ## ref: https://github.com/coreos/prometheus-operator
   ##      https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+  ##
   serviceMonitor:
     ## If the operator is installed in your cluster, set to true to create a Service Monitor Entry
+    ##
     enabled: false
     ## Specify the namespace in which the serviceMonitor resource will be created
     # namespace: ""
     ## Specify the interval at which metrics should be scraped
+    ##
     interval: 30s
     ## Specify the timeout after which the scrape is ended
     # scrapeTimeout: 30s
     ## Specify Metric Relabellings to add to the scrape endpoint
     # relabellings:
     ## Specify honorLabels parameter to add the scrape endpoint
+    ##
     honorLabels: false
     ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+    ##
     additionalLabels: {}
 
 ## Add sidecars to the pod.

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/wordpress
-  tag: 5.4.1-debian-10-r15
+  tag: 5.4.1-debian-10-r17
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -438,7 +438,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.8.0-debian-10-r47
+    tag: 0.8.0-debian-10-r49
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Some users want to change the `wp-admin.php` and `wp-login.php` paths in their installation, and that could cause issues with the readinessProbes and livenessProbes. Just like we do with other charts, allowing users to set their custom liveness and readiness probes could cover this use case.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes https://github.com/bitnami/bitnami-docker-wordpress/issues/248

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
