### PR TITLE
[bitnami/thanos] Additional labels for Prometheus ServiceMonitor

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -15,6 +15,6 @@ maintainers:
 name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
-version: 1.3.5
+version: 1.4.0
 annotations:
   category: Analytics

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -15,6 +15,6 @@ maintainers:
 name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
-version: 1.3.4
+version: 1.3.5
 annotations:
   category: Analytics

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -370,6 +370,7 @@ The following tables lists the configurable parameters of the Thanos chart and t
 | `metrics.enabled`                                    | Enable the export of Prometheus metrics                                                                | `false`                                                 |
 | `metrics.serviceMonitor.enabled`                     | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`) | `false`                                                 |
 | `metrics.serviceMonitor.namespace`                   | Namespace in which Prometheus is running                                                               | `nil`                                                   |
+| `metrics.serviceMonitor.labels`                      | Additional labels for ServiceMonitor                                                                   | `{}`                                                    |
 | `metrics.serviceMonitor.interval`                    | Interval at which metrics should be scraped.                                                           | `nil` (Prometheus Operator default value)               |
 | `metrics.serviceMonitor.scrapeTimeout`               | Timeout after which the scrape is ended                                                                | `nil` (Prometheus Operator default value)               |
 

--- a/bitnami/thanos/ci/values-with-ingress-and-metrics.yaml
+++ b/bitnami/thanos/ci/values-with-ingress-and-metrics.yaml
@@ -9,4 +9,6 @@ metrics:
   serviceMonitor:
     ## Enable only if you previously installed the Prometheus Operator 
     ## in your cluster
-    enabled: false
+    enabled: true
+    labels:
+      release: prometheus-operator

--- a/bitnami/thanos/templates/bucketweb/servicemonitor.yaml
+++ b/bitnami/thanos/templates/bucketweb/servicemonitor.yaml
@@ -8,6 +8,9 @@ metadata:
   {{- end }}
   labels: {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: bucketweb
+{{- if .Values.metrics.serviceMonitor.labels }}
+{{ toYaml .Values.metrics.serviceMonitor.labels | indent 4}}
+{{- end }}
 spec:
   selector:
     matchLabels: {{- include "thanos.matchLabels" . | nindent 6 }}

--- a/bitnami/thanos/templates/bucketweb/servicemonitor.yaml
+++ b/bitnami/thanos/templates/bucketweb/servicemonitor.yaml
@@ -9,7 +9,7 @@ metadata:
   labels: {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: bucketweb
 {{- if .Values.metrics.serviceMonitor.labels }}
-{{ toYaml .Values.metrics.serviceMonitor.labels | indent 4}}
+{{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
 {{- end }}
 spec:
   selector:

--- a/bitnami/thanos/templates/compactor/servicemonitor.yaml
+++ b/bitnami/thanos/templates/compactor/servicemonitor.yaml
@@ -9,7 +9,7 @@ metadata:
   labels: {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: compactor
 {{- if .Values.metrics.serviceMonitor.labels }}
-{{ toYaml .Values.metrics.serviceMonitor.labels | indent 4}}
+{{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
 {{- end }}
 spec:
   selector:

--- a/bitnami/thanos/templates/compactor/servicemonitor.yaml
+++ b/bitnami/thanos/templates/compactor/servicemonitor.yaml
@@ -8,6 +8,9 @@ metadata:
   {{- end }}
   labels: {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: compactor
+{{- if .Values.metrics.serviceMonitor.labels }}
+{{ toYaml .Values.metrics.serviceMonitor.labels | indent 4}}
+{{- end }}
 spec:
   selector:
     matchLabels: {{- include "thanos.matchLabels" . | nindent 6 }}

--- a/bitnami/thanos/templates/querier/servicemonitor.yaml
+++ b/bitnami/thanos/templates/querier/servicemonitor.yaml
@@ -9,7 +9,7 @@ metadata:
   labels: {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: querier
 {{- if .Values.metrics.serviceMonitor.labels }}
-{{ toYaml .Values.metrics.serviceMonitor.labels | indent 4}}
+{{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
 {{- end }}
 spec:
   selector:

--- a/bitnami/thanos/templates/querier/servicemonitor.yaml
+++ b/bitnami/thanos/templates/querier/servicemonitor.yaml
@@ -8,6 +8,9 @@ metadata:
   {{- end }}
   labels: {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: querier
+{{- if .Values.metrics.serviceMonitor.labels }}
+{{ toYaml .Values.metrics.serviceMonitor.labels | indent 4}}
+{{- end }}
 spec:
   selector:
     matchLabels: {{- include "thanos.matchLabels" . | nindent 6 }}

--- a/bitnami/thanos/templates/ruler/servicemonitor.yaml
+++ b/bitnami/thanos/templates/ruler/servicemonitor.yaml
@@ -8,6 +8,9 @@ metadata:
   {{- end }}
   labels: {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: ruler
+{{- if .Values.metrics.serviceMonitor.labels }}
+{{ toYaml .Values.metrics.serviceMonitor.labels | indent 4}}
+{{- end }}
 spec:
   selector:
     matchLabels: {{- include "thanos.matchLabels" . | nindent 6 }}

--- a/bitnami/thanos/templates/ruler/servicemonitor.yaml
+++ b/bitnami/thanos/templates/ruler/servicemonitor.yaml
@@ -9,7 +9,7 @@ metadata:
   labels: {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: ruler
 {{- if .Values.metrics.serviceMonitor.labels }}
-{{ toYaml .Values.metrics.serviceMonitor.labels | indent 4}}
+{{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
 {{- end }}
 spec:
   selector:

--- a/bitnami/thanos/templates/storegateway/servicemonitor.yaml
+++ b/bitnami/thanos/templates/storegateway/servicemonitor.yaml
@@ -9,7 +9,7 @@ metadata:
   labels: {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: storegateway
 {{- if .Values.metrics.serviceMonitor.labels }}
-{{ toYaml .Values.metrics.serviceMonitor.labels | indent 4}}
+{{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
 {{- end }}
 spec:
   selector:

--- a/bitnami/thanos/templates/storegateway/servicemonitor.yaml
+++ b/bitnami/thanos/templates/storegateway/servicemonitor.yaml
@@ -8,6 +8,9 @@ metadata:
   {{- end }}
   labels: {{- include "thanos.labels" . | nindent 4 }}
     app.kubernetes.io/component: storegateway
+{{- if .Values.metrics.serviceMonitor.labels }}
+{{ toYaml .Values.metrics.serviceMonitor.labels | indent 4}}
+{{- end }}
 spec:
   selector:
     matchLabels: {{- include "thanos.matchLabels" . | nindent 6 }}

--- a/bitnami/thanos/values-production.yaml
+++ b/bitnami/thanos/values-production.yaml
@@ -1122,6 +1122,9 @@ metrics:
     ## Namespace in which Prometheus is running
     ##
     # namespace: monitoring
+    ## Labels to add to the ServiceMonitor object
+    ##
+    # labels:
     ## Interval at which metrics should be scraped.
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
     ##

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -1124,6 +1124,9 @@ metrics:
     ## Namespace in which Prometheus is running
     ##
     # namespace: monitoring
+    ## Labels to add to the ServiceMonitor object
+    ##
+    # labels:
     ## Interval at which metrics should be scraped.
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
     ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Possibility to add own custom labels to ServiceMonitor objects in order to enable service discovery for already deployed Prometheus Operators.

**Benefits**

Service Discovery enabled for custom Prometheus Operator

**Possible drawbacks**

No drawbacks known

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
