### PR TITLE
Add lint GH action

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,0 +1,19 @@
+name: Lint and Test Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
+      - name: Run chart-testing (lint)
+        id: lint
+        uses: helm/chart-testing-action@v1.0.0-rc.2
+        with:
+          command: lint

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,7 @@
+chart-dirs:
+  - bitnami
+remote: origin
+validate-chart-schema: true
+validate-maintainers: true
+validate-yaml: true
+check-version-increment: true


### PR DESCRIPTION
**Description of the change**

Add a GitHub Action to execute some linter validations with new commits in PRs.
It is using the chart testing CLI (https://github.com/helm/chart-testing), specifically their GitHub action (https://github.com/marketplace/actions/helm-chart-testing)

Those are the configured parameters:
```
--chart-dirs strings             Directories containing Helm charts
--chart-repos strings            Additional chart repositories for dependency resolutions
--check-version-increment        Activates a check for chart version increments
--validate-chart-schema          Enable schema validation of 'Chart.yaml' using Yamale
--validate-maintainers           Enable validation of maintainer account names in chart.yml
--validate-yaml                  Enable linting of 'Chart.yaml' and values files
```

This is not blocking the merge of PRs