### PR TITLE
[bitnami/discourse] fix external database passwords when empty

### DIFF
--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: discourse
 description: A Helm chart for deploying Discourse to Kubernetes
-version: 0.1.4
+version: 0.1.5
 appVersion: 2.5.0
 engine: gotpl
 home: https://www.discourse.org/

--- a/bitnami/discourse/README.md
+++ b/bitnami/discourse/README.md
@@ -193,8 +193,8 @@ The following table lists the configurable parameters of the Discourse chart and
 | `externalDatabase.host`                   | Host of the external database                                                         | `""`                                                         |
 | `externalDatabase.port`                   | Database port number                                                                  | `5432`                                                       |
 | `externalDatabase.user`                   | Existing username in the external db                                                  | `bn_discourse`                                               |
-| `externalDatabase.password`               | Password for the above username                                                       | `nil`                                                        |
-| `externalDatabase.postgresqlPostgresPassword`| Password for the root "postgres" user (used in the installation stage)             | `nil`                                                        |
+| `externalDatabase.password`               | Password for the above username                                                       | `""`                                                         |
+| `externalDatabase.postgresqlPostgresPassword`| Password for the root "postgres" user (used in the installation stage)             | `""`                                                         |
 | `externalDatabase.database`               | Name of the existing database                                                         | `bitnami_application`                                        |
 
 ### Redis parameters

--- a/bitnami/discourse/values-production.yaml
+++ b/bitnami/discourse/values-production.yaml
@@ -49,12 +49,12 @@ discourse:
   ## Discourse host to create application URLs. The port will be automatilly included.
   ## ref: https://github.com/bitnami/bitnami-docker-discourse#configuration
   ##
-  host: ""
+  host: ''
 
   ## Discourse site name
   ## ref: https://github.com/bitnami/bitnami-docker-discourse#environment-variables
   ##
-  siteName: "My Site!"
+  siteName: 'My Site!'
 
   ## User of the application
   ## ref: https://github.com/bitnami/bitnami-docker-discourse#environment-variables
@@ -163,7 +163,6 @@ discourse:
   skipInstall: false
 
 sidekiq:
-
   containerSecurityContext: {}
   ## capabilities:
   ##   drop:
@@ -175,11 +174,11 @@ sidekiq:
 
   ## Custom command to override image cmd
   ##
-  command: ["/app-entrypoint.sh"]
+  command: ['/app-entrypoint.sh']
 
   ## Custom args for the custom commad:
   ##
-  args: ["nami", "start", "--foreground", "discourse-sidekiq"]
+  args: ['nami', 'start', '--foreground', 'discourse-sidekiq']
 
   ## Sidekiq resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -352,7 +351,7 @@ service:
   ##   http: <to set explicitly, choose port between 30000-32767>
   ##
   nodePorts:
-    http: ""
+    http: ''
 
 ## Ingress paramaters
 ##
@@ -464,7 +463,7 @@ postgresql:
   ## PostgreSQL admin password (used when `postgresqlUsername` is not `postgres`)
   ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#creating-a-database-user-on-first-run (see note!)
   ##
-  postgresqlPostgresPassword: "bitnami"
+  postgresqlPostgresPassword: 'bitnami'
 
   ## Create a database
   ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#creating-a-database-on-first-run
@@ -482,7 +481,7 @@ postgresql:
 externalDatabase:
   ## Database host
   ##
-  host: ""
+  host: ''
   ## Database port
   ##
   port: 5432
@@ -491,10 +490,10 @@ externalDatabase:
   user: bn_discourse
   ## Database password
   ##
-  password:
+  password: ''
   ## Root "postgres" password (used in the installation stage)
   ##
-  postgresqlPostgresPassword:
+  postgresqlPostgresPassword: ''
   ## Database name
   ##
   database: bitnami_application
@@ -534,10 +533,10 @@ redis:
 externalRedis:
   ## Redis host
   ##
-  host: ""
+  host: ''
   ## Redis port
   ##
   port: 6379
   ## Redis password for authentication
   ##
-  password: ""
+  password: ''

--- a/bitnami/discourse/values.yaml
+++ b/bitnami/discourse/values.yaml
@@ -49,12 +49,12 @@ discourse:
   ## Discourse host to create application URLs. The port will be automatilly included.
   ## ref: https://github.com/bitnami/bitnami-docker-discourse#configuration
   ##
-  host: ""
+  host: ''
 
   ## Discourse site name
   ## ref: https://github.com/bitnami/bitnami-docker-discourse#environment-variables
   ##
-  siteName: "My Site!"
+  siteName: 'My Site!'
 
   ## User of the application
   ## ref: https://github.com/bitnami/bitnami-docker-discourse#environment-variables
@@ -163,7 +163,6 @@ discourse:
   skipInstall: false
 
 sidekiq:
-
   containerSecurityContext: {}
   ## capabilities:
   ##   drop:
@@ -175,11 +174,11 @@ sidekiq:
 
   ## Custom command to override image cmd
   ##
-  command: ["/app-entrypoint.sh"]
+  command: ['/app-entrypoint.sh']
 
   ## Custom args for the custom commad:
   ##
-  args: ["nami", "start", "--foreground", "discourse-sidekiq"]
+  args: ['nami', 'start', '--foreground', 'discourse-sidekiq']
 
   ## Sidekiq resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -347,7 +346,7 @@ service:
   ##   http: <to set explicitly, choose port between 30000-32767>
   ##
   nodePorts:
-    http: ""
+    http: ''
 
 ## Ingress paramaters
 ##
@@ -459,7 +458,7 @@ postgresql:
   ## PostgreSQL admin password (used when `postgresqlUsername` is not `postgres`)
   ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#creating-a-database-user-on-first-run (see note!)
   ##
-  postgresqlPostgresPassword: "bitnami"
+  postgresqlPostgresPassword: 'bitnami'
 
   ## Create a database
   ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#creating-a-database-on-first-run
@@ -477,7 +476,7 @@ postgresql:
 externalDatabase:
   ## Database host
   ##
-  host: ""
+  host: ''
   ## Database port
   ##
   port: 5432
@@ -486,10 +485,10 @@ externalDatabase:
   user: bn_discourse
   ## Database password
   ##
-  password:
+  password: ''
   ## Root "postgres" password (used in the installation stage)
   ##
-  postgresqlPostgresPassword:
+  postgresqlPostgresPassword: ''
   ## Database name
   ##
   database: bitnami_application
@@ -529,10 +528,10 @@ redis:
 externalRedis:
   ## Redis host
   ##
-  host: ""
+  host: ''
   ## Redis port
   ##
   port: 6379
   ## Redis password for authentication
   ##
-  password: ""
+  password: ''


### PR DESCRIPTION
**Description of the change**

Use `""` as default in password values in order to keep it empty by default

**Benefits**

We can use empty passwords for external databases

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
