### PR TITLE
[bitnami/grafana] Support arbitrary extra volumes

### DIFF
--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 3.0.2
+version: 3.1.0
 appVersion: 7.0.6
 description: Grafana is an open source, feature rich metrics dashboard and graph editor for Graphite, Elasticsearch, OpenTSDB, Prometheus and InfluxDB.
 keywords:

--- a/bitnami/grafana/README.md
+++ b/bitnami/grafana/README.md
@@ -122,6 +122,8 @@ The following tables lists the configurable parameters of the grafana chart and 
 | `resources.limits`             | The resources limits for Grafana containers              | `{}`                           |
 | `resources.requests`           | The requested resources for Grafana containers           | `{}`                           |
 | `sidecars`                     | Attach additional sidecar containers to the Grafana pod  | `{}`                           |
+| `extraVolumes`                 | Additional volumes for the Grafana pod                   | `[]`                           |
+| `extraVolumeMounts`            | Additional volume mounts for the Grafana container       | `[]`                           |
 
 ### Persistence parameters
 

--- a/bitnami/grafana/templates/deployment.yaml
+++ b/bitnami/grafana/templates/deployment.yaml
@@ -114,6 +114,9 @@ spec:
               subPath: {{ .subPath | default "" }}
               readOnly: {{ .readOnly }}
             {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
           ports:
             - name: dashboard
               containerPort: 3000
@@ -200,4 +203,7 @@ spec:
         - name: {{ .name }}
           configMap:
             name: {{ .name }}
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
         {{- end }}

--- a/bitnami/grafana/values-production.yaml
+++ b/bitnami/grafana/values-production.yaml
@@ -268,6 +268,20 @@ persistence:
 ##
 sidecars: {}
 
+## Add extra volumes to the Grafana pod
+## Example:
+## extraVolumes:
+##   - name: my-volume
+##     emptyDir: {}
+extraVolumes: []
+
+## Add extra volume mounts to the grafana pod
+## Example:
+## extraVolumeMounts:
+##   - name: my-volume
+##     mountPath: /opt/bitnami/grafana/my-stuff
+extraVolumeMounts: []
+
 ## Service parameters
 ##
 service:

--- a/bitnami/grafana/values.yaml
+++ b/bitnami/grafana/values.yaml
@@ -268,6 +268,20 @@ persistence:
 ##
 sidecars: {}
 
+## Add extra volumes to the Grafana pod
+## Example:
+## extraVolumes:
+##   - name: my-volume
+##     emptyDir: {}
+extraVolumes: []
+
+## Add extra volume mounts to the grafana pod
+## Example:
+## extraVolumeMounts:
+##   - name: my-volume
+##     mountPath: /opt/bitnami/grafana/my-stuff
+extraVolumeMounts: []
+
 ## Service parameters
 ##
 service:


### PR DESCRIPTION
**Description of the change**

This adds handling for two new values:

- `extraVolumes`: An array of volume objects that will be injected into the Grafana pod.
- `extraVolumeMounts`: An array of volume mounts that will be injected into the Grafana container.

This is intended to support data sharing with sidecars, for example a sidecar container could be used to continuously refresh dashboards from an external source of truth.

**Benefits**

It would be possible to get more utility from the already available `sidecars` value, by allowing sidecars that can inject configuration into Grafana by writing to shared volumes.

**Possible drawbacks**

There may be a more 'integrated' approach to enabling external sources of truth for dashboards than this generic approach. However, it aligns well with the existing `sidecars` value, and many other charts have these properties, so it's not out-of-place.

**Applicable issues**

- Possibly a workaround for #2797.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files