### PR TITLE
[bitnami/kube-state-metrics] Add missing permissions to clusterole

### DIFF
--- a/bitnami/kube-state-metrics/Chart.yaml
+++ b/bitnami/kube-state-metrics/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.9.7
 description: kube-state-metrics is a simple service that listens to the Kubernetes API server and generates metrics about the state of the objects.
 name: kube-state-metrics
-version: 0.3.1
+version: 0.3.2
 keywords:
   - prometheus
   - kube-state-metrics

--- a/bitnami/kube-state-metrics/templates/clusterrole.yaml
+++ b/bitnami/kube-state-metrics/templates/clusterrole.yaml
@@ -65,10 +65,22 @@ rules:
       - limitranges
     verbs: ["list", "watch"]
   {{- end }}
+  {{- if .Values.collectors.mutatingwebhookconfigurations }}
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources:
+      - mutatingwebhookconfigurations
+    verbs: ["list", "watch"]
+  {{- end }}
   {{- if .Values.collectors.namespaces }}
   - apiGroups: [""]
     resources:
       - namespaces
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.networkpolicies }}
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - networkpolicies
     verbs: ["list", "watch"]
   {{- end }}
   {{- if .Values.collectors.nodes }}
@@ -147,6 +159,12 @@ rules:
   - apiGroups: ["autoscaling.k8s.io"]
     resources:
       - verticalpodautoscalers
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- if .Values.collectors.volumeattachments }}
+  - apiGroups: ["storage.k8s.io"]
+    resources:
+      - volumeattachments
     verbs: ["list", "watch"]
   {{- end }}
 {{- end }}

--- a/bitnami/kube-state-metrics/values-production.yaml
+++ b/bitnami/kube-state-metrics/values-production.yaml
@@ -51,7 +51,7 @@ serviceAccount:
 image:
   registry: docker.io
   repository: bitnami/kube-state-metrics
-  tag: 1.9.7-debian-10-r6
+  tag: 1.9.7-debian-10-r7
 
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/bitnami/kube-state-metrics/values.yaml
+++ b/bitnami/kube-state-metrics/values.yaml
@@ -51,7 +51,7 @@ serviceAccount:
 image:
   registry: docker.io
   repository: bitnami/kube-state-metrics
-  tag: 1.9.7-debian-10-r6
+  tag: 1.9.7-debian-10-r7
 
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
**Description of the change**

Commit 93a4afed8cd("[bitnami/kube-state-metrics] Add missing collectors")
added some missing collectors but it did not update the clusterrole so
kube-state-metrics could not fetch these resources. Lets add the missing
permissions so everything works as expected.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
