### PR TITLE
[bitnami/mongodb] Allow custom port names

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb
-version: 8.0.9
+version: 8.1.0
 appVersion: 4.2.8
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -182,6 +182,7 @@ The following tables lists the configurable parameters of the MongoDB chart and 
 |---------------------------------------------------|----------------------------------------------------------------------------------------------------|---------------------------------------------------------|
 | `service.type`                                    | Kubernetes Service type                                                                            | `ClusterIP`                                             |
 | `service.port`                                    | MongoDB service port                                                                               | `27017`                                                 |
+| `service.portName`                                | MongoDB service port name                                                                          | `mongodb`                                               |
 | `service.nodePort`                                | Port to bind to for NodePort and LoadBalancer service types                                        | `""`                                                    |
 | `service.clusterIP`                               | MongoDB service cluster IP                                                                         | `nil`                                                   |
 | `service.loadBalancerIP`                          | loadBalancerIP for MongoDB Service                                                                 | `nil`                                                   |

--- a/bitnami/mongodb/templates/replicaset/external-access-svc.yaml
+++ b/bitnami/mongodb/templates/replicaset/external-access-svc.yaml
@@ -23,12 +23,12 @@ spec:
   loadBalancerIP: {{ index $root.Values.externalAccess.service.loadBalancerIPs $i }}
   {{- end }}
   {{- if $root.Values.externalAccess.service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges: {{- toYaml $root.Values.service.loadBalancerSourceRanges | nindent 4 }}
+  loadBalancerSourceRanges: {{- toYaml $root.Values.externalAccess.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
   {{- end }}
   publishNotReadyAddresses: true
   ports:
-    - name: tcp-mongodb
+    - name: {{ .Values.service.portName }}
       port: {{ $root.Values.externalAccess.service.port }}
       {{- if not (empty $root.Values.externalAccess.service.nodePorts) }}
       nodePort: {{ index $root.Values.externalAccess.service.nodePorts $i }}

--- a/bitnami/mongodb/templates/replicaset/headless-svc.yaml
+++ b/bitnami/mongodb/templates/replicaset/headless-svc.yaml
@@ -14,7 +14,7 @@ spec:
   clusterIP: None
   publishNotReadyAddresses: true
   ports:
-    - name: tcp-mongodb
+    - name: {{ .Values.service.portName }}
       port: {{ .Values.service.port }}
       targetPort: mongodb
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/mongodb/templates/standalone/svc.yaml
+++ b/bitnami/mongodb/templates/standalone/svc.yaml
@@ -24,7 +24,7 @@ spec:
   loadBalancerSourceRanges: {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
   ports:
-    - name: tcp-mongodb
+    - name: {{ .Values.service.portName }}
       port: {{ .Values.service.port }}
       targetPort: mongodb
       {{- if and (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) .Values.service.nodePort }}

--- a/bitnami/mongodb/values-production.yaml
+++ b/bitnami/mongodb/values-production.yaml
@@ -414,6 +414,9 @@ service:
   ## MongoDB service port
   ##
   port: 27017
+  ## MongoDB service port name
+  ##
+  portName: mongodb
   ## Specify the nodePort value for the LoadBalancer and NodePort service types.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
   ##

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -414,6 +414,9 @@ service:
   ## MongoDB service port
   ##
   port: 27017
+  ## MongoDB service port name
+  ##
+  portName: mongodb
   ## Specify the nodePort value for the LoadBalancer and NodePort service types.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
   ##


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR allows user to specify the port name to use. This way, they can adapt it to their needs (e.g. Istio requirements).

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/3067

**Additional information**

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
