### PR TITLE
[bitnami/mongodb] Fix MongoDB Advertised hostname

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb
-version: 8.0.7
+version: 8.0.8
 appVersion: 4.2.8
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/bitnami/mongodb/templates/replicaset/scripts-configmap.yaml
+++ b/bitnami/mongodb/templates/replicaset/scripts-configmap.yaml
@@ -54,6 +54,7 @@ data:
   setup.sh: |-
     #!/bin/bash
 
+    {{- if .Values.externalAccess.enabled }}
     {{- if eq .Values.externalAccess.service.type "LoadBalancer" }}
     {{- if .Values.externalAccess.autoDiscovery.enabled }}
     export MONGODB_ADVERTISED_HOSTNAME="$(<${SHARED_FILE})"
@@ -66,6 +67,7 @@ data:
     export MONGODB_ADVERTISED_HOSTNAME={{ .Values.externalAccess.service.domain }}
     {{- else }}
     export MONGODB_ADVERTISED_HOSTNAME=$(curl -s https://ipinfo.io/ip)
+    {{- end }}
     {{- end }}
     {{- end }}
 


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Fix issue with MongoDB Advertised hostname not being properly defined when external access is not enabled. This feature (accessing externally) shouldn't affect the MongoDB Advertised hostname configuration when is not enabled.

**Benefits**

Using hostnames instead of IPs to configure MongoDB nodes in the replicaset

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/3044


**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

