### PR TITLE
[bitnami/mariadb-galera] Force bootstrap

### DIFF
--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb-galera
-version: 2.1.5
+version: 3.0.0
 appVersion: 10.4.13
 description: MariaDB Galera is a multi-master database cluster solution for synchronous replication and high availability.
 keywords:

--- a/bitnami/mariadb-galera/README.md
+++ b/bitnami/mariadb-galera/README.md
@@ -95,6 +95,8 @@ The following table lists the configurable parameters of the MariaDB Galera char
 | `db.name`                            | Name for new database to create                                                                                                                             | `my_database`                                                     |
 | `db.forcePassword`                   | Force users to specify a password                                                                                                                           | `false`                                                           |
 | `galera.name`                        | Galera cluster name                                                                                                                                         | `galera`                                                          |
+| `galera.bootstrap.bootstrapFromNode`    | Node number to bootstrap first                                                                                                                           | `0`                                                               |
+| `galera.bootstrap.forceSafeToBootstrap` | Force `safe_to_bootstrap: 1` in `grastate.dat`                                                                                                           | `false`                                                           |
 | `galera.mariabackup.user`            | Galera mariabackup user                                                                                                                                     | `mariabackup`                                                     |
 | `galera.mariabackup.password`        | Galera mariabackup password                                                                                                                                 | _random 10 character alphanumeric string_                         |
 | `galera.mariabackup.forcePassword`   | Force users to specify a password                                                                                                                           | `false`                                                           |
@@ -350,6 +352,95 @@ extraContainers:
       memory: 10Mi
 ```
 
+### Bootstraping a node other than 0
+
+> Note: Some of these procedures can lead to data loss, always make a backup beforehand.
+
+To restart the cluster you need to check state in which it is after being stopped, also you will need the previous password for the `rootUser` and `mariabackup`, and the deployment name. The value of `safe_to_bootstrap` in `/bitnami/mariadb/data/grastate.dat`, will indicate if it safe to bootstrap form that node. In the case it is other than node 0, it is needed to choose one and force the bootstraping from it.
+
+#### Checking `safe_to_boostrap`
+
+First you need to get the name of the persistent volume claims (pvc), for example:
+
+```bash
+$ kubectl get pvc
+NAME                              STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+data-my-galera-mariadb-galera-0   Bound    pvc-a496aded-f604-4a2d-b934-174907c4d235   8Gi        RWO            gp2            25h
+data-my-galera-mariadb-galera-1   Bound    pvc-00ba6121-9042-4760-af14-3b8a40de936c   8Gi        RWO            gp2            25h
+data-my-galera-mariadb-galera-2   Bound    pvc-61644bc9-2d7d-4e84-bf32-35e59d909b05   8Gi        RWO            gp2            25h
+```
+
+The following command will print the content of `grastate.dat` for the persistent volume claim `data-my-galera-mariadb-galera-2`. This needs to be run for each of the pvc. You will need to change this name accordinly with yours for each PVC.
+
+```bash
+kubectl run --generator=run-pod/v1 -i --rm --tty volpod --overrides='
+{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "name": "volpod"
+    },
+    "spec": {
+        "containers": [{
+            "command": [
+                "cat",
+                "/mnt/data/grastate.dat"
+            ],
+            "image": "bitnami/minideb",
+            "name": "mycontainer",
+            "volumeMounts": [{
+                "mountPath": "/mnt",
+                "name": "galeradata"
+            }]
+        }],
+        "restartPolicy": "Never",
+        "volumes": [{
+            "name": "galeradata",
+            "persistentVolumeClaim": {
+                "claimName": "data-my-galera-mariadb-galera-2"
+            }
+        }]
+    }
+}' --image="bitnami/minideb"
+```
+
+The output should be similar to this:
+
+```
+# GALERA saved state
+version: 2.1
+uuid:    6f2cbfcd-951b-11ea-a116-5f407049e57d
+seqno:   25
+safe_to_bootstrap: 1
+```
+
+Several cases can happen:
+
+#### Only one node with `safe_to_bootstrap: 1`
+
+In this case you will need the node number `N` and run:
+
+```bash
+helm install my-release bitnami/mariadb-galera \
+--set image.pullPolicy=Always \
+--set rootUser.password=XXXX \
+--set galera.mariabackup.password=YYYY \
+--set galera.bootstrap.bootstrapFromNode=N
+```
+
+#### All the nodes with `safe_to_bootstrap: 0`
+
+In this case the cluster was not stopped cleanly and you need to pick one to force the bootstrap from. The one to be choosen in the one with the highest `seqno` in `/bitnami/mariadb/data/grastate.dat`. The following example shows how to force bootstrap from node 3.
+
+```bash
+helm install my-release bitnami/mariadb-galera \
+--set image.pullPolicy=Always \
+--set rootUser.password=XXXX \
+--set galera.mariabackup.password=YYYY
+--set galera.bootstrap.bootstrapFromNode=3 \
+--set galera.bootstrap.forceSafeToBootstrap=true
+```
+
 ## Persistence
 
 The [Bitnami MariaDB Galera](https://github.com/bitnami/bitnami-docker-mariadb-galera) image stores the MariaDB data and configurations at the `/bitnami/mariadb` path of the container.
@@ -368,6 +459,10 @@ $ helm upgrade my-release bitnami/mariadb-galera \
 ```
 
 | Note: you need to substitute the placeholders _[ROOT_PASSWORD]_, _[MARIADB_PASSWORD]_ and _[MARIABACKUP_PASSWORD]_ with the values obtained from instructions in the installation notes.
