### PR TITLE
[bitnami/redis] Add failover during graceful shutdown of current sentinel master

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 10.7.1
+version: 10.7.2
 appVersion: 6.0.5
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/bitnami/redis/templates/configmap.yaml
+++ b/bitnami/redis/templates/configmap.yaml
@@ -77,15 +77,15 @@ data:
       MY_IP=$1
       MASTER_SET=$2
 
-      if [ $(get_master_ip $MASTER_SET) == $MY_IP]; then
+      if [ $(get_master_ip $MASTER_SET) == $MY_IP ]; then
         echo "This instance is current master"
       fi
 
-      if [ $(get_master_ip $MASTER_SET) == "127.0.0.1"]; then
+      if [ $(get_master_ip $MASTER_SET) == "127.0.0.1" ]; then
         echo "Current master is set to 127.0.0.1"
       fi
 
-      if [ $(redis-cli -h 10.233.81.152 -p 6379 -a $(cat /opt/bitnami/redis/secrets/redis-password) PING) != "PONG" ]; then
+      if [ "$(timeout 1 redis-cli -h $(get_master_ip $MASTER_SET) -p 6379 -a $(cat /opt/bitnami/redis/secrets/redis-password) PING)" != "PONG" ]; then
         echo "Current master is not available"
       fi
     }
@@ -105,13 +105,13 @@ data:
 
       echo "Waiting until master would be switched..."
 
-      while [ -z $(check_master_election $MY_IP $MASTER_SET) ]; do
+      while [ -n "$(check_master_election $MY_IP $MASTER_SET)" ]; do
         echo "$(check_master_election $MY_IP $MASTER_SET)"
         sleep 5
       done
 
-      echo "Master switched to $(get_master_ip $MASTER_SET)"
       echo ""
+      echo "Master switched to $(get_master_ip $MASTER_SET)"
     fi
 
     echo "Killing redis process"

--- a/bitnami/redis/templates/configmap.yaml
+++ b/bitnami/redis/templates/configmap.yaml
@@ -73,6 +73,23 @@ data:
       echo $($REDIS_COMMAND sentinel get-master-addr-by-name mymaster | head -n 1)
     }
 
+    function check_master_election {
+      MY_IP=$1
+      MASTER_SET=$2
+
+      if [ $(get_master_ip $MASTER_SET) == $MY_IP]; then
+        echo "This instance is current master"
+      fi
+
+      if [ $(get_master_ip $MASTER_SET) == "127.0.0.1"]; then
+        echo "Current master is set to 127.0.0.1"
+      fi
+
+      if [ $(redis-cli -h 10.233.81.152 -p 6379 -a $(cat /opt/bitnami/redis/secrets/redis-password) PING) != "PONG" ]; then
+        echo "Current master is not available"
+      fi
+    }
+
     MASTER_IP=$(get_master_ip $MASTER_SET)
     MY_IP=$(hostname -i)
 
@@ -88,7 +105,8 @@ data:
 
       echo "Waiting until master would be switched..."
 
-      while [ $MY_IP == $(get_master_ip $MASTER_SET) ]; do
+      while [ -z $(check_master_election $MY_IP $MASTER_SET) ]; do
+        echo "$(check_master_election $MY_IP $MASTER_SET)"
         sleep 5
       done
 

--- a/bitnami/redis/templates/configmap.yaml
+++ b/bitnami/redis/templates/configmap.yaml
@@ -46,9 +46,27 @@ data:
     sentinel down-after-milliseconds {{ .Values.sentinel.masterSet }} {{ .Values.sentinel.downAfterMilliseconds }}
     sentinel failover-timeout {{ .Values.sentinel.masterSet }} {{ .Values.sentinel.failoverTimeout }}
     sentinel parallel-syncs {{ .Values.sentinel.masterSet }} {{ .Values.sentinel.parallelSyncs }}
