### PR TITLE
[redis/chart] Add "tls-replication" yes to master sentinel

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 10.7.9
+version: 10.7.10
 appVersion: 6.0.5
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/bitnami/redis/templates/redis-master-statefulset.yaml
+++ b/bitnami/redis/templates/redis-master-statefulset.yaml
@@ -252,6 +252,7 @@ spec:
               ARGS+=("--tls-key-file" "${REDIS_SENTINEL_TLS_KEY_FILE}")
               ARGS+=("--tls-ca-cert-file" "${REDIS_SENTINEL_TLS_CA_FILE}")
               ARGS+=("--tls-auth-clients" "${REDIS_SENTINEL_TLS_AUTH_CLIENTS}")
+              ARGS+=("--tls-replication" "yes")
               {{- if .Values.tls.dhParamsFilename }}
               ARGS+=("--tls-dh-params-file" "${REDIS_SENTINEL_TLS_DH_PARAMS_FILE}")
               {{- end }}


### PR DESCRIPTION
**Description of the change**

If we do not set `tls-replication` yes in every sentinel, it will not use tls to speak with the redis servers. Only the master was missing this. This was causing the following errors in the log

```
1:M 07 Jul 2020 08:43:57.517 # Error accepting a client connection: error:1408F10B:SSL routines:ssl3_get_record:wrong version number (conn: fd=9)
1:M 07 Jul 2020 08:43:57.517 # Error accepting a client connection: error:1408F10B:SSL routines:ssl3_get_record:wrong version number (conn: fd=9)
1:M 07 Jul 2020 08:43:58.519 # Error accepting a client connection: error:1408F10B:SSL routines:ssl3_get_record:wrong version number (conn: fd=10)
1:M 07 Jul 2020 08:43:58.519 # Error accepting a client connection: error:1408F10B:SSL routines:ssl3_get_record:wrong version number
1:M 07 Jul 2020 08:43:59.590 # Error accepting a client connection: error:1408F10B:SSL routines:ssl3_get_record:wrong version number
1:M 07 Jul 2020 08:43:59.590 # Error accepting a client connection: error:1408F10B:SSL routines:ssl3_get_record:wrong version number
1:M 07 Jul 2020 08:44:00.624 # Error accepting a client connection: error:1408F10B:SSL routines:ssl3_get_record:wrong version number (conn: fd=10)
1:M 07 Jul 2020 08:44:00.624 # Error accepting a client connection: error:1408F10B:SSL routines:ssl3_get_record:wrong version number
```

This PR fixes that 

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/3045

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
