### PR TITLE
[bitnami/rabbitmq] Corrected example of extraContainerPorts

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 7.5.2
+version: 7.5.3
 appVersion: 3.8.5
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/bitnami/rabbitmq/values-production.yaml
+++ b/bitnami/rabbitmq/values-production.yaml
@@ -174,8 +174,8 @@ extraEnvVars: []
 ## Extra ports to be included in container spec, primarily informational
 ## E.g:
 ## extraContainerPorts:
-## - name: new_port_ma,e
-##   port: 1234
+## - name: new_port_name
+##   containerPort: 1234
 ##
 extraContainerPorts: []
 

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -174,8 +174,8 @@ extraEnvVars: []
 ## Extra ports to be included in container spec, primarily informational
 ## E.g:
 ## extraContainerPorts:
-## - name: new_port_ma,e
-##   port: 1234
+## - name: new_port_name
+##   containerPort: 1234
 ##
 extraContainerPorts: []
 


### PR DESCRIPTION
**Description of the change**
The example given in #2023 and merged in #2027 specified the property `ports` which is not valid when rendered in the StatefulSet. Instead `containerPorts` should be used.

This is not a functional change but updates the example comment in values.yml.

**Benefits**
It will help users of this value avoid errors on deployment.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files