### PR TITLE
[bitnami/mariadb-galera] clean default MariaDB configuration

### DIFF
--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb-galera
-version: 3.1.1
+version: 3.1.2
 appVersion: 10.4.13
 description: MariaDB Galera is a multi-master database cluster solution for synchronous replication and high availability.
 keywords:

--- a/bitnami/mariadb-galera/values-production.yaml
+++ b/bitnami/mariadb-galera/values-production.yaml
@@ -240,77 +240,75 @@ mariadbConfiguration: |-
   plugin_dir=/opt/bitnami/mariadb/plugin
 
   [mysqld]
-  default-storage-engine=InnoDB
+  default_storage_engine=InnoDB
   basedir=/opt/bitnami/mariadb
   datadir=/bitnami/mariadb/data
   plugin_dir=/opt/bitnami/mariadb/plugin
   tmpdir=/opt/bitnami/mariadb/tmp
   socket=/opt/bitnami/mariadb/tmp/mysql.sock
-  pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
-  bind-address=0.0.0.0
+  pid_file=/opt/bitnami/mariadb/tmp/mysqld.pid
+  bind_address=0.0.0.0
 
   ## Character set
-  collation-server=utf8_unicode_ci
-  init-connect='SET NAMES utf8'
-  character-set-server=utf8
+  collation_server=utf8_unicode_ci
+  init_connect='SET NAMES utf8'
+  character_set_server=utf8
 
   ## MyISAM
-  key-buffer-size=32M
-  myisam-recover-options=FORCE,BACKUP
+  key_buffer_size=32M
+  myisam_recover_options=FORCE,BACKUP
 
-  ## safety
-  skip-host-cache
-  skip-name-resolve
-  max-allowed-packet=16M
-  max-connect-errors=1000000
-  sql-mode=STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_AUTO_VALUE_ON_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY
-  sysdate-is-now=1
-  innodb=FORCE
-  innodb-strict-mode=1
-  innodb_file_per_table=1
-  # Mandatory per https://github.com/codership/documentation/issues/25
-  innodb-autoinc-lock-mode=2
-  # Per https://www.percona.com/blog/2006/08/04/innodb-double-write/
-  innodb-doublewrite=1
-  # Not fully ACID compliant, up to 1sec transaction loss in the event of total cluster failure (across both regions)
-  # Enabled for performance per https://mariadb.com/kb/en/mariadb/getting-started-with-mariadb-galera-cluster/
-  innodb_flush_log_at_trx_commit=0
+  ## Safety
+  skip_host_cache
+  skip_name_resolve
+  max_allowed_packet=16M
+  max_connect_errors=1000000
+  sql_mode=STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_AUTO_VALUE_ON_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY
+  sysdate_is_now=1
 
-  ## binary logging
-  log-bin=mysql-bin
-  expire-logs-days=14
+  ## Binary Logging
+  log_bin=mysql-bin
+  expire_logs_days=14
   # Disabling for performance per http://severalnines.com/blog/9-tips-going-production-galera-cluster-mysql
-  sync-binlog=0
+  sync_binlog=0
   # Required for Galera
-  binlog-format=row
-  ## Caches and limits
-  tmp-table-size=32M
-  max-heap-table-size=32M
+  binlog_format=row
+
+  ## Caches and Limits
+  tmp_table_size=32M
+  max_heap_table_size=32M
   # Re-enabling as now works with Maria 10.1.2
-  query-cache-type=1
-  query-cache-limit=4M
-  query-cache-size=256M
-  max-connections=500
-  thread-cache-size=50
-  open-files-limit=65535
-  table-definition-cache=4096
-  table-open-cache=4096
-  ## innodb
-  innodb-flush-method=O_DIRECT
-  innodb-log-files-in-group=2
-  innodb-log-file-size=128M
-  innodb-flush-log-at-trx-commit=1
-  innodb-file-per-table=1
+  query_cache_type=1
+  query_cache_limit=4M
+  query_cache_size=256M
+  max_connections=500
+  thread_cache_size=50
+  open_files_limit=65535
+  table_definition_cache=4096
+  table_open_cache=4096
+
+  ## InnoDB
+  innodb=FORCE
+  innodb_strict_mode=1
+  # Mandatory per https://github.com/codership/documentation/issues/25
+  innodb_autoinc_lock_mode=2
+  # Per https://www.percona.com/blog/2006/08/04/innodb-double-write/
+  innodb_doublewrite=1
+  innodb_flush_method=O_DIRECT
+  innodb_log_files_in_group=2
+  innodb_log_file_size=128M
+  innodb_flush_log_at_trx_commit=1
+  innodb_file_per_table=1
   # 80% Memory is default reco.
   # Need to re-evaluate when DB size grows
