### PR TITLE
[bitnami/thanos] guard servername verification for tls client auth

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
-version: 1.3.1
+version: 1.3.2

--- a/bitnami/thanos/templates/querier/deployment.yaml
+++ b/bitnami/thanos/templates/querier/deployment.yaml
@@ -83,7 +83,9 @@ spec:
             - --grpc-client-tls-cert=/tls/client/cert.pem
             - --grpc-client-tls-key=/tls/client/key.pem
             - --grpc-client-tls-ca=/tls/client/ca.pem
+            {{- if .Values.querier.grpcTLS.client.servername }}
             - --grpc-client-server-name={{.Values.querier.grpcTLS.client.servername}}
+            {{- end }}
             {{- end }}
             {{- range $key, $value := .Values.querier.extraFlags }}
             - --{{ $key }}{{ if $value }}={{ $value }}{{ end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Small change to guard servername verification for TLS client auth for Thanos Querier as sometimes it's not possible to require proper grpc TLS servername from peer, for example in case of multiple peers with unique dns names. 

**Benefits**

It allows to disable servername verification for TLS client auth.

**Possible drawbacks**

n/a

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
n/a

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
