### PR TITLE
[bitnami/external-dns] Fix MSI for azure-private-dns provider

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 3.2.4
+version: 3.2.5
 appVersion: 0.7.2
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/bitnami/external-dns/templates/_helpers.tpl
+++ b/bitnami/external-dns/templates/_helpers.tpl
@@ -405,10 +405,14 @@ external-dns: azure.useManagedIdentityExtension
 {{- end -}}
 {{- end -}}
 
+{{/*
+Validate values of Azure DNS:
+- must provide the Azure AAD Client Secret when provider is "azure-private-dns" and useManagedIdentityExtension is "true"
+*/}}
 {{- define "external-dns.validateValues.azurePrivateDns.useManagedIdentityExtensionAadClientSecret" -}}
 {{- if and (eq .Values.provider "azure-private-dns") (not .Values.azure.secretName) .Values.azure.aadClientSecret .Values.azure.useManagedIdentityExtension -}}
 external-dns: azure.useManagedIdentityExtension
-    You must not provide the Azure AAD Client Secret when provider="azure" and useManagedIdentityExtension is "true".
+    You must not provide the Azure AAD Client Secret when provider="azure-private-dns" and useManagedIdentityExtension is "true".
     Please unset the aadClientSecret parameter (--set azure.aadClientSecret="")
 {{- end -}}
 {{- end -}}
@@ -500,7 +504,7 @@ external-dns: azure.useManagedIdentityExtension
 
 {{/*
 Validate values of Azure Private DNS:
-- must provide the Azure AAD Client ID when provider is "azure-private-dns", secret name is not set and MSi is disabled
+- must provide the Azure AAD Client ID when provider is "azure-private-dns", secret name is not set and MSI is disabled
 */}}
 {{- define "external-dns.validateValues.azurePrivateDns.aadClientId" -}}
 {{- if and (eq .Values.provider "azure-private-dns") (not .Values.azure.secretName) (not .Values.azure.aadClientId) (not .Values.azure.useManagedIdentityExtension) -}}
@@ -517,7 +521,7 @@ Validate values of Azure Private DNS:
 {{- define "external-dns.validateValues.azurePrivateDns.aadClientSecret" -}}
 {{- if and (eq .Values.provider "azure-private-dns") (not .Values.azure.secretName) (not .Values.azure.aadClientSecret) (not .Values.azure.useManagedIdentityExtension) -}}
 external-dns: azure.useManagedIdentityExtension
-    You must provide the Azure AAD Client Secret when provider="azure" and useManagedIdentityExtension is not set.
+    You must provide the Azure AAD Client Secret when provider="azure-private-dns" and useManagedIdentityExtension is not set.
     Please set the aadClientSecret parameter (--set azure.aadClientSecret="xxxx")
 {{- end -}}
 {{- end -}}

--- a/bitnami/external-dns/templates/_helpers.tpl
+++ b/bitnami/external-dns/templates/_helpers.tpl
@@ -407,18 +407,6 @@ external-dns: azure.useManagedIdentityExtension
 
 {{/*
 Validate values of Azure DNS:
-- must provide the Azure AAD Client Secret when provider is "azure-private-dns" and useManagedIdentityExtension is "true"
-*/}}
-{{- define "external-dns.validateValues.azurePrivateDns.useManagedIdentityExtensionAadClientSecret" -}}
-{{- if and (eq .Values.provider "azure-private-dns") (not .Values.azure.secretName) .Values.azure.aadClientSecret .Values.azure.useManagedIdentityExtension -}}
-external-dns: azure.useManagedIdentityExtension
-    You must not provide the Azure AAD Client Secret when provider="azure-private-dns" and useManagedIdentityExtension is "true".
-    Please unset the aadClientSecret parameter (--set azure.aadClientSecret="")
-{{- end -}}
-{{- end -}}
-
-{{/*
-Validate values of Azure DNS:
 - must not provide the Azure AAD Client secret when provider is "azure", secretName is not set and MSI is enabled
 */}}
 {{- define "external-dns.validateValues.azure.useManagedIdentityExtensionAadClientSecret" -}}
