### PR TITLE
[bitnami/rabbitmq] Add support for multiple LDAP servers

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 7.4.8
+version: 7.5.0
 appVersion: 3.8.5
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/bitnami/rabbitmq/README.md
+++ b/bitnami/rabbitmq/README.md
@@ -108,9 +108,9 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 | `extraConfiguration`                      | Extra configuration to be appended to RabbitMQ configuration                                                         | Check `values.yaml` file                                     |
 | `advancedConfiguration`                   | Extra configuration (in classic format)                                                                              | Check `values.yaml` file                                     |
 | `ldap.enabled`                            | Enable LDAP support                                                                                                  | `false`                                                      |
-| `ldap.server`                             | LDAP server                                                                                                          | `""`                                                         |
-| `ldap.port`                               | LDAP port                                                                                                            | `389`                                                        |
-| `ldap.user_dn_pattern`                    | DN used to bind to LDAP                                                                                              | `cn=${username},dc=example,dc=org`                           |
+| `ldap.servers`                            | List of LDAP servers hostnames                                                                                       | `[]`                                                         |
+| `ldap.port`                               | LDAP servers port                                                                                                    | `389`                                                        |
+| `ldap.user_dn_pattern`                    | Pattern used to translate the provided username into a value to be used for the LDAP bind                            | `cn=${username},dc=example,dc=org`                           |
 | `ldap.tls.enabled`                        | Enable TLS for LDAP connections (check advancedConfiguration parameter in values.yml)                                | `false`                                                      |
 
 ### Statefulset parameters
@@ -432,16 +432,16 @@ extraConfiguration: |
 LDAP support can be enabled in the chart by specifying the `ldap.` parameters while creating a release. The following parameters should be configured to properly enable the LDAP support in the chart.
 
 - `ldap.enabled`: Enable LDAP support. Defaults to `false`.
-- `ldap.server`: LDAP server host. No defaults.
-- `ldap.port`: LDAP server port. `389`.
-- `ldap.user_dn_pattern`: DN used to bind to LDAP. `cn=${username},dc=example,dc=org`.
+- `ldap.servers`: List of LDAP servers hostnames. No defaults.
+- `ldap.port`: LDAP servers port. `389`.
+- `ldap.user_dn_pattern`: Pattern used to translate the provided username into a value to be used for the LDAP bind. Defaults to `cn=${username},dc=example,dc=org`.
 - `ldap.tls.enabled`: Enable TLS for LDAP connections. Defaults to `false`.
 
 For example:
 
 ```console
-ldap.enabled="true"
-ldap.server="my-ldap-server"
+ldap.enabled=true
+ldap.serverss[0]="my-ldap-server"
 ldap.port="389"
 ldap.user_dn_pattern="cn=${username},dc=example,dc=org"
 ```

--- a/bitnami/rabbitmq/templates/_helpers.tpl
+++ b/bitnami/rabbitmq/templates/_helpers.tpl
@@ -173,14 +173,15 @@ Validate values of rabbitmq - LDAP support
 */}}
 {{- define "rabbitmq.validateValues.ldap" -}}
 {{- if .Values.ldap.enabled }}
-{{- if not (and .Values.ldap.server .Values.ldap.port .Values.ldap.user_dn_pattern) }}
+{{- $serversListLength := len .Values.ldap.servers }}
+{{- if or (not (gt $serversListLength 0)) (not (and .Values.ldap.port .Values.ldap.user_dn_pattern)) }}
 rabbitmq: LDAP
-    Invalid LDAP configuration. When enabling LDAP support, the parameters "ldap.server",
+    Invalid LDAP configuration. When enabling LDAP support, the parameters "ldap.servers",
     "ldap.port", and "ldap. user_dn_pattern" are mandatory. Please provide them:
 
     $ helm install {{ .Release.Name }} bitnami/rabbitmq \
       --set ldap.enabled=true \
-      --set ldap.server="lmy-ldap-server" \
+      --set ldap.servers[0]="lmy-ldap-server" \
       --set ldap.port="389" \
       --set user_dn_pattern="cn=${username},dc=example,dc=org"
 {{- end -}}

--- a/bitnami/rabbitmq/templates/statefulset.yaml
+++ b/bitnami/rabbitmq/templates/statefulset.yaml
@@ -122,14 +122,14 @@ spec:
             - name: RABBITMQ_NODE_NAME
               value: "rabbit@$(MY_POD_NAME)"
             {{- end }}
