### PR TITLE
[bitnami/rabbitmq] make load definition secret name be templatable

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 6.25.12
+version: 6.25.13
 appVersion: 3.8.3
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/bitnami/rabbitmq/templates/statefulset.yaml
+++ b/bitnami/rabbitmq/templates/statefulset.yaml
@@ -305,7 +305,7 @@ spec:
         {{- if .Values.rabbitmq.loadDefinition.enabled }}
         - name: load-definition-volume
           secret:
-            secretName: {{ .Values.rabbitmq.loadDefinition.secretName | quote }}
+            secretName: {{ tpl .Values.rabbitmq.loadDefinition.secretName . | quote }}
         {{- end }}
         {{- if .Values.extraVolumes }}
         {{- toYaml .Values.extraVolumes | nindent 8 }}

--- a/bitnami/rabbitmq/values-production.yaml
+++ b/bitnami/rabbitmq/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/rabbitmq
-  tag: 3.8.3-debian-10-r84
+  tag: 3.8.3-debian-10-r92
 
   ## set to true if you would like to see extra information on logs
   ## it turns BASH and NAMI debugging in minideb

--- a/bitnami/rabbitmq/values-production.yaml
+++ b/bitnami/rabbitmq/values-production.yaml
@@ -121,6 +121,8 @@ rabbitmq:
 
   loadDefinition:
     enabled: false
+    ## Can be templated if needed, e.g.
+    # secretName: "{{ .Release.Name }}-load-definition"
     secretName: load-definition
 
   ## environment variables to configure rabbitmq

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/rabbitmq
-  tag: 3.8.3-debian-10-r84
+  tag: 3.8.3-debian-10-r92
 
   ## set to true if you would like to see extra information on logs
   ## it turns BASH and NAMI debugging in minideb

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -121,6 +121,8 @@ rabbitmq:
 
   loadDefinition:
     enabled: false
+    ## Can be templated if needed, e.g.
+    # secretName: "{{ .Release.Name }}-load-definition"
     secretName: load-definition
 
   ## environment variables to configure rabbitmq


### PR DESCRIPTION
**Description of the change**

Instead of using the value of `.Values.rabbitmq.loadDefinition.secretName` directly we call the function `tpl` on the value. This makes it so that the usual Helm templating is applied to the resulting value.

**Benefits**

<!-- What benefits will be realized by the code change? -->
This allows us to have an umbrella chart that creates a load definition secret with a unique name instead of a hardcoded name. This in turn allows for 2 instances of that umbrella chart to be installed in the same namespace.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
If the value has any templating it needs to be quoted, otherwise helm will complain. The example below works only when you quote it.
```yaml
secretName: "{{ .Release.Name }}-load-definition"
```

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #2653

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
