### PR TITLE
[bitnami/discourse] fix(discourse): wrong indentation

### DIFF
--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: discourse
 description: A Helm chart for deploying Discourse to Kubernetes
-version: 0.1.5
+version: 0.1.6
 appVersion: 2.5.0
 engine: gotpl
 home: https://www.discourse.org/

--- a/bitnami/discourse/templates/deployment.yaml
+++ b/bitnami/discourse/templates/deployment.yaml
@@ -75,7 +75,7 @@ spec:
                   key: redis-password
             {{- end }}
             {{- if .Values.discourse.extraEnvVars }}
-            {{- include "discourse.tplValue" (dict "value" .Values.discourse.extraEnvVars "context" $) | indent 12 }}
+            {{- include "discourse.tplValue" (dict "value" .Values.discourse.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           envFrom:
             - configMapRef:
@@ -161,7 +161,7 @@ spec:
                   key: redis-password
             {{- end }}
             {{- if .Values.sidekiq.extraEnvVars }}
-            {{- include "discourse.tplValue" (dict "value" .Values.sidekiq.extraEnvVars "context" $) | indent 12 }}
+            {{- include "discourse.tplValue" (dict "value" .Values.sidekiq.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           envFrom:
             - configMapRef:


### PR DESCRIPTION
**Description of the change**

Change `indent` to `nindent` in order to print the right indentation

**Benefits**

we can use `extraEnvVars` feature

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files