### PR TITLE
[bitnami/influxdb] Fix podManagementPolicy value name

### DIFF
--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -15,6 +15,6 @@ maintainers:
 name: influxdb
 sources:
   - https://github.com/bitnami/bitnami-docker-influxdb
-version: 0.6.0
+version: 0.6.1
 annotations:
   category: Database

--- a/bitnami/influxdb/templates/influxdb/statefulset-high-availability.yaml
+++ b/bitnami/influxdb/templates/influxdb/statefulset-high-availability.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: influxdb
 spec:
   serviceName: {{ include "influxdb.fullname" . }}-headless
-  podManagementPolicy: {{ .Values.influxdb.podManangementPolicy }}
+  podManagementPolicy: {{ .Values.influxdb.podManagementPolicy }}
   replicas: {{ .Values.influxdb.replicaCount }}
   updateStrategy:
     type: {{ .Values.influxdb.updateStrategy }}

--- a/bitnami/influxdb/values-production.yaml
+++ b/bitnami/influxdb/values-production.yaml
@@ -145,7 +145,7 @@ influxdb:
   ##
   updateStrategy: RollingUpdate
 
-  ## Pod Management Policy can be OrderedReady ot Parallel
+  ## Pod Management Policy can be OrderedReady or Parallel
   ## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#parallel-pod-management
   ##
   podManagementPolicy: OrderedReady

--- a/bitnami/influxdb/values.yaml
+++ b/bitnami/influxdb/values.yaml
@@ -146,7 +146,7 @@ influxdb:
   ##
   updateStrategy: RollingUpdate
 
-  ## Pod Management Policy can be OrderedReady ot Parallel
+  ## Pod Management Policy can be OrderedReady or Parallel
   ## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#parallel-pod-management
   ##
   podManagementPolicy: OrderedReady


### PR DESCRIPTION
After some deeper tests, I figured out that my previous PR contained a typo in value name that prevent is proper usage. All my apologize.

**Description of the change**

Fix typo in code (also in docs).

**Benefits**

Now it actually works.

**Possible drawbacks**

None added.

**Applicable issues**

None.



**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
