### PR TITLE
[bitnami/etcd] Fixing grep used to create member_id file

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: etcd
-version: 4.8.7
+version: 4.8.8
 appVersion: 3.4.9
 description: etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines
 keywords:

--- a/bitnami/etcd/templates/scripts-configmap.yaml
+++ b/bitnami/etcd/templates/scripts-configmap.yaml
@@ -50,7 +50,7 @@ data:
     ## Store member id for later member replacement
     store_member_id() {
         while ! etcdctl $AUTH_OPTIONS member list; do sleep 1; done
-        etcdctl $AUTH_OPTIONS member list | grep "$HOSTNAME" | awk '{ print $1}' | awk -F "," '{ print $1}' > "$ETCD_DATA_DIR/member_id"
+        etcdctl $AUTH_OPTIONS member list | grep -w "$HOSTNAME" | awk '{ print $1}' | awk -F "," '{ print $1}' > "$ETCD_DATA_DIR/member_id"
         echo "==> Stored member id: $(cat ${ETCD_DATA_DIR}/member_id)" 1>&3 2>&4
         exit 0
     }


### PR DESCRIPTION
**Description of the change**

The flag -w was added to the grep search used to retrieve the current node id and create member_id file.
If you had a namespace named like etcd-100 or something like this, the grep would end up getting all the 3 nodes, and writing all the 3 ids in the member_id file, which would end up creating a bunch of failures later.

**Benefits**

Now it takes the exact match, avoiding the kind of issue described above.

**Possible drawbacks**

None

**Applicable issues**

None

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)