### PR TITLE
[bitnami/drupal] Fix typo in deployment env vars

### DIFF
--- a/bitnami/drupal/Chart.yaml
+++ b/bitnami/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 8.0.0
+version: 8.0.1
 appVersion: 9.0.2
 description: One of the most versatile open source content management systems.
 keywords:

--- a/bitnami/drupal/templates/deployment.yaml
+++ b/bitnami/drupal/templates/deployment.yaml
@@ -72,7 +72,7 @@ spec:
             - name: BITNAMI_DEBUG
               value: {{ ternary "true" "false" .Values.image.debug | quote }}
             - name: ALLOW_EMPTY_PASSWORD
-              value: {{ ternary "yes" "no" .Values. allowEmptyPassword | quote }}
+              value: {{ .Values.allowEmptyPassword | quote }}
             - name: MARIADB_HOST
             {{- if .Values.mariadb.enabled }}
               value: {{ template "drupal.mariadb.fullname" . }}


### PR DESCRIPTION
Signed-off-by: Andrés Bono <andresbono@vmware.com>

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files