### PR TITLE
[bitnami/kafka] Fix instructions to use a producer

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 11.6.1
+version: 11.6.2
 appVersion: 2.5.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/templates/NOTES.txt
+++ b/bitnami/kafka/templates/NOTES.txt
@@ -61,9 +61,10 @@ Each Kafka broker can be accessed by producers via port {{ $servicePort }} on th
 
 {{- $brokerList := list }}
 {{- range $e, $i := until $replicaCount }}
-{{- $brokerList = append $brokerList (printf "%s-%d.%s-headless.%s.svc.%s" $fullname $i $fullname $releaseNamespace $clusterDomain) }}
+{{- $brokerList = append $brokerList (printf "%s-%d.%s-headless.%s.svc.%s:%d" $fullname $i $fullname $releaseNamespace $clusterDomain $servicePort) }}
 {{- end }}
 {{ join "\n" $brokerList | nindent 4 }}
+
 
 {{- if (include "kafka.client.saslAuthentication" .) }}
 


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Includes the port in the broker list, so the instructions to use a producer are correct.

**Possible drawbacks**

None

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

