### PR TITLE
[bitnami/grafana] add label to Grafana

### DIFF
--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 2.1.3
+version: 3.0.0
 appVersion: 7.0.5
 description: Grafana is an open source, feature rich metrics dashboard and graph editor for Graphite, Elasticsearch, OpenTSDB, Prometheus and InfluxDB.
 keywords:

--- a/bitnami/grafana/README.md
+++ b/bitnami/grafana/README.md
@@ -373,3 +373,15 @@ The [Bitnami Grafana](https://github.com/bitnami/bitnami-docker-grafana) image s
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
+
+## Upgrading
+
+### To 3.0.0
+
+Deployment label selector is immutable after it gets created, so you cannot "upgrade".
+
+In https://github.com/bitnami/charts/pull/2773 the deployment label selectors of the resources were updated to add the component name. Resulting in compatibility breakage.
+
+In order to "upgrade" from a previous version, you will need to [uninstall](#uninstalling-the-chart) the existing chart manually.
+
+This major version signifies this change.

--- a/bitnami/grafana/templates/configmap.yaml
+++ b/bitnami/grafana/templates/configmap.yaml
@@ -3,6 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "grafana.fullname" . }}-envvars
   labels: {{- include "grafana.labels" . | nindent 4 }}
+    app.kubernetes.io/component: grafana
 data:
   GF_SECURITY_ADMIN_USER: {{ .Values.admin.user | quote }}
   {{- if .Values.imageRenderer.enabled }}

--- a/bitnami/grafana/templates/dashboard-provider.yaml
+++ b/bitnami/grafana/templates/dashboard-provider.yaml
@@ -4,6 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "grafana.fullname" . }}-provider
   labels: {{- include "grafana.labels" . | nindent 4 }}
+    app.kubernetes.io/component: grafana
 data:
   default-provider.yaml: |-
     apiVersion: 1

--- a/bitnami/grafana/templates/deployment.yaml
+++ b/bitnami/grafana/templates/deployment.yaml
@@ -3,16 +3,19 @@ kind: Deployment
 metadata:
   name: {{ include "grafana.fullname" . }}
   labels: {{- include "grafana.labels" . | nindent 4 }}
+    app.kubernetes.io/component: grafana
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels: {{- include "grafana.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: grafana
   {{- if .Values.updateStrategy }}
   strategy: {{ toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}
   template:
     metadata:
       labels: {{- include "grafana.labels" . | nindent 8 }}
+        app.kubernetes.io/component: grafana
       annotations:
         {{- if (include "grafana.createAdminSecret" .) }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}

--- a/bitnami/grafana/templates/ingress.yaml
+++ b/bitnami/grafana/templates/ingress.yaml
@@ -4,6 +4,7 @@ kind: Ingress
 metadata:
   name: {{ include "grafana.fullname" . }}
   labels: {{- include "grafana.labels" . | nindent 4 }}
+    app.kubernetes.io/component: grafana
   annotations:
     {{- if .Values.ingress.certManager }}
     kubernetes.io/tls-acme: "true"

--- a/bitnami/grafana/templates/pvc.yaml
+++ b/bitnami/grafana/templates/pvc.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 metadata:
   name: {{ template "grafana.fullname" . }}
   labels: {{- include "grafana.labels" . | nindent 4 }}
+    app.kubernetes.io/component: grafana
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/bitnami/grafana/templates/secret.yaml
+++ b/bitnami/grafana/templates/secret.yaml
@@ -4,6 +4,7 @@ kind: Secret
 metadata:
   name: {{ template "grafana.fullname" . }}-admin
   labels: {{- include "grafana.labels" . | nindent 4 }}
+    app.kubernetes.io/component: grafana
 type: Opaque
 data:
   GF_SECURITY_ADMIN_PASSWORD: {{ ternary (randAlphaNum 10) .Values.admin.password (empty .Values.admin.password) | b64enc | quote }}

--- a/bitnami/grafana/templates/service.yaml
+++ b/bitnami/grafana/templates/service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   name: {{ include "grafana.fullname" . }}
   labels: {{- include "grafana.labels" . | nindent 4 }}
+    app.kubernetes.io/component: grafana
   {{- if or (and .Values.metrics.enabled .Values.metrics.service.annotations) .Values.service.annotations }}
   annotations:
   {{- if and .Values.metrics.enabled .Values.metrics.service.annotations }}
@@ -31,3 +32,4 @@ spec:
       nodePort: null
       {{- end }}
   selector: {{- include "grafana.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: grafana

--- a/bitnami/grafana/templates/servicemonitor.yaml
+++ b/bitnami/grafana/templates/servicemonitor.yaml
@@ -7,12 +7,14 @@ metadata:
   namespace: {{ .Values.metrics.serviceMonitor.namespace }}
   {{- end }}
   labels: {{- include "grafana.labels" . | nindent 4 }}
+    app.kubernetes.io/component: grafana
     {{- range $key, $value := .Values.metrics.serviceMonitor.selector }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
   selector:
     matchLabels: {{ include "grafana.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: grafana
   endpoints:
     - port: http
       path: "/metrics"

--- a/bitnami/grafana/templates/smtp-secret.yaml
+++ b/bitnami/grafana/templates/smtp-secret.yaml
@@ -4,6 +4,7 @@ kind: Secret
 metadata:
   name: {{ template "grafana.fullname" . }}-smtp
   labels: {{- include "grafana.labels" . | nindent 4 }}
+    app.kubernetes.io/component: grafana
 type: Opaque
 data:
   GF_SMTP_USER: {{ .Values.smtp.user | b64enc | quote }}


### PR DESCRIPTION
**Description of the change**

Label based Kubernetes network policies can not properly distinguish Grafana and the recently added Image Renderer due to common label.

Image Renderer already have a separate label, thus Grafana also shall have a separate label to fulfill need for consistency.

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>

**Benefits**

Label based Kubernetes network policies is going to properly distinguish Grafana and Image Renderer.

**Possible drawbacks**

Selector labels are changed, Chart version needed to be bumped to inform end users. Please verify `MAJOR` or `MINOR` Chart version change.

**Applicable issues**

N/A

**Additional information**
Related PR: https://github.com/bitnami/charts/pull/2638

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