+
+### To 2.0.0
+
+In this version the bootstraping was improved. Nnow it is possible to indicate a node where to bootstrap from, and force the parameter `safe_to_bootstrap`. This allows to handle situations where the cluster was not cleanly stopped. It should be safe to upgrade from v1 of the chart, but it is wise to create always a backup before performing operations where there is a risk of data loss.
 
 ### To 1.0.0
 

--- a/bitnami/mariadb-galera/README.md
+++ b/bitnami/mariadb-galera/README.md
@@ -356,7 +356,7 @@ extraContainers:
 
 > Note: Some of these procedures can lead to data loss, always make a backup beforehand.
 
-To restart the cluster you need to check state in which it is after being stopped, also you will need the previous password for the `rootUser` and `mariabackup`, and the deployment name. The value of `safe_to_bootstrap` in `/bitnami/mariadb/data/grastate.dat`, will indicate if it safe to bootstrap form that node. In the case it is other than node 0, it is needed to choose one and force the bootstraping from it.
+To restart the cluster you need to check the state in which it is after being stopped, also you will need the previous password for the `rootUser` and `mariabackup`, and the deployment name. The value of `safe_to_bootstrap` in `/bitnami/mariadb/data/grastate.dat`, will indicate if it is safe to bootstrap form that node. In the case it is other than node 0, it is needed to choose one and force the bootstraping from it.
 
 #### Checking `safe_to_boostrap`
 
