### PR TITLE
[bitnami/zookeeper] Fix backwards incompatibility issue

### DIFF
--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -95,7 +95,7 @@ The following tables lists the configurable parameters of the ZooKeeper chart an
 | `logLevel`                                        | Log level of ZooKeeper server                                                                                                     | `ERROR`                                                 |
 | `jvmFlags`                                        | Default JVMFLAGS for the ZooKeeper process                                                                                        | `nil`                                                   |
 | `config`                                          | Configure ZooKeeper with a custom zoo.conf file                                                                                   | `nil`                                                   |
-| `dataLogDir`                                      | Data log directory                                                                                                                | `/bitnami/zookeeper/dataLog`                            |
+| `dataLogDir`                                      | Data log directory                                                                                                                | `""`                                                   |
 
 ### Statefulset parameters
 

--- a/bitnami/zookeeper/values-production.yaml
+++ b/bitnami/zookeeper/values-production.yaml
@@ -176,9 +176,10 @@ heapSize: 1024
 ##
 logLevel: ERROR
 
-## Data log directory. Specifying this option will direct zookeeper to write the transaction log to the dataLogDir rather than the dataDir.
-## This allows a dedicated log device to be used, and helps avoid competition between logging and snaphots.
-dataLogDir: /bitnami/zookeeper/dataLog
+## Example:
+## dataLogDir: /bitnami/zookeeper/dataLog
+##
+dataLogDir: ""
 
 ## Default JVMFLAGS for the ZooKeeper process
 ##

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -185,7 +185,10 @@ logLevel: ERROR
 
 ## Data log directory. Specifying this option will direct zookeeper to write the transaction log to the dataLogDir rather than the dataDir.
 ## This allows a dedicated log device to be used, and helps avoid competition between logging and snaphots.
-dataLogDir: /bitnami/zookeeper/dataLog
+## Example:
+## dataLogDir: /bitnami/zookeeper/dataLog
+##
+dataLogDir: ""
 
 ## Default JVMFLAGS for the ZooKeeper process
 ##


### PR DESCRIPTION
**Description of the change**

The "dataLogDir" should be set to `""` by default to avoid updating the default volumeClainTemplates since that introduces a backwards incompatibility issue:

```
UPGRADE FAILED: (...) updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden
```

**Benefits**

Fix compatibility issue

**Possible drawbacks**

None

**Additional information**

Introduced at https://github.com/bitnami/charts/pull/2994

**Checklist**

- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/) (not needed, the previous version wasn't released yet)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

