### PR TITLE
[bitnami/dokuwiki] Inject certificates into image

### DIFF
--- a/bitnami/dokuwiki/Chart.yaml
+++ b/bitnami/dokuwiki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dokuwiki
-version: 6.0.18
+version: 6.1.0
 appVersion: 0.20180422.202005011246
 description: DokuWiki is a standards-compliant, simple to use wiki optimized for creating
   documentation. It is targeted at developer teams, workgroups, and small companies.

--- a/bitnami/dokuwiki/templates/_certificates.tpl
+++ b/bitnami/dokuwiki/templates/_certificates.tpl
@@ -1,0 +1,126 @@
+{{/* Templates for certificates injection */}}
+
+{{/*
+Return the proper Redmine image name
+*/}}
+{{- define "certificates.image" -}}
+{{- $registryName := default .Values.certificates.image.registry .Values.image.registry -}}
+{{- $repositoryName := .Values.certificates.image.repository -}}
+{{- $tag := .Values.certificates.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "certificates.initContainer" -}}
+{{- if .Values.certificates.customCAs }}
+- name: certificates
+  image: {{ template "certificates.image" . }}
+  imagePullPolicy: {{ default .Values.image.pullPolicy .Values.certificates.image.pullPolicy }}
+  imagePullSecrets:
+  {{- range (default .Values.image.pullSecrets .Values.certificates.image.pullSecrets) }}
+    - name: {{ . }}
+  {{- end }}
+  command:
+  {{- if .Values.certificates.customCertificate.certificateSecret }}
+  - sh
+  - -c
+  - if command -v apk >/dev/null; then apk add --no-cache ca-certificates openssl && update-ca-certificates;
+    else apt-get update && apt-get install -y ca-certificates openssl; fi
+  {{- else }}
+  - sh
+  - -c
+  - if command -v apk >/dev/null; then apk add --no-cache ca-certificates openssl && update-ca-certificates;
+    else apt-get update && apt-get install -y ca-certificates openssl; fi
+    && openssl req -new -x509 -days 3650 -nodes -sha256
+       -subj "/CN=$(hostname)" -addext "subjectAltName = DNS:$(hostname)"
+       -out  /etc/ssl/certs/ssl-cert-snakeoil.pem
+       -keyout /etc/ssl/private/ssl-cert-snakeoil.key -extensions v3_req
+  {{- end }}
+  {{- if .Values.certificates.extraEnvVars }}
+  env:
+  {{- tpl (toYaml .Values.certificates.extraEnvVars) $ | nindent 2 }}
+  {{- end }}
+  volumeMounts:
+    - name: etc-ssl-certs
+      mountPath: /etc/ssl/certs
+      readOnly: false
+    - name: etc-ssl-private
+      mountPath: /etc/ssl/private
+      readOnly: false
+    - name: custom-ca-certificates
+      mountPath: /usr/local/share/ca-certificates
+      readOnly: true
+{{- end }}
+{{- end }}
+
+{{- define "certificates.volumes" -}}
+{{- if .Values.certificates.customCAs }}
+- name: etc-ssl-certs
+  emptyDir:
+    medium: "Memory"
+- name: etc-ssl-private
+  emptyDir:
+    medium: "Memory"
+- name: custom-ca-certificates
+  projected:
+    defaultMode: 0400
+    sources:
+    {{- range $index, $customCA := .Values.certificates.customCAs }}
+    - secret:
+        name: {{ $customCA.secret }}
+        # items not specified, will mount all keys
+    {{- end }}
+{{- end -}}
+{{- if .Values.certificates.customCertificate.certificateSecret }}
+- name: custom-certificate
+  secret:
+    secretName: {{ .Values.certificates.customCertificate.certificateSecret }}
+{{- if .Values.certificates.customCertificate.chainSecret }}
+- name: custom-certificate-chain
+  secret:
+    secretName: {{ .Values.certificates.customCertificate.chainSecret.name }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "certificates.volumeMount" -}}
+{{- if .Values.certificates.customCAs }}
+- name: etc-ssl-certs
+  mountPath: /etc/ssl/certs/
+  readOnly: false
+- name: etc-ssl-private
+  mountPath: /etc/ssl/private/
+  readOnly: false
+- name: custom-ca-certificates
+  mountPath: /usr/local/share/ca-certificates
+  readOnly: true
+{{- end -}}
+{{- if .Values.certificates.customCertificate.certificateSecret }}
+- name: custom-certificate
+  mountPath: {{ .Values.certificates.customCertificate.certificateLocation }}
+  subPath: tls.crt
+  readOnly: true
+- name: custom-certificate
+  mountPath: {{ .Values.certificates.customCertificate.keyLocation }}
+  subPath: tls.key
+  readOnly: true
+{{- if .Values.certificates.customCertificate.chainSecret }}
+- name: custom-certificate-chain
+  mountPath: {{ .Values.certificates.customCertificate.chainLocation }}
+  subPath: {{ .Values.certificates.customCertificate.chainSecret.key }}
+  readOnly: true
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/bitnami/dokuwiki/templates/deployment.yaml
+++ b/bitnami/dokuwiki/templates/deployment.yaml
@@ -45,6 +45,8 @@ spec:
       - ip: "127.0.0.1"
         hostnames:
         - "status.localhost"
+      initContainers:
+      {{- include "certificates.initContainer" . | indent 8 }}
       containers:
       - name: {{ template "dokuwiki.fullname" . }}
         image: {{ template "dokuwiki.image" . }}
@@ -93,6 +95,7 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
+        {{- include "certificates.volumeMount" . | indent 8 }}
         - name: dokuwiki-data
           mountPath: /bitnami/dokuwiki
 {{- if .Values.metrics.enabled }}
@@ -119,6 +122,7 @@ spec:
   {{ toYaml .Values.metrics.resources | indent 10 }}
 {{- end }}
       volumes:
+      {{- include "certificates.volumes" . | indent 6 }}
       - name: dokuwiki-data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:

--- a/bitnami/dokuwiki/values.yaml
+++ b/bitnami/dokuwiki/values.yaml
@@ -209,3 +209,32 @@ metrics:
     ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
     ##
   # resources: {}
+
+# Add custom certificates and certificate authorities to redmine container
+certificates:
+  customCertificate:
+    certificateSecret: ""
+    chainSecret: {}
+    # name: secret-name
+    # key: secret-key
+    certificateLocation: /etc/ssl/certs/ssl-cert-snakeoil.pem
+    keyLocation: /etc/ssl/private/ssl-cert-snakeoil.key
+    chainLocation: /etc/ssl/certs/mychain.pem
+  customCA: []
+  # - secret: custom-CA
+  # - secret: more-custom-CAs
+  image:
+    registry: docker.io
+    repository: bitnami/minideb
+    tag: buster
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: IfNotPresent
+    # pullPolicy:
+    # pullSecrets
+    #   - myRegistryKeySecretName
+  extraEnvVars: []
+  # - name: myvar
+  #   value: myval


### PR DESCRIPTION
**Description of the change**

Add a certificate authority into the redmine image. Pulls CA from kubernetes secret using a sidecar init container.

**Benefits**

- Allows LDAP authentication using LDAPS to servers with an internal certificate.
- Adds a snakeoil certificate to the container. Used can be used for TLS sessions to the ingress.
- Allows injection of custom user certificate into image.

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

Readme has not been fully aligned. Can create an additional commit to realign the table if required.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files