### PR TITLE
[bitnami/etcd] Fix snapshotter job when there's only one replica

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: etcd
-version: 4.8.10
+version: 4.8.11
 appVersion: 3.4.9
 description: etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines
 keywords:

--- a/bitnami/etcd/templates/scripts-configmap.yaml
+++ b/bitnami/etcd/templates/scripts-configmap.yaml
@@ -11,6 +11,10 @@
 {{- $etcdClientProtocol := include "etcd.clientProtocol" . }}
 {{- $initSnapshotFilename := .Values.startFromSnapshot.snapshotFilename }}
 {{- $snapshotHistoryLimit := .Values.disasterRecovery.cronjob.snapshotHistoryLimit }}
+{{- $endpoints := list }}
+{{- range $e, $i := until $replicaCount }}
+{{- $endpoints = append $endpoints (printf "%s-%d.%s.%s.svc.%s:%d" $etcdFullname $i $etcdHeadlessServiceName $releaseNamespace $clusterDomain $peerPort) }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -38,10 +42,8 @@ data:
 
     # Constants
     HOSTNAME="$(hostname -s)"
-    AUTH_OPTIONS="{{ $etcdAuthOptions }}"
-    ETCDCTL_ENDPOINTS="{{range $i, $e := until $replicaCount }}{{ $etcdClientProtocol }}://{{ $etcdFullname }}-{{ $e }}.{{ $etcdHeadlessServiceName }}.{{ $releaseNamespace }}.svc.{{ $clusterDomain }}:{{ $clientPort }},{{ end }}"
-    # Remove the last comma "," introduced in the string
-    export ETCDCTL_ENDPOINTS="$(sed 's/,/ /g' <<< $ETCDCTL_ENDPOINTS | awk '{$1=$1};1' | sed 's/ /,/g')"
+    AUTH_OPTIONS={{ $etcdAuthOptions | quote }}
+    export ETCDCTL_ENDPOINTS={{ join "," $endpoints | quote }}
     export ROOT_PASSWORD="${ETCD_ROOT_PASSWORD:-}"
     if [[ -n "${ETCD_ROOT_PASSWORD:-}" ]]; then
       unset ETCD_ROOT_PASSWORD
@@ -204,10 +206,8 @@ data:
     fi
 
     # Constants
-    AUTH_OPTIONS="{{ $etcdAuthOptions }}"
-    ETCDCTL_ENDPOINTS="{{range $i, $e := until $replicaCount }}{{ $etcdClientProtocol }}://{{ $etcdFullname }}-{{ $e }}.{{ $etcdHeadlessServiceName }}.{{ $releaseNamespace }}.svc.{{ $clusterDomain }}:{{ $clientPort }},{{ end }}"
-    # Remove the last comma "," introduced in the string
-    export ETCDCTL_ENDPOINTS="$(sed 's/,/ /g' <<< $ETCDCTL_ENDPOINTS | awk '{$1=$1};1' | sed 's/ /,/g')"
+    AUTH_OPTIONS={{ $etcdAuthOptions | quote }}
+    export ETCDCTL_ENDPOINTS={{ join "," $endpoints | quote }}
 
     etcdctl $AUTH_OPTIONS member remove --debug=true "$(cat "$ETCD_DATA_DIR/member_id")" > "$(dirname "$ETCD_DATA_DIR")/member_removal.log" 2>&1
   probes.sh: |-
@@ -230,7 +230,7 @@ data:
     fi
 
     # Constants
-    AUTH_OPTIONS="{{ $etcdAuthOptions }}"
+    AUTH_OPTIONS={{ $etcdAuthOptions | quote }}
 
     echo "==> [DEBUG] Probing etcd cluster"
     echo "==> [DEBUG] Probe command: \"etcdctl $AUTH_OPTIONS endpoint health\""
@@ -247,7 +247,7 @@ data:
     exec 3>&1
     exec 4>&2
 
-    if [ "${BITNAMI_SNAPSHOT_DEBUG}" = true -o "${BITNAMI_DEBUG}" = true ]; then
+    if [[ "${BITNAMI_SNAPSHOT_DEBUG}" = true ]] | [[ "${BITNAMI_DEBUG}" = true ]]; then
       echo "==> Bash debug is on"
       set -x
     else
@@ -257,30 +257,28 @@ data:
     fi
 
     # Constants
-    AUTH_OPTIONS="{{ $etcdAuthOptions }}"
-    ETCDCTL_ENDPOINTS="{{range $i, $e := until $replicaCount }}{{ $etcdClientProtocol }}://{{ $etcdFullname }}-{{ $e }}.{{ $etcdHeadlessServiceName }}.{{ $releaseNamespace }}.svc.{{ $clusterDomain }}:{{ $clientPort }},{{ end }}"
-    # Remove the last comma "," introduced in the string
-    export ETCDCTL_ENDPOINTS="${ETCDCTL_ENDPOINTS%%,}"
+    AUTH_OPTIONS={{ $etcdAuthOptions | quote }}
+    export ETCDCTL_ENDPOINTS={{ join "," $endpoints | quote }}
 
     mkdir -p "/snapshots" 1>&3 2>&4
 
-    # walk over each node in the list, check if node healthy make snapshot and exit, otherwise try another node
-    while read -d, ETCDCTL_ENDPOINTS; do
-        echo "Using endpoint ${ETCDCTL_ENDPOINTS}" 1>&3 2>&4
-        if etcdctl $AUTH_OPTIONS endpoint health; then
+    read -r -a endpoints <<< "$(tr ',;' ' ' <<< "$ETCDCTL_ENDPOINTS")"
+    for endp in "${endpoints[@]}"; do
+        echo "Using endpoint $endp" 1>&3 2>&4
+        if etcdctl $AUTH_OPTIONS endpoint health --endpoints=${endp}; then
             echo "Snapshotting the keyspace..." 1>&3 2>&4
             current_time="$(date -u "+%Y-%m-%d_%H-%M")"
-            etcdctl $AUTH_OPTIONS snapshot save "/snapshots/db-${current_time}" 1>&3 2>&4
+            etcdctl $AUTH_OPTIONS snapshot save "/snapshots/db-${current_time}" --endpoints=${endp} 1>&3 2>&4
             find /snapshots/ -maxdepth 1 -type f -name 'db-*' \! -name "db-${current_time}" \
-                    | sort -r \
-                    | tail -n+$((1 + {{ $snapshotHistoryLimit }})) \
-                    | xargs rm -f 1>&3 2>&4
+                | sort -r \
+                | tail -n+$((1 + {{ $snapshotHistoryLimit }})) \
+                | xargs rm -f 1>&3 2>&4
             exit 0
         else
             echo "Warning - etcd endpoint ${ETCDCTL_ENDPOINTS} not healthy" 1>&3 2>&4
             echo "Trying another endpoint." 1>&3 2>&4
         fi
-    done <<< "$ETCDCTL_ENDPOINTS"
+    done
 
     # exit with error if all endpoints are bad
     echo "Error - all etcd endpoints are unhealthy!" 1>&3 2>&4

--- a/bitnami/etcd/templates/scripts-configmap.yaml
+++ b/bitnami/etcd/templates/scripts-configmap.yaml
@@ -247,7 +247,7 @@ data:
     exec 3>&1
     exec 4>&2
 
-    if [[ "${BITNAMI_SNAPSHOT_DEBUG}" = true ]] | [[ "${BITNAMI_DEBUG}" = true ]]; then
+    if [[ "${BITNAMI_SNAPSHOT_DEBUG}" = true ]] || [[ "${BITNAMI_DEBUG}" = true ]]; then
       echo "==> Bash debug is on"
       set -x
     else

--- a/bitnami/etcd/templates/statefulset.yaml
+++ b/bitnami/etcd/templates/statefulset.yaml
@@ -130,8 +130,12 @@ spec:
               value: "etcd-cluster-k8s"
             - name: ETCD_INITIAL_CLUSTER_STATE
               value: {{ .Values.etcd.initialClusterState }}
+            {{- $initialCluster := list }}
+            {{- range $e, $i := until $replicaCount }}
+            {{- $initialCluster = append $initialCluster (printf "%s-%d=%s://%s-%d.%s.%s.svc.%s:%d" $etcdFullname $i $etcdPeerProtocol $etcdFullname $i $etcdHeadlessServiceName $releaseNamespace $clusterDomain $peerPort) }}
+            {{- end }}
             - name: ETCD_INITIAL_CLUSTER
-              value: {{range $i, $e := until $replicaCount }}{{ $etcdFullname }}-{{ $e }}={{ $etcdPeerProtocol }}://{{ $etcdFullname }}-{{ $e }}.{{ $etcdHeadlessServiceName }}.{{ $releaseNamespace }}.svc.{{ $clusterDomain }}:{{ $peerPort }},{{ end }}
+              value: {{ join "," $initialCluster | quote }}
             {{- end }}
             - name: ALLOW_NONE_AUTHENTICATION
               value: {{ ternary "yes" "no" (or .Values.auth.rbac.enabled .Values.allowNoneAuthentication) | quote }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR fixes an issue with the snapshotter job being unable to create snapshots when there's only one replica

**Benefits**

You can periodically create snapshots when deploying the chart with one replica

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/3112

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)