### PR TITLE
[bitnami/postgresql] Update readme with delete PVC details

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 8.10.8
+version: 8.10.9
 appVersion: 11.8.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/bitnami/postgresql/README.md
+++ b/bitnami/postgresql/README.md
@@ -42,7 +42,15 @@ To uninstall/delete the `my-release` deployment:
 $ helm delete my-release
 ```
 
-The command removes all the Kubernetes components associated with the chart and deletes the release.
+The command removes all the Kubernetes components but PVC's associated with the chart and deletes the release.
+
+To delete the PVC's associated with `my-release`:
+
+```console
+$ kubectl delete pvc -l release=my-release
+```
+
+> **Note**: Deleting the PVC's will delete postgresql data as well. Please be cautious before doing it.
 
 ## Parameters
 


### PR DESCRIPTION
**Description of the change**

When Postgresql is initially installed using the readme instructions, It generates a random password for the `Postgres` db user. On subsequent installations after uninstalling the chart, it never deletes the PVC's associated with the StatefulSets; Hence, there will be password mismatch errors with text `psql: FATAL:  password authentication failed for user "postgres"`. I added details with a note in the chart's uninstall section to give additional info. It doesn't have any functionality changes, but only README.

**Benefits**

This will benefit people testing PostgreSQL chart locally or dev environments.

**Possible drawbacks**

* There are chances that someone might delete PVC's accidentally following the instructions.
* 

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
