### PR TITLE
[bitnami/rabbitmq] Fix issue with mnesia dir when forcing boot

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 7.5.4
+version: 7.5.5
 appVersion: 3.8.5
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/bitnami/rabbitmq/templates/statefulset.yaml
+++ b/bitnami/rabbitmq/templates/statefulset.yaml
@@ -112,7 +112,7 @@ spec:
             - name: K8S_ADDRESS_TYPE
               value: {{ .Values.clustering.addressType }}
             - name: RABBITMQ_FORCE_BOOT
-              value: {{ ternary "true" "false" .Values.clustering.forceBoot | quote }}
+              value: {{ ternary "yes" "no" .Values.clustering.forceBoot | quote }}
             {{- if (eq "hostname" .Values.clustering.addressType) }}
             - name: RABBITMQ_NODE_NAME
               value: "rabbit@$(MY_POD_NAME).$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.{{ .Values.clusterDomain }}"
@@ -122,6 +122,8 @@ spec:
             - name: RABBITMQ_NODE_NAME
               value: "rabbit@$(MY_POD_NAME)"
             {{- end }}
+            - name: RABBITMQ_MNESIA_DIR
+              value: "/bitnami/rabbitmq/mnesia/$(RABBITMQ_NODE_NAME)"
             - name: RABBITMQ_LDAP_ENABLE
               value: {{ ternary "yes" "no" .Values.ldap.enabled | quote }}
             {{- if .Values.ldap.enabled }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR ensures the **RABBITMQ_MNESIA_DIR** env. variable is properly set, so `rabbitmqctl force_boot` doesn't exit with error "mnesia_dir_not_found". It also ensure the **RABBITMQ_FORCE_BOOT** is set to "yes/no" instead of "true/false" as required by the container.
 
**Benefits**

Mnesia directory is properly set in env. vars.

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/3096

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
