### PR TITLE
[bitnami/kafka] Fix exporter when authentication is disabled

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 11.1.0
+version: 11.1.1
 appVersion: 2.5.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/templates/kafka-metrics-deployment.yaml
+++ b/bitnami/kafka/templates/kafka-metrics-deployment.yaml
@@ -50,12 +50,14 @@ spec:
               --{{ $key }}{{ if $value }}={{ $value }}{{ end }} \
               {{- end }}
               --web.listen-address=:9308
+          {{- if (include "kafka.client.saslAuthentication" .) }}
           env:
             - name: SASL_USER_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "kafka.jaasSecretName" . }}
                   key: client-password
+          {{- end }}
           ports:
             - name: metrics
               containerPort: 9308

--- a/bitnami/kafka/templates/log4j-configmap.yaml
+++ b/bitnami/kafka/templates/log4j-configmap.yaml
@@ -6,5 +6,5 @@ metadata:
   labels: {{- include "kafka.labels" . | nindent 4 }}
 data:
   log4j.properties: |-
-    {{ .Values.log4j | indent 4 }}
+    {{ .Values.log4j | nindent 4 }}
 {{- end -}}

--- a/bitnami/kafka/values-production.yaml
+++ b/bitnami/kafka/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/kafka
-  tag: 2.5.0-debian-10-r59
+  tag: 2.5.0-debian-10-r62
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -484,7 +484,7 @@ externalAccess:
     image:
       registry: docker.io
       repository: bitnami/kubectl
-      tag: 1.17.4-debian-10-r85
+      tag: 1.17.4-debian-10-r88
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -654,7 +654,7 @@ metrics:
     image:
       registry: docker.io
       repository: bitnami/kafka-exporter
-      tag: 1.2.0-debian-10-r134
+      tag: 1.2.0-debian-10-r137
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -742,7 +742,7 @@ metrics:
     image:
       registry: docker.io
       repository: bitnami/jmx-exporter
-      tag: 0.13.0-debian-10-r23
+      tag: 0.13.0-debian-10-r26
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/kafka
-  tag: 2.5.0-debian-10-r59
+  tag: 2.5.0-debian-10-r62
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -484,7 +484,7 @@ externalAccess:
     image:
       registry: docker.io
       repository: bitnami/kubectl
-      tag: 1.17.4-debian-10-r85
+      tag: 1.17.4-debian-10-r88
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -654,7 +654,7 @@ metrics:
     image:
       registry: docker.io
       repository: bitnami/kafka-exporter
-      tag: 1.2.0-debian-10-r134
+      tag: 1.2.0-debian-10-r137
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -742,7 +742,7 @@ metrics:
     image:
       registry: docker.io
       repository: bitnami/jmx-exporter
-      tag: 0.13.0-debian-10-r23
+      tag: 0.13.0-debian-10-r26
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR fixes an issue with the Kafka exporter when authentication is not enabled, since it's depending on a secret that's not created.

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/2758

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

