### PR TITLE
Fix missing templating to generate initcontainers for mongodb-sharded…

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb-sharded
-version: 1.5.7
+version: 1.5.8
 appVersion: 4.2.8
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications. Sharded topology.
 keywords:

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
@@ -56,6 +56,12 @@ spec:
             - name: datadir
               mountPath: {{ .Values.configsvr.persistence.mountPath }}
         {{- end }}
+        {{- with $.Values.configsvr.initContainers }}
+        {{- include "mongodb-sharded.tplValue" ( dict "value" . "context" $ ) | nindent 8}}
+        {{- end }}
+        {{- with $.Values.common.initContainers }}
+        {{- include "mongodb-sharded.tplValue" ( dict "value" . "context" $ ) | nindent 8}}
+        {{- end }}
       containers:
         - name: mongodb
           image: {{ include "mongodb-sharded.image" . }}

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-deployment.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-deployment.yaml
@@ -41,6 +41,15 @@ spec:
         fsGroup: {{ .Values.securityContext.fsGroup }}
       {{- end }}
       {{- include "mongodb-sharded.imagePullSecrets" . | nindent 6 }}
+      {{- if or (ge (len $.Values.mongos.initContainers) 1) (ge (len $.Values.common.initContainers) 1) }}
+      initContainers:
+        {{- with $.Values.mongos.initContainers }}
+        {{- include "mongodb-sharded.tplValue" ( dict "value" . "context" $ ) | nindent 8}}
+        {{- end }}
+        {{- with $.Values.common.initContainers }}
+        {{- include "mongodb-sharded.tplValue" ( dict "value" . "context" $ ) | nindent 8}}
+        {{- end }}
+      {{- end }}
       containers:
         - name: mongos
           image: {{ include "mongodb-sharded.image" . }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
@@ -46,6 +46,15 @@ spec:
         fsGroup: {{ $.Values.securityContext.fsGroup }}
       {{- end }}
       {{- include "mongodb-sharded.imagePullSecrets" $ | nindent 6 }}
+      {{- if or (ge (len $.Values.shardsvr.arbiter.initContainers) 1) (ge (len $.Values.common.initContainers) 1) }}
+      initContainers:
+        {{- with $.Values.shardsvr.arbiter.initContainers }}
+        {{- include "mongodb-sharded.tplValue" ( dict "value" . "context" $ ) | nindent 8}}
+        {{- end }}
+        {{- with $.Values.common.initContainers }}
+        {{- include "mongodb-sharded.tplValue" ( dict "value" . "context" $ ) | nindent 8}}
+        {{- end }}
+      {{- end }}
       containers:
         - name: {{ include "mongodb-sharded.name" $ }}-arbiter
           image: {{ include "mongodb-sharded.image" $ }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -59,6 +59,12 @@ spec:
             - name: datadir
               mountPath: {{ $.Values.shardsvr.persistence.mountPath }}
         {{- end }}
+        {{- with $.Values.shardsvr.dataNode.initContainers }}
+        {{- include "mongodb-sharded.tplValue" ( dict "value" . "context" $ ) | nindent 8}}
+        {{- end }}
+        {{- with $.Values.common.initContainers }}
+        {{- include "mongodb-sharded.tplValue" ( dict "value" . "context" $ ) | nindent 8}}
+        {{- end }}
       containers:
         - name: mongodb
           image: {{ include "mongodb-sharded.image" $ }}


### PR DESCRIPTION
… mongodb-sharded

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
This change will fix the generation of initContainers that are described into values.yaml file but where the templating logic is currently missing.

