### PR TITLE
[bitnami/spark] Allow release namespace to be overridden through global parameter

### DIFF
--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 2.0.0
+version: 2.1.0
 appVersion: 3.0.0
 description: Spark is a fast and general-purpose cluster computing system.
 name: spark

--- a/bitnami/spark/README.md
+++ b/bitnami/spark/README.md
@@ -43,7 +43,13 @@ $ helm delete my-release
 
 The command removes all the Kubernetes components associated with the chart and deletes the release. Use the option `--purge` to delete all persistent volumes too.
 
-## Parameters
+## Global parameters
+
+| Parameter                                 | Description                                                                                                | Default                                                      |
+|-------------------------------------------|------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `global.namespaceOverride`                | Global string to override the release namespace                                                            | `nil`                                                        |
+
+## Common Parameters
 
 The following tables lists the configurable parameters of the spark chart and their default values.
 

--- a/bitnami/spark/README.md
+++ b/bitnami/spark/README.md
@@ -43,13 +43,7 @@ $ helm delete my-release
 
 The command removes all the Kubernetes components associated with the chart and deletes the release. Use the option `--purge` to delete all persistent volumes too.
 
-## Global parameters
-
-| Parameter                                 | Description                                                                                                | Default                                                      |
-|-------------------------------------------|------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `global.namespaceOverride`                | Global string to override the release namespace                                                            | `nil`                                                        |
-
-## Common Parameters
+## Parameters
 
 The following tables lists the configurable parameters of the spark chart and their default values.
 
@@ -57,6 +51,7 @@ The following tables lists the configurable parameters of the spark chart and th
 |---------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
 | `global.imageRegistry`                      | Global Docker image registry                                                                                                               | `nil`                                                   |
 | `global.imagePullSecrets`                   | Global Docker registry secret names as an array                                                                                            | `[]` (does not add image pull secrets to deployed pods) |
+| `global.namespaceOverride`                | Global string to override the release namespace                                                            | `nil`                                                        |
 | `image.registry`                            | spark image registry                                                                                                                       | `docker.io`                                             |
 | `image.repository`                          | spark Image name                                                                                                                           | `bitnami/spark`                                         |
 | `image.tag`                                 | spark Image tag                                                                                                                            | `{TAG_NAME}`                                            |

--- a/bitnami/spark/templates/_helpers.tpl
+++ b/bitnami/spark/templates/_helpers.tpl
@@ -172,3 +172,18 @@ Usage:
         {{- tpl (.value | toYaml) .context }}
     {{- end }}
 {{- end -}}
+
+{{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts.
+*/}}
+{{- define "spark.namespace" -}}
+    {{- if .Values.global -}}
+        {{- if .Values.global.namespaceOverride }}
+            {{- .Values.global.namespaceOverride -}}
+        {{- else -}}
+            {{- .Release.Namespace -}}
+        {{- end -}}
+    {{- else -}}
+        {{- .Release.Namespace -}}
+    {{- end }}
+{{- end -}}

--- a/bitnami/spark/templates/headless-svc.yaml
+++ b/bitnami/spark/templates/headless-svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "spark.fullname" . }}-headless
+  namespace: {{ include "spark.namespace" . }}
   labels: {{- include "spark.labels" . | nindent 4 }}
 spec:
   type: ClusterIP

--- a/bitnami/spark/templates/hpa-worker.yaml
+++ b/bitnami/spark/templates/hpa-worker.yaml
@@ -5,6 +5,7 @@ metadata:
   labels: {{- include "spark.labels" . | nindent 4 }}
     app.kubernetes.io/component: worker-autoscaler
   name: {{ include "spark.fullname" . }}-autoscaler
+  namespace: {{ include "spark.namespace" . }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/bitnami/spark/templates/ingress.yaml
+++ b/bitnami/spark/templates/ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "spark.fullname" . }}-ingress
+  namespace: {{ include "spark.namespace" . }}
   labels: {{- include "spark.labels" . | nindent 4 }}
     app.kubernetes.io/component: ingress
   annotations:

--- a/bitnami/spark/templates/secret.yaml
+++ b/bitnami/spark/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "spark.fullname" . }}-secret
+  namespace: {{ include "spark.namespace" . }}
   labels: {{- include "spark.labels" . | nindent 4 }}
 type: Opaque
 data:

--- a/bitnami/spark/templates/statefulset-master.yaml
+++ b/bitnami/spark/templates/statefulset-master.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "spark.fullname" . }}-master
+  namespace: {{ include "spark.namespace" . }}
   labels: {{- include "spark.labels" . | nindent 4 }}
     app.kubernetes.io/component: master
 spec:

--- a/bitnami/spark/templates/statefulset-worker.yaml
+++ b/bitnami/spark/templates/statefulset-worker.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "spark.fullname" . }}-worker
+  namespace: {{ include "spark.namespace" . }}
   labels: {{- include "spark.labels" . | nindent 4 }}
     app.kubernetes.io/component: worker
 spec:

--- a/bitnami/spark/templates/svc-master.yaml
+++ b/bitnami/spark/templates/svc-master.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "spark.master.service.name" . }}
+  namespace: {{ include "spark.namespace" . }}
   labels: {{- include "spark.labels" . | nindent 4 }}
   {{- if .Values.service.annotations }}
   annotations: {{- include "spark.tplValue" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}

--- a/bitnami/spark/values-production.yaml
+++ b/bitnami/spark/values-production.yaml
@@ -6,6 +6,8 @@
 #   imageRegistry: myRegistryName
 #   imagePullSecrets:
 #     - myRegistryKeySecretName
+## Override the namespace for resource deployed by the chart, but can itself be overridden by the local namespaceOverride
+#   namespaceOverride: my-global-namespace
 
 ## Bitnami Spark image version
 ## ref: https://hub.docker.com/r/bitnami/spark/tags/

--- a/bitnami/spark/values.yaml
+++ b/bitnami/spark/values.yaml
@@ -6,6 +6,8 @@
 #   imageRegistry: myRegistryName
 #   imagePullSecrets:
 #     - myRegistryKeySecretName
+## Override the namespace for resource deployed by the chart, but can itself be overridden by the local namespaceOverride
+#   namespaceOverride: my-global-namespace
 
 ## Bitnami Spark image version
 ## ref: https://hub.docker.com/r/bitnami/spark/tags/


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Allow users of the chart to override the release namespace through global parameters

**Benefits**

Users will be able to override the release namespace of the chart by passing a global parameter.
In case this chart is used as a sub-chart in an umbrella chart - the parent chart would be able to override the namespace parameter for this chart without affecting other sub-charts directly.

**Possible drawbacks**

None. The --namespace directive would still take precedence if specified.

**Applicable issues**

NA

**Additional information**

NA

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
