### PR TITLE
[bitnami/kafka] Add custom labels/annotations parameters

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 11.5.1
+version: 11.6.0
 appVersion: 2.5.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -63,6 +63,8 @@ The following tables lists the configurable parameters of the Kafka chart and th
 | `nameOverride`                                    | String to partially override kafka.fullname                                                                                       | `nil`                                                   |
 | `fullnameOverride`                                | String to fully override kafka.fullname                                                                                           | `nil`                                                   |
 | `clusterDomain`                                   | Default Kubernetes cluster domain                                                                                                 | `cluster.local`                                         |
+| `commonLabels`                                    | Labels to add to all deployed objects                                                                                             | `{}`                                                    |
+| `commonAnnotations`                               | Annotations to add to all deployed objects                                                                                        | `{}`                                                    |
 | `extraDeploy`                                     | Array of extra objects to deploy with the release                                                                                 | `nil` (evaluated as a template)                         |
 
 ### Kafka parameters

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -569,10 +569,10 @@ extraDeploy: |-
               volumeMounts:
                 - name: configuration
                   mountPath: /opt/bitnami/kafka/config
-            volumes:
-              - name: configuration
-                configMap:
-                  name: {{ include "kafka.fullname" . }}-connect
+          volumes:
+            - name: configuration
+              configMap:
+                name: {{ include "kafka.fullname" . }}-connect
   - apiVersion: v1
     kind: ConfigMap
     metadata:

--- a/bitnami/kafka/requirements.lock
+++ b/bitnami/kafka/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: zookeeper
   repository: https://charts.bitnami.com/bitnami
-  version: 5.19.1
-digest: sha256:fd7146bca361b0f635a50ecaaee3453e8a718ac7dfa1bc70505b5466a0a8c4d1
-generated: "2020-07-23T08:36:23.179206+02:00"
+  version: 5.17.3
+digest: sha256:06e8f5c4909c05f395ab408fb959154cb6be9c2c052cf7e15a9283faaacb409e
+generated: "2020-07-14T11:52:20.750766784Z"

--- a/bitnami/kafka/requirements.lock
+++ b/bitnami/kafka/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: zookeeper
   repository: https://charts.bitnami.com/bitnami
-  version: 5.17.3
-digest: sha256:06e8f5c4909c05f395ab408fb959154cb6be9c2c052cf7e15a9283faaacb409e
-generated: "2020-07-14T11:52:20.750766784Z"
+  version: 5.19.1
+digest: sha256:fd7146bca361b0f635a50ecaaee3453e8a718ac7dfa1bc70505b5466a0a8c4d1
+generated: "2020-07-23T08:36:23.179206+02:00"

