### PR TITLE
[bitnami/influxdb] Remove duplicated volume declaration when using existingClaim

### DIFF
--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -15,6 +15,6 @@ maintainers:
 name: influxdb
 sources:
   - https://github.com/bitnami/bitnami-docker-influxdb
-version: 0.6.1
+version: 0.6.2
 annotations:
   category: Database

--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -15,6 +15,6 @@ maintainers:
 name: influxdb
 sources:
   - https://github.com/bitnami/bitnami-docker-influxdb
-version: 0.6.0
+version: 0.6.1
 annotations:
   category: Database

--- a/bitnami/influxdb/templates/influxdb/statefulset-high-availability.yaml
+++ b/bitnami/influxdb/templates/influxdb/statefulset-high-availability.yaml
@@ -274,11 +274,6 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.existingClaim }}
-  {{- end }}
-  {{- if and .Values.persistence.enabled .Values.persistence.existingClaim }}
-        - name: data
-          persistentVolumeClaim:
-            claimName: {{ .Values.persistence.existingClaim }}
   {{- else if not .Values.persistence.enabled }}
         - name: data
           emptyDir: {}


### PR DESCRIPTION
**Description of the change**

StatefulSet for `high-availability` scenario currently fail to load an existing PVC if provided through `existingClaim`. Indeed, it seems that a condition control is duplicated in the file ([L273-277](https://github.com/bitnami/charts/compare/master...Cicatrice:influxdb/remove-duplicated-volume?expand=1#diff-0115111cf8953cfc7f877813c8a3dedbL273-L277), then [L278-281](https://github.com/bitnami/charts/compare/master...Cicatrice:influxdb/remove-duplicated-volume?expand=1#diff-0115111cf8953cfc7f877813c8a3dedbL278-L281)). This lead the `data` volume to be declared twice and the pod is failing to start.

**Benefits**

Using `existingClaim` is working now and pod is starting.

**Possible drawbacks**

None identified so far

**Applicable issues**

None (except behaviour described before)

Error message in StatefulSet without this PR: 
`create Pod test-influx-influxdb-0 in StatefulSet test-influx-influxdb failed error: Pod "test-influx-influxdb-0" is invalid: spec.volumes[2].name: Duplicate value: "data"`


**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.