-  innodb-buffer-pool-size=2G
+  innodb_buffer_pool_size=2G
   innodb_file_format=Barracuda
 
-  ## logging
-  log-error=/opt/bitnami/mariadb/logs/mysqld.log
-  slow-query-log-file=/opt/bitnami/mariadb/logs/mysqld.log
-  log-queries-not-using-indexes=1
-  slow-query-log=1
+  ## Logging
+  log_error=/opt/bitnami/mariadb/logs/mysqld.log
+  slow_query_log_file=/opt/bitnami/mariadb/logs/mysqld.log
+  log_queries_not_using_indexes=1
+  slow_query_log=1
 
   ## SSL
   ## Use extraVolumes and extraVolumeMounts to mount /certs filesystem
@@ -326,7 +324,8 @@ mariadbConfiguration: |-
   wsrep_cluster_address=gcomm://
   wsrep_cluster_name=galera
   wsrep_sst_auth="root:"
-  innodb-flush-log-at-trx-commit=2
+  # Enabled for performance per https://mariadb.com/kb/en/innodb-system-variables/#innodb_flush_log_at_trx_commit
+  innodb_flush_log_at_trx_commit=2
   # MYISAM REPLICATION SUPPORT #
   wsrep_replicate_myisam=ON
 

--- a/bitnami/mariadb-galera/values-production.yaml
+++ b/bitnami/mariadb-galera/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/mariadb-galera
-  tag: 10.4.13-debian-10-r21
+  tag: 10.4.13-debian-10-r22
 
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/bitnami/mariadb-galera/values.yaml
+++ b/bitnami/mariadb-galera/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/mariadb-galera
-  tag: 10.4.13-debian-10-r21
+  tag: 10.4.13-debian-10-r22
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/mariadb-galera/values.yaml
+++ b/bitnami/mariadb-galera/values.yaml
@@ -240,77 +240,75 @@ mariadbConfiguration: |-
   plugin_dir=/opt/bitnami/mariadb/plugin
 
   [mysqld]
-  default-storage-engine=InnoDB
+  default_storage_engine=InnoDB
   basedir=/opt/bitnami/mariadb
   datadir=/bitnami/mariadb/data
   plugin_dir=/opt/bitnami/mariadb/plugin
   tmpdir=/opt/bitnami/mariadb/tmp
   socket=/opt/bitnami/mariadb/tmp/mysql.sock
-  pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
-  bind-address=0.0.0.0
+  pid_file=/opt/bitnami/mariadb/tmp/mysqld.pid
+  bind_address=0.0.0.0
 
   ## Character set
-  collation-server=utf8_unicode_ci
-  init-connect='SET NAMES utf8'
-  character-set-server=utf8
+  collation_server=utf8_unicode_ci
+  init_connect='SET NAMES utf8'
+  character_set_server=utf8
 
   ## MyISAM
-  key-buffer-size=32M
-  myisam-recover-options=FORCE,BACKUP
+  key_buffer_size=32M
+  myisam_recover_options=FORCE,BACKUP
 
-  ## safety
-  skip-host-cache
-  skip-name-resolve
-  max-allowed-packet=16M
-  max-connect-errors=1000000
-  sql-mode=STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_AUTO_VALUE_ON_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY
-  sysdate-is-now=1
-  innodb=FORCE
-  innodb-strict-mode=1
-  innodb_file_per_table=1
-  # Mandatory per https://github.com/codership/documentation/issues/25
-  innodb-autoinc-lock-mode=2
-  # Per https://www.percona.com/blog/2006/08/04/innodb-double-write/
-  innodb-doublewrite=1
-  # Not fully ACID compliant, up to 1sec transaction loss in the event of total cluster failure (across both regions)
-  # Enabled for performance per https://mariadb.com/kb/en/mariadb/getting-started-with-mariadb-galera-cluster/
-  innodb_flush_log_at_trx_commit=0
+  ## Safety
+  skip_host_cache
+  skip_name_resolve
+  max_allowed_packet=16M
+  max_connect_errors=1000000
+  sql_mode=STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_AUTO_VALUE_ON_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY
+  sysdate_is_now=1
 
