### PR TITLE
[bitnami/rabbitmq] Use less intrusive probes

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 7.4.3
+version: 7.4.4
 appVersion: 3.8.5
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/bitnami/rabbitmq/templates/statefulset.yaml
+++ b/bitnami/rabbitmq/templates/statefulset.yaml
@@ -202,8 +202,7 @@ spec:
               command:
                 - /bin/bash
                 - -ec
-                - |
-                  /opt/bitnami/scripts/rabbitmq/apicheck.sh "http://{{ .Values.auth.username }}:$RABBITMQ_PASSWORD@127.0.0.1:15672/api/healthchecks/node" '{"status":"ok"}'
+                - rabbitmq-diagnostics -q check_running
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -218,8 +217,7 @@ spec:
               command:
                 - /bin/bash
                 - -ec
-                - |
-                  /opt/bitnami/scripts/rabbitmq/healthcheck.sh "http://{{ .Values.auth.username }}:$RABBITMQ_PASSWORD@127.0.0.1:15672/api/healthchecks/node" '{"status":"ok"}'
+                - rabbitmq-diagnostics -q check_running
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

When RabbitMQ is under a heavy load, it can reach its defined limits (for CPU, memory or disk usage). When this happens, RabbitMQ has its own mechanisms to stop accepting requests until it liberates some resources. You can find more information in the links below:

- https://www.rabbitmq.com/memory.html
- https://www.rabbitmq.com/disk-alarms.html

The current probes are very intrusive, they try to authenticate vs RabbitMQ and that's a problem when you're under a stressful situation since the probes will fail restarting the container, provoking issues in the Mnesia tables similar to the ones below:

```
rabbitmq-1 rabbitmq 2020-06-24 21:54:08.746 [warning] <0.268.0> Error while waiting for Mnesia tables: {failed_waiting_for_tables,['rabbit@rabbitmq-1.rabbitmq-headless.mhill.svc.cluster.local','rabbit@rabbitmq-0.rabbitmq-headless.mhill.svc.cluster.local'],{node_not_running,'rabbit@rabbitmq-1.rabbitmq-headless.mhill.svc.cluster.local'}}
```

This PR changes the probes so they use the `rabbitmq-diagnostics -q check_running` health check. More information in the link below:

- https://www.rabbitmq.com/monitoring.html#health-checks

**Benefits**

RabbitMQ can manage situations with heavy load using its own mechanisms.

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/2868

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

