### PR TITLE
[bitnami/owncloud] Add support for custom CA certificates

### DIFF
--- a/bitnami/owncloud/Chart.yaml
+++ b/bitnami/owncloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: owncloud
-version: 8.1.17
+version: 8.2.0
 appVersion: 10.4.1
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/bitnami/owncloud/README.md
+++ b/bitnami/owncloud/README.md
@@ -108,6 +108,19 @@ The following table lists the configurable parameters of the ownCloud chart and 
 | `metrics.image.pullSecrets`          | Specify docker-registry secret names as an array                                                      | `[]` (does not add image pull secrets to deployed pods)      |
 | `metrics.podAnnotations`             | Additional annotations for Metrics exporter pod                                                       | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
 | `metrics.resources`                  | Exporter resource requests/limit                                                                      | {}                                                           |
+| `certificates.customCertificate.certificateSecret`| Secret containing the certificate and key to add                                         | `""`                                                         |
+| `certificates.customCertificate.chainSecret.name` | Name of the secret containing the certificate chain                                      | `""`                                                         |
+| `certificates.customCertificate.chainSecret.key`  | Key of the certificate chain file inside the secret                                      | `""`                                                         |
+| `certificates.customCertificate.certificateLocation`| Location in the container to store the certificate                                     | `/etc/ssl/certs/ssl-cert-snakeoil.pem`                       |
+| `certificates.customCertificate.keyLocation`| Location in the container to store the private key                                             | `/etc/ssl/private/ssl-cert-snakeoil.key`                     |
+| `certificates.customCertificate.chainLocation`| Location in the container to store the certificate chain                                     | `/etc/ssl/certs/chain.pem`                                   |
+| `certificates.customCAs`             | Defines a list of secrets to import into the container trust store                                    | `[]`                                                         |
+| `certificates.image.registry`        | Container sidecar registry                                                                            | `docker.io`                                                  |
+| `certificates.image.repository`      | Container sidecar image                                                                               | `bitnami/minideb`                                            |
+| `certificates.image.tag`             | Container sidecar image tag                                                                           | `buster`                                                     |
+| `certificates.image.pullPolicy`      | Container sidecar image pull policy                                                                   | `IfNotPresent`                                               |
+| `certificates.image.pullSecrets`     | Container sidecar image pull secrets                                                                  | `image.pullSecrets`                                          |
+| `certificates.extraEnvVars`          | Container sidecar extra environment variables (eg proxy)                                              | `[]`                                                         |
 
 The above parameters map to the env variables defined in [bitnami/owncloud](http://github.com/bitnami/bitnami-docker-owncloud). For more information please refer to the [bitnami/owncloud](http://github.com/bitnami/bitnami-docker-owncloud) image documentation.
 
@@ -159,6 +172,21 @@ Persistent Volume Claims are used to keep the data across deployments. There is 
 
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
 
+## CA Certificates
+
+Custom CA certificates not included in the base docker image can be added by means of existing secrets. The secret must exist in the same namespace and contain the desired CA certificates to import. By default, all found certificate files will be loaded.
+
+```yaml
+certificates:
+  customCAs:
+  - secret: my-ca-1
+  - secret: my-ca-2
+```
+
+> Tip! You can create a secret containing your CA certificates using the following command:
+```bash
+kubectl create secret generic my-ca-1 --from-file my-ca-1.crt
+```
 ## Upgrading
 
 ### 7.0.0

--- a/bitnami/owncloud/templates/_certificates.tpl
+++ b/bitnami/owncloud/templates/_certificates.tpl
@@ -1,0 +1,128 @@
+{{/* Templates for certificates injection */}}
+
+{{/*
+Return the proper image name used for setting up Certificates
+*/}}
+{{- define "certificates.image" -}}
+{{- $registryName := default .Values.certificates.image.registry .Values.image.registry -}}
+{{- $repositoryName := .Values.certificates.image.repository -}}
+{{- $tag := .Values.certificates.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "certificates.initContainer" -}}
+{{- if .Values.certificates.customCAs }}
+- name: certificates
+  image: {{ template "certificates.image" . }}
+  imagePullPolicy: {{ default .Values.image.pullPolicy .Values.certificates.image.pullPolicy }}
+  {{- if .Values.image.pullSecrets}}
+  imagePullSecrets:
+  {{- range (default .Values.image.pullSecrets .Values.certificates.image.pullSecrets) }}
+    - name: {{ . }}
+  {{- end }}
+  {{- end }}
+  command:
+  {{- if .Values.certificates.customCertificate.certificateSecret }}
+  - sh
+  - -c
+  - if command -v apk >/dev/null; then apk add --no-cache ca-certificates openssl && update-ca-certificates;
+    else apt-get update && apt-get install -y ca-certificates openssl; fi
+  {{- else }}
+  - sh
+  - -c
+  - if command -v apk >/dev/null; then apk add --no-cache ca-certificates openssl && update-ca-certificates;
+    else apt-get update && apt-get install -y ca-certificates openssl; fi
+    && openssl req -new -x509 -days 3650 -nodes -sha256
+       -subj "/CN=$(hostname)" -addext "subjectAltName = DNS:$(hostname)"
+       -out  /etc/ssl/certs/ssl-cert-snakeoil.pem
+       -keyout /etc/ssl/private/ssl-cert-snakeoil.key -extensions v3_req
+  {{- end }}
+  {{- if .Values.certificates.extraEnvVars }}
+  env:
+  {{- tpl (toYaml .Values.certificates.extraEnvVars) $ | nindent 2 }}
+  {{- end }}
+  volumeMounts:
+    - name: etc-ssl-certs
+      mountPath: /etc/ssl/certs
+      readOnly: false
+    - name: etc-ssl-private
+      mountPath: /etc/ssl/private
+      readOnly: false
+    - name: custom-ca-certificates
+      mountPath: /usr/local/share/ca-certificates
+      readOnly: true
+{{- end }}
+{{- end }}
+
+{{- define "certificates.volumes" -}}
+{{- if .Values.certificates.customCAs }}
+- name: etc-ssl-certs
+  emptyDir:
+    medium: "Memory"
+- name: etc-ssl-private
+  emptyDir:
+    medium: "Memory"
+- name: custom-ca-certificates
+  projected:
+    defaultMode: 0400
+    sources:
+    {{- range $index, $customCA := .Values.certificates.customCAs }}
+    - secret:
+        name: {{ $customCA.secret }}
+        # items not specified, will mount all keys
+    {{- end }}
+{{- end -}}
+{{- if .Values.certificates.customCertificate.certificateSecret }}
+- name: custom-certificate
+  secret:
+    secretName: {{ .Values.certificates.customCertificate.certificateSecret }}
+{{- if .Values.certificates.customCertificate.chainSecret }}
+- name: custom-certificate-chain
+  secret:
+    secretName: {{ .Values.certificates.customCertificate.chainSecret.name }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "certificates.volumeMount" -}}
+{{- if .Values.certificates.customCAs }}
+- name: etc-ssl-certs
+  mountPath: /etc/ssl/certs/
+  readOnly: false
+- name: etc-ssl-private
+  mountPath: /etc/ssl/private/
+  readOnly: false
+- name: custom-ca-certificates
+  mountPath: /usr/local/share/ca-certificates
+  readOnly: true
+{{- end -}}
+{{- if .Values.certificates.customCertificate.certificateSecret }}
+- name: custom-certificate
+  mountPath: {{ .Values.certificates.customCertificate.certificateLocation }}
+  subPath: tls.crt
+  readOnly: true
+- name: custom-certificate
+  mountPath: {{ .Values.certificates.customCertificate.keyLocation }}
+  subPath: tls.key
+  readOnly: true
+{{- if .Values.certificates.customCertificate.chainSecret }}
+- name: custom-certificate-chain
+  mountPath: {{ .Values.certificates.customCertificate.chainLocation }}
+  subPath: {{ .Values.certificates.customCertificate.chainSecret.key }}
+  readOnly: true
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/bitnami/owncloud/templates/deployment.yaml
+++ b/bitnami/owncloud/templates/deployment.yaml
@@ -38,6 +38,8 @@ spec:
       - ip: "127.0.0.1"
         hostnames:
         - "status.localhost"
