### PR TITLE
[bitnami/postgresql] Helm label best practices

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 8.10.14
+version: 9.0.0
 appVersion: 11.8.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/bitnami/postgresql/requirements.lock
+++ b/bitnami/postgresql/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 0.3.1
+digest: sha256:5e6ff12a223956c2028856a803240b31ef3d7cfa745025d7fe84b8938d6497e1
+generated: "2020-07-10T09:46:24.735519+02:00"

--- a/bitnami/postgresql/requirements.yaml
+++ b/bitnami/postgresql/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+  - name: common
+    version: 0.x.x
+    repository: https://charts.bitnami.com/bitnami

--- a/bitnami/postgresql/templates/configmap.yaml
+++ b/bitnami/postgresql/templates/configmap.yaml
@@ -4,10 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "postgresql.fullname" . }}-configuration
   labels:
-    app: {{ template "postgresql.name" . }}
-    chart: {{ template "postgresql.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "postgresql.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/postgresql/templates/extended-config-configmap.yaml
+++ b/bitnami/postgresql/templates/extended-config-configmap.yaml
@@ -4,10 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "postgresql.fullname" . }}-extended-configuration
   labels:
-    app: {{ template "postgresql.name" . }}
-    chart: {{ template "postgresql.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "postgresql.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/postgresql/templates/initialization-configmap.yaml
+++ b/bitnami/postgresql/templates/initialization-configmap.yaml
@@ -4,10 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "postgresql.fullname" . }}-init-scripts
   labels:
-    app: {{ template "postgresql.name" . }}
-    chart: {{ template "postgresql.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "postgresql.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/postgresql/templates/metrics-configmap.yaml
+++ b/bitnami/postgresql/templates/metrics-configmap.yaml
@@ -4,10 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "postgresql.metricsCM" . }}
   labels:
