### PR TITLE
[bitnami/node-exporter] Update chart to Node Exporter 1

### DIFF
--- a/bitnami/node-exporter/Chart.yaml
+++ b/bitnami/node-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.18.1
+appVersion: 1.0.1
 description: Prometheus exporter for hardware and OS metrics exposed by UNIX kernels, with pluggable metric collectors.
 name: node-exporter
 version: 1.0.0

--- a/bitnami/node-exporter/Chart.yaml
+++ b/bitnami/node-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.18.1
 description: Prometheus exporter for hardware and OS metrics exposed by UNIX kernels, with pluggable metric collectors.
 name: node-exporter
-version: 0.2.14
+version: 1.0.0
 keywords:
   - prometheus
   - node-exporter

--- a/bitnami/node-exporter/values.yaml
+++ b/bitnami/node-exporter/values.yaml
@@ -50,7 +50,7 @@ serviceAccount:
 image:
   registry: docker.io
   repository: bitnami/node-exporter
-  tag: 0.18.1-debian-10-r120
+  tag: 1.0.1-debian-10-r0
 
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
**Description of the change**
New major release of the Nginx chart featuring Node Exporter 1.

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)