### PR TITLE
[bitnami/mongodb] Fix MongoDB service port names

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb
-version: 8.0.9
+version: 8.0.10
 appVersion: 4.2.8
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/bitnami/mongodb/templates/arbiter/headless-svc.yaml
+++ b/bitnami/mongodb/templates/arbiter/headless-svc.yaml
@@ -13,7 +13,7 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: tcp-mongodb
+    - name: mongodb
       port: {{ .Values.service.port }}
       targetPort: mongodb
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/mongodb/templates/replicaset/external-access-svc.yaml
+++ b/bitnami/mongodb/templates/replicaset/external-access-svc.yaml
@@ -28,7 +28,7 @@ spec:
   {{- end }}
   publishNotReadyAddresses: true
   ports:
-    - name: tcp-mongodb
+    - name: mongodb
       port: {{ $root.Values.externalAccess.service.port }}
       {{- if not (empty $root.Values.externalAccess.service.nodePorts) }}
       nodePort: {{ index $root.Values.externalAccess.service.nodePorts $i }}

--- a/bitnami/mongodb/templates/replicaset/headless-svc.yaml
+++ b/bitnami/mongodb/templates/replicaset/headless-svc.yaml
@@ -14,7 +14,7 @@ spec:
   clusterIP: None
   publishNotReadyAddresses: true
   ports:
-    - name: tcp-mongodb
+    - name: mongodb
       port: {{ .Values.service.port }}
       targetPort: mongodb
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/mongodb/templates/standalone/svc.yaml
+++ b/bitnami/mongodb/templates/standalone/svc.yaml
@@ -24,7 +24,7 @@ spec:
   loadBalancerSourceRanges: {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
   ports:
-    - name: tcp-mongodb
+    - name: mongodb
       port: {{ .Values.service.port }}
       targetPort: mongodb
       {{- if and (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) .Values.service.nodePort }}


### PR DESCRIPTION
Signed-off-by: Christian Bandowski <christian@myvm.de>

**Description of the change**

Changed the port names within the services from `tcp-mongodb` to `mongodb`.

**Benefits**

Connecting via MongoDB SRV connection string will work using the headless service. Right now it doesn't work because the name of the port will be used as a prefix for the required DNS query and mongo is using `mongodb` and not `tcp-mongodb` as the prefix for the port name. More information available in #3067.

**Possible drawbacks**

If someone already referencing the `tcp-mongodb` port by name he could get into troubles.

**Applicable issues**

  - fixes #3067

**Additional information**


**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
