### PR TITLE
[bitnami/minio] make minio service istio-compatible

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 3.4.12
+version: 3.4.13
 appVersion: 2020.6.22
 description: MinIO is an object storage server, compatible with Amazon S3 cloud storage service, mainly used for storing unstructured data (such as photos, videos, log files, etc.)
 keywords:

--- a/bitnami/minio/templates/ingress.yaml
+++ b/bitnami/minio/templates/ingress.yaml
@@ -21,7 +21,7 @@ spec:
           - path: {{ default "/" .path }}
             backend:
               serviceName: {{ include "minio.fullname" $ }}
-              servicePort: minio
+              servicePort: http-minio
     {{- end }}
   tls:
     {{- range .Values.ingress.hosts }}

--- a/bitnami/minio/templates/service.yaml
+++ b/bitnami/minio/templates/service.yaml
@@ -13,7 +13,7 @@ spec:
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
   ports:
-    - name: minio
+    - name: http-minio
       port: {{ .Values.service.port }}
       targetPort: minio
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePort)) }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Hey guys! This change simply prefixes the Minio service port name with `http-`, in order to make Minio work with Istio mTLS (which requires [strict port naming](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/))

**Benefits**

Istio users will be able to use Minio without having to deploy an _additional_ service (which is my current workaround) with a port matching the Istio protocol/port-naming requirements.

**Possible drawbacks**

None - port name is immaterial to non-Istio users

**Applicable issues**

None

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
