### PR TITLE
[bitnami/external-dns] Fix/setting pdns api key

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -1,12 +1,7 @@
 apiVersion: v1
 name: external-dns
-<<<<<<< HEAD
-version: 3.2.1
+version: 3.2.2
 appVersion: 0.7.2
-=======
-version: 3.1.1
-appVersion: 0.7.1
->>>>>>> bump Chart.yaml to 3.1.1
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:
   - external-dns

--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -1,7 +1,12 @@
 apiVersion: v1
 name: external-dns
+<<<<<<< HEAD
 version: 3.2.1
 appVersion: 0.7.2
+=======
+version: 3.1.1
+appVersion: 0.7.1
+>>>>>>> bump Chart.yaml to 3.1.1
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:
   - external-dns

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -390,7 +390,7 @@ spec:
                   name: {{ template "external-dns.secretName" . }}
                   key: rfc2136_tsig_secret
             {{- end }}
-            {{- if and (eq .Values.provider "pdns") }}
+            {{- if eq .Values.provider "pdns" }}
             # PowerDNS environment variables
             - name: PDNS_API_KEY
               valueFrom:

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -390,7 +390,15 @@ spec:
                   name: {{ template "external-dns.secretName" . }}
                   key: rfc2136_tsig_secret
             {{- end }}
-            {{- if and (eq .Values.provider "pdns") (or .Values.pdns.apiKey .Values.pdns.secretName) }}
+            {{- if and (eq .Values.provider "pdns") .Values.pdns.apiKey }}
+            # PowerDNS environment variables
+            - name: PDNS_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "external-dns.secretName" . }}
+                  key: pdns_api_key
+            {{- end }}
+            {{- if and (eq .Values.provider "pdns") .Values.pdns.secretName }}
             # PowerDNS environment variables
             - name: PDNS_API_KEY
               valueFrom:

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -390,15 +390,7 @@ spec:
                   name: {{ template "external-dns.secretName" . }}
                   key: rfc2136_tsig_secret
             {{- end }}
-            {{- if and (eq .Values.provider "pdns") .Values.pdns.apiKey }}
-            # PowerDNS environment variables
-            - name: PDNS_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "external-dns.secretName" . }}
-                  key: pdns_api_key
-            {{- end }}
-            {{- if and (eq .Values.provider "pdns") .Values.pdns.secretName }}
+            {{- if and (eq .Values.provider "pdns") }}
             # PowerDNS environment variables
             - name: PDNS_API_KEY
               valueFrom:

--- a/bitnami/external-dns/templates/secret.yaml
+++ b/bitnami/external-dns/templates/secret.yaml
@@ -48,7 +48,7 @@ data:
   infoblox_wapi_password: {{ .Values.infoblox.wapiPassword | b64enc | quote }}
   {{- end }}
   {{- if eq .Values.provider "pdns" }}
-  pdns_api_key: {{ .Values.pdns.apiKey . | b64enc | quote }}
+  pdns_api_key: {{ .Values.pdns.apiKey | b64enc | quote }}
   {{- end }}
   {{- if eq .Values.provider "rfc2136" }}
   rfc2136_tsig_secret: {{ .Values.rfc2136.tsigSecret | b64enc | quote }}

--- a/bitnami/external-dns/values-production.yaml
+++ b/bitnami/external-dns/values-production.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/external-dns
-  tag: 0.7.2-debian-10-r13
+  tag: 0.7.2-debian-10-r20
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/external-dns/values.yaml
+++ b/bitnami/external-dns/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/external-dns
-  tag: 0.7.2-debian-10-r13
+  tag: 0.7.2-debian-10-r20
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This fixes the ability for the external-dns chart to set the API key using the pdns.apiKey option instead of the secret

**Benefits**

Since #2451 broke support to use the pdns.apiKey

**Possible drawbacks**

Possibly breaks using pdns.secretName

**Applicable issues**

  - fixes #2706 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
