### PR TITLE
[bitnami/drupal] Update chart to Drupal 9

### DIFF
--- a/bitnami/drupal/Chart.yaml
+++ b/bitnami/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 6.2.22
+version: 7.0.0
 appVersion: 8.9.0
 description: One of the most versatile open source content management systems.
 keywords:

--- a/bitnami/drupal/Chart.yaml
+++ b/bitnami/drupal/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: drupal
 version: 7.0.0
-appVersion: 8.9.0
+appVersion: 9.0.0
 description: One of the most versatile open source content management systems.
 keywords:
 - drupal

--- a/bitnami/drupal/requirements.lock
+++ b/bitnami/drupal/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 7.5.0
-digest: sha256:d88e53f79f79e9c44c5423f27cfbea41ea1eb9e6f5aa59df2212f107486ed5da
-generated: "2020-06-03T19:58:59.879132782Z"
+  version: 7.5.1
+digest: sha256:b4885fbfac1c2e29f38d28211c9df74a70d068a12043b7a355f93a14d27da7a0
+generated: "2020-06-09T14:04:18.001667522Z"

--- a/bitnami/drupal/values.yaml
+++ b/bitnami/drupal/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/drupal
-  tag: 8.9.0-debian-10-r0
+  tag: 9.0.0-debian-10-r0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -287,7 +287,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.8.0-debian-10-r63
+    tag: 0.8.0-debian-10-r69
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**
Update the chart to use Drupal 9. As it is a major version of the application, we are increasing the chart in a major as well.

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
