### PR TITLE
[bitnami/nginx-ingress-controller] Introduced .Release.Namespace in o…

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress-controller
-version: 5.3.25
+version: 5.4.0
 appVersion: 0.33.0
 description: Chart for the nginx Ingress controller
 keywords:

--- a/bitnami/nginx-ingress-controller/templates/addheaders-configmap.yaml
+++ b/bitnami/nginx-ingress-controller/templates/addheaders-configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "nginx-ingress.fullname" . }}-custom-add-headers
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nginx-ingress.labels" . | nindent 4 }}
     component: {{ .Values.name }}
 data: {{- toYaml .Values.addHeaders | nindent 2 }}

--- a/bitnami/nginx-ingress-controller/templates/controller-configmap.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "nginx-ingress.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nginx-ingress.labels" . | nindent 4 }}
     component: {{ .Values.name }}
 data:

--- a/bitnami/nginx-ingress-controller/templates/controller-daemonset.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-daemonset.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "nginx-ingress.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nginx-ingress.labels" . | nindent 4 }}
     component: {{ .Values.name }}
 spec:

--- a/bitnami/nginx-ingress-controller/templates/controller-deployment.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "nginx-ingress.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nginx-ingress.labels" . | nindent 4 }}
     component: {{ .Values.name }}
 spec:

--- a/bitnami/nginx-ingress-controller/templates/controller-hpa.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-hpa.yaml
@@ -4,6 +4,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "nginx-ingress.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nginx-ingress.labels" . | nindent 4 }}
     component: {{ .Values.name }}
 spec:

--- a/bitnami/nginx-ingress-controller/templates/controller-metrics-service.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-metrics-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "nginx-ingress.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nginx-ingress.labels" . | nindent 4 }}
     component: {{ .Values.name }}
     {{- if .Values.metrics.service.labels }}

--- a/bitnami/nginx-ingress-controller/templates/controller-poddisruptionbudget.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "nginx-ingress.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nginx-ingress.labels" . | nindent 4 }}
     component: {{ .Values.name }}
 spec:

--- a/bitnami/nginx-ingress-controller/templates/controller-prometheusrules.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-prometheusrules.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ template "nginx-ingress.fullname" . }}
   {{- if .Values.metrics.prometheusRule.namespace }}
   namespace: {{ .Values.metrics.prometheusRule.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
   {{- end }}
   labels: {{- include "nginx-ingress.labels" . | nindent 4 }}
     component: {{ .Values.name }}

--- a/bitnami/nginx-ingress-controller/templates/controller-service.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "nginx-ingress.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nginx-ingress.labels" . | nindent 4 }}
     component: {{ .Values.name }}
     {{- if .Values.service.labels }}

--- a/bitnami/nginx-ingress-controller/templates/controller-servicemonitor.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-servicemonitor.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ template "nginx-ingress.fullname" . }}
   {{- if .Values.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
   {{- end }}
   labels: {{- include "nginx-ingress.labels" . | nindent 4 }}
     component: {{ .Values.name }}

--- a/bitnami/nginx-ingress-controller/templates/default-backend-deployment.yaml
+++ b/bitnami/nginx-ingress-controller/templates/default-backend-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nginx-ingress.labels" . | nindent 4 }}
     component: {{ .Values.defaultBackend.name }}
 spec:

--- a/bitnami/nginx-ingress-controller/templates/default-backend-poddisruptionbudget.yaml
+++ b/bitnami/nginx-ingress-controller/templates/default-backend-poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nginx-ingress.labels" . | nindent 4 }}
     component: {{ .Values.defaultBackend.name }}
 spec:

--- a/bitnami/nginx-ingress-controller/templates/default-backend-service.yaml
+++ b/bitnami/nginx-ingress-controller/templates/default-backend-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nginx-ingress.labels" . | nindent 4 }}
     component: {{ .Values.defaultBackend.name }}
   {{- if .Values.defaultBackend.service.annotations }}

--- a/bitnami/nginx-ingress-controller/templates/podsecuritypolicy.yaml
+++ b/bitnami/nginx-ingress-controller/templates/podsecuritypolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ template "podSecurityPolicy.apiVersion" . }}
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "nginx-ingress.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nginx-ingress.labels" . | nindent 4 }}
 spec:
   allowedCapabilities:

--- a/bitnami/nginx-ingress-controller/templates/proxyheaders-configmap.yaml
+++ b/bitnami/nginx-ingress-controller/templates/proxyheaders-configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "nginx-ingress.fullname" . }}-custom-proxy-headers
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nginx-ingress.labels" . | nindent 4 }}
     component: {{ .Values.name }}
 data:

--- a/bitnami/nginx-ingress-controller/templates/role.yaml
+++ b/bitnami/nginx-ingress-controller/templates/role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: {{ template "nginx-ingress.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nginx-ingress.labels" . | nindent 4 }}
 rules:
   - apiGroups:

--- a/bitnami/nginx-ingress-controller/templates/rolebinding.yaml
+++ b/bitnami/nginx-ingress-controller/templates/rolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: {{ template "nginx-ingress.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nginx-ingress.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bitnami/nginx-ingress-controller/templates/serviceaccount.yaml
+++ b/bitnami/nginx-ingress-controller/templates/serviceaccount.yaml
@@ -3,5 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "nginx-ingress.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nginx-ingress.labels" . | nindent 4 }}
 {{- end -}}

--- a/bitnami/nginx-ingress-controller/templates/tcp-configmap.yaml
+++ b/bitnami/nginx-ingress-controller/templates/tcp-configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "nginx-ingress.fullname" . }}-tcp
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nginx-ingress.labels" . | nindent 4 }}
     component: {{ .Values.name }}
 data: {{- include "nginx-ingress.tplValue" (dict "value" .Values.tcp "context" $) | nindent 2 }}

--- a/bitnami/nginx-ingress-controller/templates/udp-configmap.yaml
+++ b/bitnami/nginx-ingress-controller/templates/udp-configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "nginx-ingress.fullname" . }}-udp
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "nginx-ingress.labels" . | nindent 4 }}
     component: {{ .Values.name }}
 data: {{- include "nginx-ingress.tplValue" (dict "value" .Values.udp "context" $) | nindent 2 }}


### PR DESCRIPTION
**Description of the change**

Hi, it's me again :-)
The PR is connected with issue #2006
and follows the same scheme as:
#2156
#2159
#2177
#2316
but this time for nginx-ingress-controller.

**Benefits**

TLDR; ability to deploy the helm chart in gitops-friendly way, for details read the issue here: #2006

**Possible drawbacks**
Not known

**Applicable issues**

#2006

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
