### PR TITLE
[bitnami/kafka] fix kafka-exporter-certificates secret volume definition

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 11.0.0
+version: 11.0.1
 appVersion: 2.5.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/requirements.lock
+++ b/bitnami/kafka/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: zookeeper
   repository: https://charts.bitnami.com/bitnami
-  version: 5.14.5
-digest: sha256:f8cd5aa25edbf081a5d73179074e1e15f23f906c16fd7e659452007cb3f72c87
-generated: "2020-06-02T06:05:08.819633821Z"
+  version: 5.15.1
+digest: sha256:f86268d481850be01b7070b037d302d636a0b18a15acbd31fe1d2588a1bff40d
+generated: "2020-06-04T15:06:53.80614726Z"

--- a/bitnami/kafka/templates/kafka-metrics-deployment.yaml
+++ b/bitnami/kafka/templates/kafka-metrics-deployment.yaml
@@ -69,7 +69,8 @@ spec:
               readOnly: true
       volumes:
         - name: kafka-exporter-certificates
-          secretName: {{ .Values.metrics.kafka.certificatesSecret }}
-          defaultMode: 256
+          secret:
+            secretName: {{ .Values.metrics.kafka.certificatesSecret }}
+            defaultMode: 256
       {{- end }}
 {{- end }}

--- a/bitnami/kafka/values-production.yaml
+++ b/bitnami/kafka/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/kafka
-  tag: 2.5.0-debian-10-r54
+  tag: 2.5.0-debian-10-r57
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -480,7 +480,7 @@ externalAccess:
     image:
       registry: docker.io
       repository: bitnami/kubectl
-      tag: 1.17.4-debian-10-r82
+      tag: 1.17.4-debian-10-r84
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -650,7 +650,7 @@ metrics:
     image:
       registry: docker.io
       repository: bitnami/kafka-exporter
-      tag: 1.2.0-debian-10-r131
+      tag: 1.2.0-debian-10-r133
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -738,7 +738,7 @@ metrics:
     image:
       registry: docker.io
       repository: bitnami/jmx-exporter
-      tag: 0.13.0-debian-10-r20
+      tag: 0.13.0-debian-10-r22
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/kafka
-  tag: 2.5.0-debian-10-r54
+  tag: 2.5.0-debian-10-r57
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -480,7 +480,7 @@ externalAccess:
     image:
       registry: docker.io
       repository: bitnami/kubectl
-      tag: 1.17.4-debian-10-r82
+      tag: 1.17.4-debian-10-r84
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -650,7 +650,7 @@ metrics:
     image:
       registry: docker.io
       repository: bitnami/kafka-exporter
-      tag: 1.2.0-debian-10-r131
+      tag: 1.2.0-debian-10-r133
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -738,7 +738,7 @@ metrics:
     image:
       registry: docker.io
       repository: bitnami/jmx-exporter
-      tag: 0.13.0-debian-10-r20
+      tag: 0.13.0-debian-10-r22
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
**Description of the change**

Fixing kafka metrics deployment when using kafka-export-certificates : missing "secret:" in YAML definition.

**Benefits**

Now the volume kafka-export-certificates is working with specified secret.

**Possible drawbacks**

None

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

