### PR TITLE
Add support for helm lint and helm install in PRs via GH Actions

### DIFF
--- a/.github/ct-install.yaml
+++ b/.github/ct-install.yaml
@@ -1,0 +1,12 @@
+chart-dirs:
+  - bitnami
+chart-repos:
+  - bitnami=https://charts.bitnami.com/bitnami
+debug: true
+excluded-charts:
+  - common
+  - kubeapps
+  - kibana
+  - kong
+  - mariadb-galera
+remote: origin

--- a/.github/ct-lint.yaml
+++ b/.github/ct-lint.yaml
@@ -2,9 +2,9 @@ chart-dirs:
   - bitnami
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
+check-version-increment: true
+debug: true
 remote: origin
 validate-chart-schema: true
 validate-maintainers: true
-debug: true
 validate-yaml: true
-check-version-increment: true

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -3,7 +3,7 @@ name: Lint and Test Charts
 on: pull_request
 
 jobs:
-  lint-test:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -13,7 +13,24 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Run chart-testing (lint)
-        id: lint
         uses: helm/chart-testing-action@v1.0.0-rc.2
         with:
+          config: .github/ct-lint.yaml
           command: lint
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.0.0-rc.1
+
+      - name: Run chart-testing (install)
+        uses: helm/chart-testing-action@v1.0.0-rc.2
+        with:
+          config: .github/ct-install.yaml
+          command: install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,10 +28,11 @@ When submitting a PR make sure that it:
 
 ### PR Approval and Release Process
 
-1. Changes are manually reviewed by Bitnami team members.
-2. Once the changes are accepted, the PR is tested into the CI pipeline, the chart is installed and tested on top of different k8s platforms.
-3. If everything works fine, the `bitnami-bot` will add a new commit to the PR updating all the Docker images tags and dependencies. If something fails, the review process continues.
-4. When the PR passes all tests it is merged in the GitHub master branch and the new version of the chart is pushed to the registry. Please note that may be a slight difference between the appearance of the code in GitHub and the chart in the registry.
+1. Changes are automatically linted and tested using the [`ct` tool](https://github.com/helm/chart-testing) as a [GitHub action](https://github.com/helm/chart-testing-action). Those tests are based on `helm install`, `helm lint` and `helm test` commands and provide quick feedback about the changes in the PR. For those tests, the chart is installed on top of [kind](https://github.com/kubernetes-sigs/kind) and this step is not blocking (as opposed to 3rd step).
+2. Changes are manually reviewed by Bitnami team members.
+3. Once the changes are accepted, the PR is tested into the Bitnami CI pipeline, the chart is installed and tested (verification and functional tests) on top of different k8s platforms.
+4. If everything works fine, the `bitnami-bot` will add a new commit to the PR updating all the Docker images tags and dependencies. If something fails, the review process continues.
+5. When the PR passes all tests it is merged in the GitHub master branch and the new version of the chart is pushed to the registry. Please note that may be a slight difference between the appearance of the code in GitHub and the chart in the registry.
 
 ### Adding a new chart to the repository
 

--- a/bitnami/apache/ci/ct-values.yaml
+++ b/bitnami/apache/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/dokuwiki/ci/ct-values.yaml
+++ b/bitnami/dokuwiki/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/drupal/ci/ct-values.yaml
+++ b/bitnami/drupal/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/ghost/ci/ct-values.yaml
+++ b/bitnami/ghost/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/jasperreports/ci/ct-values.yaml
+++ b/bitnami/jasperreports/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/jenkins/ci/ct-values.yaml
+++ b/bitnami/jenkins/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/joomla/ci/ct-values.yaml
+++ b/bitnami/joomla/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/magento/ci/ct-values.yaml
+++ b/bitnami/magento/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/mediawiki/ci/ct-values.yaml
+++ b/bitnami/mediawiki/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/moodle/ci/ct-values.yaml
+++ b/bitnami/moodle/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/nginx-ingress-controller/ci/ct-values.yaml
+++ b/bitnami/nginx-ingress-controller/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/nginx/ci/ct-values.yaml
+++ b/bitnami/nginx/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/odoo/ci/ct-values.yaml
+++ b/bitnami/odoo/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/opencart/ci/ct-values.yaml
+++ b/bitnami/opencart/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/orangehrm/ci/ct-values.yaml
+++ b/bitnami/orangehrm/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/osclass/ci/ct-values.yaml
+++ b/bitnami/osclass/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/owncloud/ci/ct-values.yaml
+++ b/bitnami/owncloud/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/parse/ci/ct-values.yaml
+++ b/bitnami/parse/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/phabricator/ci/ct-values.yaml
+++ b/bitnami/phabricator/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/phpbb/ci/ct-values.yaml
+++ b/bitnami/phpbb/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/postgresql-ha/ci/ct-values.yaml
+++ b/bitnami/postgresql-ha/ci/ct-values.yaml
@@ -1,0 +1,1 @@
+fullnameOverride: test

--- a/bitnami/prestashop/ci/ct-values.yaml
+++ b/bitnami/prestashop/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/redmine/ci/ct-values.yaml
+++ b/bitnami/redmine/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/suitecrm/ci/ct-values.yaml
+++ b/bitnami/suitecrm/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/tensorflow-resnet/ci/ct-values.yaml
+++ b/bitnami/tensorflow-resnet/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/testlink/ci/ct-values.yaml
+++ b/bitnami/testlink/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/tomcat/ci/ct-values.yaml
+++ b/bitnami/tomcat/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/wildfly/ci/ct-values.yaml
+++ b/bitnami/wildfly/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP

--- a/bitnami/wordpress/ci/ct-values.yaml
+++ b/bitnami/wordpress/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+service:
+  type: ClusterIP


### PR DESCRIPTION
**Description of the change**
Add support for `helm lint` and `helm install` in PRs via [helm/chart-testing `ct`](https://github.com/helm/chart-testing) and [helm/chart-testing-action](https://github.com/helm/chart-testing-action).

The lint feature via `helm lint` was already implemented and working since some days ago, this PR adds the feature to install the charts (`helm install`) using [kind](https://github.com/kubernetes-sigs/kind).

Some charts are using the default parameters, in others, I need to create a `ci` folder to include a custom `ct-values.yaml` file in order to change the `service.type` from `LoadBalancer` to `ClusterIP`, if not the chart is not fully deployed in the kind cluster. Apart from that, due to the peculiarities of this deployment configuration (kind + `ct`) and the default parameters in some charts as well as the special development & release process of some charts like kubeapps, common, kibana, etc; `helm install` was disabled for PRs of the mentioned charts.

As this is a testing feature that implements changes in the repo itself (although the required `ci` folder is placed inside the chart) I think it is not needed to bump the chart version and force the release of the charts. The charts will be released due to other reasons (PRs, new versions, etc), then the version will be bumped and those changes will be included in the next release (whenever it happens, there is no rush). As expected, linter & testing is going to fail in this PR because the chart version was not bumped, what is a good test that the new workflow is working as expected.

**Benefits**

Charts are tested (basic tests, just `helm install`) and linted (via `helm lint`) when new changes are pushed to a PR.