### PR TITLE
[bitnami/mongodb-sharded] Allow only deploying mongos.

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb-sharded
-version: 1.4.4
+version: 1.5.0
 appVersion: 4.2.8
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications. Sharded topology.
 keywords:

--- a/bitnami/mongodb-sharded/README.md
+++ b/bitnami/mongodb-sharded/README.md
@@ -157,6 +157,10 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `configsvr.persistence.accessModes`           | Use volume as ReadOnly or ReadWrite                                                                                                                       | `[ReadWriteOnce]`                                        |
 | `configsvr.persistence.size`                  | Size of data volume                                                                                                                                       | `8Gi`                                                    |
 | `configsvr.persistence.annotations`           | Persistent Volume annotations                                                                                                                             | `{}`                                                     |
+| `configsvr.external.host`           | Primary node of an external config server replicaset                                                                                                                              | `nil`                                                     |
+| `configsvr.external.rootPassword`           | Root passworrd of the external config server replicaset                                                                                                                              | `nil`                                                     |
+| `configsvr.external.replicasetName`           | Replicaset name of an external config server                                                                                                                              | `nil`                                                     |
+| `configsvr.external.replicasetKey`           | Replicaset key of an external config server                                                                                                                              | `nil`                                                     |
 
 ### Mongos configuration
 
