### PR TITLE
[bitnam/redis-cluster]Fixed the extraVolume wrong value key and service lable indent error

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis-cluster
-version: 3.1.3
+version: 3.1.4
 appVersion: 6.0.5
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/bitnami/redis-cluster/templates/metrics-svc.yaml
+++ b/bitnami/redis-cluster/templates/metrics-svc.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}-metrics
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.metrics.service.labels }}
-    {{ include "common.tplvalues.render" ( dict "value" .Values.metrics.service.labels "context" $ ) | indent 4 }}
+    {{ include "common.tplvalues.render" ( dict "value" .Values.metrics.service.labels "context" $ ) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/redis-cluster/templates/redis-statefulset.yaml
+++ b/bitnami/redis-cluster/templates/redis-statefulset.yaml
@@ -339,7 +339,7 @@ spec:
         - name: redis-tmp-conf
           emptyDir: {}
         {{- if .Values.redis.extraVolumes }}
-        {{- include "common.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $ ) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.redis.extraVolumes "context" $ ) | nindent 8 }}
         {{- end }}
         {{- if .Values.tls.enabled }}
         - name: redis-certificates

--- a/bitnami/redis-cluster/templates/redis-statefulset.yaml
+++ b/bitnami/redis-cluster/templates/redis-statefulset.yaml
@@ -308,7 +308,7 @@ spec:
             runAsUser: 0
         {{- end }}
         {{- if .Values.redis.initContainers }}
-        {{- toYaml .Values.redis.initContainers | nindent 10 }}
+        {{- toYaml .Values.redis.initContainers | nindent 8 }}
         {{- end }}
       {{- end }}
       volumes:

--- a/bitnami/redis-cluster/templates/redis-svc.yaml
+++ b/bitnami/redis-cluster/templates/redis-svc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.service.labels -}}
-    {{ include "common.tplvalues.render" ( dict "value" .Values.service.labels "context" $ ) | indent 4 }}
+    {{ include "common.tplvalues.render" ( dict "value" .Values.service.labels "context" $ ) | nindent 4 }}
     {{- end -}}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

* Fix the **ExtraVolume** value in statefulset section  
* Replace the **indent** to **nindent** in redis service label section, 
* Fix the statfulset initcontainer indent section.
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
* The ExtraVolume can be setup properly.
* The service customized the label now can be defined properly.
* The initcontainer in statefulset should work. 
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
No drawbacks
<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #2981

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