@@ -450,6 +438,18 @@ Validate values of Azure DNS:
 external-dns: azure.useManagedIdentityExtension
     You must provide the Azure AAD Client Secret when provider="azure" and useManagedIdentityExtension is not set.
     Please set the aadClientSecret parameter (--set azure.aadClientSecret="xxxx")
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate values of Azure Private DNS:
+- must provide the Azure AAD Client Secret when provider is "azure-private-dns", secretName is not set and useManagedIdentityExtension is "true"
+*/}}
+{{- define "external-dns.validateValues.azurePrivateDns.useManagedIdentityExtensionAadClientSecret" -}}
+{{- if and (eq .Values.provider "azure-private-dns") (not .Values.azure.secretName) .Values.azure.aadClientSecret .Values.azure.useManagedIdentityExtension -}}
+external-dns: azure.useManagedIdentityExtension
+    You must not provide the Azure AAD Client Secret when provider="azure-private-dns", secretName is not set, and useManagedIdentityExtension is "true".
+    Please unset the aadClientSecret parameter (--set azure.aadClientSecret="")
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/external-dns/templates/_helpers.tpl
+++ b/bitnami/external-dns/templates/_helpers.tpl
@@ -236,7 +236,8 @@ Compile all warnings into a single message, and call fail.
 {{- $messages := append $messages (include "external-dns.validateValues.azurePrivateDns.subscriptionId" .) -}}
 {{- $messages := append $messages (include "external-dns.validateValues.azurePrivateDns.aadClientId" .) -}}
 {{- $messages := append $messages (include "external-dns.validateValues.azurePrivateDns.aadClientSecret" .) -}}
-{{- $messages := append $messages (include "external-dns.validateValues.azurePrivateDns.useManagedIdentityExtensionNotSupported" .) -}}
+{{- $messages := append $messages (include "external-dns.validateValues.azurePrivateDns.useManagedIdentityExtensionAadClientId" .) -}}
+{{- $messages := append $messages (include "external-dns.validateValues.azurePrivateDns.useManagedIdentityExtensionAadClientSecret" .) -}}
 {{- $messages := append $messages (include "external-dns.validateValues.transip.account" .) -}}
 {{- $messages := append $messages (include "external-dns.validateValues.transip.apiKey" .) -}}
 {{- $messages := append $messages (include "external-dns.validateValues.ovh.consumerKey" .) -}}
@@ -404,6 +405,14 @@ external-dns: azure.useManagedIdentityExtension
 {{- end -}}
 {{- end -}}
 
+{{- define "external-dns.validateValues.azurePrivateDns.useManagedIdentityExtensionAadClientSecret" -}}
+{{- if and (eq .Values.provider "azure-private-dns") (not .Values.azure.secretName) .Values.azure.aadClientSecret .Values.azure.useManagedIdentityExtension -}}
+external-dns: azure.useManagedIdentityExtension
+    You must not provide the Azure AAD Client Secret when provider="azure" and useManagedIdentityExtension is "true".
+    Please unset the aadClientSecret parameter (--set azure.aadClientSecret="")
+{{- end -}}
+{{- end -}}
+
 {{/*
 Validate values of Azure DNS:
 - must not provide the Azure AAD Client secret when provider is "azure", secretName is not set and MSI is enabled
@@ -479,40 +488,39 @@ external-dns: azure.subscriptionId
 
 {{/*
 Validate values of Azure Private DNS:
-- must provide the Azure AAD Client ID when provider is "azure-private-dns" and secretName is not set
+- must not provide the Azure AAD Client Secret when provider is "azure-private-dns", secretName is not set and MSI is enabled
 */}}
