### PR TITLE
Add note about OpenEBS for persistent storage option

### DIFF
--- a/bitnami/cassandra/README.md
+++ b/bitnami/cassandra/README.md
@@ -246,7 +246,7 @@ initDBConfigMap=init-db
 
 The [Bitnami cassandra](https://github.com/bitnami/bitnami-docker-cassandra) image stores the cassandra data at the `/bitnami/cassandra` path of the container.
 
-Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.  Persistent volumes can also be created dynamically with other CNCF software like OpenEBS.  See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
+Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube. Persistent volumes can also be created dynamically with other CNCF software like OpenEBS. See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
 
 ### Adjust permissions of persistent volume mountpoint
 

--- a/bitnami/cassandra/README.md
+++ b/bitnami/cassandra/README.md
@@ -246,8 +246,7 @@ initDBConfigMap=init-db
 
 The [Bitnami cassandra](https://github.com/bitnami/bitnami-docker-cassandra) image stores the cassandra data at the `/bitnami/cassandra` path of the container.
 
-Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
-See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
+Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.  Persistent volumes can also be created dynamically with other CNCF software like OpenEBS.  See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
 
 ### Adjust permissions of persistent volume mountpoint
 


### PR DESCRIPTION
Hi all,

Some of us at MayaData were discussing the docs on this chart (primarily how we often find the most useful docs and info in the Bitnami charts as opposed to other sources :^).  We were wondering if you would update it and mention OpenEBS as an option for persistence.

**Description of the change**

Docs update to point out that there are other non-provider based ways to create persistent volumes.

**Benefits**

OnPrem users can't take advantage of orchestrated storage in AWS, GCP, etc.  OpenEBS orchestrates local storage on prem or in instances with local block devs on board.

**Possible drawbacks**

None.  Minor change.  Happy to provide more info and details about how to use openebs with Cassandra.  Would love to collaborate on some chart mods to automate setup for storage in a few common scenarios.  

**Additional information**

www.openebs.io for more info :^)
Thanks much,
Brian