### PR TITLE
[bitnami/thanos] Add Ingress for Querier GRPC service

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
-version: 1.0.2
+version: 1.1.0

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -160,6 +160,17 @@ The following tables lists the configurable parameters of the Thanos chart and t
 | `querier.ingress.secrets[0].name`               | TLS Secret Name                                                                                        | `nil`                                                   |
 | `querier.ingress.secrets[0].certificate`        | TLS Secret Certificate                                                                                 | `nil`                                                   |
 | `querier.ingress.secrets[0].key`                | TLS Secret Key                                                                                         | `nil`                                                   |
+| `querier.ingress.grpc.enabled`                  | Enable ingress controller resource (GRPC)                                                              | `false`                                                 |
+| `querier.ingress.grpc.certManager`              | Add annotations for cert-manager (GRPC)                                                                | `false`                                                 |
+| `querier.ingress.grpc.hostname`                 | Default host for the ingress resource (GRPC)                                                           | `thanos.local`                                          |
+| `querier.ingress.grpc.annotations`              | Ingress annotations (GRPC)                                                                             | `[]`                                                    |
+| `querier.ingress.grpc.extraHosts[0].name`       | Additional hostnames to be covered (GRPC)                                                              | `nil`                                                   |
+| `querier.ingress.grpc.extraHosts[0].path`       | Additional hostnames to be covered (GRPC)                                                              | `nil`                                                   |
+| `querier.ingress.grpc.extraTls[0].hosts[0]`     | TLS configuration for additional hostnames to be covered (GRPC)                                        | `nil`                                                   |
+| `querier.ingress.grpc.extraTls[0].secretName`   | TLS configuration for additional hostnames to be covered (GRPC)                                        | `nil`                                                   |
+| `querier.ingress.grpc.secrets[0].name`          | TLS Secret Name (GRPC)                                                                                 | `nil`                                                   |
+| `querier.ingress.grpc.secrets[0].certificate`   | TLS Secret Certificate (GRPC)                                                                          | `nil`                                                   |
+| `querier.ingress.grpc.secrets[0].key`           | TLS Secret Key (GRPC)                                                                                  | `nil`                                                   |
 
 ### Thanos Bucket Web parameters
 

--- a/bitnami/thanos/requirements.lock
+++ b/bitnami/thanos/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: minio
   repository: https://charts.bitnami.com/bitnami
-  version: 3.4.2
-digest: sha256:4c768bfa3ed5f34553b8b91b6c287d659d547eb9efa027cbcb6e5f2d14ed496f
-generated: "2020-05-29T09:28:20.547408529Z"
+  version: 3.4.4
+digest: sha256:660e7f7e92f7d3070133a6102d112012a53c9b4eca2a33cdadd72560173fb1c6
+generated: "2020-06-02T07:55:53.287753419Z"

--- a/bitnami/thanos/templates/querier/ingress.yaml
+++ b/bitnami/thanos/templates/querier/ingress.yaml
@@ -43,3 +43,49 @@ spec:
     {{- end }}
   {{- end }}
 {{- end }}