--- a/bitnami/kafka/templates/configmap.yaml
+++ b/bitnami/kafka/templates/configmap.yaml
@@ -4,6 +4,12 @@ kind: ConfigMap
 metadata:
   name: {{ template "kafka.fullname" . }}-configuration
   labels: {{- include "kafka.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 data:
   server.properties: |-
     {{ .Values.config | nindent 4 }}

--- a/bitnami/kafka/templates/configmap.yaml
+++ b/bitnami/kafka/templates/configmap.yaml
@@ -5,10 +5,10 @@ metadata:
   name: {{ template "kafka.fullname" . }}-configuration
   labels: {{- include "kafka.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
   server.properties: |-

--- a/bitnami/kafka/templates/jaas-secret.yaml
+++ b/bitnami/kafka/templates/jaas-secret.yaml
@@ -4,6 +4,12 @@ kind: Secret
 metadata:
   name: {{ template "kafka.fullname" . }}-jaas
   labels: {{- include "kafka.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   {{- if (include "kafka.client.saslAuthentication" .) }}

--- a/bitnami/kafka/templates/jaas-secret.yaml
+++ b/bitnami/kafka/templates/jaas-secret.yaml
@@ -5,10 +5,10 @@ metadata:
   name: {{ template "kafka.fullname" . }}-jaas
   labels: {{- include "kafka.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 type: Opaque
 data:

--- a/bitnami/kafka/templates/jks-secret.yaml
+++ b/bitnami/kafka/templates/jks-secret.yaml
@@ -5,10 +5,10 @@ metadata:
   name: {{ template "kafka.fullname" . }}-jks
   labels: {{- include "kafka.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 type: Opaque
 data:

--- a/bitnami/kafka/templates/jks-secret.yaml
+++ b/bitnami/kafka/templates/jks-secret.yaml
@@ -4,6 +4,12 @@ kind: Secret
 metadata:
   name: {{ template "kafka.fullname" . }}-jks
   labels: {{- include "kafka.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   {{- $root := . }}

--- a/bitnami/kafka/templates/jmx-configmap.yaml
+++ b/bitnami/kafka/templates/jmx-configmap.yaml
@@ -5,10 +5,10 @@ metadata:
   name: {{ template "kafka.fullname" . }}-jmx-configuration
   labels: {{- include "kafka.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
   jmx-kafka-prometheus.yml: |-

--- a/bitnami/kafka/templates/jmx-configmap.yaml
+++ b/bitnami/kafka/templates/jmx-configmap.yaml
@@ -4,6 +4,12 @@ kind: ConfigMap
 metadata:
   name: {{ template "kafka.fullname" . }}-jmx-configuration
   labels: {{- include "kafka.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 data:
   jmx-kafka-prometheus.yml: |-
     {{- include "kafka.tplValue" ( dict "value" .Values.metrics.jmx.config "context" $ ) | nindent 4 }}

--- a/bitnami/kafka/templates/jmx-metrics-svc.yaml
+++ b/bitnami/kafka/templates/jmx-metrics-svc.yaml
@@ -5,8 +5,17 @@ metadata:
   name: {{ template "kafka.fullname" . }}-jmx-metrics
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
-  {{- if .Values.metrics.jmx.service.annotations }}
-  annotations: {{ include "kafka.tplValue" ( dict "value" .Values.metrics.jmx.service.annotations "context" $) | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.metrics.jmx.service.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.metrics.jmx.service.annotations }}
+    {{ include "kafka.tplValue" ( dict "value" .Values.metrics.jmx.service.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.metrics.jmx.service.type }}

--- a/bitnami/kafka/templates/jmx-metrics-svc.yaml
+++ b/bitnami/kafka/templates/jmx-metrics-svc.yaml
@@ -6,7 +6,7 @@ metadata:
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
     {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if or .Values.metrics.jmx.service.annotations .Values.commonAnnotations }}
   annotations:
@@ -14,7 +14,7 @@ metadata:
     {{ include "kafka.tplValue" ( dict "value" .Values.metrics.jmx.service.annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:

--- a/bitnami/kafka/templates/kafka-metrics-deployment.yaml
+++ b/bitnami/kafka/templates/kafka-metrics-deployment.yaml
@@ -11,10 +11,10 @@ metadata:
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics
     {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   replicas: 1

--- a/bitnami/kafka/templates/kafka-metrics-deployment.yaml
+++ b/bitnami/kafka/templates/kafka-metrics-deployment.yaml
@@ -10,6 +10,12 @@ metadata:
   name: {{ template "kafka.fullname" . }}-exporter
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   selector:

--- a/bitnami/kafka/templates/kafka-metrics-svc.yaml
+++ b/bitnami/kafka/templates/kafka-metrics-svc.yaml
@@ -6,7 +6,7 @@ metadata:
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics
     {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if or .Values.metrics.kafka.service.annotations .Values.commonAnnotations }}
   annotations:
@@ -14,7 +14,7 @@ metadata:
     {{ include "kafka.tplValue" ( dict "value" .Values.metrics.kafka.service.annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:

--- a/bitnami/kafka/templates/kafka-metrics-svc.yaml
+++ b/bitnami/kafka/templates/kafka-metrics-svc.yaml
@@ -5,8 +5,17 @@ metadata:
   name: {{ template "kafka.fullname" . }}-metrics
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics
-  {{- if .Values.metrics.kafka.service.annotations }}
-  annotations: {{ include "kafka.tplValue" ( dict "value" .Values.metrics.kafka.service.annotations "context" $) | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.metrics.kafka.service.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.metrics.kafka.service.annotations }}
+    {{ include "kafka.tplValue" ( dict "value" .Values.metrics.kafka.service.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.metrics.kafka.service.type }}

--- a/bitnami/kafka/templates/log4j-configmap.yaml
+++ b/bitnami/kafka/templates/log4j-configmap.yaml
@@ -4,6 +4,12 @@ kind: ConfigMap
 metadata:
   name: {{ include "kafka.log4j.configMapName" . }}
   labels: {{- include "kafka.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 data:
   log4j.properties: |-
     {{ .Values.log4j | nindent 4 }}

--- a/bitnami/kafka/templates/log4j-configmap.yaml
+++ b/bitnami/kafka/templates/log4j-configmap.yaml
@@ -5,10 +5,10 @@ metadata:
   name: {{ include "kafka.log4j.configMapName" . }}
   labels: {{- include "kafka.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
   log4j.properties: |-

--- a/bitnami/kafka/templates/poddisruptionbudget.yaml
+++ b/bitnami/kafka/templates/poddisruptionbudget.yaml
@@ -7,10 +7,10 @@ metadata:
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
     {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   {{- if .Values.pdb.minAvailable }}

--- a/bitnami/kafka/templates/poddisruptionbudget.yaml
+++ b/bitnami/kafka/templates/poddisruptionbudget.yaml
@@ -6,6 +6,12 @@ metadata:
   name: {{ template "kafka.fullname" . }}
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.pdb.minAvailable }}
   minAvailable: {{ .Values.pdb.minAvailable }}

--- a/bitnami/kafka/templates/role.yaml
+++ b/bitnami/kafka/templates/role.yaml
@@ -5,6 +5,12 @@ metadata:
   name: {{ template "kafka.fullname" . }}
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups:
       - ""

--- a/bitnami/kafka/templates/role.yaml
+++ b/bitnami/kafka/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
     {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 rules:
   - apiGroups:

--- a/bitnami/kafka/templates/rolebinding.yaml
+++ b/bitnami/kafka/templates/rolebinding.yaml
@@ -5,6 +5,12 @@ metadata:
   name: {{ template "kafka.fullname" . }}
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 roleRef:
   kind: Role
   name: {{ template "kafka.fullname" . }}

--- a/bitnami/kafka/templates/rolebinding.yaml
+++ b/bitnami/kafka/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
     {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 roleRef:
   kind: Role

--- a/bitnami/kafka/templates/scripts-configmap.yaml
+++ b/bitnami/kafka/templates/scripts-configmap.yaml
@@ -4,10 +4,10 @@ metadata:
   name: {{ template "kafka.fullname" . }}-scripts
   labels: {{- include "kafka.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
   {{- $fullname := include "kafka.fullname" . }}

--- a/bitnami/kafka/templates/scripts-configmap.yaml
+++ b/bitnami/kafka/templates/scripts-configmap.yaml
@@ -3,6 +3,12 @@ kind: ConfigMap
 metadata:
   name: {{ template "kafka.fullname" . }}-scripts
   labels: {{- include "kafka.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 data:
   {{- $fullname := include "kafka.fullname" . }}
   {{- $releaseNamespace := .Release.Namespace }}

--- a/bitnami/kafka/templates/serviceaccount.yaml
+++ b/bitnami/kafka/templates/serviceaccount.yaml
@@ -5,4 +5,10 @@ metadata:
   name: {{ template "kafka.serviceAccountName" . }}
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/bitnami/kafka/templates/serviceaccount.yaml
+++ b/bitnami/kafka/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
     {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/bitnami/kafka/templates/servicemonitor-jmx-metrics.yaml
+++ b/bitnami/kafka/templates/servicemonitor-jmx-metrics.yaml
@@ -11,6 +11,12 @@ metadata:
     {{- range $key, $value := .Values.metrics.serviceMonitor.selector }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels: {{- include "kafka.matchLabels" . | nindent 6 }}

--- a/bitnami/kafka/templates/servicemonitor-jmx-metrics.yaml
+++ b/bitnami/kafka/templates/servicemonitor-jmx-metrics.yaml
@@ -12,10 +12,10 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   selector:

--- a/bitnami/kafka/templates/servicemonitor-metrics.yaml
+++ b/bitnami/kafka/templates/servicemonitor-metrics.yaml
@@ -11,6 +11,12 @@ metadata:
     {{- range $key, $value := .Values.metrics.serviceMonitor.selector }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels: {{- include "kafka.matchLabels" . | nindent 6 }}

--- a/bitnami/kafka/templates/servicemonitor-metrics.yaml
+++ b/bitnami/kafka/templates/servicemonitor-metrics.yaml
@@ -12,10 +12,10 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   selector:

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -14,6 +14,12 @@ metadata:
   name: {{ include "kafka.fullname" . }}
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   podManagementPolicy: Parallel
   replicas: {{ .Values.replicaCount }}

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -15,10 +15,10 @@ metadata:
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
     {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   podManagementPolicy: Parallel

--- a/bitnami/kafka/templates/svc-external-access.yaml
+++ b/bitnami/kafka/templates/svc-external-access.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/component: kafka
     pod: {{ $targetPod }}
     {{- if $root.Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" $root.Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplvalue" ( dict "value" $root.Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if or $root.Values.externalAccess.service.annotations $root.Values.commonAnnotations }}
   annotations:
@@ -22,7 +22,7 @@ metadata:
     {{ include "kafka.tplValue" ( dict "value" $root.Values.externalAccess.service.annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if $root.Values.commonAnnotations }}
-    {{- include "common.tplvalues.render" ( dict "value" $root.Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplvalue" ( dict "value" $root.Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:

--- a/bitnami/kafka/templates/svc-external-access.yaml
+++ b/bitnami/kafka/templates/svc-external-access.yaml
@@ -13,8 +13,17 @@ metadata:
   labels: {{- include "kafka.labels" $ | nindent 4 }}
     app.kubernetes.io/component: kafka
     pod: {{ $targetPod }}
-  {{- if $root.Values.externalAccess.service.annotations }}
-  annotations: {{- include "kafka.tplValue" ( dict "value" $root.Values.externalAccess.service.annotations "context" $) | nindent 4 }}
+    {{- if $root.Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" $root.Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or $root.Values.externalAccess.service.annotations $root.Values.commonAnnotations }}
+  annotations:
+    {{- if $root.Values.externalAccess.service.annotations }}
+    {{ include "kafka.tplValue" ( dict "value" $root.Values.externalAccess.service.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if $root.Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" $root.Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   type: {{ $root.Values.externalAccess.service.type }}

--- a/bitnami/kafka/templates/svc-headless.yaml
+++ b/bitnami/kafka/templates/svc-headless.yaml
@@ -4,6 +4,12 @@ metadata:
   name: {{ template "kafka.fullname" . }}-headless
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/bitnami/kafka/templates/svc-headless.yaml
+++ b/bitnami/kafka/templates/svc-headless.yaml
@@ -5,10 +5,10 @@ metadata:
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
     {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   type: ClusterIP

--- a/bitnami/kafka/templates/svc.yaml
+++ b/bitnami/kafka/templates/svc.yaml
@@ -4,8 +4,17 @@ metadata:
   name: {{ template "kafka.fullname" . }}
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
-  {{- if .Values.service.annotations }}
-  annotations: {{- include "kafka.tplValue" (dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.service.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.service.annotations }}
+    {{ include "kafka.tplValue" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/bitnami/kafka/templates/svc.yaml
+++ b/bitnami/kafka/templates/svc.yaml
@@ -5,7 +5,7 @@ metadata:
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
     {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if or .Values.service.annotations .Values.commonAnnotations }}
   annotations:
@@ -13,7 +13,7 @@ metadata:
     {{ include "kafka.tplValue" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:

--- a/bitnami/kafka/values-production.yaml
+++ b/bitnami/kafka/values-production.yaml
@@ -44,6 +44,14 @@ image:
 ##
 clusterDomain: cluster.local
 
+## Add labels to all the deployed resources
+##
+commonLabels: {}
+
+## Add annotations to all the deployed resources
+##
+commonAnnotations: {}
+
 ## Kafka Configuration
 ## Specify content for server.properties
 ## The server.properties is auto-generated based on other parameters when this paremeter is not specified

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -44,6 +44,14 @@ image:
 ##
 clusterDomain: cluster.local
 
+## Add labels to all the deployed resources
+##
+commonLabels: {}
+
+## Add annotations to all the deployed resources
+##
+commonAnnotations: {}
+
 ## Kafka Configuration
 ## Specify content for server.properties
 ## The server.properties is auto-generated based on other parameters when this paremeter is not specified


### PR DESCRIPTION
**Description of the change**

This PR adds 2 new parameters that allow adding custom labels & annotations to every K8s manifest: `commonLabels` and `commonAnnotations`.

It also adapts the Parameters section in the README.md so it lists the parameters per section/component.

**Benefits**

Users can use custom labels/annotations.

**Possible drawbacks**

None

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files