### PR TITLE
[bitnami/kafka] Remove line used for debugging purposes

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 11.2.2
+version: 11.2.3
 appVersion: 2.5.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/templates/scripts-configmap.yaml
+++ b/bitnami/kafka/templates/scripts-configmap.yaml
@@ -103,7 +103,6 @@ data:
         mkdir -p /opt/bitnami/kafka/config/certs
         cp "/certs/kafka.truststore.jks" "/opt/bitnami/kafka/config/certs/kafka.truststore.jks"
         cp "/certs/kafka-${ID}.keystore.jks" "/opt/bitnami/kafka/config/certs/kafka.keystore.jks"
-        ls /bitnami/kafka/config/certs/
     else
         echo "Couldn't find the expected Java Key Stores (JKS) files! They are mandatory when encryption via TLS is enabled."
         exit 1


### PR DESCRIPTION
**Description of the change**

This PR just removes an line from the setup.sh script, since it has no value (it was used for debugging purposes)

**Possible drawbacks**

None

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
