### PR TITLE
fix speaker daemonSet nodeSelector variable path

### DIFF
--- a/bitnami/metallb/templates/daemonset.yaml
+++ b/bitnami/metallb/templates/daemonset.yaml
@@ -100,7 +100,7 @@ spec:
             add: {{- toYaml .Values.speaker.securityContext.capabilities.add | nindent 12 }}
       {{- end }}
       nodeSelector:
-      {{- if .Values.controller.nodeSelector }} {{- include "metallb.tplValue" (dict "value" .Values.controller.nodeSelector "context" $) | nindent 8 }}
+      {{- if .Values.speaker.nodeSelector }} {{- include "metallb.tplValue" (dict "value" .Values.speaker.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
         "kubernetes.io/os": linux
       {{- if .Values.speaker.affinity }}


### PR DESCRIPTION
It seems that speaker daemonset is (wrongly) using controller vars. It visibly looks like a copy and paste problem.

This patch fix that !

**Checklist**
- [*] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).