### PR TITLE
bitnami/spring-cloud-dataflow: Trim blank lines for better formatting of configmaps

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: spring-cloud-dataflow
-version: 0.2.1
+version: 0.2.2
 appVersion: 2.5.2
 description: Spring Cloud Data Flow is a microservices-based toolkit for building streaming and batch data processing pipelines in Cloud Foundry and Kubernetes.
 keywords:

--- a/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
@@ -17,15 +17,15 @@ data:
                 accounts:
                   {{ .Values.server.configuration.accountName }}:
                     {{- if .Values.deployer.resources.limits }}
-                    limits: {{- toYaml .Values.deployer.resources.limits | nindent 22 }}
+                    limits: {{- toYaml .Values.deployer.resources.limits | trim | nindent 22 }}
                     {{- end }}
                     {{- if .Values.deployer.resources.requests }}
-                    requests: {{- toYaml .Values.deployer.resources.requests | nindent 22 }}
+                    requests: {{- toYaml .Values.deployer.resources.requests | trim | nindent 22 }}
                     {{- end }}
+          {{- end }}
           {{- if .Values.server.configuration.containerRegistries }}
           container:
             registry-configurations: {{- include "common.tplvalues.render" (dict "value" .Values.server.configuration.containerRegistries "context" $) | nindent 14 }}
-          {{- end }}
           {{- end }}
           {{- if .Values.metrics.enabled }}
           {{- $fullname := include "scdf.fullname" . }}

--- a/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
@@ -24,10 +24,10 @@ data:
                     environmentVariables: 'SPRING_CLOUD_STREAM_KAFKA_BINDER_BROKERS=${{ printf "{" }}{{ template "scdf.envrelease" . }}_KAFKA_SERVICE_HOST}:${{ printf "{" }}{{ template "scdf.envrelease" . }}_KAFKA_SERVICE_PORT},SPRING_CLOUD_STREAM_KAFKA_BINDER_ZK_NODES=${{ printf "{" }}{{ template "scdf.envrelease" . }}_ZOOKEEPER_SERVICE_HOST}:${{ printf "{" }}{{ template "scdf.envrelease" . }}_ZOOKEEPER_SERVICE_PORT}'
                     {{- end }}
                     {{- if .Values.deployer.resources.limits }}
-                    limits: {{- toYaml .Values.deployer.resources.limits | nindent 22 }}
+                    limits: {{- toYaml .Values.deployer.resources.limits | trim | nindent 22 }}
                     {{- end }}
                     {{- if .Values.deployer.resources.requests }}
-                    requests: {{- toYaml .Values.deployer.resources.requests | nindent 22 }}
+                    requests: {{- toYaml .Values.deployer.resources.requests | trim | nindent 22 }}
                     {{- end }}
                     readinessProbeDelay: {{ .Values.deployer.readinessProbe.initialDelaySeconds }}
                     livenessProbeDelay: {{ .Values.deployer.livenessProbe.initialDelaySeconds }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

trim `toYaml` output in order to avoid blank lines and improve readability of the generated configmap

**Benefits**

The generated configmap resource will be more readable

**Possible drawbacks**

None

**Applicable issues**

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
