### PR TITLE
[bitnami/spring-cloud-dataflow] Add parameters to configure dataflow deployer properties and possibility to use existing password secrets

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: spring-cloud-dataflow
-version: 0.2.10
+version: 0.3.0
 appVersion: 2.5.3
 description: Spring Cloud Data Flow is a microservices-based toolkit for building streaming and batch data processing pipelines in Cloud Foundry and Kubernetes.
 keywords:

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: spring-cloud-dataflow
-version: 0.2.9
+version: 0.2.10
 appVersion: 2.5.3
 description: Spring Cloud Data Flow is a microservices-based toolkit for building streaming and batch data processing pipelines in Cloud Foundry and Kubernetes.
 keywords:

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -65,6 +65,8 @@ The following tables lists the configurable parameters of the Spring Cloud Data 
 | `deployer.resources.requests`                   | Streaming applications resource requests                   | `{}`                                                    |
 | `deployer.resources.readinessProbe`             | Streaming applications readiness probes requests           | Check `values.yaml` file                                |
 | `deployer.resources.livenessProbe`              | Streaming applications liveness probes  requests           | Check `values.yaml` file                                |
+| `deployer.nodeSelector`                         | Streaming applications nodeSelector                        | `""`                                                    |
+| `deployer.tolerations`                          | Streaming applications tolerations                         | `{}`                                                    |
 
 ### Dataflow Server parameters
 
@@ -237,6 +239,7 @@ The following tables lists the configurable parameters of the Spring Cloud Data 
 | `externalDatabase.host`                         | Host of the external database                                           | `localhost`                         |
 | `externalDatabase.port`                         | External database port number                                           | `3306`                              |
 | `externalDatabase.password`                     | Password for the above username                                         | `""`                                |
+| `externalDatabase.existingPasswordSecret`       | Existing secret with database password                                  | `""`                                |
 | `externalDatabase.dataflow.user`                | Existing username in the external db to be used by Dataflow server      | `dataflow`                          |
 | `externalDatabase.dataflow.database`            | Name of the existing database to be used by Dataflow server             | `dataflow`                          |
 | `externalDatabase.skipper.user`                 | Existing username in the external db to be used by Skipper server       | `skipper`                           |
@@ -255,6 +258,8 @@ The following tables lists the configurable parameters of the Spring Cloud Data 
 | `externalRabbitmq.port`                         | External RabbitMQ port number                                           | `5672`                                                  |
 | `externalRabbitmq.username`                     | External RabbitMQ username                                              | `guest`                                                 |
 | `externalRabbitmq.password`                     | External RabbitMQ password                                              | `guest`                                                 |
+| `externalRabbitmq.vhost`                        | External RabbitMQ virtual host                                          | `/`                                                     |
+| `externalRabbitmq.existingPasswordSecret`       | Existing secret with RabbitMQ password                                  | `""`                                                    |
 
 ### Kafka chart parameters
 

--- a/bitnami/spring-cloud-dataflow/templates/_helpers.tpl
+++ b/bitnami/spring-cloud-dataflow/templates/_helpers.tpl
@@ -252,7 +252,9 @@ Return the Skipper Database User
 Return the Database secret name
 */}}
 {{- define "scdf.database.secretName" -}}
-{{- if .Values.mariadb.enabled }}
+{{- if .Values.externalDatabase.existingPasswordSecret -}}
+    {{- printf "%s" .Values.externalDatabase.existingPasswordSecret -}}
+{{- else if .Values.mariadb.enabled }}
     {{- printf "%s" (include "scdf.mariadb.fullname" .) -}}
 {{- else -}}
     {{- printf "%s-%s" (include "scdf.fullname" .) "externaldb" -}}
@@ -296,10 +298,23 @@ Return the RabbitMQ username
 Return the RabbitMQ secret name
 */}}
 {{- define "scdf.rabbitmq.secretName" -}}