-  ## binary logging
-  log-bin=mysql-bin
-  expire-logs-days=14
+  ## Binary Logging
+  log_bin=mysql-bin
+  expire_logs_days=14
   # Disabling for performance per http://severalnines.com/blog/9-tips-going-production-galera-cluster-mysql
-  sync-binlog=0
+  sync_binlog=0
   # Required for Galera
-  binlog-format=row
-  ## Caches and limits
-  tmp-table-size=32M
-  max-heap-table-size=32M
+  binlog_format=row
+
+  ## Caches and Limits
+  tmp_table_size=32M
+  max_heap_table_size=32M
   # Re-enabling as now works with Maria 10.1.2
-  query-cache-type=1
-  query-cache-limit=4M
-  query-cache-size=256M
-  max-connections=500
-  thread-cache-size=50
-  open-files-limit=65535
-  table-definition-cache=4096
-  table-open-cache=4096
-  ## innodb
-  innodb-flush-method=O_DIRECT
-  innodb-log-files-in-group=2
-  innodb-log-file-size=128M
-  innodb-flush-log-at-trx-commit=1
-  innodb-file-per-table=1
+  query_cache_type=1
+  query_cache_limit=4M
+  query_cache_size=256M
+  max_connections=500
+  thread_cache_size=50
+  open_files_limit=65535
+  table_definition_cache=4096
+  table_open_cache=4096
+
+  ## InnoDB
+  innodb=FORCE
+  innodb_strict_mode=1
+  # Mandatory per https://github.com/codership/documentation/issues/25
+  innodb_autoinc_lock_mode=2
+  # Per https://www.percona.com/blog/2006/08/04/innodb-double-write/
+  innodb_doublewrite=1
+  innodb_flush_method=O_DIRECT
+  innodb_log_files_in_group=2
+  innodb_log_file_size=128M
+  innodb_flush_log_at_trx_commit=1
+  innodb_file_per_table=1
   # 80% Memory is default reco.
   # Need to re-evaluate when DB size grows
-  innodb-buffer-pool-size=2G
+  innodb_buffer_pool_size=2G
   innodb_file_format=Barracuda
 
-  ## logging
-  log-error=/opt/bitnami/mariadb/logs/mysqld.log
-  slow-query-log-file=/opt/bitnami/mariadb/logs/mysqld.log
-  log-queries-not-using-indexes=1
-  slow-query-log=1
+  ## Logging
+  log_error=/opt/bitnami/mariadb/logs/mysqld.log
+  slow_query_log_file=/opt/bitnami/mariadb/logs/mysqld.log
+  log_queries_not_using_indexes=1
+  slow_query_log=1
 
   ## SSL
   ## Use extraVolumes and extraVolumeMounts to mount /certs filesystem
@@ -326,7 +324,8 @@ mariadbConfiguration: |-
   wsrep_cluster_address=gcomm://
   wsrep_cluster_name=galera
   wsrep_sst_auth="root:"
-  innodb-flush-log-at-trx-commit=2
+  # Enabled for performance per https://mariadb.com/kb/en/innodb-system-variables/#innodb_flush_log_at_trx_commit
+  innodb_flush_log_at_trx_commit=2
   # MYISAM REPLICATION SUPPORT #
   wsrep_replicate_myisam=ON
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

- use underscores in the default config to make it consistent with [official documentation](https://mariadb.com/kb/en/server-system-variables/). MySQL unfortunately accepts both and it makes it messy and easy to define something twice (key-buffer-size and then key_buffer_size)
- remove duplicates of key_buffer_size and innodb_file_per_table options (set them only once)
- add new lines between some subsections

**Benefits**

Increased readability of default my.cnf options, underscores consistent with official documentation, easily searchable there

**Possible drawbacks**

none

**Applicable issues**

none

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