@@ -391,6 +395,10 @@ extraEnvVars:
 ```
 
 Alternatively, you can use a ConfigMap or a Secret with the environment variables. To do so, use the `extraEnvVarsCM` or the `extraEnvVarsSecret` values.
+
+### Using an external config server
+
+It is possible to not deploy any shards or a config server. For example, it is possible to simply deploy `mongos` instances that point to an external MongoDB sharded database. If that is the case, set the `configsvr.external.host` and `configsvr.external.replicasetName` for the mongos instances to connect. For authentication, set the `configsvr.external.rootPassword` and `configsvr.external.replicasetKey` values.
 
 ## Persistence
 

--- a/bitnami/mongodb-sharded/templates/_helpers.tpl
+++ b/bitnami/mongodb-sharded/templates/_helpers.tpl
@@ -247,6 +247,7 @@ Compile all warnings into a single message, and call fail.
 {{- define "mongodb-sharded.validateValues" -}}
   {{- $messages := list -}}
   {{- $messages := append $messages (include "mongodb-sharded.validateValues.mongodbCustomDatabase" .) -}}
+  {{- $messages := append $messages (include "mongodb-sharded.validateValues.externalCfgServer" .) -}}
   {{- $messages := append $messages (include "mongodb-sharded.validateValues.replicas" .) -}}
   {{- $messages := append $messages (include "mongodb-sharded.validateValues.config" .) -}}
   {{- $messages := without $messages "" -}}
@@ -273,7 +274,7 @@ mongodb: mongodbUsername, mongodbDatabase
 {{/*
 Validate values of MongoDB - If using an external config server, then both the host and the replicaset name should be set.
 */}}
-{{- define "mongodb-sharded.validateValues.replicas" -}}
+{{- define "mongodb-sharded.validateValues.externalCfgServer" -}}
 {{- if and .Values.configsvr.external.replicasetName (not .Values.configsvr.external.host) -}}
 mongodb: invalidExternalConfigServer
     You specified a replica set name for the external config server but not a host. Set both configsvr.external.replicasetName and configsvr.external.host

--- a/bitnami/mongodb-sharded/templates/_helpers.tpl
+++ b/bitnami/mongodb-sharded/templates/_helpers.tpl
@@ -71,7 +71,19 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{- define "mongodb-sharded.configServer.primaryHost" -}}
+  {{- if .Values.configsvr.external.host -}}
+  {{- .Values.configsvr.external.host }}
+  {{- else -}}
   {{- printf "%s-configsvr-0.%s-headless.%s.svc.%s" (include "mongodb-sharded.fullname" . ) (include "mongodb-sharded.fullname" .) .Release.Namespace .Values.clusterDomain -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "mongodb-sharded.configServer.rsName" -}}
+  {{- if .Values.configsvr.external.replicasetName -}}
+    {{- .Values.configsvr.external.replicasetName }}
+  {{- else }}
+    {{- printf "%s-configsvr" ( include "mongodb-sharded.fullname" . ) -}}
+  {{- end }}
 {{- end -}}
 
 {{- define "mongodb-sharded.mongos.configCM" -}}
@@ -259,24 +271,43 @@ mongodb: mongodbUsername, mongodbDatabase
 {{- end -}}
 
 {{/*
+Validate values of MongoDB - If using an external config server, then both the host and the replicaset name should be set.
+*/}}
+{{- define "mongodb-sharded.validateValues.replicas" -}}
+{{- if and .Values.configsvr.external.replicasetName (not .Values.configsvr.external.host) -}}
+mongodb: invalidExternalConfigServer
+    You specified a replica set name for the external config server but not a host. Set both configsvr.external.replicasetName and configsvr.external.host
+{{- end -}}
+{{- if and (not .Values.configsvr.external.replicasetName) .Values.configsvr.external.host -}}
+mongodb: invalidExternalConfigServer
+    You specified a host for the external config server but not the replica set name. Set both configsvr.external.replicasetName and configsvr.external.host
+{{- end -}}
+{{- if and .Values.configsvr.external.host (not .Values.configsvr.external.rootPassword) -}}
+mongodb: invalidExternalConfigServer
+    You specified a host for the external config server but not the root password. Set the configsvr.external.rootPassword value.
+{{- end -}}
+{{- if and .Values.configsvr.external.host (not .Values.configsvr.external.replicasetKey) -}}
+mongodb: invalidExternalConfigServer
+    You specified a host for the external config server but not the replica set key. Set the configsvr.external.replicasetKey value.
+{{- end -}}
+{{- end -}}
+
+{{/*
 Validate values of MongoDB - The number of shards must be positive, as well as the data node replicas
 */}}
 {{- define "mongodb-sharded.validateValues.replicas" -}}
-{{- if le (int .Values.shards) 0 }}
-mongodb: invalidShardNumber
-    You specified an invalid number of shards. Please set shards with a positive number
-{{- end -}}
-{{- if le (int .Values.shardsvr.dataNode.replicas) 0 }}
+{{- if and (le (int .Values.shardsvr.dataNode.replicas) 0) (ge (int .Values.shards) 1) }}
 mongodb: invalidShardSvrReplicas
-    You specified an invalid number of replicas per shard. Please set shardsvr.dataNode.replicas with a positive number
+    You specified an invalid number of replicas per shard. Please set shardsvr.dataNode.replicas with a positive number or set the number of shards to 0.
 {{- end -}}
 {{- if lt (int .Values.shardsvr.arbiter.replicas) 0 }}
 mongodb: invalidShardSvrArbiters
     You specified an invalid number of arbiters per shard. Please set shardsvr.arbiter.replicas with a number greater or equal than 0
 {{- end -}}
-{{- if le (int .Values.configsvr.replicas) 0 }}
+{{- if and (le (int .Values.configsvr.replicas) 0) (not .Values.configsvr.external.host) }}
 mongodb: invalidConfigSvrReplicas
-    You specified an invalid number of replicas per shard. Please set configsvr.replicas with a positive number
+    You specified an invalid number of replicas per shard. Please set configsvr.replicas with a positive number or set the configsvr.external.host value to use
+    an external config server replicaset
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-configmap.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.configsvr.config }}
+{{- if and (not .Values.configsvr.external.host) .Values.configsvr.config }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-poddisruptionbudget.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.configsvr.pdb.enabled -}}
+{{- if and (not .Values.configsvr.external.host) .Values.configsvr.pdb.enabled -}}
 kind: PodDisruptionBudget
 apiVersion: policy/v1beta1
 metadata:

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.configsvr.external.host }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -330,3 +331,4 @@ spec:
         - name: datadir
           emptyDir: {}
   {{- end }}
+{{- end }}

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-deployment.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-deployment.yaml
@@ -87,7 +87,7 @@ spec:
             - name: MONGODB_CFG_PRIMARY_HOST
               value: {{ include "mongodb-sharded.configServer.primaryHost" . }}
             - name: MONGODB_CFG_REPLICA_SET_NAME
-              value: {{ printf "%s-configsvr" ( include "mongodb-sharded.fullname" . ) }}
+              value: {{ include "mongodb-sharded.configServer.rsName" . }}
             - name: MONGODB_SYSTEM_LOG_VERBOSITY
               value: {{ .Values.common.mongodbSystemLogVerbosity | quote }}
             - name: MONGODB_DISABLE_SYSTEM_LOG

--- a/bitnami/mongodb-sharded/templates/secrets.yaml
+++ b/bitnami/mongodb-sharded/templates/secrets.yaml
@@ -5,7 +5,9 @@ metadata:
   labels: {{- include "mongodb-sharded.labels" $ | nindent 4 }}
 type: Opaque
 data:
-  {{- if .Values.mongodbRootPassword }}
+  {{- if .Values.configsvr.external.rootPassword }}
+  mongodb-root-password: {{ .Values.configsvr.external.rootPassword | b64enc | quote }}
+  {{- else if .Values.mongodbRootPassword }}
   mongodb-root-password: {{ .Values.mongodbRootPassword | b64enc | quote }}
   {{- else }}
   mongodb-root-password: {{ randAlphaNum 10 | b64enc | quote }}
@@ -17,7 +19,9 @@ data:
   mongodb-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
   {{- end }}
-  {{- if .Values.replicaSetKey }}
+  {{- if .Values.configsvr.external.replicasetKey }}
+  mongodb-replica-set-key: {{ .Values.configsvr.external.replicasetKey | b64enc | quote }}
+  {{- else if .Values.replicaSetKey }}
   mongodb-replica-set-key: {{ .Values.replicaSetKey | b64enc | quote }}
   {{- else }}
   mongodb-replica-set-key: {{ randAlphaNum 10 | b64enc | quote }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-configmap.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.shardsvr.arbiter.config }}
+{{- if and .Values.shards .Values.shardsvr.arbiter.replicas .Values.shardsvr.arbiter.config }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
@@ -1,4 +1,4 @@
-{{- if $.Values.shardsvr.arbiter.replicas }}
+{{- if and $.Values.shards $.Values.shardsvr.arbiter.replicas }}
 {{- $replicas := $.Values.shards | int }}
 {{- range $i, $e := until $replicas }}
 apiVersion: apps/v1

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-configmap.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.shardsvr.dataNode.config }}
+{{- if and .Values.shards .Values.shardsvr.dataNode.config }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-poddisruptionbudget.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.shardsvr.dataNode.pdb.enabled -}}
+{{- if and .Values.shards .Values.shardsvr.dataNode.pdb.enabled -}}
 {{- $replicas := .Values.shards | int -}}
 {{- range $i, $e := until $replicas -}}
 kind: PodDisruptionBudget

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.shards }}
 {{- $replicas := .Values.shards | int }}
 {{- range $i, $e := until $replicas }}
 apiVersion: apps/v1
@@ -312,5 +313,6 @@ spec:
   {{- end }}
 {{- if lt $i (sub $replicas 1) }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/bitnami/mongodb-sharded/values-production.yaml
+++ b/bitnami/mongodb-sharded/values-production.yaml
@@ -48,18 +48,21 @@ fullnameOverride:
 ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#setting-the-root-password-on-first-run
 ##
 ## mongodbRootPassword: password
+##
 mongodbRootPassword:
 
 ## Create a non-root MongoDB user
 ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#setting-the-root-password-on-first-run
 ##
 ## mongodbUsername: user
+##
 mongodbUsername:
 
 ## non-root MongoDB user password
 ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#setting-the-root-password-on-first-run
 ##
 ## mongodbPassword: password
+##
 mongodbPassword:
 
 ## Create database on first run
@@ -72,12 +75,14 @@ mongodbDatabase:
 ## ref:
 ##
 ## replicaSetKey: testkey123
+##
 replicaSetKey:
 
 ## Name of a secret containing all the credentials above
 ## ref:
 ##
 ## existingSecret: name-of-existing-secret
+##
 existingSecret:
 
 ## Mount credentials as files instead of using environment variables
@@ -162,6 +167,7 @@ shardsvr:
     ##     ports:
     ##       - name: portname
     ##         containerPort: 1234
+    ##
     sidecars:
     ## Add init containers to the pod
     ## For example:
@@ -270,6 +276,7 @@ shardsvr:
     ##     ports:
     ##       - name: portname
     ##         containerPort: 1234
+    ##
     sidecars:
     ## Add init containers to the pod
     ## For example:
@@ -400,6 +407,7 @@ configsvr:
   ##     ports:
   ##       - name: portname
   ##         containerPort: 1234
+  ##
   sidecars:
   ## Add init containers to the pod
   ## For example:
@@ -469,6 +477,16 @@ configsvr:
     ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
     ##
     annotations: {}
+
+  ## Use a external config server instead of deploying one
+  ##
+  external:
+    ## Host name of the config server primary node
+    ##
+    host:
+    ## Name of the replica set
+    ##
+    replicasetName:
 
 ## Mongos properties
 ## ref: https://docs.mongodb.com/manual/reference/program/mongos/#bin.mongos
@@ -540,6 +558,7 @@ mongos:
   ##     ports:
   ##       - name: portname
   ##         containerPort: 1234
+  ##
   sidecars:
   ## Add init containers to the pod
   ## For example:
@@ -631,6 +650,7 @@ common:
   ##     ports:
   ##       - name: portname
   ##         containerPort: 1234
+  ##
   sidecars:
   ## Add init containers to the pod
   ## For example:
@@ -720,6 +740,7 @@ service:
 
   ## Specify the externalIP value ClusterIP service type.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips
+  ##
   externalIPs: []
 
   ## Specify the loadBalancerIP value for LoadBalancer service types.
@@ -778,6 +799,7 @@ metrics:
 
   ## String with extra arguments to the metrics exporter
   ## ref: https://github.com/dcu/mongodb_exporter/blob/master/mongodb_exporter.go
+  ##
   extraArgs: ""
 
   ## Metrics exporter resource requests and limits
@@ -787,6 +809,7 @@ metrics:
 
   ## Metrics exporter liveness and readiness probes
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+  ##
   livenessProbe:
     enabled: false
     initialDelaySeconds: 15
@@ -803,6 +826,7 @@ metrics:
     successThreshold: 1
 
   ## Metrics exporter pod Annotation
+  ##
   podAnnotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9216"
@@ -816,5 +840,6 @@ metrics:
     ## Defaults to what's used if you follow CoreOS [Prometheus Install Instructions](https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#tldr)
     ## [Prometheus Selector Label](https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-operator-1)
     ## [Kube Prometheus Selector Label](https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#exporters)
+    ##
     selector:
       prometheus: kube-prometheus

--- a/bitnami/mongodb-sharded/values-production.yaml
+++ b/bitnami/mongodb-sharded/values-production.yaml
@@ -484,9 +484,15 @@ configsvr:
     ## Host name of the config server primary node
     ##
     host:
+    ## Root password of the config server primary node
+    ##
+    rootPassword:
     ## Name of the replica set
     ##
     replicasetName:
+    ## Replica set key
+    ##
+    replicasetKey:
 
 ## Mongos properties
 ## ref: https://docs.mongodb.com/manual/reference/program/mongos/#bin.mongos

--- a/bitnami/mongodb-sharded/values-production.yaml
+++ b/bitnami/mongodb-sharded/values-production.yaml
@@ -14,7 +14,7 @@ global: {}
 image:
   registry: docker.io
   repository: bitnami/mongodb-sharded
-  tag: 4.2.8-debian-10-r4
+  tag: 4.2.8-debian-10-r13
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -794,7 +794,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mongodb-exporter
-    tag: 0.11.0-debian-10-r55
+    tag: 0.11.0-debian-10-r63
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/mongodb-sharded/values.yaml
+++ b/bitnami/mongodb-sharded/values.yaml
@@ -48,18 +48,21 @@ fullnameOverride:
 ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#setting-the-root-password-on-first-run
 ##
 ## mongodbRootPassword: password
+##
 mongodbRootPassword:
 
 ## Replica Set key (shared for shards and config servers)
 ## ref:
 ##
 ## replicaSetKey: testkey123
+##
 replicaSetKey:
 
 ## Name of a secret containing all the credentials above
 ## ref:
 ##
 ## existingSecret: name-of-existing-secret
+##
 existingSecret:
 
 ## Mount credentials as files instead of using environment variables
@@ -144,6 +147,7 @@ shardsvr:
     ##     ports:
     ##       - name: portname
     ##         containerPort: 1234
+    ##
     sidecars: []
     ## Add init containers to the pod
     ## For example:
@@ -252,6 +256,7 @@ shardsvr:
     ##     ports:
     ##       - name: portname
     ##         containerPort: 1234
+    ##
     sidecars: []
     ## Add init containers to the pod
     ## For example:
@@ -382,6 +387,7 @@ configsvr:
   ##     ports:
   ##       - name: portname
   ##         containerPort: 1234
+  ##
   sidecars: []
   ## Add init containers to the pod
   ## For example:
@@ -451,6 +457,22 @@ configsvr:
     ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
     ##
     annotations: {}
+
+  ## Use a external config server instead of deploying one
+  ##
+  external:
+    ## Host name of the config server primary node
+    ##
+    host:
+    ## Root password of the config server primary node
+    ##
+    rootPassword:
+    ## Name of the replica set
+    ##
+    replicasetName:
+    ## Replica set key
+    ##
+    replicasetKey:
 
 ## Mongos properties
 ## ref: https://docs.mongodb.com/manual/reference/program/mongos/#bin.mongos
@@ -522,6 +544,7 @@ mongos:
   ##     ports:
   ##       - name: portname
   ##         containerPort: 1234
+  ##
   sidecars: []
   ## Add init containers to the pod
   ## For example:
@@ -559,7 +582,6 @@ mongos:
     ## Use 0 to disable
     ##
     maxUnavailable: 1
-
 
 ## Properties for all of the pods in the cluster (shards, config servers and mongos)
 ##
@@ -608,6 +630,7 @@ common:
   ##     ports:
   ##       - name: portname
   ##         containerPort: 1234
+  ##
   sidecars: []
   ## Add init containers to the pod
   ## For example:
@@ -704,6 +727,7 @@ service:
 
   ## Specify the externalIP value ClusterIP service type.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips
+  ##
   externalIPs: []
 
   ## Specify the loadBalancerIP value for LoadBalancer service types.
@@ -762,6 +786,7 @@ metrics:
 
   ## String with extra arguments to the metrics exporter
   ## ref: https://github.com/dcu/mongodb_exporter/blob/master/mongodb_exporter.go
+  ##
   extraArgs: ""
 
   ## Metrics exporter resource requests and limits
@@ -771,6 +796,7 @@ metrics:
 
   ## Metrics exporter liveness and readiness probes
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+  ##
   livenessProbe:
     enabled: false
     initialDelaySeconds: 15
@@ -787,6 +813,7 @@ metrics:
     successThreshold: 1
 
   ## Metrics exporter pod Annotation
+  ##
   podAnnotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9216"
@@ -800,5 +827,6 @@ metrics:
     ## Defaults to what's used if you follow CoreOS [Prometheus Install Instructions](https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#tldr)
     ## [Prometheus Selector Label](https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-operator-1)
     ## [Kube Prometheus Selector Label](https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#exporters)
+    ##
     selector:
       prometheus: kube-prometheus

--- a/bitnami/mongodb-sharded/values.yaml
+++ b/bitnami/mongodb-sharded/values.yaml
@@ -14,7 +14,7 @@ global: {}
 image:
   registry: docker.io
   repository: bitnami/mongodb-sharded
-  tag: 4.2.8-debian-10-r4
+  tag: 4.2.8-debian-10-r13
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -775,7 +775,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mongodb-exporter
-    tag: 0.11.0-debian-10-r55
+    tag: 0.11.0-debian-10-r63
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
There are cases where users may want to only deploy mongos instances. This can be done by allowing an external config server to be set. This PR adds that value and also allows shards to deployed and not the config server (in case we want to have the config server externally for security reasons). The requirement would be 


  - Provide host, replica set name, password and replica set key of the external config server. The rest of the shard components will use this credential.

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes https://github.com/bitnami/charts/issues/2827

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
