### PR TITLE
[bitnami/thanos]: Move querier Ingress config to querier section

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
-version: 0.7.0
+version: 1.0.0

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -149,6 +149,17 @@ The following tables lists the configurable parameters of the Thanos chart and t
 | `querier.pdb.create`                            | Enable/disable a Pod Disruption Budget creation                                                        | `false`                                                 |
 | `querier.pdb.minAvailable`                      | Minimum number/percentage of pods that should remain scheduled                                         | `1`                                                     |
 | `querier.pdb.maxUnavailable`                    | Maximum number/percentage of pods that may be made unavailable                                         | `nil`                                                   |
+| `querier.ingress.enabled`                       | Enable ingress controller resource                                                                     | `false`                                                 |
+| `querier.ingress.certManager`                   | Add annotations for cert-manager                                                                       | `false`                                                 |
+| `querier.ingress.hostname`                      | Default host for the ingress resource                                                                  | `thanos.local`                                          |
+| `querier.ingress.annotations`                   | Ingress annotations                                                                                    | `[]`                                                    |
+| `querier.ingress.extraHosts[0].name`            | Additional hostnames to be covered                                                                     | `nil`                                                   |
+| `querier.ingress.extraHosts[0].path`            | Additional hostnames to be covered                                                                     | `nil`                                                   |
+| `querier.ingress.extraTls[0].hosts[0]`          | TLS configuration for additional hostnames to be covered                                               | `nil`                                                   |
+| `querier.ingress.extraTls[0].secretName`        | TLS configuration for additional hostnames to be covered                                               | `nil`                                                   |
+| `querier.ingress.secrets[0].name`               | TLS Secret Name                                                                                        | `nil`                                                   |
+| `querier.ingress.secrets[0].certificate`        | TLS Secret Certificate                                                                                 | `nil`                                                   |
+| `querier.ingress.secrets[0].key`                | TLS Secret Key                                                                                         | `nil`                                                   |
 
 ### Thanos Bucket Web parameters
 
@@ -326,22 +337,6 @@ The following tables lists the configurable parameters of the Thanos chart and t
 | `ruler.pdb.create`                              | Enable/disable a Pod Disruption Budget creation                                                        | `false`                                                 |
 | `ruler.pdb.minAvailable`                        | Minimum number/percentage of pods that should remain scheduled                                         | `1`                                                     |
 | `ruler.pdb.maxUnavailable`                      | Maximum number/percentage of pods that may be made unavailable                                         | `nil`                                                   |
-
-### Ingress parameters
-
-| Parameter                                       | Description                                                                                            | Default                                                 |
-|-------------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `ingress.enabled`                               | Enable ingress controller resource                                                                     | `false`                                                 |
-| `ingress.certManager`                           | Add annotations for cert-manager                                                                       | `false`                                                 |
-| `ingress.hostname`                              | Default host for the ingress resource                                                                  | `thanos.local`                                          |
-| `ingress.annotations`                           | Ingress annotations                                                                                    | `[]`                                                    |
-| `ingress.extraHosts[0].name`                    | Additional hostnames to be covered                                                                     | `nil`                                                   |
-| `ingress.extraHosts[0].path`                    | Additional hostnames to be covered                                                                     | `nil`                                                   |
-| `ingress.extraTls[0].hosts[0]`                  | TLS configuration for additional hostnames to be covered                                               | `nil`                                                   |
-| `ingress.extraTls[0].secretName`                | TLS configuration for additional hostnames to be covered                                               | `nil`                                                   |
-| `ingress.secrets[0].name`                       | TLS Secret Name                                                                                        | `nil`                                                   |
-| `ingress.secrets[0].certificate`                | TLS Secret Certificate                                                                                 | `nil`                                                   |
-| `ingress.secrets[0].key`                        | TLS Secret Key                                                                                         | `nil`                                                   |
 
 ### Metrics parameters
 
@@ -546,3 +541,20 @@ By default, the chart is configured to use Kubernetes Security Context to automa
 As an alternative, this chart supports using an initContainer to change the ownership of the volumes before mounting it in the final destination.
 
 You can enable this initContainer by setting `volumePermissions.enabled` to `true`.
