### PR TITLE
[bitnami/redis] only send cert in healthcheck if authClients is true

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 10.7.5
+version: 10.7.6
 appVersion: 6.0.5
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/bitnami/redis/templates/health-configmap.yaml
+++ b/bitnami/redis/templates/health-configmap.yaml
@@ -28,9 +28,11 @@ data:
 {{- if .Values.tls.enabled }}
         -p $REDIS_TLS_PORT \
         --tls \
-        --cert {{ template "redis.tlsCert" . }} \
-        --key {{ template "redis.tlsCertKey" . }} \
         --cacert {{ template "redis.tlsCACert" . }} \
+        {{- if .Values.tls.authClients }}
+          --cert {{ template "redis.tlsCert" . }} \
+          --key {{ template "redis.tlsCertKey" . }} \
+        {{- end }}
 {{- else }}
         -p $REDIS_PORT \
 {{- end }}
@@ -59,9 +61,11 @@ data:
 {{- if .Values.tls.enabled }}
         -p $REDIS_TLS_PORT \
         --tls \
-        --cert {{ template "redis.tlsCert" . }} \
-        --key {{ template "redis.tlsCertKey" . }} \
         --cacert {{ template "redis.tlsCACert" . }} \
+        {{- if .Values.tls.authClients }}
+          --cert {{ template "redis.tlsCert" . }} \
+          --key {{ template "redis.tlsCertKey" . }} \
+        {{- end }}
 {{- else }}
         -p $REDIS_PORT \
 {{- end }}


### PR DESCRIPTION

**Description of the change**

This change fixes issue https://github.com/bitnami/charts/issues/2940 - in the health check, certs are only sent if authClients is set to True.


**Applicable issues**

  - fixes #2940 

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
