### PR TITLE
[bitnami/mongodb] Fix MongoDB metrics when auth is disabled

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb
-version: 8.1.1
+version: 8.1.2
 appVersion: 4.2.8
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -291,7 +291,7 @@ spec:
               {{- if .Values.auth.enabled }}
               /bin/mongodb_exporter --mongodb.uri mongodb://root:$(echo $MONGODB_ROOT_PASSWORD | sed -r "s/@/%40/g;s/:/%3A/g")@localhost:27017/admin {{ .Values.metrics.extraFlags }}
               {{- else }}
-              /bin/mongodb_exporter --mongodb.uri mongodb://root@localhost:27017/admin {{ .Values.metrics.extraFlags }}
+              /bin/mongodb_exporter --mongodb.uri mongodb://localhost:27017/admin {{ .Values.metrics.extraFlags }}
               {{- end }}
           env:
           {{- if .Values.auth.enabled }}

--- a/bitnami/mongodb/templates/standalone/dep-sts.yaml
+++ b/bitnami/mongodb/templates/standalone/dep-sts.yaml
@@ -218,10 +218,10 @@ spec:
         - name: metrics
           image: {{ template "mongodb.metrics.image" . }}
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
-          {{- if .Values.securityContext.enabled }}
+          {{- if .Values.containerSecurityContext.enabled }}
           securityContext:
             runAsNonRoot: true
-            runAsUser: {{ .Values.securityContext.runAsUser }}
+            runAsUser: {{ .Values.containerSecurityContext.runAsUser }}
           {{- end }}
           command:
             - /bin/bash
@@ -231,7 +231,7 @@ spec:
               {{- if .Values.auth.enabled }}
               /bin/mongodb_exporter --mongodb.uri mongodb://root:$(echo $MONGODB_ROOT_PASSWORD | sed -r "s/@/%40/g;s/:/%3A/g")@localhost:27017/admin {{ .Values.metrics.extraFlags }}
               {{- else }}
-              /bin/mongodb_exporter --mongodb.uri mongodb://root@localhost:27017/admin {{ .Values.metrics.extraFlags }}
+              /bin/mongodb_exporter --mongodb.uri mongodb://localhost:27017/admin {{ .Values.metrics.extraFlags }}
               {{- end }}
           env:
           {{- if .Values.auth.enabled }}


### PR DESCRIPTION
Signed-off-by: Andrés Bono <andresbono@vmware.com>

**Description of the change**

- Fix MongoDB metrics when auth is disabled
- Adapt `securityContext` values to new `containerSecurityContext`

**Applicable issues**

  - fixes #2977

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files