### PR TITLE
[bitnami/kube-state-metrics]: Do not scrape service twice

### DIFF
--- a/bitnami/kube-state-metrics/Chart.yaml
+++ b/bitnami/kube-state-metrics/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.9.7
 description: kube-state-metrics is a simple service that listens to the Kubernetes API server and generates metrics about the state of the objects.
 name: kube-state-metrics
-version: 0.3.0
+version: 0.3.1
 keywords:
   - prometheus
   - kube-state-metrics

--- a/bitnami/kube-state-metrics/templates/service.yaml
+++ b/bitnami/kube-state-metrics/templates/service.yaml
@@ -3,7 +3,9 @@ kind: Service
 metadata:
   name: {{ template "kube-state-metrics.fullname" . }}
   annotations:
+    {{- if not .Values.serviceMonitor.enabled }}
     prometheus.io/scrape: "true"
+    {{- end }}
     {{- with .Values.service.annotations }}
     {{- include "kube-state-metrics.tplValue" (dict "value" .Values.service.annotations "context" $) | nindent 4 }}
     {{- end }}

--- a/bitnami/kube-state-metrics/values-production.yaml
+++ b/bitnami/kube-state-metrics/values-production.yaml
@@ -51,7 +51,7 @@ serviceAccount:
 image:
   registry: docker.io
   repository: bitnami/kube-state-metrics
-  tag: 1.9.7-debian-10-r5
+  tag: 1.9.7-debian-10-r6
 
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/bitnami/kube-state-metrics/values.yaml
+++ b/bitnami/kube-state-metrics/values.yaml
@@ -51,7 +51,7 @@ serviceAccount:
 image:
   registry: docker.io
   repository: bitnami/kube-state-metrics
-  tag: 1.9.7-debian-10-r5
+  tag: 1.9.7-debian-10-r6
 
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
If we are using the ServiceMonitor resource to scrape the
kube-state-metrics service, we shouldn't use the prometheus annotation
as this may result scraping the service twice

**Benefits**
- Avoid scraping the service twice

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`