### PR TITLE
[prometheus-operator] add conditional ingress apiVersion

### DIFF
--- a/bitnami/prometheus-operator/Chart.yaml
+++ b/bitnami/prometheus-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.39.0
 description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 name: prometheus-operator
-version: 0.20.0
+version: 0.20.1
 keywords:
   - prometheus
   - alertmanager

--- a/bitnami/prometheus-operator/requirements.lock
+++ b/bitnami/prometheus-operator/requirements.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.2.14
 - name: kube-state-metrics
   repository: https://charts.bitnami.com/bitnami
-  version: 0.2.3
-digest: sha256:0e6e1ddb813615e1b0772254b8a6b56e7c4614e3946a14e71d974552965c8441
-generated: "2020-06-04T23:21:24.217561567Z"
+  version: 0.3.2
+digest: sha256:c3ad5c6d50510de948f695a1e49fc4a8070f0db0dfcfd5333dfb57b39d372c53
+generated: "2020-06-16T08:42:05.488315829Z"

--- a/bitnami/prometheus-operator/templates/_helpers.tpl
+++ b/bitnami/prometheus-operator/templates/_helpers.tpl
@@ -533,3 +533,15 @@ Return the appropriate apiVersion for deployment.
 {{- print "apps/v1" -}}
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "prometheus-operator.capabilities.ingress.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/bitnami/prometheus-operator/templates/_helpers.tpl
+++ b/bitnami/prometheus-operator/templates/_helpers.tpl
@@ -538,7 +538,7 @@ Return the appropriate apiVersion for deployment.
 {{/*
 Return the appropriate apiVersion for ingress.
 */}}
-{{- define "prometheus-operator.capabilities.ingress.apiVersion" -}}
+{{- define "prometheus-operator.ingress.apiVersion" -}}
 {{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "extensions/v1beta1" -}}
 {{- else -}}

--- a/bitnami/prometheus-operator/templates/alertmanager/ingress.yaml
+++ b/bitnami/prometheus-operator/templates/alertmanager/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.alertmanager.enabled .Values.alertmanager.ingress.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "prometheus-operator.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "prometheus-operator.alertmanager.fullname" . }}

--- a/bitnami/prometheus-operator/templates/prometheus/ingress.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.prometheus.enabled .Values.prometheus.ingress.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "prometheus-operator.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "prometheus-operator.prometheus.fullname" . }}

--- a/bitnami/prometheus-operator/values-production.yaml
+++ b/bitnami/prometheus-operator/values-production.yaml
@@ -42,7 +42,7 @@ operator:
   image:
     registry: docker.io
     repository: bitnami/prometheus-operator
-    tag: 0.39.0-debian-10-r32
+    tag: 0.39.0-debian-10-r39
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -216,7 +216,7 @@ operator:
     image:
       registry: docker.io
       repository: bitnami/configmap-reload
-      tag: 0.3.0-debian-10-r133
+      tag: 0.3.0-debian-10-r141
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -247,7 +247,7 @@ prometheus:
   image:
     registry: docker.io
     repository: bitnami/prometheus
-    tag: 2.18.1-debian-10-r28
+    tag: 2.19.0-debian-10-r6
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -698,7 +698,7 @@ alertmanager:
   image:
     registry: docker.io
     repository: bitnami/alertmanager
-    tag: 0.20.0-debian-10-r135
+    tag: 0.20.0-debian-10-r140
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/bitnami/prometheus-operator/values.yaml
+++ b/bitnami/prometheus-operator/values.yaml
@@ -42,7 +42,7 @@ operator:
   image:
     registry: docker.io
     repository: bitnami/prometheus-operator
-    tag: 0.39.0-debian-10-r32
+    tag: 0.39.0-debian-10-r39
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -216,7 +216,7 @@ operator:
     image:
       registry: docker.io
       repository: bitnami/configmap-reload
-      tag: 0.3.0-debian-10-r133
+      tag: 0.3.0-debian-10-r141
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -247,7 +247,7 @@ prometheus:
   image:
     registry: docker.io
     repository: bitnami/prometheus
-    tag: 2.18.1-debian-10-r28
+    tag: 2.19.0-debian-10-r6
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -704,7 +704,7 @@ alertmanager:
   image:
     registry: docker.io
     repository: bitnami/alertmanager
-    tag: 0.20.0-debian-10-r135
+    tag: 0.20.0-debian-10-r140
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION
Signed-off-by: Christian Kotzbauer <christian.kotzbauer@gmail.com>

**Description of the change**
Use conditional apiVersion for `Ingress` resource of Altermanager and Prometheus to ensure compat with K8s 1.19

**Benefits**
Add compat with K8s 1.19

**Possible drawbacks**

**Applicable issues**

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
