### PR TITLE
[bitnami/mysql] Add debug to slave statefulset

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mysql
-version: 6.14.4
+version: 6.14.5
 appVersion: 8.0.20
 description: Chart to create a Highly available MySQL cluster
 keywords:

--- a/bitnami/mysql/templates/slave-statefulset.yaml
+++ b/bitnami/mysql/templates/slave-statefulset.yaml
@@ -67,6 +67,8 @@ spec:
           image: {{ template "mysql.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           env:
+            - name: BITNAMI_DEBUG
+              value: {{ ternary "true" "false" .Values.image.debug | quote }}
             - name: MYSQL_REPLICATION_MODE
               value: "slave"
             - name: MYSQL_MASTER_HOST


### PR DESCRIPTION
Signed-off-by: Andrés Bono <andresbono@vmware.com>

**Description of the change**

Add debug capabilities to slave statefulset. We support it for master pods already.

**Applicable issues**

 - #3091

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files