+      initContainers:
+      {{- include "certificates.initContainer" . | indent 8 }}
       containers:
       - name: {{ template "owncloud.fullname" . }}
         image: {{ template "owncloud.image" . }}
@@ -112,6 +114,7 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
+        {{- include "certificates.volumeMount" . | indent 8 }}
         - name: owncloud-data
           mountPath: /bitnami/owncloud
 {{- if .Values.metrics.enabled }}
@@ -138,6 +141,7 @@ spec:
   {{ toYaml .Values.metrics.resources | indent 10 }}
 {{- end }}
       volumes:
+      {{- include "certificates.volumes" . | indent 6 }}
       - name: owncloud-data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:

--- a/bitnami/owncloud/values.yaml
+++ b/bitnami/owncloud/values.yaml
@@ -281,8 +281,8 @@ certificates:
     certificateLocation: /etc/ssl/certs/ssl-cert-snakeoil.pem
     keyLocation: /etc/ssl/private/ssl-cert-snakeoil.key
     chainLocation: /etc/ssl/certs/mychain.pem
-  customCAs:
-    - secret: certificates-tls-secret
+  customCA: []
+  # - secret: custom-CA
   # - secret: more-custom-CAs
   image:
     registry: docker.io

--- a/bitnami/owncloud/values.yaml
+++ b/bitnami/owncloud/values.yaml
@@ -270,3 +270,32 @@ metrics:
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
   # resources: {}
+
+# Add custom certificates and certificate authorities to owncloud container
+certificates:
+  customCertificate:
+    certificateSecret: ""
+    chainSecret: {}
+    # name: secret-name
+    # key: secret-key
+    certificateLocation: /etc/ssl/certs/ssl-cert-snakeoil.pem
+    keyLocation: /etc/ssl/private/ssl-cert-snakeoil.key
+    chainLocation: /etc/ssl/certs/mychain.pem
+  customCAs:
+    - secret: certificates-tls-secret
+  # - secret: more-custom-CAs
+  image:
+    registry: docker.io
+    repository: bitnami/minideb
+    tag: buster
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: IfNotPresent
+    # pullPolicy:
+    # pullSecrets
+    #   - myRegistryKeySecretName
+  extraEnvVars: []
+  # - name: myvar
+  #   value: myval


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Add the possibility of importing multiple CAs into the owncloud image by using a secret and sidecar init container.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
* Allows LDAP authentication using LDAPS to servers with an internal certificate.
* Adds a snakeoil certificate to the container that could be used for TLS sessions to the ingress.
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

None
<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #2913

**Additional information**
This PR is based on changes from #2774
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
