### PR TITLE
[bitnami/external-dns] allow gcp project autodetection

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 3.2.0
+version: 3.2.1
 appVersion: 0.7.2
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -159,9 +159,9 @@ spec:
             {{- end }}
             {{- if eq .Values.provider "google" }}
             # Google Arguments
-              {{- if .Values.google.project }}
+            {{- if .Values.google.project }}
             - --google-project={{ .Values.google.project }}
-              {{- end }}
+            {{- end }}
             {{- end }}
             {{- if eq .Values.provider "infoblox" }}
             # Infloblox Arguments

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -159,7 +159,9 @@ spec:
             {{- end }}
             {{- if eq .Values.provider "google" }}
             # Google Arguments
+              {{- if .Values.google.project }}
             - --google-project={{ .Values.google.project }}
+              {{- end }}
             {{- end }}
             {{- if eq .Values.provider "infoblox" }}
             # Infloblox Arguments

--- a/bitnami/external-dns/values-production.yaml
+++ b/bitnami/external-dns/values-production.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/external-dns
-  tag: 0.7.2-debian-10-r6
+  tag: 0.7.2-debian-10-r13
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/external-dns/values.yaml
+++ b/bitnami/external-dns/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/external-dns
-  tag: 0.7.2-debian-10-r6
+  tag: 0.7.2-debian-10-r13
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Don't set the argument `--google-project` unless a value is provided. Without this argument, autodetection will happen as intended.

**Benefits**

kubernetes-sigs/external-dns#492 and kubernetes-sigs/external-dns#494 added autodetection of the GCP project, but the empty value provided in `values.yaml` is still picked up if the arg `--google-project=` is provided. The args override the env var `EXTERNAL_DNS_GOOGLE_PROJECT`, meaning this can only be overridden by patching the args array.

**Applicable issues**

kubernetes-sigs/external-dns/492 and kubernetes-sigs/external-dns/494

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

[edited 2020-06-15 - it does work as is, but can't be overridden]