### PR TITLE
[bitnami/prometheus-operator] Adjust thanos-sidecar for prom-op no longer using mount subpaths

### DIFF
--- a/bitnami/prometheus-operator/Chart.yaml
+++ b/bitnami/prometheus-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.40.0
 description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 name: prometheus-operator
-version: 0.23.0
+version: 0.24.0
 keywords:
   - prometheus
   - alertmanager

--- a/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -212,6 +212,9 @@ spec:
       volumeMounts:
         - mountPath: /prometheus
           name: prometheus-{{ template "prometheus-operator.prometheus.fullname" . }}-db
+          {{- if not (.Values.prometheus.storageSpec.disableMountSubPath | default true) }}
+          subPath: prometheus-db
+          {{- end }}
     {{- end }}
     {{- if .Values.prometheus.containers }}
     {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.containers "context" $) | nindent 4 }}

--- a/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -212,7 +212,6 @@ spec:
       volumeMounts:
         - mountPath: /prometheus
           name: prometheus-{{ template "prometheus-operator.prometheus.fullname" . }}-db
-          subPath: prometheus-db
     {{- end }}
     {{- if .Values.prometheus.containers }}
     {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.containers "context" $) | nindent 4 }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Seems like `storage.disableMountSubPath`'s default value was recently changed to `true`. This is a breaking change, in that it will break setups for users who have manually changed it to `false`. On the other hand, the current state leaves the Thanos sidecar silently unable to upload blocks.

This adapts the sidecar to use the root of the `prometheus-db` volume, just like the prom-op-managed containers.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

This should make the Thanos sidecar able to ship metrics again in its default configuration.

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

This will have the opposite effect for people who have manually re-disabled `disableMountSubPath` via their values.yaml.

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
