### PR TITLE
[bitnami/nginx] Update chart to Nginx 1.19

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx
-version: 5.7.2
+version: 6.0.0
 appVersion: 1.17.10
 description: Chart for the nginx server
 keywords:

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: nginx
 version: 6.0.0
-appVersion: 1.17.10
+appVersion: 1.19.0
 description: Chart for the nginx server
 keywords:
   - nginx

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/nginx
-  tag: 1.17.10-debian-10-r64
+  tag: 1.19.0-debian-10-r0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -54,7 +54,7 @@ cloneStaticSiteFromGit:
   image:
     registry: docker.io
     repository: bitnami/git
-    tag: 2.27.0-debian-10-r7
+    tag: 2.27.0-debian-10-r12
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -217,7 +217,7 @@ ldapDaemon:
   image:
     registry: docker.io
     repository: bitnami/nginx-ldap-auth-daemon
-    tag: 0.20200116.0-debian-10-r32
+    tag: 0.20200116.0-debian-10-r40
     pullPolicy: IfNotPresent
 
   ## LDAP Daemon port
@@ -425,7 +425,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/nginx-exporter
-    tag: 0.7.0-debian-10-r49
+    tag: 0.7.0-debian-10-r54
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**
New major release of the Nginx chart featuring Nginx 1.19.

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)