### PR TITLE
[bitnami/redmine] Move certificate.extraEnvVars to certificate.image

### DIFF
--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redmine
-version: 14.2.2
+version: 14.2.3
 appVersion: 4.1.1
 description: A flexible project management web application.
 keywords:

--- a/bitnami/redmine/README.md
+++ b/bitnami/redmine/README.md
@@ -241,6 +241,7 @@ $ helm install test --set persistence.existingClaim=PVC_REDMINE,mariadb.persiste
 ## Certificates
 
 ### CA Certificates
+
 Custom CA certificates not included in the base docker image can be added with
 the following configuration. The secret must exist in the same namespace as the
 deployment. Will load all certificates files it finds in the secret.
@@ -253,6 +254,7 @@ certificates:
 ```
 
 #### Secret
+
 Secret can be created with:
 
 ```bash
@@ -260,6 +262,7 @@ kubectl create secret generic my-ca-1 --from-file my-ca-1.crt
 ```
 
 ### TLS Certificate
+
 A web server TLS Certificate can be injected into the container with the
 following configuration. The certificate will be stored at the location
 specified in the certificateLocation value.
@@ -276,6 +279,7 @@ certificates:
 ```
 
 #### Secret
+
 The certificate tls secret can be created with:
 
 ```bash
@@ -283,6 +287,7 @@ kubectl create secret tls my-secret --cert tls.crt --key tls.key
 ```
 
 The certificate chain is created with:
+
 ```bash
 kubectl create secret generic my-cert-chain --from-file chain.pem
 ```

--- a/bitnami/redmine/README.md
+++ b/bitnami/redmine/README.md
@@ -238,8 +238,9 @@ The following example includes two PVCs, one for Redmine and another for MariaDB
 $ helm install test --set persistence.existingClaim=PVC_REDMINE,mariadb.persistence.existingClaim=PVC_MARIADB bitnami/redmine
 ```
 
-## CA Certificates
+## Certificates
 
+### CA Certificates
 Custom CA certificates not included in the base docker image can be added with
 the following configuration. The secret must exist in the same namespace as the
 deployment. Will load all certificates files it finds in the secret.
@@ -251,11 +252,39 @@ certificates:
   - secret: my-ca-2
 ```
 
-###Secret
+#### Secret
 Secret can be created with:
 
 ```bash
 kubectl create secret generic my-ca-1 --from-file my-ca-1.crt
+```
+
+### TLS Certificate
+A web server TLS Certificate can be injected into the container with the
+following configuration. The certificate will be stored at the location
+specified in the certificateLocation value.
+
+```yaml
+certificates:
+  customCertificate:
+    certificateSecret: my-secret
+    certificateLocation: /ssl/server.pem
+    keyLocation: /ssl/key.pem
+    chainSecret:
+      name: my-cert-chain
+      key: chain.pem
+```
+
+#### Secret
+The certificate tls secret can be created with:
+
+```bash
+kubectl create secret tls my-secret --cert tls.crt --key tls.key
+```
+
+The certificate chain is created with:
+```bash
+kubectl create secret generic my-cert-chain --from-file chain.pem
 ```
 
 ## Upgrading


### PR DESCRIPTION
**Description of the change**

The change moves one of the certificate image variables to the correct location in the values file. Additionally it adds documentation on how to add user certificates into the readme.

**Benefits**

Everything that relates to the init container image is now in the correct hierarchy.

**Possible drawbacks**

If someone has already started using the feature (only added a couple of days ago) then it will require them to move the variable to the new location.

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files