-{{- define "external-dns.validateValues.azurePrivateDns.aadClientId" -}}
-{{- if and (eq .Values.provider "azure-private-dns") (not .Values.azure.secretName) (not .Values.azure.aadClientId) -}}
-external-dns: azure.aadClientId
-    You must provide the Azure AAD Client ID when provider="azure-private-dns".
-    Please set the aadClientId parameter (--set azure.aadClientId="xxxx")
+{{- define "external-dns.validateValues.azurePrivateDns.useManagedIdentityExtensionAadClientId" -}}
+{{- if and (eq .Values.provider "azure-private-dns") (not .Values.azure.secretName) .Values.azure.aadClientId .Values.azure.useManagedIdentityExtension -}}
+external-dns: azure.useManagedIdentityExtension
+    You must not provide the Azure AAD Client ID when provider="azure-private-dns" and useManagedIdentityExtension is "true".
+    Please unset the aadClientId parameter (--set azure.aadClientId="")
 {{- end -}}
 {{- end -}}
 
 {{/*
 Validate values of Azure Private DNS:
-- must provide the Azure AAD Client Secret when provider is "azure-private-dns" and secretName is not set
+- must provide the Azure AAD Client ID when provider is "azure-private-dns", secret name is not set and MSi is disabled
+*/}}
+{{- define "external-dns.validateValues.azurePrivateDns.aadClientId" -}}
+{{- if and (eq .Values.provider "azure-private-dns") (not .Values.azure.secretName) (not .Values.azure.aadClientId) (not .Values.azure.useManagedIdentityExtension) -}}
+external-dns: azure.useManagedIdentityExtension
+    You must provide the Azure AAD Client ID when provider="azure-private-dns" and useManagedIdentityExtension is not set.
+    Please set the aadClientSecret parameter (--set azure.aadClientId="xxxx")
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate values of Azure Private DNS:
+- must provide the Azure AAD Client Secret when provider is "azure-private-dns", secretName is not set and MSI is disabled
 */}}
 {{- define "external-dns.validateValues.azurePrivateDns.aadClientSecret" -}}
-{{- if and (eq .Values.provider "azure-private-dns") (not .Values.azure.secretName) (not .Values.azure.aadClientSecret) -}}
-external-dns: azure.aadClientSecret
-    You must provide the Azure AAD Client Secret when provider="azure-private-dns".
+{{- if and (eq .Values.provider "azure-private-dns") (not .Values.azure.secretName) (not .Values.azure.aadClientSecret) (not .Values.azure.useManagedIdentityExtension) -}}
+external-dns: azure.useManagedIdentityExtension
+    You must provide the Azure AAD Client Secret when provider="azure" and useManagedIdentityExtension is not set.
     Please set the aadClientSecret parameter (--set azure.aadClientSecret="xxxx")
 {{- end -}}
 {{- end -}}
-
-{{/*
-Validate values of Azure Private DNS:
-- MSI is not currently supported by external-dns for azure-private-dns, see https://github.com/kubernetes-sigs/external-dns/issues/1510
-*/}}
-{{- define "external-dns.validateValues.azurePrivateDns.useManagedIdentityExtensionNotSupported" -}}
-{{- if and (eq .Values.provider "azure-private-dns") (.Values.azure.useManagedIdentityExtension) -}}
-external-dns: azure.useManagedIdentityExtension
-    The value useManagedIdentityExtension is not supported in provider "azure-private-dns"
-    Please set the aadClientId & aadClientSecret values and unset useManagedIdentityExtension (--set azure.useManagedIdentityExtension=false,azure.aadClientID="xxxx",azure.aadClientSecret="xxxx")
-{{- end -}}
-{{- end -}}
-
 
 {{/*
 Validate values of TransIP DNS:

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -237,6 +237,7 @@ spec:
             - name: AZURE_TENANT_ID
               value: {{ .Values.azure.tenantId }}
             {{- end }}
+            {{- if not .Values.azure.useManagedIdentityExtension }}
             {{- if or .Values.azure.aadClientId .Values.azure.aadClientSecret .Values.azure.secretName }}
             - name: AZURE_CLIENT_SECRET
               valueFrom:
@@ -248,6 +249,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "external-dns.secretName" . }}
                   key: azure_aad_client_id
+            {{- end }}
             {{- end }}
             {{- end }}
             {{- if eq .Values.provider "cloudflare" }}
@@ -447,7 +449,7 @@ spec:
               mountPath: {{ .Values.aws.credentials.mountPath }}
               readOnly: true
             {{- end }}
-            {{- if eq .Values.provider "azure" }}
+            {{- if or (eq .Values.provider "azure") (eq .Values.provider "azure-private-dns") }}
             # Azure mountPath(s)
             - name: azure-config-file
               {{- if or .Values.azure.secretName (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId) }}
@@ -505,7 +507,7 @@ spec:
           secret:
             secretName: {{ template "external-dns.secretName" . }}
         {{- end }}
-        {{- if eq .Values.provider "azure" }}
+        {{- if or (eq .Values.provider "azure") (eq .Values.provider "azure-private-dns") }}
         # Azure volume(s)
         - name: azure-config-file
           {{- if or .Values.azure.secretName (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId) }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Add support for Azure MSi when using azure-private-dns provider

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #2851

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
