### PR TITLE
[bitnami/mongodb] Fix helpers sintax

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb
-version: 8.0.5
+version: 8.0.6
 appVersion: 4.2.8
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/bitnami/mongodb/templates/_helpers.tpl
+++ b/bitnami/mongodb/templates/_helpers.tpl
@@ -224,7 +224,7 @@ Validate values of MongoDB - number of replicas must be the same than LoadBalanc
 {{- define "mongodb.validateValues.loadBalancerIPsListLength" -}}
 {{- $replicaCount := int .Values.replicaCount }}
 {{- $loadBalancerListLength := len .Values.externalAccess.service.loadBalancerIPs }}
-{{- if and (eq .Values.architecture "replicaset") .Values.externalAccess.enabled (not .Values.externalAccess.autoDiscovery.enabled ) (eq .Values.externalAccess.service.type "LoadBalancer") (not (eq $replicaCount $loadBalancerListLength ))  -}}
+{{- if and (eq .Values.architecture "replicaset") .Values.externalAccess.enabled (not .Values.externalAccess.autoDiscovery.enabled ) (eq .Values.externalAccess.service.type "LoadBalancer") (not (eq $replicaCount $loadBalancerListLength )) -}}
 mongodb: .Values.externalAccess.service.loadBalancerIPs
     Number of replicas and loadBalancerIPs array length must be the same.
 {{- end -}}
@@ -236,7 +236,7 @@ Validate values of MongoDB - number of replicas must be the same than NodePort l
 {{- define "mongodb.validateValues.nodePortListLength" -}}
 {{- $replicaCount := int .Values.replicaCount }}
 {{- $nodePortListLength := len .Values.externalAccess.service.nodePorts }}
-{{- if and (eq .Values.architecture "replicaset") .Values.externalAccess.enabled (eq .Values.externalAccess.service.type "NodePort") (not (eq $replicaCount $nodePortListLength ))  -}}
+{{- if and (eq .Values.architecture "replicaset") .Values.externalAccess.enabled (eq .Values.externalAccess.service.type "NodePort") (not (eq $replicaCount $nodePortListLength )) -}}
 mongodb: .Values.externalAccess.service.nodePorts
     Number of replicas and nodePorts array length must be the same.
 {{- end -}}


### PR DESCRIPTION
**Description of the change**

Adjust helpers sintax, users with helm <3 is with deploy problem in v8.0.x

**Benefits**

Fix problem related on https://github.com/bitnami/charts/issues/3014.

**Possible drawbacks**

None.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #3014

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ X ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ X ] Variables are documented in the README.md
- [ X ] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ X ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files