-            {{- if .Values.ldap.enabled }}
             - name: RABBITMQ_LDAP_ENABLE
-              value: "yes"
+              value: {{ ternary "yes" "no" .Values.ldap.enabled | quote }}
+            {{- if .Values.ldap.enabled }}
             - name: RABBITMQ_LDAP_TLS
               value: {{ ternary "yes" "no" .Values.ldap.tls.enabled | quote }}
-            - name: RABBITMQ_LDAP_SERVER
-              value: {{ .Values.ldap.server }}
-            - name: RABBITMQ_LDAP_SERVER_PORT
+            - name: RABBITMQ_LDAP_SERVERS
+              value: {{ .Values.ldap.servers | join "," | quote }}
+            - name: RABBITMQ_LDAP_SERVERS_PORT
               value: {{ .Values.ldap.port | quote }}
             - name: RABBITMQ_LDAP_USER_DN_PATTERN
               value: {{ .Values.ldap.user_dn_pattern }}

--- a/bitnami/rabbitmq/values-production.yaml
+++ b/bitnami/rabbitmq/values-production.yaml
@@ -209,8 +209,9 @@ configuration: |-
   {{- if .Values.ldap.enabled }}
   auth_backends.1 = rabbit_auth_backend_ldap
   auth_backends.2 = internal
-  auth_ldap.servers.1  = {{ .Values.ldap.server }}
-  auth_ldap.port = {{ .Values.ldap.port }}
+  {{- range $index, $server := .Values.ldap.servers }}
+  auth_ldap.servers.{{ add $index 1 }} = {{ $server }}
+  {{- end }}  auth_ldap.port = {{ .Values.ldap.port }}
   auth_ldap.user_dn_pattern = {{ .Values.ldap.user_dn_pattern  }}
   {{- if .Values.ldap.tls.enabled }}
   auth_ldap.use_ssl = true
@@ -257,11 +258,19 @@ advancedConfiguration: |-
 ##
 ldap:
   enabled: false
-  server: ""
+  ## List of LDAP servers hostnames
+  ##
+  servers: []
+  ## LDAP servers port
+  ##
   port: "389"
+  ## Pattern used to translate the provided username into a value to be used for the LDAP bind
+  ## ref: https://www.rabbitmq.com/ldap.html#usernames-and-dns
+  ##
   user_dn_pattern: cn=${username},dc=example,dc=org
   tls:
-    # If you enabled TLS/SSL you can set advaced options using the advancedConfiguration parameter.
+    ## If you enabled TLS/SSL you can set advaced options using the advancedConfiguration parameter.
+    ##
     enabled: false
 
 ## extraVolumes and extraVolumeMounts allows you to mount other volumes

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -209,7 +209,9 @@ configuration: |-
   {{- if .Values.ldap.enabled }}
   auth_backends.1 = rabbit_auth_backend_ldap
   auth_backends.2 = internal
-  auth_ldap.servers.1  = {{ .Values.ldap.server }}
+  {{- range $index, $server := .Values.ldap.servers }}
+  auth_ldap.servers.{{ add $index 1 }} = {{ $server }}
+  {{- end }}
   auth_ldap.port = {{ .Values.ldap.port }}
   auth_ldap.user_dn_pattern = {{ .Values.ldap.user_dn_pattern  }}
   {{- if .Values.ldap.tls.enabled }}
@@ -257,11 +259,19 @@ advancedConfiguration: |-
 ##
 ldap:
   enabled: false
-  server: ""
+  ## List of LDAP servers hostnames
+  ##
+  servers: []
+  ## LDAP servers port
+  ##
   port: "389"
+  ## Pattern used to translate the provided username into a value to be used for the LDAP bind
+  ## ref: https://www.rabbitmq.com/ldap.html#usernames-and-dns
+  ##
   user_dn_pattern: cn=${username},dc=example,dc=org
   tls:
-    # If you enabled TLS/SSL you can set advaced options using the advancedConfiguration parameter.
+    ## If you enabled TLS/SSL you can set advaced options using the advancedConfiguration parameter.
+    ##
     enabled: false
 
 ## extraVolumes and extraVolumeMounts allows you to mount other volumes


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR add support for multiple LDAP servers by allowing to set an array of server hostnames/IPs instead of a single LDAP server.

**Benefits**

Users can use N LDAP servers to provide authentication on RabbitMQ.

**Possible drawbacks**

None

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files