+---
+{{- if .Values.querier.ingress.grpc.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ include "thanos.fullname" . }}-grpc
+  labels: {{- include "thanos.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.querier.ingress.grpc.certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- range $key, $value := .Values.querier.ingress.grpc.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- if .Values.querier.ingress.grpc.hostname }}
+    - host: {{ .Values.querier.ingress.grpc.hostname }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ template "thanos.fullname" . }}-querier
+              servicePort: grpc
+    {{- end }}
+    {{- range .Values.querier.ingress.extraHosts }}
+    - host: {{ .name }}
+      http:
+        paths:
+          - path: {{ default "/" .path }}
+            backend:
+              serviceName: {{ template "thanos.fullname" $ }}-querier
+              servicePort: grpc
+    {{- end }}
+  {{- if or .Values.querier.ingress.grpc.tls .Values.querier.ingress.grpc.extraTls .Values.querier.ingress.grpc.hosts }}
+  tls:
+    {{- if .Values.querier.ingress.grpc.tls }}
+    - hosts:
+        - {{ .Values.querier.ingress.grpc.hostname }}
+      secretName: {{ printf "%s-tls" .Values.querier.ingress.grpc.hostname }}
+    {{- end }}
+    {{- if .Values.querier.ingress.grpc.extraTls }}
+    {{- toYaml .Values.querier.ingress.grpc.extraTls | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/bitnami/thanos/values-production.yaml
+++ b/bitnami/thanos/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/thanos
-  tag: 0.12.2-scratch-r14
+  tag: 0.12.2-scratch-r15
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##

--- a/bitnami/thanos/values-production.yaml
+++ b/bitnami/thanos/values-production.yaml
@@ -287,6 +287,39 @@ querier:
     ## - name: thanos.local-tls
     ##   key:
 
+    ## Create an ingress object for the GRPC service. This requires an HTTP/2
+    ## capable Ingress controller (eg. traefik using AWS NLB). Example annotations
+    ## - ingress.kubernetes.io/protocol: h2c
+    ## - service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    ## - service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+    ## For more information see https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/
+    ## and also the documentation for your ingress controller.
+    ##
+    ## The options that are accepted are identical to the HTTP one listed above
+    grpc:
+      enabled: false
+      certManager: false
+      hostname: thanos-grpc.local
+      annotations: {}
+
+      ## - hosts:
+      ##     - thanos.local
+      ##   secretName: thanos-grpc.local-tls
+
+      ## extraHosts:
+      ## - name: thanos-grpc.local
+      ##   path: /
+
+      ## extraTls:
+      ## - hosts:
+      ##     - thanos-grpc.local
+      ##   secretName: thanos-grpc.local-tls
+
+      secrets: []
+      ## - name: thanos-grpc.local-tls
+      ##   key:
+      ##   certificate:
+
 ## Thanos Bucket Web parameters
 ##
 bucketweb:

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/thanos
-  tag: 0.12.2-scratch-r14
+  tag: 0.12.2-scratch-r15
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -288,6 +288,39 @@ querier:
     ##   key:
     ##   certificate:
 
+    ## Create an ingress object for the GRPC service. This requires an HTTP/2
+    ## capable Ingress controller (eg. traefik using AWS NLB). Example annotations
+    ## - ingress.kubernetes.io/protocol: h2c
+    ## - service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    ## - service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+    ## For more information see https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/
+    ## and also the documentation for your ingress controller.
+    ##
+    ## The options that are accepted are identical to the HTTP one listed above
+    grpc:
+      enabled: false
+      certManager: false
+      hostname: thanos-grpc.local
+      annotations: {}
+
+      ## - hosts:
+      ##     - thanos.local
+      ##   secretName: thanos-grpc.local-tls
+
+      ## extraHosts:
+      ## - name: thanos-grpc.local
+      ##   path: /
+
+      ## extraTls:
+      ## - hosts:
+      ##     - thanos-grpc.local
+      ##   secretName: thanos-grpc.local-tls
+
+      secrets: []
+      ## - name: thanos-grpc.local-tls
+      ##   key:
+      ##   certificate:
+
 ## Thanos Bucket Web parameters
 ##
 bucketweb:


### PR DESCRIPTION
**Description of the change**

The querier uses a GRPC service which is useful when you have stacked
Thanos deployments. For example, it's possible to have a single observer
cluster which monitors many different clusters. Each one of these
clusters, including the observer, may have its own Thanos stack running.
However, from the observer cluster, the querier needs to connect to the
each cluster's querier in order to have a global view from all the
clusters. As such, in order to do that, we need to expose the Querier
GRPC service through the ingress in order to allow cluster-to-cluster
communication.


**Benefits**
- Allows hierarchical Thanos deployments

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files