+
+## Upgrading
+
+### To 1.0.0
+If you are upgrading from a `<1.0.0` release you need to move your Querier Ingress information to the new values settings:
+```
+ingress.enabled -> querier.ingress.enabled
+ingress.certManager -> querier.ingress.certManager
+ingress.hostname -> querier.ingress.hostname
+ingress.annotations -> querier.ingress.annotations
+ingress.extraHosts[0].name -> querier.ingress.extraHosts[0].name
+ingress.extraHosts[0].path -> querier.ingress.extraHosts[0].path
+ingress.extraHosts[0].hosts[0] -> querier.ingress.extraHosts[0].hosts[0]
+ingress.extraHosts[0].secretName -> querier.ingress.extraHosts[0].secretName
+ingress.secrets[0].name -> querier.ingress.secrets[0].name
+ingress.secrets[0].certificate -> querier.ingress.secrets[0].certificate
+ingress.secrets[0].key -> querier.ingress.secrets[0].key

--- a/bitnami/thanos/templates/NOTES.txt
+++ b/bitnami/thanos/templates/NOTES.txt
@@ -27,13 +27,13 @@ Thanos Querier can be accessed through following DNS name from within your clust
 
 To access Thanos Querier from outside the cluster execute the following commands:
 
-{{- if .Values.ingress.enabled }}
+{{- if .Values.querier.ingress.enabled }}
 
 1. Get the Thanos Querier URL and associate Thanos Querier hostname to your cluster external IP:
 
    export CLUSTER_IP=$(minikube ip) # On Minikube. Use: `kubectl cluster-info` on others K8s clusters
-   echo "Thanos Querier URL: http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.hostname }}/"
-   echo "$CLUSTER_IP  {{ .Values.ingress.hostname }}" | sudo tee -a /etc/hosts
+   echo "Thanos Querier URL: http{{ if .Values.querier.ingress.tls }}s{{ end }}://{{ .Values.querier.ingress.hostname }}/"
+   echo "$CLUSTER_IP  {{ .Values.querier.ingress.hostname }}" | sudo tee -a /etc/hosts
 
 {{- else }}
 

--- a/bitnami/thanos/templates/querier/ingress.yaml
+++ b/bitnami/thanos/templates/querier/ingress.yaml
@@ -1,20 +1,20 @@
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.querier.ingress.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "thanos.fullname" . }}
   labels: {{- include "thanos.labels" . | nindent 4 }}
   annotations:
-    {{- if .Values.ingress.certManager }}
+    {{- if .Values.querier.ingress.certManager }}
     kubernetes.io/tls-acme: "true"
     {{- end }}
-    {{- range $key, $value := .Values.ingress.annotations }}
+    {{- range $key, $value := .Values.querier.ingress.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
   rules:
-    {{- if .Values.ingress.hostname }}
-    - host: {{ .Values.ingress.hostname }}
+    {{- if .Values.querier.ingress.hostname }}
+    - host: {{ .Values.querier.ingress.hostname }}
       http:
         paths:
           - path: /
@@ -22,7 +22,7 @@ spec:
               serviceName: {{ template "thanos.fullname" . }}-querier
               servicePort: http
     {{- end }}
-    {{- range .Values.ingress.extraHosts }}
+    {{- range .Values.querier.ingress.extraHosts }}
     - host: {{ .name }}
       http:
         paths:
@@ -31,15 +31,15 @@ spec:
               serviceName: {{ template "thanos.fullname" $ }}-querier
               servicePort: http
     {{- end }}
-  {{- if or .Values.ingress.tls .Values.ingress.extraTls .Values.ingress.hosts }}
+  {{- if or .Values.querier.ingress.tls .Values.querier.ingress.extraTls .Values.querier.ingress.hosts }}
   tls:
-    {{- if .Values.ingress.tls }}
+    {{- if .Values.querier.ingress.tls }}
     - hosts:
-        - {{ .Values.ingress.hostname }}
-      secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
+        - {{ .Values.querier.ingress.hostname }}
+      secretName: {{ printf "%s-tls" .Values.querier.ingress.hostname }}
     {{- end }}
-    {{- if .Values.ingress.extraTls }}
-    {{- toYaml .Values.ingress.extraTls | nindent 4 }}
+    {{- if .Values.querier.ingress.extraTls }}
+    {{- toYaml .Values.querier.ingress.extraTls | nindent 4 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/bitnami/thanos/values-production.yaml
+++ b/bitnami/thanos/values-production.yaml
@@ -236,6 +236,57 @@ querier:
     ##
     # maxUnavailable: 1
 
+  ## Configure the ingress resource that allows you to access Thanos Querier
+  ## ref: http://kubernetes.io/docs/user-guide/ingress/
+  ##
+  ingress:
+    ## Set to true to enable ingress record generation
+    ##
+    enabled: false
+
+    ## Set this to true in order to add the corresponding annotations for cert-manager
+    ##
+    certManager: false
+
+    ## When the ingress is enabled, a host pointing to this will be created
+    ##
+    hostname: thanos.local
+
+    ## Ingress annotations done as key:value pairs
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+    ##
+    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+    ##
+    annotations: {}
+
+    ## The list of additional hostnames to be covered with this ingress record.
+    ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+    ## extraHosts:
+    ## - name: thanos.local
+    ##   path: /
+
+    ## The tls configuration for additional hostnames to be covered with this ingress record.
+    ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+    ## extraTls:
+    ## - hosts:
+    ##     - thanos.local
+    ##   secretName: thanos.local-tls
+
+    ## If you're providing your own certificates, please use this to add the certificates as secrets
+    ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+    ## -----BEGIN RSA PRIVATE KEY-----
+    ##
+    ## name should line up with a tlsSecret set further up
+    ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+    ##
+    ## It is also possible to create and manage the certificates outside of this helm chart
+    ## Please see README.md for more information
+    ##
+    secrets: []
+    ## - name: thanos.local-tls
+    ##   key:
+
 ## Thanos Bucket Web parameters
 ##
 bucketweb:
@@ -1000,58 +1051,6 @@ metrics:
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
     ##
     # scrapeTimeout: 10s
-
-## Configure the ingress resource that allows you to access Thanos Querier
-## ref: http://kubernetes.io/docs/user-guide/ingress/
-##
-ingress:
-  ## Set to true to enable ingress record generation
-  ##
-  enabled: false
-
-  ## Set this to true in order to add the corresponding annotations for cert-manager
-  ##
-  certManager: false
-
-  ## When the ingress is enabled, a host pointing to this will be created
-  ##
-  hostname: thanos.local
-
-  ## Ingress annotations done as key:value pairs
-  ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
-  ##
-  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
-  ##
-  annotations: {}
-
-  ## The list of additional hostnames to be covered with this ingress record.
-  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
-  ## extraHosts:
-  ## - name: thanos.local
-  ##   path: /
-
-  ## The tls configuration for additional hostnames to be covered with this ingress record.
-  ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
-  ## extraTls:
-  ## - hosts:
-  ##     - thanos.local
-  ##   secretName: thanos.local-tls
-
-  ## If you're providing your own certificates, please use this to add the certificates as secrets
-  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
-  ## -----BEGIN RSA PRIVATE KEY-----
-  ##
-  ## name should line up with a tlsSecret set further up
-  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
-  ##
-  ## It is also possible to create and manage the certificates outside of this helm chart
-  ## Please see README.md for more information
-  ##
-  secrets: []
-  ## - name: thanos.local-tls
-  ##   key:
-  ##   certificate:
 
 ## Init Container paramaters
 ## Change the owner and group of the persistent volume(s) mountpoint(s) to 'runAsUser:fsGroup' on each component

--- a/bitnami/thanos/values-production.yaml
+++ b/bitnami/thanos/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/thanos
-  tag: 0.12.2-scratch-r11
+  tag: 0.12.2-scratch-r12
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -236,6 +236,58 @@ querier:
     ##
     # maxUnavailable: 1
 
+  ## Configure the ingress resource that allows you to access Thanos Querier
+  ## ref: http://kubernetes.io/docs/user-guide/ingress/
+  ##
+  ingress:
+    ## Set to true to enable ingress record generation
+    ##
+    enabled: false
+
+    ## Set this to true in order to add the corresponding annotations for cert-manager
+    ##
+    certManager: false
+
+    ## When the ingress is enabled, a host pointing to this will be created
+    ##
+    hostname: thanos.local
+
+    ## Ingress annotations done as key:value pairs
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+    ##
+    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+    ##
+    annotations: {}
+
+    ## The list of additional hostnames to be covered with this ingress record.
+    ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+    ## extraHosts:
+    ## - name: thanos.local
+    ##   path: /
+
+    ## The tls configuration for additional hostnames to be covered with this ingress record.
+    ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+    ## extraTls:
+    ## - hosts:
+    ##     - thanos.local
+    ##   secretName: thanos.local-tls
+
+    ## If you're providing your own certificates, please use this to add the certificates as secrets
+    ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+    ## -----BEGIN RSA PRIVATE KEY-----
+    ##
+    ## name should line up with a tlsSecret set further up
+    ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+    ##
+    ## It is also possible to create and manage the certificates outside of this helm chart
+    ## Please see README.md for more information
+    ##
+    secrets: []
+    ## - name: thanos.local-tls
+    ##   key:
+    ##   certificate:
+
 ## Thanos Bucket Web parameters
 ##
 bucketweb:
@@ -1003,58 +1055,6 @@ metrics:
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
     ##
     # scrapeTimeout: 10s
-
-## Configure the ingress resource that allows you to access Thanos Querier
-## ref: http://kubernetes.io/docs/user-guide/ingress/
-##
-ingress:
-  ## Set to true to enable ingress record generation
-  ##
-  enabled: false
-
-  ## Set this to true in order to add the corresponding annotations for cert-manager
-  ##
-  certManager: false
-
-  ## When the ingress is enabled, a host pointing to this will be created
-  ##
-  hostname: thanos.local
-
-  ## Ingress annotations done as key:value pairs
-  ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
-  ##
-  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
-  ##
-  annotations: {}
-
-  ## The list of additional hostnames to be covered with this ingress record.
-  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
-  ## extraHosts:
-  ## - name: thanos.local
-  ##   path: /
-
-  ## The tls configuration for additional hostnames to be covered with this ingress record.
-  ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
-  ## extraTls:
-  ## - hosts:
-  ##     - thanos.local
-  ##   secretName: thanos.local-tls
-
-  ## If you're providing your own certificates, please use this to add the certificates as secrets
-  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
-  ## -----BEGIN RSA PRIVATE KEY-----
-  ##
-  ## name should line up with a tlsSecret set further up
-  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
-  ##
-  ## It is also possible to create and manage the certificates outside of this helm chart
-  ## Please see README.md for more information
-  ##
-  secrets: []
-  ## - name: thanos.local-tls
-  ##   key:
-  ##   certificate:
 
 ## Init Container paramaters
 ## Change the owner and group of the persistent volume(s) mountpoint(s) to 'runAsUser:fsGroup' on each component

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/thanos
-  tag: 0.12.2-scratch-r11
+  tag: 0.12.2-scratch-r12
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##


### PR DESCRIPTION
**Description of the change**

Thanos querier is not the only component which can benefit from an ingress
object. bucketweb, storegateway, querier etc can all use an ingress
resource to be exposed outside of cluster. As such, it's cleaner to have
the ingress configuration for querier in the relevant section instead of
having it as a global configuration option. This enables us to form a
pattern on how to introduce ingresses to the rest of the resources.

**Benefits**
- Uniformity on how the Ingress resource for each component is defined

**Possible drawbacks**

- This is a breaking change so people need to perform certain steps during the update otherwise they risk ending up without a Querier ingress.

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files