+{{- if .Values.sentinel.configmap }}
+    # User-supplied sentinel configuration:
+{{- tpl .Values.sentinel.configmap . | nindent 4 }}
+{{- end }}
+{{- end }}
+---
+{{- if .Values.sentinel.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "redis.fullname" . }}-shutdown-script
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "redis.name" . }}
+    chart: {{ template "redis.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+data:
   shutdown.sh: |-
     #!/bin/bash
-    MASTER_SET={{ .Values.sentinel.masterSet }}
+    MASTER_SET="{{ .Values.sentinel.masterSet }}"
     REDIS_COMMAND="redis-cli -p 26379"
 
     function get_master_ip {
@@ -80,8 +98,4 @@ data:
 
     echo "Killing redis process"
     kill 1
-{{- if .Values.sentinel.configmap }}
-    # User-supplied sentinel configuration:
-{{- tpl .Values.sentinel.configmap . | nindent 4 }}
-{{- end }}
 {{- end }}

--- a/bitnami/redis/templates/configmap.yaml
+++ b/bitnami/redis/templates/configmap.yaml
@@ -48,7 +48,7 @@ data:
     sentinel parallel-syncs {{ .Values.sentinel.masterSet }} {{ .Values.sentinel.parallelSyncs }}
   shutdown.sh: |-
     #!/bin/bash
-    MASTER_SET=$1
+    MASTER_SET={{ .Values.sentinel.masterSet }}
     REDIS_COMMAND="redis-cli -p 26379"
 
     function get_master_ip {

--- a/bitnami/redis/templates/configmap.yaml
+++ b/bitnami/redis/templates/configmap.yaml
@@ -46,6 +46,40 @@ data:
     sentinel down-after-milliseconds {{ .Values.sentinel.masterSet }} {{ .Values.sentinel.downAfterMilliseconds }}
     sentinel failover-timeout {{ .Values.sentinel.masterSet }} {{ .Values.sentinel.failoverTimeout }}
     sentinel parallel-syncs {{ .Values.sentinel.masterSet }} {{ .Values.sentinel.parallelSyncs }}
+  shutdown.sh: |-
+    #!/bin/bash
+    MASTER_SET=$1
+    REDIS_COMMAND="redis-cli -p 26379"
+
+    function get_master_ip {
+      echo $($REDIS_COMMAND sentinel get-master-addr-by-name mymaster | head -n 1)
+    }
+
+    MASTER_IP=$(get_master_ip $MASTER_SET)
+    MY_IP=$(hostname -i)
+
+    echo "My ip: $MY_IP"
+    echo "Current master ip: $MASTER_IP"
+
+    if [ $MY_IP == $MASTER_IP ]; then
+      echo ""
+      echo "I'm the current master"
+      echo "Performing failover"
+
+      $REDIS_COMMAND sentinel failover $MASTER_SET
+
+      echo "Waiting until master would be switched..."
+
+      while [ $MY_IP == $(get_master_ip $MASTER_SET) ]; do
+        sleep 5
+      done
+
+      echo "Master switched to $(get_master_ip $MASTER_SET)"
+      echo ""
+    fi
+
+    echo "Killing redis process"
+    kill 1
 {{- if .Values.sentinel.configmap }}
     # User-supplied sentinel configuration:
 {{- tpl .Values.sentinel.configmap . | nindent 4 }}

--- a/bitnami/redis/templates/redis-master-statefulset.yaml
+++ b/bitnami/redis/templates/redis-master-statefulset.yaml
@@ -295,6 +295,10 @@ spec:
             - name: REDIS_SENTINEL_PORT
               value: {{ .Values.sentinel.port | quote }}
             {{- end }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ['/bin/sh', '-c', '/opt/bitnami/redis-sentinel/mounted-etc/shutdown.sh']
           ports:
             - name: redis-sentinel
               containerPort: {{ .Values.sentinel.port }}

--- a/bitnami/redis/templates/redis-master-statefulset.yaml
+++ b/bitnami/redis/templates/redis-master-statefulset.yaml
@@ -162,6 +162,12 @@ spec:
           ports:
             - name: redis
               containerPort: {{ .Values.redisPort }}
+          {{- if .Values.sentinel.enabled }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ['/bin/sh', '-c', '/shutdown.sh']
+          {{- end }}
           {{- if .Values.master.livenessProbe.enabled }}
           livenessProbe:
             initialDelaySeconds: {{ .Values.master.livenessProbe.initialDelaySeconds }}
@@ -211,6 +217,11 @@ spec:
             - name: redis-certificates
               mountPath: /opt/bitnami/redis/certs
               readOnly: true
+            {{- end }}
+            {{- if .Values.sentinel.enabled }}
+            - name: shutdown-script
+              mountPath: /shutdown.sh
+              subPath: shutdown.sh
             {{- end }}
         {{- if and .Values.cluster.enabled .Values.sentinel.enabled }}
         - name: sentinel
@@ -295,10 +306,6 @@ spec:
             - name: REDIS_SENTINEL_PORT
               value: {{ .Values.sentinel.port | quote }}
             {{- end }}
-          lifecycle:
-            preStop:
-              exec:
-                command: ['/bin/sh', '-c', '/opt/bitnami/redis-sentinel/mounted-etc/shutdown.sh']
           ports:
             - name: redis-sentinel
               containerPort: {{ .Values.sentinel.port }}
@@ -470,6 +477,12 @@ spec:
           secret:
             secretName: {{ required "A secret containing the certificates for the TLS traffic is required when TLS in enabled" .Values.tls.certificatesSecret }}
             defaultMode: 256
+        {{- end }}
+        {{- if .Values.sentinel.enabled }}
+        - name: shutdown-script
+          configMap:
+            name: {{ template "redis.fullname" . }}-shutdown-script
+            defaultMode: 0755
         {{- end }}
   {{- if and .Values.master.persistence.enabled (not .Values.persistence.existingClaim) }}
   volumeClaimTemplates:

--- a/bitnami/redis/templates/redis-slave-statefulset.yaml
+++ b/bitnami/redis/templates/redis-slave-statefulset.yaml
@@ -500,10 +500,10 @@ spec:
             defaultMode: 256
     {{- end }}
     {{- if .Values.sentinel.enabled }}
-    - name: shutdown-script
-      configMap:
-        name: {{ template "redis.fullname" . }}-shutdown-script
-        defaultMode: 0755
+        - name: shutdown-script
+          configMap:
+            name: {{ template "redis.fullname" . }}-shutdown-script
+            defaultMode: 0755
     {{- end }}
   volumeClaimTemplates:
     - metadata:

--- a/bitnami/redis/templates/redis-slave-statefulset.yaml
+++ b/bitnami/redis/templates/redis-slave-statefulset.yaml
@@ -187,6 +187,12 @@ spec:
           ports:
             - name: redis
               containerPort: {{ .Values.redisPort }}
+          {{- if .Values.sentinel.enabled }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ['/bin/sh', '-c', '/shutdown.sh']
+          {{- end }}
           {{- if .Values.slave.livenessProbe.enabled }}
           livenessProbe:
             initialDelaySeconds: {{ .Values.slave.livenessProbe.initialDelaySeconds }}
@@ -243,6 +249,11 @@ spec:
             - name: redis-certificates
               mountPath: /opt/bitnami/redis/certs
               readOnly: true
+            {{- end }}
+            {{- if .Values.sentinel.enabled }}
+            - name: shutdown-script
+              mountPath: /shutdown.sh
+              subPath: shutdown.sh
             {{- end }}
         {{- if and .Values.cluster.enabled .Values.sentinel.enabled }}
         - name: sentinel
@@ -324,10 +335,6 @@ spec:
             - name: REDIS_SENTINEL_PORT
               value: {{ .Values.sentinel.port | quote }}
             {{- end }}
-          lifecycle:
-            preStop:
-              exec:
-                command: ['/bin/sh', '-c', '/opt/bitnami/redis-sentinel/mounted-etc/shutdown.sh']
           ports:
             - name: redis-sentinel
               containerPort: {{ .Values.sentinel.port }}
@@ -491,6 +498,12 @@ spec:
           secret:
             secretName: {{ required "A secret containing the certificates for the TLS traffic is required when TLS in enabled" .Values.tls.certificatesSecret }}
             defaultMode: 256
+    {{- end }}
+    {{- if .Values.sentinel.enabled }}
+    - name: shutdown-script
+      configMap:
+        name: {{ template "redis.fullname" . }}-shutdown-script
+        defaultMode: 0755
     {{- end }}
   volumeClaimTemplates:
     - metadata:

--- a/bitnami/redis/templates/redis-slave-statefulset.yaml
+++ b/bitnami/redis/templates/redis-slave-statefulset.yaml
@@ -324,6 +324,10 @@ spec:
             - name: REDIS_SENTINEL_PORT
               value: {{ .Values.sentinel.port | quote }}
             {{- end }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ['/bin/sh', '-c', '/opt/bitnami/redis-sentinel/mounted-etc/shutdown.sh']
           ports:
             - name: redis-sentinel
               containerPort: {{ .Values.sentinel.port }}


### PR DESCRIPTION
/resolves https://github.com/bitnami/charts/issues/2749

Current potential problems:
- [x] I'm not sure that preStop hook for sentinel container is a good idea, cause redis container could be stopped before sentinel container. Currently I implement preStop hook in sentinel pod cause we only need this logic in configurations with sentinel enabled.

- [ ] Currently graceful shutdown script not waits until needed number of slaves would be synced.
I'm not sure is that possible. Also I don't understand if current behaviour could cause dataloss.

- [ ] I still see 127.0.0.1 logs in sentinel logs
Example of logs:
```
1:X 11 Jun 2020 20:24:21.536 * +sentinel-address-switch master mymaster 10.233.94.202 6379 ip 10.233.69.68 port 26379 for fa465dba9473f478c0e5d3a242fa0a7f7ad29b85
1:X 11 Jun 2020 20:24:22.386 * +sentinel-address-switch master mymaster 10.233.94.202 6379 ip 127.0.0.1 port 26379 for fa465dba9473f478c0e5d3a242fa0a7f7ad29b85
1:X 11 Jun 2020 20:24:23.553 * +sentinel-address-switch master mymaster 10.233.94.202 6379 ip 10.233.69.68 port 26379 for fa465dba9473f478c0e5d3a242fa0a7f7ad29b85
1:X 11 Jun 2020 20:24:24.404 * +sentinel-address-switch master mymaster 10.233.94.202 6379 ip 127.0.0.1 port 26379 for fa465dba9473f478c0e5d3a242fa0a7f7ad29b85
```

- [ ] I still haven't properly tested this change

- [ ] Didn't found way to show shutdown script logs

- [ ] I'm not sure but maybe we should check that all sentinel nodes knows (returns) new master address

- [ ] Current master and slave are separate statefullsets so on helm upgrade at same time 2 pods are shutting down (one master and one slave). I believe it's a good idea to use PodDistributionBudget to prevent that - https://github.com/bitnami/charts/pull/2822

- [ ]  I caught one time situation when one master pod and one slave pod was scheduled on same node. I believe it could cause problems if that node will disappear, so I think it's a good idea to prevent such behaviour by affinity rule (for production config) or maybe by PodDistributionBudget