### PR TITLE
[bitnami/redis] Fix conditional to mount TLS certificates on slave statefulset with persistence disabled

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 10.7.1
+version: 10.7.2
 appVersion: 6.0.5
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/bitnami/redis/templates/redis-slave-statefulset.yaml
+++ b/bitnami/redis/templates/redis-slave-statefulset.yaml
@@ -478,16 +478,16 @@ spec:
           emptyDir: {}
         - name: redis-tmp-conf
           emptyDir: {}
-    {{- if not .Values.slave.persistence.enabled }}
-        - name: redis-data
-          emptyDir: {}
-    {{- else }}
     {{- if .Values.tls.enabled }}
         - name: redis-certificates
           secret:
             secretName: {{ required "A secret containing the certificates for the TLS traffic is required when TLS in enabled" .Values.tls.certificatesSecret }}
             defaultMode: 256
     {{- end }}
+    {{- if not .Values.slave.persistence.enabled }}
+        - name: redis-data
+          emptyDir: {}
+    {{- else }}
   volumeClaimTemplates:
     - metadata:
         name: redis-data

--- a/bitnami/redis/values-production.yaml
+++ b/bitnami/redis/values-production.yaml
@@ -18,7 +18,7 @@ image:
   ## Bitnami Redis image tag
   ## ref: https://github.com/bitnami/bitnami-docker-redis#supported-tags-and-respective-dockerfile-links
   ##
-  tag: 6.0.5-debian-10-r2
+  tag: 6.0.5-debian-10-r7
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -60,7 +60,7 @@ sentinel:
     ## Bitnami Redis image tag
     ## ref: https://github.com/bitnami/bitnami-docker-redis-sentinel#supported-tags-and-respective-dockerfile-links
     ##
-    tag: 6.0.5-debian-10-r1
+    tag: 6.0.5-debian-10-r7
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -559,7 +559,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/redis-exporter
-    tag: 1.6.1-debian-10-r28
+    tag: 1.7.0-debian-10-r1
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -18,7 +18,7 @@ image:
   ## Bitnami Redis image tag
   ## ref: https://github.com/bitnami/bitnami-docker-redis#supported-tags-and-respective-dockerfile-links
   ##
-  tag: 6.0.5-debian-10-r2
+  tag: 6.0.5-debian-10-r7
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -60,7 +60,7 @@ sentinel:
     ## Bitnami Redis image tag
     ## ref: https://github.com/bitnami/bitnami-docker-redis-sentinel#supported-tags-and-respective-dockerfile-links
     ##
-    tag: 6.0.5-debian-10-r1
+    tag: 6.0.5-debian-10-r7
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -559,7 +559,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/redis-exporter
-    tag: 1.6.1-debian-10-r28
+    tag: 1.7.0-debian-10-r1
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Currently, when persistence is disabled, the redis slave statefulset does not mount the `redis-certificates` volume from the secrets when TLS is enabled, due to an error with the conditional in the YAML.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

This will allow the use of TLS even when persistence is disabled.

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

None.

<!-- Describe any known limitations with your change -->

**Applicable issues**

  - Issue identified by @tbnguyen1407 in #2622.

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

None.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
