### PR TITLE
bitnami/metallb: add pre-upgrade to helm hooks for memberlist

### DIFF
--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: metallb
 description: The Metal LB for Kubernetes
-version: 0.1.17
+version: 0.2.0
 appVersion: 0.9.3
 keywords:
   - "load-balancer"

--- a/bitnami/metallb/templates/secret.yaml
+++ b/bitnami/metallb/templates/secret.yaml
@@ -8,6 +8,6 @@ metadata:
   labels: {{- include "metallb.labels" . | nindent 4 }}
     app.kubernetes.io/component: speaker
   annotations:
-    "helm.sh/hook": "pre-install"
+    "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
 {{- end }}


### PR DESCRIPTION
**Description of the change**
Add pre-upgrade hook to memberlist

**Benefits**
If I add metallb chart as a dependency to another chart with an existing release, when I run `helm upgrade`  memberlist secret will be installed, as opposed to not being installed at all.

**Possible drawbacks**

**Applicable issues**
memberlist secret is not installed at all on upgrade
- https://github.com/helm/helm/issues/8401

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
