### PR TITLE
[bitnami/node] Fix alpha storage-class annotation

### DIFF
--- a/bitnami/node/Chart.yaml
+++ b/bitnami/node/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node
-version: 11.4.25
+version: 11.4.26
 appVersion: 10.21.0
 description: Event-driven I/O server-side JavaScript environment based on V8
 keywords:

--- a/bitnami/node/templates/pvc.yaml
+++ b/bitnami/node/templates/pvc.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "node.fullname" . }}-binding
   labels: {{- include "node.labels" . | nindent 4 }}
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ ternary "default" (include "node.storageClass" .) (empty (include "node.storageClass" .)) }}
+    volume.alpha.kubernetes.io/storage-class: {{ ternary "default" (trimPrefix "storageClassName: " (include "node.storageClass" .)) (empty (include "node.storageClass" .)) }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/bitnami/node/values.yaml
+++ b/bitnami/node/values.yaml
@@ -149,10 +149,14 @@ resources:
 persistence:
   enabled: false
   path: /app/data
-  ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
-  ## Default: volume.alpha.kubernetes.io/storage-class: default
+  ## Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
   ##
-  # storageClass:
+  # storageClass: "-"
   accessMode: ReadWriteOnce
   size: 1Gi
 

--- a/bitnami/node/values.yaml
+++ b/bitnami/node/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/node
-  tag: 10.21.0-debian-10-r18
+  tag: 10.21.0-debian-10-r19
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -72,7 +72,7 @@ volumePermissions:
 git:
   registry: docker.io
   repository: bitnami/git
-  tag: 2.27.0-debian-10-r17
+  tag: 2.27.0-debian-10-r18
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

The storage-class anotation is not being set properly when storageClass is enabled, as it includes a "storageClassName:" prefix which does not render properly with YAML.

**Benefits**

<!-- What benefits will be realized by the code change? -->
This PR fixes the previous issue, allowing users to set a custom storage class.
**Possible drawbacks**

<!-- Describe any known limitations with your change -->
None
**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #2571

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
