### PR TITLE
[bitnami/metallb] Fix speaker daemonSet nodeSelector path

### DIFF
--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: metallb
 description: The Metal LB for Kubernetes
-version: 0.1.17
+version: 0.1.18
 appVersion: 0.9.3
 keywords:
   - "load-balancer"

--- a/bitnami/metallb/templates/daemonset.yaml
+++ b/bitnami/metallb/templates/daemonset.yaml
@@ -100,7 +100,7 @@ spec:
             add: {{- toYaml .Values.speaker.securityContext.capabilities.add | nindent 12 }}
       {{- end }}
       nodeSelector:
-      {{- if .Values.controller.nodeSelector }} {{- include "metallb.tplValue" (dict "value" .Values.controller.nodeSelector "context" $) | nindent 8 }}
+      {{- if .Values.speaker.nodeSelector }} {{- include "metallb.tplValue" (dict "value" .Values.speaker.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
         "kubernetes.io/os": linux
       {{- if .Values.speaker.affinity }}


### PR DESCRIPTION
It seems that speaker daemonset is (wrongly) using controller vars. It visibly looks like a copy/paste problem.

This patch fix that !
Thanks a lot :)

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files