### PR TITLE
[bitnami/mariadb] Namespace inclusion (Issue #2006)

### DIFF
--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb
-version: 7.5.2
+version: 7.6.0
 appVersion: 10.3.23
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/bitnami/mariadb/templates/initialization-configmap.yaml
+++ b/bitnami/mariadb/templates/initialization-configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "master.fullname" . }}-init-scripts
+  namespace: {{ .Release.Namespace }}
   labels:
     app: "{{ template "mariadb.name" . }}"
     chart: "{{ template "mariadb.chart" . }}"

--- a/bitnami/mariadb/templates/master-configmap.yaml
+++ b/bitnami/mariadb/templates/master-configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "master.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: "{{ template "mariadb.name" . }}"
     component: "master"

--- a/bitnami/mariadb/templates/master-pdb.yaml
+++ b/bitnami/mariadb/templates/master-pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "mariadb.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: "{{ template "mariadb.name" . }}"
     component: "master"

--- a/bitnami/mariadb/templates/master-statefulset.yaml
+++ b/bitnami/mariadb/templates/master-statefulset.yaml
@@ -2,6 +2,7 @@ apiVersion: {{ template "mariadb.statefulset.apiVersion" . }}
 kind: StatefulSet
 metadata:
   name: {{ template "master.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "mariadb.name" . }}
     chart: {{ template "mariadb.chart" . }}

--- a/bitnami/mariadb/templates/master-svc.yaml
+++ b/bitnami/mariadb/templates/master-svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "mariadb.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: "{{ template "mariadb.name" . }}"
     component: "master"

--- a/bitnami/mariadb/templates/role.yaml
+++ b/bitnami/mariadb/templates/role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "master.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: "{{ template "mariadb.name" . }}"
     chart: "{{ template "mariadb.chart" . }}"

--- a/bitnami/mariadb/templates/rolebinding.yaml
+++ b/bitnami/mariadb/templates/rolebinding.yaml
@@ -3,6 +3,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "master.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: "{{ template "mariadb.name" . }}"
     chart: "{{ template "mariadb.chart" . }}"

--- a/bitnami/mariadb/templates/secrets.yaml
+++ b/bitnami/mariadb/templates/secrets.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "mariadb.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: "{{ template "mariadb.name" . }}"
     chart: "{{ template "mariadb.chart" . }}"

--- a/bitnami/mariadb/templates/serviceaccount.yaml
+++ b/bitnami/mariadb/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "mariadb.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: "{{ template "mariadb.name" . }}"
     chart: "{{ template "mariadb.chart" . }}"

--- a/bitnami/mariadb/templates/servicemonitor.yaml
+++ b/bitnami/mariadb/templates/servicemonitor.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ template "mariadb.fullname" . }}
   {{- if .Values.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
   {{- end }}
   labels:
     app: "{{ template "mariadb.name" . }}"

--- a/bitnami/mariadb/templates/slave-configmap.yaml
+++ b/bitnami/mariadb/templates/slave-configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "slave.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: "{{ template "mariadb.name" . }}"
     component: "slave"

--- a/bitnami/mariadb/templates/slave-pdb.yaml
+++ b/bitnami/mariadb/templates/slave-pdb.yaml
@@ -4,6 +4,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "mariadb.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: "{{ template "mariadb.name" . }}"
     component: "slave"

--- a/bitnami/mariadb/templates/slave-statefulset.yaml
+++ b/bitnami/mariadb/templates/slave-statefulset.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ template "mariadb.statefulset.apiVersion" . }}
 kind: StatefulSet
 metadata:
   name: {{ template "slave.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "mariadb.name" . }}
     chart: {{ template "mariadb.chart" . }}

--- a/bitnami/mariadb/templates/slave-svc.yaml
+++ b/bitnami/mariadb/templates/slave-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "slave.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: "{{ template "mariadb.name" . }}"
     chart: "{{ template "mariadb.chart" . }}"

--- a/bitnami/mariadb/templates/test-runner.yaml
+++ b/bitnami/mariadb/templates/test-runner.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ template "mariadb.fullname" . }}-test-{{ randAlphaNum 5 | lower }}"
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": test-success
 spec:

--- a/bitnami/mariadb/templates/tests.yaml
+++ b/bitnami/mariadb/templates/tests.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "mariadb.fullname" . }}-tests
+  namespace: {{ .Release.Namespace }}
 data:
   run.sh: |-
     @test "Testing MariaDB is accessible" {


### PR DESCRIPTION
**Description of the change**

This PR adds .Release.Namespace to objects meta. Similar to #2159, #2156 or #2316

**Benefits**

Ability to use the helm chart when having declarative definition of all cluster objects rendered using helm template, for example in tools like Spinnaker.

**Possible drawbacks**

none

**Applicable issues**

#2006

**Additional information**

Discussion under Issue #2006 should explain everything.

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
