### PR TITLE
[bitnami/redis] update rest of health checks for TLS

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 10.7.7
+version: 10.7.8
 appVersion: 6.0.5
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/bitnami/redis/templates/health-configmap.yaml
+++ b/bitnami/redis/templates/health-configmap.yaml
@@ -95,9 +95,11 @@ data:
 {{- if .Values.tls.enabled }}
         -p $REDIS_SENTINEL_TLS_PORT_NUMBER \
         --tls \
-        --cert {{ template "redis.tlsCert" . }} \
-        --key {{ template "redis.tlsCertKey" . }} \
         --cacert {{ template "redis.tlsCACert" . }} \
+        {{- if .Values.tls.authClients }}
+          --cert {{ template "redis.tlsCert" . }} \
+          --key {{ template "redis.tlsCertKey" . }} \
+        {{- end }}
 {{- else }}
         -p $REDIS_SENTINEL_PORT \
 {{- end }}
@@ -142,9 +144,11 @@ data:
         -p $REDIS_MASTER_PORT_NUMBER \
 {{- if .Values.tls.enabled }}
         --tls \
-        --cert {{ template "redis.tlsCert" . }} \
-        --key {{ template "redis.tlsCertKey" . }} \
         --cacert {{ template "redis.tlsCACert" . }} \
+        {{- if .Values.tls.authClients }}
+          --cert {{ template "redis.tlsCert" . }} \
+          --key {{ template "redis.tlsCertKey" . }} \
+        {{- end }}
 {{- end }}
         ping
     )
@@ -171,9 +175,11 @@ data:
         -p $REDIS_MASTER_PORT_NUMBER \
 {{- if .Values.tls.enabled }}
         --tls \
-        --cert {{ template "redis.tlsCert" . }} \
-        --key {{ template "redis.tlsCertKey" . }} \
         --cacert {{ template "redis.tlsCACert" . }} \
+        {{- if .Values.tls.authClients }}
+          --cert {{ template "redis.tlsCert" . }} \
+          --key {{ template "redis.tlsCertKey" . }} \
+        {{- end }}
 {{- end }}
         ping
     )


### PR DESCRIPTION


**Description of the change**
In https://github.com/bitnami/charts/pull/2966, I fixed some of the health checks, but didn't realize it occurred in more places. This PR fixes the rest of the places.

**Applicable issues**

  - fixes #2940


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
