### PR TITLE
[bitnami/etcd] Ensure ETCD_DATA_DIR permissions are set to 700

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: etcd
-version: 4.8.14
+version: 4.9.0
 appVersion: 3.4.9
 description: etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines
 keywords:

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: etcd
 version: 4.9.0
-appVersion: 3.4.9
+appVersion: 3.4.10
 description: etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines
 keywords:
   - etcd

--- a/bitnami/etcd/templates/scripts-configmap.yaml
+++ b/bitnami/etcd/templates/scripts-configmap.yaml
@@ -144,6 +144,12 @@ data:
 {{- end }}
     else
         echo "==> Detected data from previous deployments..." 1>&3 2>&4
+        if [[ $(stat -c "%a" "$ETCD_DATA_DIR") != *700 ]]; then
+            echo "==> Setting data directory permissions to 700 in a recursive way (required in etcd >=3.4.10)" 1>&3 2>&4
+            chmod -R 700 $ETCD_DATA_DIR
+        else
+            echo "==> The data directory is already configured with the proper permissions" 1>&3 2>&4
+        fi
         if [[ {{ $replicaCount }} -eq 1 ]]; then
             echo "==> Single node cluster detected!!" 1>&3 2>&4
         elif is_disastrous_failure; then
@@ -181,18 +187,12 @@ data:
         fi
     fi
 
-    if [[ $(stat -c "%a" "$ETCD_DATA_DIR") != *700 ]]; then
-        echo "==> Setting data directory permissions to 700 in a recursive way (required in etcd >=3.4.10)" 1>&3 2>&4
-        chmod -R 700 $ETCD_DATA_DIR
-    else
-        echo "==> The data directory is already configured with the proper permissions" 1>&3 2>&4
-    fi
-
     {{- if .Values.configFileConfigMap }}
     exec etcd --config-file /opt/bitnami/etcd/conf/etcd.conf.yml 1>&3 2>&4
     {{- else }}
     exec etcd 1>&3 2>&4
     {{- end }}
+
   prestop-hook.sh: |-
     #!/bin/bash
 

--- a/bitnami/etcd/templates/scripts-configmap.yaml
+++ b/bitnami/etcd/templates/scripts-configmap.yaml
@@ -192,7 +192,6 @@ data:
     {{- else }}
     exec etcd 1>&3 2>&4
     {{- end }}
-
   prestop-hook.sh: |-
     #!/bin/bash
 

--- a/bitnami/etcd/templates/scripts-configmap.yaml
+++ b/bitnami/etcd/templates/scripts-configmap.yaml
@@ -181,6 +181,13 @@ data:
         fi
     fi
 
+    if [[ $(stat -c "%a" "$ETCD_DATA_DIR") != *700 ]]; then
+        echo "==> Setting data directory permissions to 700 in a recursive way (required in etcd >=3.4.10)" 1>&3 2>&4
+        chmod -R 700 $ETCD_DATA_DIR
+    else
+        echo "==> The data directory is already configured with the proper permissions" 1>&3 2>&4
+    fi
+
     {{- if .Values.configFileConfigMap }}
     exec etcd --config-file /opt/bitnami/etcd/conf/etcd.conf.yml 1>&3 2>&4
     {{- else }}

--- a/bitnami/etcd/values-production.yaml
+++ b/bitnami/etcd/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/etcd
-  tag: 3.4.9-debian-10-r53
+  tag: 3.4.10-debian-10-r1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/etcd/values.yaml
+++ b/bitnami/etcd/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/etcd
-  tag: 3.4.9-debian-10-r53
+  tag: 3.4.10-debian-10-r1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
**Description of the change**

Since etcd 3.4.10 (release in process on our side), etcd checks that permissions of the data directory are 700, in order to support upgrades in a smooth way, we are going to set the proper permissions before initializing etcd if needed

The image for the new version already contains the data dir folder created using the proper permission

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files