@@ -414,7 +414,7 @@ seqno:   25
 safe_to_bootstrap: 1
 ```
 
-Several cases can happen:
+There are two possible scenarios:
 
 #### Only one node with `safe_to_bootstrap: 1`
 
@@ -462,7 +462,7 @@ $ helm upgrade my-release bitnami/mariadb-galera \
 
 ### To 2.0.0
 
-In this version the bootstraping was improved. Nnow it is possible to indicate a node where to bootstrap from, and force the parameter `safe_to_bootstrap`. This allows to handle situations where the cluster was not cleanly stopped. It should be safe to upgrade from v1 of the chart, but it is wise to create always a backup before performing operations where there is a risk of data loss.
+In this version the bootstraping was improved. Now it is possible to indicate a node where to bootstrap from, and force the parameter `safe_to_bootstrap`. This allows to handle situations where the cluster was not cleanly stopped. It should be safe to upgrade from v1 of the chart, but it is wise to create always a backup before performing operations where there is a risk of data loss.
 
 ### To 1.0.0
 

--- a/bitnami/mariadb-galera/templates/statefulset.yaml
+++ b/bitnami/mariadb-galera/templates/statefulset.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ template "mariadb-galera.fullname" . }}
   labels: {{- include "mariadb-galera.labels" . | nindent 4 }}
 spec:
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels: {{- include "mariadb-galera.matchLabels" . | nindent 6 }}
@@ -49,7 +50,24 @@ spec:
         - name: "mariadb-galera"
           image: {{ template "mariadb-galera.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          command:
+            - bash
+            - -ec
+            - |
+                {{- $fullname := include "mariadb-galera.fullname" . }}
+                {{- $bootstrapFromNode := int .Values.galera.bootstrap.bootstrapFromNode }}
+                # Bootstrap from the indicated node
+                NODE_ID="${MY_POD_NAME#"{{ $fullname }}-"}"
+                if [[ "$NODE_ID" -eq "{{ $bootstrapFromNode }}" ]]; then
+                    export MARIADB_GALERA_CLUSTER_BOOTSTRAP=yes
+                    export MARIADB_GALERA_FORCE_SAFETOBOOTSTRAP={{ ternary "yes" "no" .Values.galera.bootstrap.forceSafeToBootstrap }}
+                fi
+                exec /opt/bitnami/scripts/mariadb-galera/entrypoint.sh /opt/bitnami/scripts/mariadb-galera/run.sh
           env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: BITNAMI_DEBUG
               value: {{ ternary "true" "false" .Values.image.debug | quote }}
             - name: MARIADB_GALERA_CLUSTER_NAME
@@ -193,6 +211,8 @@ spec:
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
+            - name: previous-boot
+              mountPath: /opt/bitnami/mariadb/.bootstrap
             - name: data
               mountPath: {{ .Values.persistence.mountPath }}
               {{- if .Values.persistence.subPath }}
@@ -257,6 +277,8 @@ spec:
         {{- include "mariadb-galera.tplValue" (dict "value" .Values.extraContainers "context" $) | nindent 8 }}
         {{- end }}
       volumes:
+        - name: previous-boot
+          emptyDir: {}
         {{- if .Values.tls.enabled }}
         - name: mariadb-galera-certificates
           secret:

--- a/bitnami/mariadb-galera/values-production.yaml
+++ b/bitnami/mariadb-galera/values-production.yaml
@@ -50,6 +50,11 @@ image:
 ##
 clusterDomain: cluster.local
 
+## StatefulSet controller supports relax its ordering guarantees while preserving its uniqueness and identity guarantees. There are two valid pod management policies: OrderedReady and Parallel
+## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy
+##
+podManagementPolicy: OrderedReady
+
 ## MariaDB Gallera K8s svc properties
 ##
 service:
@@ -165,6 +170,15 @@ galera:
   ## Galera cluster name
   ##
   name: galera
+
+  ## Bootstraping options
+  bootstrap:
+    ## Node to bootstrap from, you will need to change this parameter incase you want to bootstrap from other node
+    ##
+    bootstrapFromNode: 0
+    ## Force bootstrap
+    ## This will set safe_to_bootstrap=1 in the node indicated by bootstrapFromNode.
+    forceSafeToBootstrap: false
 
   ## Credentials to perform backups
   ##

--- a/bitnami/mariadb-galera/values-production.yaml
+++ b/bitnami/mariadb-galera/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/mariadb-galera
-  tag: 10.4.13-debian-10-r8
+  tag: 10.4.13-debian-10-r16
 
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -532,7 +532,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mysqld-exporter
-    tag: 0.12.1-debian-10-r121
+    tag: 0.12.1-debian-10-r127
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/mariadb-galera/values.yaml
+++ b/bitnami/mariadb-galera/values.yaml
@@ -49,6 +49,11 @@ image:
 ##
 clusterDomain: cluster.local
 
+## StatefulSet controller supports relax its ordering guarantees while preserving its uniqueness and identity guarantees. There are two valid pod management policies: OrderedReady and Parallel
+## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy
+##
+podManagementPolicy: OrderedReady
+
 ## MariaDB Gallera K8s svc properties
 ##
 service:
@@ -164,6 +169,16 @@ galera:
   ## Galera cluster name
   ##
   name: galera
+
+  ## Bootstraping options
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb-galera#bootstraping
+  bootstrap:
+    ## Node to bootstrap from, you will need to change this parameter incase you want to bootstrap from other node
+    ##
+    bootstrapFromNode: 0
+    ## Force bootstrap
+    ## This will set safe_to_bootstrap=1 in the node indicated by bootstrapFromNode.
+    forceSafeToBootstrap: false
 
   ## Credentials to perform backups
   ##

--- a/bitnami/mariadb-galera/values.yaml
+++ b/bitnami/mariadb-galera/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/mariadb-galera
-  tag: 10.4.13-debian-10-r8
+  tag: 10.4.13-debian-10-r16
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -532,7 +532,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mysqld-exporter
-    tag: 0.12.1-debian-10-r121
+    tag: 0.12.1-debian-10-r127
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**
This will enable to force the bootstraping from a node and also to force the safe_to_bootstrap parameter.

**Benefits**
This will allow to start not cleanly stopped cluster, also will help the backup/restore procedures.

**Possible drawbacks**
These cases need to be treated with care, backups are always recommended because data loss may occur .

**Applicable issues**
  - This should help if not solve the issue #2574

**Additional information**
Needs a new container image

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
