### PR TITLE
[bitnami/prometheus-operator] Use the operator template for container name

### DIFF
--- a/bitnami/prometheus-operator/Chart.yaml
+++ b/bitnami/prometheus-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.40.0
 description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 name: prometheus-operator
-version: 0.25.0
+version: 0.25.1
 keywords:
   - prometheus
   - alertmanager

--- a/bitnami/prometheus-operator/templates/prometheus-operator/deployment.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/deployment.yaml
@@ -58,7 +58,7 @@ spec:
         podAffinity: {{- include "prometheus-operator.tplValue" (dict "value" .Values.operator.podAffinity "context" $) | nindent 10 }}
         {{- end }}
       containers:
-        - name: {{ template "prometheus-operator.name" . }}
+        - name: {{ template "prometheus-operator.operator.name" . }}
           image: {{ template "prometheus-operator.image" . }}
           imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
           args:


### PR DESCRIPTION
Using the top level 'prometheus-operator.name' template can have weird
consequences in some cases. For example, imagine we use the default
value of 'prometheus-operator' as Chart name. In this case, the template
will strip the '-operator' part and the container will end up being
named 'prometheus'. However, the name 'prometheus' is also used by the
prometheus CRD when it creates prometheus instances. As such, it makes
it harder to distinguish between the prometheus-operator container and
those in the actual prometheus instances. It's better to have a clear
identification for the container that belongs to the opearator


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
