### PR TITLE
[bitnami/airflow] Fix LDAP when tls is not enabled

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: airflow
-version: 6.3.6
+version: 6.3.7
 appVersion: 1.10.11
 description: Apache Airflow is a platform to programmatically author, schedule and monitor workflows.
 keywords:

--- a/bitnami/airflow/templates/deployment-web.yaml
+++ b/bitnami/airflow/templates/deployment-web.yaml
@@ -226,19 +226,19 @@ spec:
                   key: airflow-fernetKey
             - name: AIRFLOW_WEBSERVER_HOST
               value: {{ template "airflow.fullname" . }}
-              {{- if .Values.airflow.baseUrl }}
+            {{- if .Values.airflow.baseUrl }}
             - name: AIRFLOW_BASE_URL
               value: {{ .Values.airflow.baseUrl }}
-              {{- end }}
+            {{- end }}
             - name: AIRFLOW_LOAD_EXAMPLES
               {{- if .Values.airflow.loadExamples }}
               value: "yes"
               {{- else }}
               value: "no"
               {{- end }}
-              {{- if .Values.ldap.enabled }}
             - name: AIRFLOW_LDAP_ENABLE
-              value: "yes"
+              value: {{ ternary "yes" "no" .Values.ldap.enabled | quote }}
+            {{- if .Values.ldap.enabled }}
             - name: AIRFLOW_LDAP_URI
               value: {{ .Values.ldap.uri }}
             - name: AIRFLOW_LDAP_SEARCH
@@ -253,14 +253,14 @@ spec:
                   key: bind-password
             - name: AIRFLOW_LDAP_UID_FIELD
               value: {{ .Values.ldap.uidField }}
-              {{- if .Values.ldap.tls.enabled }}
             - name: AIRFLOW_LDAP_USE_TLS
-              value: "yes"
+              value: {{ ternary "yes" "no" .Values.ldap.tls.enabled | quote }}
+            {{- if .Values.ldap.tls.enabled }}
             - name: AIRFLOW_LDAP_ALLOW_SELF_SIGNED
               value: {{ .Values.ldap.tls.allowSelfSigned }}
             - name: AIRFLOW_LDAP_TLS_CA_CERTIFICATE
               value: {{ include "airflow.ldapCAFilename" . | quote }}
-              {{- end }}
+            {{- end }}
             {{- end }}
             {{- if .Values.airflow.extraEnvVars }}
               {{- toYaml .Values.airflow.extraEnvVars | nindent 12 }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR ensures that `AIRFLOW_LDAP_ENABLE` and `AIRFLOW_LDAP_USE_TLS` are always properly set to avoid issues like the referred one.

**Benefits**

You can configure LDAP without TLS

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/bitnami-docker-airflow/issues/54

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

