### PR TITLE
[bitnami/phpmyadmin] phpmyadmin fix default probes

### DIFF
--- a/bitnami/phpmyadmin/Chart.yaml
+++ b/bitnami/phpmyadmin/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: phpmyadmin
-version: 5.0.5
+version: 5.0.6
 appVersion: 5.0.2
 description: phpMyAdmin is an mysql administration frontend
 keywords:

--- a/bitnami/phpmyadmin/values.yaml
+++ b/bitnami/phpmyadmin/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/phpmyadmin
-  tag: 5.0.2-debian-10-r58
+  tag: 5.0.2-debian-10-r63
   ## Specify a imagePullPolicy
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
@@ -184,7 +184,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.8.0-debian-10-r43
+    tag: 0.8.0-debian-10-r51
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/phpmyadmin/values.yaml
+++ b/bitnami/phpmyadmin/values.yaml
@@ -123,20 +123,20 @@ ingress:
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 ##
 livenessProbe:
-  # initialDelaySeconds: 30
-  # timeoutSeconds: 30
-  # periodSeconds: 10
-  # successThreshold: 1
-  # failureThreshold: 6
+  initialDelaySeconds: 30
+  timeoutSeconds: 30
+  periodSeconds: 10
+  successThreshold: 1
+  failureThreshold: 6
   httpGet:
     path: /
     port: http
 readinessProbe:
-  # initialDelaySeconds: 30
-  # timeoutSeconds: 30
-  # periodSeconds: 10
-  # successThreshold: 1
-  # failureThreshold: 6
+  initialDelaySeconds: 30
+  timeoutSeconds: 30
+  periodSeconds: 10
+  successThreshold: 1
+  failureThreshold: 6
   httpGet:
     path: /
     port: http


### PR DESCRIPTION
**Description of the change**

When `successThreshold` or `failureThreshold` are not set, the probes don't work. 

```
NAME                          READY   STATUS    RESTARTS   AGE
phpmyadmin-6dc7f4f97-bhtrn    0/1     Running   6          7m53s
phpmyadmin-mariadb-master-0   1/1     Running   0          7m53s
phpmyadmin-mariadb-slave-0    1/1     Running   0          7m53s
```

Set by default some liveness and readiness probe values.

**Benefits**

We can deploy the chart with default values.

**Possible drawbacks**

N/A

**Applicable issues**

  - related #2627

**Additional information**

N/A

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

