### PR TITLE
Print offending value in validateValues

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql-ha
-version: 3.4.0
+version: 3.4.1
 appVersion: 11.8.0
 description: Chart for PostgreSQL with HA architecture (using Replication Manager (repmgr) and Pgpool).
 keywords:

--- a/bitnami/postgresql-ha/templates/_helpers.tpl
+++ b/bitnami/postgresql-ha/templates/_helpers.tpl
@@ -752,7 +752,7 @@ Compile all warnings into a single message, and call fail.
 {{- $nodeHostname := printf "%s-00.%s.%s.svc.%s:1234" $postgresqlFullname $postgresqlHeadlessServiceName $releaseNamespace $clusterDomain }}
 {{- if gt (len $nodeHostname) 128 -}}
 postgresql-ha: Nodes hostnames
-    PostgreSQL nodes hostnames exceeds the characters limit for Pgpool: 128.
+    PostgreSQL nodes hostnames ({{ $nodeHostname }}) exceeds the characters limit for Pgpool: 128.
     Consider using a shorter release name or namespace.
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Hi,

I'm debugging why I'm hitting this issue and is really difficult because
it's a remote CI, and this chart is a dependency of my dependency,
and ... I don't want to waste your time.

My point is - if there is an invalid value that doesn't contain secrets, please print it.
Helm is such a terrible combination of templates and yamls files, with absolutely no
resistance for mistakes like typos, that in a larger setups is really difficult to track
the root cause of problems, and a printout like this at very least confirms if the
value is what we think it should be.