### PR TITLE
[bitnami/thanos]: Add bucketweb Ingress resource

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
-version: 0.6.0
+version: 0.7.0

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -184,6 +184,17 @@ The following tables lists the configurable parameters of the Thanos chart and t
 | `bucketweb.pdb.create`                          | Enable/disable a Pod Disruption Budget creation                                                        | `false`                                                 |
 | `bucketweb.pdb.minAvailable`                    | Minimum number/percentage of pods that should remain scheduled                                         | `1`                                                     |
 | `bucketweb.pdb.maxUnavailable`                  | Maximum number/percentage of pods that may be made unavailable                                         | `nil`                                                   |
+| `bucketweb.ingress.enabled`                     | Enable ingress controller resource                                                                     | `false`                                                 |
+| `bucketweb.ingress.certManager`                 | Add annotations for cert-manager                                                                       | `false`                                                 |
+| `bucketweb.ingress.hostname`                    | Default host for the ingress resource                                                                  | `thanos-bucketweb.local`                                |
+| `bucketweb.ingress.annotations`                 | Ingress annotations                                                                                    | `[]`                                                    |
+| `bucketweb.ingress.extraHosts[0].name`          | Additional hostnames to be covered                                                                     | `nil`                                                   |
+| `bucketweb.ingress.extraHosts[0].path`          | Additional hostnames to be covered                                                                     | `nil`                                                   |
+| `bucketweb.ingress.extraTls[0].hosts[0]`        | TLS configuration for additional hostnames to be covered                                               | `nil`                                                   |
+| `bucketweb.ingress.extraTls[0].secretName`      | TLS configuration for additional hostnames to be covered                                               | `nil`                                                   |
+| `bucketweb.ingress.secrets[0].name`             | TLS Secret Name                                                                                        | `nil`                                                   |
+| `bucketweb.ingress.secrets[0].certificate`      | TLS Secret Certificate                                                                                 | `nil`                                                   |
+| `bucketweb.ingress.secrets[0].key`              | TLS Secret Key                                                                                         | `nil`                                                   |
 
 ### Thanos Compactor parameters
 

--- a/bitnami/thanos/templates/bucketweb/ingress.yaml
+++ b/bitnami/thanos/templates/bucketweb/ingress.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.bucketweb.ingress.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ include "thanos.fullname" . }}-bucketweb
+  labels: {{- include "thanos.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.bucketweb.ingress.certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- range $key, $value := .Values.bucketweb.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- if .Values.bucketweb.ingress.hostname }}
+    - host: {{ .Values.bucketweb.ingress.hostname }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ template "thanos.fullname" . }}-bucketweb
+              servicePort: http
+    {{- end }}
+    {{- range .Values.bucketweb.ingress.extraHosts }}
+    - host: {{ .name }}
+      http:
+        paths:
+          - path: {{ default "/" .path }}
+            backend:
+              serviceName: {{ template "thanos.fullname" $ }}-bucketweb
+              servicePort: http
+    {{- end }}
+  {{- if or .Values.bucketweb.ingress.tls .Values.bucketweb.ingress.extraTls .Values.bucketweb.ingress.hosts }}
+  tls:
+    {{- if .Values.bucketweb.ingress.tls }}
+    - hosts:
+        - {{ .Values.bucketweb.ingress.hostname }}
+      secretName: {{ printf "%s-tls" .Values.bucketweb.ingress.hostname }}
+    {{- end }}
+    {{- if .Values.bucketweb.ingress.extraTls }}
+    {{- toYaml .Values.bucketweb.ingress.extraTls | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/bitnami/thanos/values-production.yaml
+++ b/bitnami/thanos/values-production.yaml
@@ -384,6 +384,57 @@ bucketweb:
     ##
     # maxUnavailable: 1
 
+  ## Configure the ingress resource that allows you to access Thanos Bucketweb
+  ## ref: http://kubernetes.io/docs/user-guide/ingress/
+  ##
+  ingress:
+    ## Set to true to enable ingress record generation
+    ##
+    enabled: false
+
+    ## Set this to true in order to add the corresponding annotations for cert-manager
+    ##
+    certManager: false
+
+    ## When the ingress is enabled, a host pointing to this will be created
+    ##
+    hostname: thanos-bucketweb.local
+
+    ## Ingress annotations done as key:value pairs
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+    ##
+    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+    ##
+    annotations: {}
+
+    ## The list of additional hostnames to be covered with this ingress record.
+    ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+    ## extraHosts:
+    ## - name: thanos-bucketweb.local
+    ##   path: /
+
+    ## The tls configuration for additional hostnames to be covered with this ingress record.
+    ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+    ## extraTls:
+    ## - hosts:
+    ##     - thanos-bucketweb.local
+    ##   secretName: thanos-bucketweb.local-tls
+
+    ## If you're providing your own certificates, please use this to add the certificates as secrets
+    ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+    ## -----BEGIN RSA PRIVATE KEY-----
+    ##
+    ## name should line up with a tlsSecret set further up
+    ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+    ##
+    ## It is also possible to create and manage the certificates outside of this helm chart
+    ## Please see README.md for more information
+    ##
+    secrets: []
+    ## - name: thanos-bucketweb.local-tls
+    ##   key:
+
 ## Thanos Compactor parameters
 ##
 compactor:

--- a/bitnami/thanos/values-production.yaml
+++ b/bitnami/thanos/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/thanos
-  tag: 0.12.2-scratch-r10
+  tag: 0.12.2-scratch-r11
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -384,6 +384,58 @@ bucketweb:
     ##
     # maxUnavailable: 1
 
+  ## Configure the ingress resource that allows you to access Thanos Bucketweb
+  ## ref: http://kubernetes.io/docs/user-guide/ingress/
+  ##
+  ingress:
+    ## Set to true to enable ingress record generation
+    ##
+    enabled: false
+
+    ## Set this to true in order to add the corresponding annotations for cert-manager
+    ##
+    certManager: false
+
+    ## When the ingress is enabled, a host pointing to this will be created
+    ##
+    hostname: thanos-bucketweb.local
+
+    ## Ingress annotations done as key:value pairs
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+    ##
+    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+    ##
+    annotations: {}
+
+    ## The list of additional hostnames to be covered with this ingress record.
+    ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+    ## extraHosts:
+    ## - name: thanos-bucketweb.local
+    ##   path: /
+
+    ## The tls configuration for additional hostnames to be covered with this ingress record.
+    ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+    ## extraTls:
+    ## - hosts:
+    ##     - thanos-bucketweb.local
+    ##   secretName: thanos-bucketweb.local-tls
+
+    ## If you're providing your own certificates, please use this to add the certificates as secrets
+    ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+    ## -----BEGIN RSA PRIVATE KEY-----
+    ##
+    ## name should line up with a tlsSecret set further up
+    ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+    ##
+    ## It is also possible to create and manage the certificates outside of this helm chart
+    ## Please see README.md for more information
+    ##
+    secrets: []
+    ## - name: thanos-bucketweb.local-tls
+    ##   key:
+    ##   certificate:
+
 ## Thanos Compactor parameters
 ##
 compactor:

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/thanos
-  tag: 0.12.2-scratch-r10
+  tag: 0.12.2-scratch-r11
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##


### PR DESCRIPTION
**Description of the change**

Add the ability to enable an Ingress resource for the bucketweb service.
This allows accessing the web UI for the storage bucket from outside the
cluster.

**Additional information**
This builds on top of #2643 which bumps the chart to 0.5.4

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files