### PR TITLE
[bitnami/zookeeper] Fix podAnnotations template rendering

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zookeeper
-version: 5.14.4
+version: 5.14.5
 appVersion: 3.6.1
 description: A centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services for distributed applications.
 keywords:

--- a/bitnami/zookeeper/templates/_helpers.tpl
+++ b/bitnami/zookeeper/templates/_helpers.tpl
@@ -216,9 +216,9 @@ Return podAnnotations
 */}}
 {{- define "zookeeper.podAnnotations" -}}
 {{- if .Values.podAnnotations }}
-{{- toYaml .Values.podAnnotations }}
+{{- toYaml .Values.podAnnotations | nindent 0 }}
 {{- end }}
 {{- if .Values.metrics.podAnnotations }}
-{{- include "zookeeper.tplValue" ( dict "value" .Values.metrics.podAnnotations "context" $) }}
+{{- include "zookeeper.tplValue" ( dict "value" .Values.metrics.podAnnotations "context" $) | nindent 0 }}
 {{- end }}
 {{- end -}}

--- a/bitnami/zookeeper/values-production.yaml
+++ b/bitnami/zookeeper/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/zookeeper
-  tag: 3.6.1-debian-10-r20
+  tag: 3.6.1-debian-10-r27
   
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/zookeeper
-  tag: 3.6.1-debian-10-r20
+  tag: 3.6.1-debian-10-r27
   
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
Template rendering was failing when multiple podAnnotation were
provided, leading to malfunction. Enforce same indentation in the
different annotations.

Signed-off-by: joancafom <jcarmona@bitnami.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Enforcement of equal indentation when more than one pod annotation source is provided in _helpers.tpl_.
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
Allow the user to provide both metrics annotations and custom pod ones.
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
None
<!-- Describe any known limitations with your change -->

**Applicable issues**
 - fixes #2652
<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
