### PR TITLE
[bitnami/ghost]: Make ingress annotations work again

### DIFF
--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ghost
-version: 10.0.7
+version: 10.0.8
 appVersion: 3.16.1
 description: A simple, powerful publishing platform that allows you to share your stories with the world
 keywords:

--- a/bitnami/ghost/requirements.lock
+++ b/bitnami/ghost/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 0.2.3
+  version: 0.2.4
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
   version: 7.4.2
-digest: sha256:7cb7f32e29346db49ba63980a7f40b5f1acfd6123ae929b9686bdf64f2c6aedf
-generated: "2020-05-26T10:55:32.469746652Z"
+digest: sha256:986d4ce17a554e027db4b32fabae155e318addb015e0b4e337634866bd7611c5
+generated: "2020-06-01T10:06:12.798604433Z"

--- a/bitnami/ghost/templates/ingress.yaml
+++ b/bitnami/ghost/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
   annotations:
   {{- if .Values.ingress.annotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.annotations "context" $) | indent 4 }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
   {{- end }}
   {{- if .Values.ingress.certManager }}
     kubernetes.io/tls-acme: "true"

--- a/bitnami/ghost/values.yaml
+++ b/bitnami/ghost/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/ghost
-  tag: 3.16.1-debian-10-r7
+  tag: 3.16.1-debian-10-r13
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
**Description of the change**

This allows me to have multiple ingress annotations, all with the correct indentation.

**Benefits**

Multiple ingress annotations will work :)


**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #2722 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
