### PR TITLE
[bitnami/kafka] Fix conflict when mounting custom configuration, and JKS files from a secret

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 11.2.1
+version: 11.2.2
 appVersion: 2.5.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/requirements.lock
+++ b/bitnami/kafka/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: zookeeper
   repository: https://charts.bitnami.com/bitnami
-  version: 5.16.0
-digest: sha256:2421a8d461cc85b48a3033c1b028941ba6a3c03c990627dd83dca10822f03e9a
-generated: "2020-06-05T08:30:22.207864551Z"
+  version: 5.17.0
+digest: sha256:9b41fdc9d6248b982f0f7fd7dfda622e7aafc50ecb7d8bdfcdb6af7d3da742c7
+generated: "2020-06-19T10:02:13.441982636Z"

--- a/bitnami/kafka/templates/scripts-configmap.yaml
+++ b/bitnami/kafka/templates/scripts-configmap.yaml
@@ -100,9 +100,9 @@ data:
 
     {{- if (include "kafka.tlsEncryption" .) }}
     if [[ -f "/certs/kafka.truststore.jks" ]] && [[ -f "/certs/kafka-${ID}.keystore.jks" ]]; then
-        mkdir -p /bitnami/kafka/config/certs
-        cp "/certs/kafka.truststore.jks" "/bitnami/kafka/config/certs/kafka.truststore.jks"
-        cp "/certs/kafka-${ID}.keystore.jks" "/bitnami/kafka/config/certs/kafka.keystore.jks"
+        mkdir -p /opt/bitnami/kafka/config/certs
+        cp "/certs/kafka.truststore.jks" "/opt/bitnami/kafka/config/certs/kafka.truststore.jks"
+        cp "/certs/kafka-${ID}.keystore.jks" "/opt/bitnami/kafka/config/certs/kafka.keystore.jks"
         ls /bitnami/kafka/config/certs/
     else
         echo "Couldn't find the expected Java Key Stores (JKS) files! They are mandatory when encryption via TLS is enabled."

--- a/bitnami/kafka/values-production.yaml
+++ b/bitnami/kafka/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/kafka
-  tag: 2.5.0-debian-10-r69
+  tag: 2.5.0-debian-10-r71
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -484,7 +484,7 @@ externalAccess:
     image:
       registry: docker.io
       repository: bitnami/kubectl
-      tag: 1.17.4-debian-10-r93
+      tag: 1.17.4-debian-10-r95
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -654,7 +654,7 @@ metrics:
     image:
       registry: docker.io
       repository: bitnami/kafka-exporter
-      tag: 1.2.0-debian-10-r142
+      tag: 1.2.0-debian-10-r144
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -742,7 +742,7 @@ metrics:
     image:
       registry: docker.io
       repository: bitnami/jmx-exporter
-      tag: 0.13.0-debian-10-r31
+      tag: 0.13.0-debian-10-r33
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/kafka
-  tag: 2.5.0-debian-10-r69
+  tag: 2.5.0-debian-10-r71
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -489,7 +489,7 @@ externalAccess:
     image:
       registry: docker.io
       repository: bitnami/kubectl
-      tag: 1.17.4-debian-10-r93
+      tag: 1.17.4-debian-10-r95
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -659,7 +659,7 @@ metrics:
     image:
       registry: docker.io
       repository: bitnami/kafka-exporter
-      tag: 1.2.0-debian-10-r142
+      tag: 1.2.0-debian-10-r144
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -747,7 +747,7 @@ metrics:
     image:
       registry: docker.io
       repository: bitnami/jmx-exporter
-      tag: 0.13.0-debian-10-r31
+      tag: 0.13.0-debian-10-r33
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR fixes a conflict that occurs when mounting custom configuration, and JKS files from a secret. The initialisation scripts tries to create some directory but it's unable to do so since there's a configmap (readonly) mounted in the same path. 

```
mkdir: cannot create directory '/bitnami/kafka/config/certs': Permission denied
cp: cannot create regular file '/bitnami/kafka/config/certs/kafka.truststore.jks': No such file or directory
cp: cannot create regular file '/bitnami/kafka/config/certs/kafka.keystore.jks': No such file or directory
ls: cannot access '/bitnami/kafka/config/certs/': No such file or directory
```

We can directly copy the certificates to the final location, and that's enough to solve the issue.

**Benefits**

Combining TLS authentication with custom config files.

**Possible drawbacks**

None

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

