### PR TITLE
[bitnami/etcd] Fix issue on snapshooting cronjob

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: etcd
-version: 4.8.12
+version: 4.8.13
 appVersion: 3.4.9
 description: etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines
 keywords:

--- a/bitnami/etcd/README.md
+++ b/bitnami/etcd/README.md
@@ -274,7 +274,7 @@ auth.client.existingSecret=etcd-client-certs
 You can enable auto disaster recovery by periodically snapshotting the keyspace. If the cluster permanently loses more than (N-1)/2 members, it tries to recover the cluster from a previous snapshot. You can enable it using the following parameters:
 
 ```console
-persistence.enable=true
+persistence.enabled=true
 disasterRecovery.enabled=true
 disasterRecovery.pvc.size=2Gi
 disasterRecovery.pvc.storageClassName=nfs
@@ -320,7 +320,7 @@ You can use the command below to upgrade your chart by starting a new cluster us
 ```console
 $ helm install new-release bitnami/etcd \
   --set statefulset.replicaCount=3 \
-  --set persistence.enable=true \
+  --set persistence.enabled=true \
   --set persistence.size=8Gi \
   --set startFromSnapshot.enabled=true \
   --set startFromSnapshot.existingClaim=my-claim \

--- a/bitnami/etcd/templates/scripts-configmap.yaml
+++ b/bitnami/etcd/templates/scripts-configmap.yaml
@@ -265,10 +265,10 @@ data:
     read -r -a endpoints <<< "$(tr ',;' ' ' <<< "$ETCDCTL_ENDPOINTS")"
     for endp in "${endpoints[@]}"; do
         echo "Using endpoint $endp" 1>&3 2>&4
-        if etcdctl $AUTH_OPTIONS endpoint health --endpoints=${endp}; then
+        if (unset -v ETCDCTL_ENDPOINTS; etcdctl $AUTH_OPTIONS endpoint health --endpoints=${endp}); then
             echo "Snapshotting the keyspace..." 1>&3 2>&4
             current_time="$(date -u "+%Y-%m-%d_%H-%M")"
-            etcdctl $AUTH_OPTIONS snapshot save "/snapshots/db-${current_time}" --endpoints=${endp} 1>&3 2>&4
+            unset -v ETCDCTL_ENDPOINTS; etcdctl $AUTH_OPTIONS snapshot save "/snapshots/db-${current_time}" --endpoints=${endp} 1>&3 2>&4
             find /snapshots/ -maxdepth 1 -type f -name 'db-*' \! -name "db-${current_time}" \
                 | sort -r \
                 | tail -n+$((1 + {{ $snapshotHistoryLimit }})) \


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Fix issue introduced by me in latest PR: https://github.com/bitnami/charts/pull/3119

You cannot set the `--endpoints` and the environment variable `ETCDCTL_ENDPOINTS` at the same point since the `etcdctl` complains.

We were already using the same workaround (unsetting the env. var) in the `setup.sh` script.

**Possible drawbacks**

None

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)