### PR TITLE
[bitnami/kafka] Provide a way to create JKS secret from local directory

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 11.2.4
+version: 11.3.0
 appVersion: 2.5.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -426,7 +426,9 @@ kubectl create secret generic kafka-jks --from-file=./kafka.truststore.jks --fro
 
 > **Note**: the command above assumes you already created the trustore and keystores files. This [script](https://raw.githubusercontent.com/confluentinc/confluent-platform-security-tools/master/kafka-generate-ssl.sh) can help you with the JKS files generation.
 
-You can create the secret and deploy the chart with authentication using the following parameters:
+As an alternative to manually create the secret before installing the chart, you can put your JKS files inside the chart folder `files/jks`, an a secret including them will be generated. Please note this alternative requires to have the chart downloaded locally, so you will have to clone this repository or fetch the chart before installing it.
+
+You can deploy the chart with authentication using the following parameters:
 
 ```console
 replicaCount=2

--- a/bitnami/kafka/files/jks/README.md
+++ b/bitnami/kafka/files/jks/README.md
@@ -1,0 +1,10 @@
+# Java Key Stores
+
+You can copy here your Java Key Stores (JKS) files so a secret is created including them. Remember to use a truststore (`kafka.truststore.jks`) and one keystore (`kafka.keystore.jks`) per Kafka broker you have in the cluster. For instance, if you have 3 brokers you need to copy here the following files:
+
+- kafka.truststore.jks
+- kafka-0.keystore.jks
+- kafka-1.keystore.jks
+- kafka-2.keystore.jks
+
+Find more info in [this section](https://github.com/bitnami/charts/tree/master/bitnami/kafka#enable-security-for-kafka-and-zookeeper) of the README.md file.

--- a/bitnami/kafka/templates/NOTES.txt
+++ b/bitnami/kafka/templates/NOTES.txt
@@ -77,14 +77,17 @@ You need to configure your Kafka client to access using SASL authentication. To 
 
     - client.properties:
 
+        security.protocol={{ $clientProtocol }}
+        sasl.mechanism=PLAIN
         {{- if eq .Values.auth.clientProtocol "sasl_tls" }}
         ssl.truststore.location=/tmp/kafka.truststore.jks
         {{- if .Values.auth.jksPassword }}
         ssl.truststore.password={{ .Values.auth.jksPassword }}
         {{- end }}
         {{- end }}
-        security.protocol={{ $clientProtocol }}
-        sasl.mechanism=PLAIN
+        {{- if eq .Values.auth.tlsEndpointIdentificationAlgorithm "" }}
+        ssl.endpoint.identification.algorithm=
+        {{- end }}
 
 {{- end }}
 

--- a/bitnami/kafka/templates/jks-secret.yaml
+++ b/bitnami/kafka/templates/jks-secret.yaml
@@ -1,0 +1,13 @@
+{{- if (include "kafka.createJksSecret" .) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "kafka.fullname" . }}-jks
+  labels: {{- include "kafka.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- $root := . }}
+  {{- range $path, $bytes := .Files.Glob "files/jks/*.jks" }}
+  {{ base $path }}: {{ $root.Files.Get $path | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -388,7 +388,7 @@ spec:
         {{- if (include "kafka.tlsEncryption" .) }}
         - name: kafka-certificates
           secret:
-            secretName: {{ required "A secret containing the Kafka JKS files is required when TLS encryption in enabled" .Values.auth.jksSecret }}
+            secretName: {{ include "kafka.jksSecretName" . }}
             defaultMode: 256
         {{- end }}
         {{- if .Values.extraVolumes }}

--- a/bitnami/kafka/values-production.yaml
+++ b/bitnami/kafka/values-production.yaml
@@ -240,6 +240,7 @@ auth:
   ## 3) Rename your keystores to `kafka-X.keystore.jks` where X is the ID of each Kafka broker.
   ## 4) Run the command below where SECRET_NAME is the name of the secret you want to create:
   ##       kubectl create secret generic SECRET_NAME --from-file=./kafka.truststore.jks --from-file=./kafka-0.keystore.jks --from-file=./kafka-1.keystore.jks ...
+  ## Alternatively, you can put your JKS files under the files/jks directory
   ##
   # jksSecret:
 

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -240,6 +240,7 @@ auth:
   ## 3) Rename your keystores to `kafka-X.keystore.jks` where X is the ID of each Kafka broker.
   ## 4) Run the command below where SECRET_NAME is the name of the secret you want to create:
   ##       kubectl create secret generic SECRET_NAME --from-file=./kafka.truststore.jks --from-file=./kafka-0.keystore.jks --from-file=./kafka-1.keystore.jks ...
+  ## Alternatively, you can put your JKS files under the files/jks directory
   ##
   # jksSecret:
 


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Although the recommended way to configure Kafka with TLS encryption is to create a secret containing the JKS files beforehand, there are users with limitations to do so since they wan to be able to install everything related to Kafka in a single "helm install" command.

This PR gives an answer to these users by providing a way to load the JKS files from a local directory, and create a secret with them.

**Benefits**

Install Kafka with TLS in a single command.

**Possible drawbacks**

None

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files