### PR TITLE
[bitnami/fluentd] Add missing service type for fluentd aggregator

### DIFF
--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd
-version: 1.2.9
+version: 1.2.10
 appVersion: 1.11.1
 description: Fluentd is an open source data collector for unified logging layer
 keywords:

--- a/bitnami/fluentd/templates/aggregator-svc.yaml
+++ b/bitnami/fluentd/templates/aggregator-svc.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.aggregator.enabled .Values.aggregator.service.ports -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fluentd.fullname" . }}-aggregator
+  labels: {{- include "fluentd.labels" . | nindent 4 }}
+    app.kubernetes.io/component: aggregator
+    app: aggregator
+  {{- if .Values.aggregator.service.annotations }}
+  annotations: {{- include "fluentd.tplValue" (dict "value" .Values.aggregator.service.annotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.aggregator.service.type }}
+  {{- if and .Values.aggregator.service.loadBalancerIP (eq .Values.aggregator.service.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.aggregator.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and .Values.aggregator.service.loadBalancerSourceRanges (eq .Values.aggregator.service.type "LoadBalancer") }}
+  loadBalancerSourceRanges:
+  {{- with .Values.aggregator.service.loadBalancerSourceRanges }}
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+  {{- if and (eq .Values.aggregator.service.type "ClusterIP") .Values.aggregator.service.clusterIP }}
+  clusterIP: {{ .Values.aggregator.service.clusterIP }}
+  {{- end }}
+  ports:
+  {{- range $key, $value := .Values.aggregator.service.ports }}
+    - name: {{ $key }}
+      {{ toYaml $value | nindent 6 }}
+  {{- end }}
+  selector: {{- include "fluentd.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: aggregator
+{{- end -}}

--- a/bitnami/fluentd/templates/svc-headless.yaml
+++ b/bitnami/fluentd/templates/svc-headless.yaml
@@ -6,6 +6,9 @@ metadata:
   labels: {{- include "fluentd.labels" . | nindent 4 }}
     app.kubernetes.io/component: aggregator
     app: aggregator
+  {{- if .Values.aggregator.service.annotations }}
+  annotations: {{- include "fluentd.tplValue" (dict "value" .Values.aggregator.service.annotations "context" $) | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.aggregator.service.type }}
   {{- if and .Values.aggregator.service.loadBalancerIP (eq .Values.aggregator.service.type "LoadBalancer") }}

--- a/bitnami/fluentd/templates/svc-headless.yaml
+++ b/bitnami/fluentd/templates/svc-headless.yaml
@@ -6,23 +6,9 @@ metadata:
   labels: {{- include "fluentd.labels" . | nindent 4 }}
     app.kubernetes.io/component: aggregator
     app: aggregator
-  {{- if .Values.aggregator.service.annotations }}
-  annotations: {{- include "fluentd.tplValue" (dict "value" .Values.aggregator.service.annotations "context" $) | nindent 4 }}
-  {{- end }}
 spec:
-  type: {{ .Values.aggregator.service.type }}
-  {{- if and .Values.aggregator.service.loadBalancerIP (eq .Values.aggregator.service.type "LoadBalancer") }}
-  loadBalancerIP: {{ .Values.aggregator.service.loadBalancerIP }}
-  {{- end }}
-  {{- if and .Values.aggregator.service.loadBalancerSourceRanges (eq .Values.aggregator.service.type "LoadBalancer") }}
-  loadBalancerSourceRanges:
-  {{- with .Values.aggregator.service.loadBalancerSourceRanges }}
-    {{ toYaml . | nindent 4 }}
-  {{- end }}
-  {{- end }}
-  {{- if eq .Values.aggregator.service.type "ClusterIP" }}
+  type: ClusterIP
   clusterIP: None
-  {{- end }}
   ports:
   {{- range $key, $value := .Values.aggregator.service.ports }}
     - name: {{ $key }}

--- a/bitnami/fluentd/templates/svc-headless.yaml
+++ b/bitnami/fluentd/templates/svc-headless.yaml
@@ -7,8 +7,19 @@ metadata:
     app.kubernetes.io/component: aggregator
     app: aggregator
 spec:
-  type: ClusterIP
+  type: {{ .Values.aggregator.service.type }}
+  {{- if and .Values.aggregator.service.loadBalancerIP (eq .Values.aggregator.service.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.aggregator.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and .Values.aggregator.service.loadBalancerSourceRanges (eq .Values.aggregator.service.type "LoadBalancer") }}
+  loadBalancerSourceRanges:
+  {{- with .Values.aggregator.service.loadBalancerSourceRanges }}
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+  {{- if eq .Values.aggregator.service.type "ClusterIP" }}
   clusterIP: None
+  {{- end }}
   ports:
   {{- range $key, $value := .Values.aggregator.service.ports }}
     - name: {{ $key }}


### PR DESCRIPTION
**Description of the change**

- Current `master` version of bitnami chart for `fluentd` has in `values.yaml` described to specify the service type and LoadBalancer specs for the aggregator, although the service does not provide that support to actually use these values;
- This change adds that functionality that was already expected in the `values.yaml` file as it can be seen on issue #3239

**Benefits**

- This will enable users to use fluentd as an aggregator through a LoadBalancer service (e.g. across clusters or zones through Internal LB)

**Possible drawbacks**

- None can be foreseen given that this just extends the functionality, everything else remains the same;

**Applicable issues**
  - fixes #3239


**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md **(nothing changed)**
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files **(nothing changed)**

