### PR TITLE
[bitnami/common] fix image pull secrets helper

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: common
 # Please make sure that version and appVersion are always the same.
-version: 0.2.2
-appVersion: 0.2.2
+version: 0.2.3
+appVersion: 0.2.3
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 keywords:
   - common

--- a/bitnami/common/templates/_images.tpl
+++ b/bitnami/common/templates/_images.tpl
@@ -22,7 +22,10 @@ Return the proper Docker Image Registry Secret Names
 {{- define "common.images.pullSecrets" -}}
 {{- if .global }}
 {{- if .global.imagePullSecrets }}
-imagePullSecrets: {{ .global.imagePullSecrets | toYaml | nindent 2 }}
+imagePullSecrets:
+  {{- range .global.imagePullSecrets }}
+  - name: {{ . }}
+  {{- end }}
 {{- end }}
 {{- else }}
 {{- $pullSecrets := list }}
@@ -32,7 +35,10 @@ imagePullSecrets: {{ .global.imagePullSecrets | toYaml | nindent 2 }}
   {{- end }}
 {{- end }}
 {{- if $pullSecrets }}
-imagePullSecrets: {{ $pullSecrets | toYaml | nindent 2 }}
+imagePullSecrets:
+  {{- range $pullSecrets }}
+  - name: {{ . }}
+  {{- end }}
 {{- end }}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
**Description of the change**

Add `name` to the `common.images.pullSecrets` template helper. 

**Benefits**

We are able to specify `pullSecrets`.

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

