### PR TITLE
[bitnami/mongodb-sharded] Adapt env. variables

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb-sharded
-version: 1.5.1
+version: 1.5.2
 appVersion: 4.2.8
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications. Sharded topology.
 keywords:

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
@@ -89,7 +89,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: MONGODB_PRIMARY_HOST
+            - name: MONGODB_INITIAL_PPRIMARY_HOST
               value: {{ include "mongodb-sharded.configServer.primaryHost" . }}
             - name: MONGODB_REPLICA_SET_NAME
               value: {{ printf "%s-configsvr" ( include "mongodb-sharded.fullname" . ) }}

--- a/bitnami/mongodb-sharded/templates/replicaset-entrypoint-configmap.yaml
+++ b/bitnami/mongodb-sharded/templates/replicaset-entrypoint-configmap.yaml
@@ -19,10 +19,10 @@ data:
       info "Setting node as secondary"
       export MONGODB_REPLICA_SET_MODE=secondary
       {{- if .Values.usePasswordFile }}
-      export MONGODB_PRIMARY_ROOT_PASSWORD_FILE="$MONGODB_ROOT_PASSWORD_FILE"
+      export MONGODB_INITIAL_PPRIMARY_ROOT_PASSWORD_FILE="$MONGODB_ROOT_PASSWORD_FILE"
       unset MONGODB_ROOT_PASSWORD_FILE
       {{- else }}
-      export MONGODB_PRIMARY_ROOT_PASSWORD="$MONGODB_ROOT_PASSWORD"
+      export MONGODB_INITIAL_PPRIMARY_ROOT_PASSWORD="$MONGODB_ROOT_PASSWORD"
       unset MONGODB_ROOT_PASSWORD
       {{- end }}
     fi

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               value: "shardsvr"
             - name: MONGODB_REPLICA_SET_MODE
               value: "arbiter"
-            - name: MONGODB_PRIMARY_HOST
+            - name: MONGODB_INITIAL_PPRIMARY_HOST
               value: {{ printf "%s-shard%d-data-0.%s-headless.%s.svc.%s" (include "mongodb-sharded.fullname" $ ) $i (include "mongodb-sharded.fullname" $ ) $.Release.Namespace $.Values.clusterDomain }}
             - name: MONGODB_REPLICA_SET_NAME
               value: {{ printf "%s-shard-%d" ( include "mongodb-sharded.fullname" $ ) $i }}
@@ -102,12 +102,12 @@ spec:
               value: "no"
             {{- end }}
             {{- if $.Values.usePasswordFile }}
-            - name: MONGODB_PRIMARY_ROOT_PASSWORD_FILE
+            - name: MONGODB_INITIAL_PPRIMARY_ROOT_PASSWORD_FILE
               value: "/bitnami/mongodb/secrets/mongodb-root-password"
             - name: MONGODB_REPLICA_SET_KEY_FILE
               value: "/bitnami/mongodb/secrets/mongodb-replica-set-key"
             {{- else }}
-            - name: MONGODB_PRIMARY_ROOT_PASSWORD
+            - name: MONGODB_INITIAL_PPRIMARY_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "mongodb-sharded.secret" $ }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -94,7 +94,7 @@ spec:
                   fieldPath: metadata.name
             - name: MONGODB_MONGOS_HOST
               value: {{ include "mongodb-sharded.fullname" $ }}
-            - name: MONGODB_PRIMARY_HOST
+            - name: MONGODB_INITIAL_PPRIMARY_HOST
               value: {{ printf "%s-shard%d-data-0.%s-headless.%s.svc.%s" (include "mongodb-sharded.fullname" $ ) $i (include "mongodb-sharded.fullname" $ ) $.Release.Namespace $.Values.clusterDomain }}
             - name: MONGODB_REPLICA_SET_NAME
               value: {{ printf "%s-shard-%d" ( include "mongodb-sharded.fullname" $ ) $i }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Rename `MONGODB_PRIMARY_XXX` env vars to `MONGODB_INITIAL_PRIMARY_XXX` so they're more accurate.

**Benefits**

Accurate env. var names.

**Possible drawbacks**

None

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