-{{- if .Values.rabbitmq.enabled }}
+{{- if .Values.externalRabbitmq.existingPasswordSecret -}}
+    {{- printf "%s" .Values.externalRabbitmq.existingPasswordSecret -}}
+{{- else if .Values.rabbitmq.enabled }}
     {{- printf "%s" (include "scdf.rabbitmq.fullname" .) -}}
 {{- else -}}
     {{- printf "%s-%s" (include "scdf.fullname" .) "externalrabbitmq" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the RabbitMQ host
+*/}}
+{{- define "scdf.rabbitmq.vhost" -}}
+{{- if .Values.rabbitmq.enabled }}
+    {{- printf "/" -}}
+{{- else -}}
+    {{- printf "%s" .Values.externalRabbitmq.vhost -}}
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/spring-cloud-dataflow/templates/externaldb-secrets.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/externaldb-secrets.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.mariadb.enabled }}
+{{- if and (not .Values.mariadb.enabled) (not .Values.externalDatabase.existingPasswordSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,5 +6,5 @@ metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 type: Opaque
 data:
-  mariadb-password: {{ .Values.externalDatabase.password | b64enc | quote }}
+  datasource-password: {{ .Values.externalDatabase.password | b64enc | quote }}
 {{- end }}

--- a/bitnami/spring-cloud-dataflow/templates/externaldb-secrets.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/externaldb-secrets.yaml
@@ -6,5 +6,5 @@ metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 type: Opaque
 data:
-  datasource-password: {{ .Values.externalDatabase.password | b64enc | quote }}
+  mariadb-password: {{ .Values.externalDatabase.password | b64enc | quote }}
 {{- end }}

--- a/bitnami/spring-cloud-dataflow/templates/externalrabbitmq-secrets.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/externalrabbitmq-secrets.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.externalRabbitmq.enabled) (not .Values.rabbitmq.enabled) }}
+{{- if and (.Values.externalRabbitmq.enabled) (not .Values.rabbitmq.enabled) (not .Values.externalRabbitmq.existingPasswordSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
@@ -72,7 +72,11 @@ data:
         url: 'jdbc:{{ $databaseScheme }}://{{ $databaseHost }}:{{ $databasePort }}/{{ $databaseName }}{{ $jdbcParameters }}'
         driverClassName: {{ include "scdf.database.driver" . }}
         username: {{ include "scdf.database.server.user" . }}
+        {{ if .Values.externalDatabase.existingPasswordSecret }}
         password: ${datasource-password}
+        {{- else -}}
+        password: ${mariadb-password}
+        {{- end }}
         testOnBorrow: true
         validationQuery: "SELECT 1"
 {{ end }}

--- a/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
@@ -72,7 +72,7 @@ data:
         url: 'jdbc:{{ $databaseScheme }}://{{ $databaseHost }}:{{ $databasePort }}/{{ $databaseName }}{{ $jdbcParameters }}'
         driverClassName: {{ include "scdf.database.driver" . }}
         username: {{ include "scdf.database.server.user" . }}
-        password: ${mariadb-password}
+        password: ${datasource-password}
         testOnBorrow: true
         validationQuery: "SELECT 1"
 {{ end }}

--- a/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
@@ -19,7 +19,8 @@ data:
                     {{- $rabbitmqHost := include "scdf.rabbitmq.host" . }}
                     {{- $rabbitmqPort := include "scdf.rabbitmq.port" . }}
                     {{- $rabbitmqUser := include "scdf.rabbitmq.user" . }}
-                    environmentVariables: 'SPRING_RABBITMQ_HOST={{ $rabbitmqHost }},SPRING_RABBITMQ_PORT={{ $rabbitmqPort }},SPRING_RABBITMQ_USERNAME={{ $rabbitmqUser }},SPRING_RABBITMQ_PASSWORD=${rabbitmq-password}'
+                    {{- $rabbitmqVhost := include "scdf.rabbitmq.vhost" . }}
+                    environmentVariables: 'SPRING_RABBITMQ_HOST={{ $rabbitmqHost }},SPRING_RABBITMQ_PORT={{ $rabbitmqPort }},SPRING_RABBITMQ_USERNAME={{ $rabbitmqUser }},SPRING_RABBITMQ_PASSWORD=${rabbitmq-password},SPRING_RABBITMQ_VIRTUAL_HOST={{ $rabbitmqVhost }}'
                     {{- else if .Values.kafka.enabled }}
                     environmentVariables: 'SPRING_CLOUD_STREAM_KAFKA_BINDER_BROKERS=${{ printf "{" }}{{ .Release.Name }}_KAFKA_SERVICE_HOST}:${{ printf "{" }}{{ .Release.Name }}_KAFKA_SERVICE_PORT},SPRING_CLOUD_STREAM_KAFKA_BINDER_ZK_NODES=${{ printf "{" }}{{ .Release.Name }}_ZOOKEEPER_SERVICE_HOST}:${{ printf "{" }}{{ .Release.Name }}_ZOOKEEPER_SERVICE_PORT}'
                     {{- end }}
@@ -31,6 +32,8 @@ data:
                     {{- end }}
                     readinessProbeDelay: {{ .Values.deployer.readinessProbe.initialDelaySeconds }}
                     livenessProbeDelay: {{ .Values.deployer.livenessProbe.initialDelaySeconds }}
+                    nodeSelector: {{ .Values.deployer.nodeSelector }}
+                    tolerations: {{- toYaml .Values.deployer.tolerations | nindent 22 }}
       {{- $hibernateDialect := include "scdf.database.hibernate.dialect" .  }}
       {{- if $hibernateDialect }}
       jpa:
@@ -47,7 +50,7 @@ data:
         url: 'jdbc:{{ $databaseScheme }}://{{ $databaseHost }}:{{ $databasePort }}/{{ $databaseName }}{{ $jdbcParameters }}'
         driverClassName: {{ include "scdf.database.driver" . }}
         username: {{ include "scdf.database.skipper.user" . }}
-        password: ${mariadb-password}
+        password: ${datasource-password}
         testOnBorrow: true
         validationQuery: "SELECT 1"
 {{ end }}

--- a/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
@@ -50,7 +50,11 @@ data:
         url: 'jdbc:{{ $databaseScheme }}://{{ $databaseHost }}:{{ $databasePort }}/{{ $databaseName }}{{ $jdbcParameters }}'
         driverClassName: {{ include "scdf.database.driver" . }}
         username: {{ include "scdf.database.skipper.user" . }}
+        {{ if .Values.externalDatabase.existingPasswordSecret }}
         password: ${datasource-password}
+        {{- else -}}
+        password: ${mariadb-password}
+        {{- end }}
         testOnBorrow: true
         validationQuery: "SELECT 1"
 {{ end }}

--- a/bitnami/spring-cloud-dataflow/values-production.yaml
+++ b/bitnami/spring-cloud-dataflow/values-production.yaml
@@ -584,6 +584,10 @@ deployer:
     initialDelaySeconds: 120
   livenessProbe:
     initialDelaySeconds: 90
+  # The node selectors to apply to the streaming applications deployments in "key:value" format.
+  # Multiple node selectors are comma separated.
+  nodeSelector: ""
+  tolerations: {}
 
 ## Init containers parameters:
 ## wait-for-backends: Wait for the database and other services (such as Kafka or RabbitMQ) used when enabling streaming
@@ -760,6 +764,7 @@ externalDatabase:
   # driver:
   # scheme:
   password: ''
+  # existingPasswordSecret: name-of-existing-secret
   ## Data Flow user and database
   ##
   dataflow:

--- a/bitnami/spring-cloud-dataflow/values-production.yaml
+++ b/bitnami/spring-cloud-dataflow/values-production.yaml
@@ -792,6 +792,26 @@ rabbitmq:
     password: ''
 
 ##
+## External RabbitMQ Configuration
+##
+## All of these values are ignored when rabbitmq.enabled is set to true
+##
+externalRabbitmq:
+  ## Enables or disables external RabbitMQ, can be disabled when Kafka is using
+  ##
+  enabled: false
+  ## RabbitMQ host and port
+  ##
+  host: localhost
+  port: 5672
+  ## RabbitMQ username and password, password will be saved in a kubernetes secret
+  ##
+  username: guest
+  password: guest
+  # vhost: /
+  # existingPasswordSecret: name-of-existing-secret
+
+##
 ## Kafka chart configuration
 ##
 ## https://github.com/bitnami/charts/blob/master/bitnami/kafka/values.yaml

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -584,6 +584,10 @@ deployer:
     initialDelaySeconds: 120
   livenessProbe:
     initialDelaySeconds: 90
+  # The node selectors to apply to the streaming applications deployments in "key:value" format.
+  # Multiple node selectors are comma separated.
+  nodeSelector: ""
+  tolerations: {}
 
 ## Init containers parameters:
 ## wait-for-backends: Wait for the database and other services (such as Kafka or RabbitMQ) used when enabling streaming
@@ -743,6 +747,7 @@ externalDatabase:
   # driver:
   # scheme:
   password: ''
+  # existingPasswordSecret: name-of-existing-secret
   ## Data Flow user and database
   ##
   dataflow:
@@ -785,6 +790,8 @@ externalRabbitmq:
   ##
   username: guest
   password: guest
+  # vhost: /
+  # existingPasswordSecret: name-of-existing-secret
 
 ##
 ## Kafka chart configuration


### PR DESCRIPTION
**Description of the change**

Spring Cloud Dataflow chart improvements:  added nodeSelector and tolerations properties to deployer, provided possibility to use existing password secrets for datasource and RabbitMQ, added RabbitMQ virtual host parameter, renamed mariadb-password to datasource-password

**Benefits**

Improve process of customization how Streams and Tasks are deployed to kubernetes. Better security when we could use existing password secrets for external datasource and external rabbitmq instead of creating it with helm chart.

**Possible drawbacks**

None.

**Applicable issues**

None.

**Additional information**

None.

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