-    app: {{ template "postgresql.name" . }}
-    chart: {{ template "postgresql.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "postgresql.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/postgresql/templates/metrics-svc.yaml
+++ b/bitnami/postgresql/templates/metrics-svc.yaml
@@ -4,10 +4,7 @@ kind: Service
 metadata:
   name: {{ template "postgresql.fullname" . }}-metrics
   labels:
-    app: {{ template "postgresql.name" . }}
-    chart: {{ template "postgresql.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  {{- include "common.labels.standard" . | nindent 4 }}
   annotations:
   {{- if .Values.commonAnnotations }}
     {{- include "postgresql.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
@@ -23,7 +20,6 @@ spec:
       port: 9187
       targetPort: http-metrics
   selector:
-    app: {{ template "postgresql.name" . }}
-    release: {{ .Release.Name }}
+  {{- include "common.labels.matchLabels" . | nindent 4 }}
     role: master
 {{- end }}

--- a/bitnami/postgresql/templates/networkpolicy.yaml
+++ b/bitnami/postgresql/templates/networkpolicy.yaml
@@ -4,18 +4,14 @@ apiVersion: {{ template "postgresql.networkPolicy.apiVersion" . }}
 metadata:
   name: {{ template "postgresql.fullname" . }}
   labels:
-    app: {{ template "postgresql.name" . }}
-    chart: {{ template "postgresql.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "postgresql.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   podSelector:
     matchLabels:
-      app: {{ template "postgresql.name" . }}
-      release: {{ .Release.Name | quote }}
+    {{- include "common.labels.matchLabels" . | nindent 6 }}
   ingress:
     # Allow inbound connections
     - ports:
@@ -31,8 +27,7 @@ spec:
           {{- end }}
         - podSelector:
             matchLabels:
-              app: {{ template "postgresql.name" . }}
-              release: {{ .Release.Name | quote }}
+            {{- include "common.labels.matchLabels" . | nindent 14 }}
               role: slave
       {{- end }}
     # Allow prometheus scrapes

--- a/bitnami/postgresql/templates/podsecuritypolicy.yaml
+++ b/bitnami/postgresql/templates/podsecuritypolicy.yaml
@@ -4,10 +4,7 @@ kind: PodSecurityPolicy
 metadata:
   name: {{ template "postgresql.fullname" . }}
   labels:
-    app: {{ template "postgresql.name" . }}
-    chart: {{ template "postgresql.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "postgresql.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/postgresql/templates/prometheusrule.yaml
+++ b/bitnami/postgresql/templates/prometheusrule.yaml
@@ -7,10 +7,7 @@ metadata:
   namespace: {{ . }}
 {{- end }}
   labels:
-    app: {{ template "postgresql.name" . }}
-    chart: {{ template "postgresql.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  {{- include "common.labels.standard" . | nindent 4 }}
   {{- with .Values.metrics.prometheusRule.additionalLabels }}
   {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/bitnami/postgresql/templates/role.yaml
+++ b/bitnami/postgresql/templates/role.yaml
@@ -4,10 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "postgresql.fullname" . }}
   labels:
-    app: {{ template "postgresql.name" . }}
-    chart: {{ template "postgresql.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "postgresql.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/postgresql/templates/rolebinding.yaml
+++ b/bitnami/postgresql/templates/rolebinding.yaml
@@ -4,10 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "postgresql.fullname" . }}
   labels:
-    app: {{ template "postgresql.name" . }}
-    chart: {{ template "postgresql.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "postgresql.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/postgresql/templates/secrets.yaml
+++ b/bitnami/postgresql/templates/secrets.yaml
@@ -4,10 +4,7 @@ kind: Secret
 metadata:
   name: {{ template "postgresql.fullname" . }}
   labels:
-    app: {{ template "postgresql.name" . }}
-    chart: {{ template "postgresql.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "postgresql.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/postgresql/templates/serviceaccount.yaml
+++ b/bitnami/postgresql/templates/serviceaccount.yaml
@@ -3,10 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ template "postgresql.name" . }}
-    chart: {{ template "postgresql.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  {{- include "common.labels.standard" . | nindent 4 }}
   name: {{ template "postgresql.fullname" . }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "postgresql.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}

--- a/bitnami/postgresql/templates/servicemonitor.yaml
+++ b/bitnami/postgresql/templates/servicemonitor.yaml
@@ -7,10 +7,7 @@ metadata:
   namespace: {{ .Values.metrics.serviceMonitor.namespace }}
   {{- end }}
   labels:
-    app: {{ template "postgresql.name" . }}
-    chart: {{ template "postgresql.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.metrics.serviceMonitor.additionalLabels }}
     {{- toYaml .Values.metrics.serviceMonitor.additionalLabels | nindent 4 }}
     {{- end }}
@@ -32,6 +29,5 @@ spec:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      app: {{ template "postgresql.name" . }}
-      release: {{ .Release.Name }}
+    {{- include "common.labels.matchLabels" . | nindent 6 }}
 {{- end }}

--- a/bitnami/postgresql/templates/statefulset-slaves.yaml
+++ b/bitnami/postgresql/templates/statefulset-slaves.yaml
@@ -4,10 +4,7 @@ kind: StatefulSet
 metadata:
   name: "{{ template "postgresql.fullname" . }}-slave"
   labels:
-    app: {{ template "postgresql.name" . }}
-    chart: {{ template "postgresql.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  {{- include "common.labels.standard" . | nindent 4 }}
 {{- with .Values.slave.labels }}
 {{ toYaml . | indent 4 }}
 {{- end }}
@@ -23,17 +20,13 @@ spec:
   replicas: {{ .Values.replication.slaveReplicas }}
   selector:
     matchLabels:
-      app: {{ template "postgresql.name" . }}
-      release: {{ .Release.Name | quote }}
+    {{- include "common.labels.matchLabels" . | nindent 6 }}
       role: slave
   template:
     metadata:
       name: {{ template "postgresql.fullname" . }}
       labels:
-        app: {{ template "postgresql.name" . }}
-        chart: {{ template "postgresql.chart" . }}
-        release: {{ .Release.Name | quote }}
-        heritage: {{ .Release.Service | quote }}
+      {{- include "common.labels.standard" . | nindent 8 }}
         role: slave
 {{- with .Values.slave.podLabels }}
 {{ toYaml . | indent 8 }}

--- a/bitnami/postgresql/templates/statefulset.yaml
+++ b/bitnami/postgresql/templates/statefulset.yaml
@@ -3,10 +3,7 @@ kind: StatefulSet
 metadata:
   name: {{ template "postgresql.master.fullname" . }}
   labels:
-    app: {{ template "postgresql.name" . }}
-    chart: {{ template "postgresql.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  {{- include "common.labels.standard" . | nindent 4 }}
   {{- with .Values.master.labels }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -27,17 +24,13 @@ spec:
     {{- end }}
   selector:
     matchLabels:
-      app: {{ template "postgresql.name" . }}
-      release: {{ .Release.Name | quote }}
+    {{- include "common.labels.matchLabels" . | nindent 6 }}
       role: master
   template:
     metadata:
       name: {{ template "postgresql.fullname" . }}
       labels:
-        app: {{ template "postgresql.name" . }}
-        chart: {{ template "postgresql.chart" . }}
-        release: {{ .Release.Name | quote }}
-        heritage: {{ .Release.Service | quote }}
+      {{- include "common.labels.standard" . | nindent 8 }}
         role: master
       {{- with .Values.master.podLabels }}
       {{- toYaml . | nindent 8 }}

--- a/bitnami/postgresql/templates/svc-headless.yaml
+++ b/bitnami/postgresql/templates/svc-headless.yaml
@@ -3,10 +3,7 @@ kind: Service
 metadata:
   name: {{ template "postgresql.fullname" . }}-headless
   labels:
-    app: {{ template "postgresql.name" . }}
-    chart: {{ template "postgresql.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "postgresql.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
@@ -18,5 +15,4 @@ spec:
       port: {{ template "postgresql.port" . }}
       targetPort: tcp-postgresql
   selector:
-    app: {{ template "postgresql.name" . }}
-    release: {{ .Release.Name | quote }}
+  {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/postgresql/templates/svc-read.yaml
+++ b/bitnami/postgresql/templates/svc-read.yaml
@@ -10,10 +10,7 @@ kind: Service
 metadata:
   name: {{ template "postgresql.fullname" . }}-read
   labels:
-    app: {{ template "postgresql.name" . }}
-    chart: {{ template "postgresql.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  {{- include "common.labels.standard" . | nindent 4 }}
   annotations:
   {{- if .Values.commonAnnotations }}
   {{- include "postgresql.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
@@ -40,7 +37,6 @@ spec:
       nodePort: {{ $serviceNodePort }}
       {{- end }}
   selector:
-    app: {{ template "postgresql.name" . }}
-    release: {{ .Release.Name | quote }}
+  {{- include "common.labels.matchLabels" . | nindent 4 }}
     role: slave
 {{- end }}

--- a/bitnami/postgresql/templates/svc.yaml
+++ b/bitnami/postgresql/templates/svc.yaml
@@ -9,10 +9,7 @@ kind: Service
 metadata:
   name: {{ template "postgresql.fullname" . }}
   labels:
-    app: {{ template "postgresql.name" . }}
-    chart: {{ template "postgresql.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+  {{- include "common.labels.standard" . | nindent 4 }}
   annotations:
   {{- if .Values.commonAnnotations }}
   {{- include "postgresql.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
@@ -39,6 +36,5 @@ spec:
       nodePort: {{ $serviceNodePort }}
       {{- end }}
   selector:
-    app: {{ template "postgresql.name" . }}
-    release: {{ .Release.Name | quote }}
+  {{- include "common.labels.matchLabels" . | nindent 4 }}
     role: master


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This PR replaces the labels `app=`, `chart=`, `release=` and `heritage=` with their new counterparts (`app.kubernetes.io/name`, `helm.sh/chart`, `app.kubernetes.io/instance`, `app.kubernetes.io/managed-by`) according to the [Helm label best practices](https://helm.sh/docs/chart_best_practices/labels/).

Please let me know whether this change qualifies as a new major, minor or patch version (as this change may break existing queries based on old labels, see possible drawbacks).

**Benefits**

Please take a look at the related problem mentioned in #2889 

**Possible drawbacks**

Customers who implemented search queries based on existing labels must update those queries after deploying this change.

**Applicable issues**

  - fixes #2889 

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
