### PR TITLE
[bitnami/rabbitmq] Allow nodes to communicate with each other out of the box  when NetworkPolicy is enabled

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 7.5.6
+version: 7.5.7
 appVersion: 3.8.5
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/bitnami/rabbitmq/templates/networkpolicy.yaml
+++ b/bitnami/rabbitmq/templates/networkpolicy.yaml
@@ -25,6 +25,9 @@ spec:
             matchLabels:
               app: {{ template "rabbitmq.name" . }}
               release: {{ .Release.Name }}
+        - podSelector:
+            matchLabels:
+            {{- include "common.labels.matchLabels" . | nindent 14 }}
         {{- if .Values.networkPolicy.additionalRules }}
         {{- include "common.tplvalues.render" (dict "value" .Values.networkPolicy.additionalRules "context" $) | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
**Description of the change**

The Chart doesn't allow a cluster nodes to communicate with each other when:
```
networkPolicy:
    enabled: true
    allowExternal: true
```
As the nodes don't get the labels: https://github.com/bitnami/charts/blob/master/bitnami/rabbitmq/templates/networkpolicy.yaml#L26

I didn't want to remove them to avoid the breaking change, I don't know is adding a new `podSelector` is considered as a breaking change (as we change the behaviour), or a bugfix/patch.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
