### PR TITLE
[bitnami/postgresql-ha] Fix num replicas parameter

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql-ha
-version: 3.4.5
+version: 3.4.6
 appVersion: 11.8.0
 description: Chart for PostgreSQL with HA architecture (using Replication Manager (repmgr) and Pgpool).
 keywords:

--- a/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
@@ -167,7 +167,7 @@ spec:
               value: {{ (include "postgresql-ha.repmgrDatabase" .) | quote }}
             {{- end }}
             - name: POSTGRESQL_NUM_SYNCHRONOUS_REPLICAS
-              value: {{ .Values.postgresql.replicaCount | quote }}
+              value: {{ sub .Values.postgresql.replicaCount 1 | quote }}
           ports:
             - name: postgresql
               containerPort: 5432

--- a/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
@@ -167,7 +167,7 @@ spec:
               value: {{ (include "postgresql-ha.repmgrDatabase" .) | quote }}
             {{- end }}
             - name: POSTGRESQL_NUM_SYNCHRONOUS_REPLICAS
-              value: {{ sub .Values.postgresql.replicaCount 1 | quote }}
+              value: {{ sub (int .Values.postgresql.replicaCount) 1 | quote }}
           ports:
             - name: postgresql
               containerPort: 5432


### PR DESCRIPTION
**Description of the change**
Set the right amount of replicas to keep in sync
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
Fix issue in previous version, that made the clients waits forever. 
<!-- What benefits will be realized by the code change? -->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
