### PR TITLE
[bitnami/external-dns] Fix cloudflare env vars

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 3.1.1
+version: 3.1.2
 appVersion: 0.7.2
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -247,7 +247,6 @@ spec:
             {{- end }}
             {{- if eq .Values.provider "cloudflare" }}
             # Cloudflare environment variables
-            {{- if .Values.cloudflare.secretName }}
             - name: CF_API_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -260,16 +259,6 @@ spec:
                   name: {{ template "external-dns.secretName" . }}
                   key: cloudflare_api_key
                   optional: true
-            {{- else }}
-            {{- if .Values.cloudflare.apiToken }}
-            - name: CF_API_TOKEN
-              value: {{ .Values.cloudflare.apiToken | quote }}
-            {{- end }}
-            {{- if .Values.cloudflare.apiKey  }}
-            - name: CF_API_KEY
-              value: {{ .Values.cloudflare.apiKey | quote }}
-            {{- end }}
-            {{- end }}
             - name: CF_API_EMAIL
               value: {{ .Values.cloudflare.email | quote }}
             {{- end }}

--- a/bitnami/external-dns/values-production.yaml
+++ b/bitnami/external-dns/values-production.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/external-dns
-  tag: 0.7.2-debian-10-r0
+  tag: 0.7.2-debian-10-r2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/external-dns/values.yaml
+++ b/bitnami/external-dns/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/external-dns
-  tag: 0.7.2-debian-10-r0
+  tag: 0.7.2-debian-10-r2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Cloudflare sensitive data (apiToken/key) now uses secrets in deployment files to prevent them from being printed in plaintext.

Signed-off-by: joancafom <jcarmona@bitnami.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Usage of built-in secrets to retrieve sensitive env vars for Cloudflare.
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
This data is not leaked in plaintext in deployments
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
NA
<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #2751

**Additional information**
I have removed extra conditions as the simple use of the template function `external-dns.secretName` should suffice to retrieve the correct name of the secret to be used (whether it is generated by the user or automatically created by the release)
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
