### PR TITLE
[bitnami/wordpress] Document MaintenanceMode limitation & add missing parameters

### DIFF
--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 9.3.22
+version: 9.4.0
 appVersion: 5.4.2
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -294,7 +294,7 @@ mariadb.master.persistence.storageClass=nfs
 
 When performing admin operations that require activating the maintenance mode (such as updating a plugin or theme), it's activated in only one replica (see: [bug report](https://core.trac.wordpress.org/ticket/50797)). This implies that WP could be attending requests on other replicas while performing admin operations, with unpredictable consequences.
 
-To avoid that, you can manually activate/deactivate the maintenance mode on every replica using the WP CLI. For instance, if you installed WP with replicas you can run the commands below to activate the maintenance mode (the following example assumes that the release name is `wordpress`):
+To avoid that, you can manually activate/deactivate the maintenance mode on every replica using the WP CLI. For instance, if you installed WP with three replicas, you can run the commands below to activate the maintenance mode in all of them (assuming that the release name is `wordpress`):
 
 ```console
 kubectl exec $(kubectl get pods -l app.kubernetes.io/name=wordpress -o jsonpath='{.items[0].metadata.name}') -c wordpress -- wp maintenance-mode activate

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -292,7 +292,7 @@ mariadb.master.persistence.storageClass=nfs
 
 #### Known limitations
 
-When performing admin operations that require activating the maintenance mode (such as updating a plugin or theme), it's activated in only one replica (this is related to some limitation that doesn't allow us to change the maintenance file path to include it in the NFS volume, find more information on [this ticket](https://core.trac.wordpress.org/ticket/50797)). This implies that WP could be attending requests on other replicas while performing admin operations, with unpredictable consequences.
+When performing admin operations that require activating the maintenance mode (such as updating a plugin or theme), it's activated in only one replica (see: [bug report](https://core.trac.wordpress.org/ticket/50797)). This implies that WP could be attending requests on other replicas while performing admin operations, with unpredictable consequences.
 
 To avoid that, you can manually activate/deactivate the maintenance mode on every replica using the WP CLI. For instance, if you installed WP with replicas you can run the commands below to activate the maintenance mode (the following example assumes that the release name is `wordpress`):
 

--- a/bitnami/wordpress/templates/NOTES.txt
+++ b/bitnami/wordpress/templates/NOTES.txt
@@ -1,5 +1,9 @@
 ** Please be patient while the chart is being deployed **
 
+Your WordPress site can be accessed through the following DNS name from within your cluster:
+
+    {{ include "wordpress.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} (port {{ .Values.service.port }})
+
 To access your WordPress site from outside the cluster follow the steps below:
 
 {{- if .Values.ingress.enabled }}

--- a/bitnami/wordpress/templates/deployment.yaml
+++ b/bitnami/wordpress/templates/deployment.yaml
@@ -3,6 +3,12 @@ kind: Deployment
 metadata:
   name: {{ template "wordpress.fullname" . }}
   labels: {{- include "wordpress.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "wordpress.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "wordpress.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels: {{- include "wordpress.matchLabels" . | nindent 6 }}
@@ -52,6 +58,12 @@ spec:
         - name: wordpress
           image: {{ template "wordpress.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          {{- if .Values.command }}
+          command: {{- include "wordpress.tplValue" ( dict "value" .Values.command "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.args }}
+          args: {{- include "wordpress.tplValue" ( dict "value" .Values.args "context" $) | nindent 12 }}
+          {{- end }}
           env:
             {{- if .Values.image.debug }}
             - name: NAMI_DEBUG
@@ -140,7 +152,7 @@ spec:
             successThreshold: {{ .Values.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
             httpGet:
-              path: /wp-login.php
+              path: /wp-admin/install.php
               port: {{ ternary "https" "http" .Values.healthcheckHttps }}
               {{- if .Values.healthcheckHttps }}
               scheme: HTTPS

--- a/bitnami/wordpress/templates/externaldb-secrets.yaml
+++ b/bitnami/wordpress/templates/externaldb-secrets.yaml
@@ -4,6 +4,12 @@ kind: Secret
 metadata:
   name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
   labels: {{- include "wordpress.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "wordpress.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "wordpress.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   mariadb-password: {{ .Values.externalDatabase.password | b64enc | quote }}

--- a/bitnami/wordpress/templates/ingress.yaml
+++ b/bitnami/wordpress/templates/ingress.yaml
@@ -4,12 +4,18 @@ kind: Ingress
 metadata:
   name: {{ template "wordpress.fullname" . }}
   labels: {{- include "wordpress.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "wordpress.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   annotations:
     {{- if .Values.ingress.certManager }}
     kubernetes.io/tls-acme: "true"
     {{- end }}
     {{- if .Values.ingress.annotations }}
     {{- include "wordpress.tplValue" (dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "wordpress.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
 spec:
   rules:

--- a/bitnami/wordpress/templates/pvc.yaml
+++ b/bitnami/wordpress/templates/pvc.yaml
@@ -4,6 +4,12 @@ apiVersion: v1
 metadata:
   name: {{ template "wordpress.fullname" . }}
   labels: {{- include "wordpress.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "wordpress.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "wordpress.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/bitnami/wordpress/templates/secrets.yaml
+++ b/bitnami/wordpress/templates/secrets.yaml
@@ -3,6 +3,12 @@ kind: Secret
 metadata:
   name: {{ template "wordpress.fullname" . }}
   labels: {{- include "wordpress.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "wordpress.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "wordpress.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   {{- if .Values.wordpressPassword }}

--- a/bitnami/wordpress/templates/servicemonitor.yaml
+++ b/bitnami/wordpress/templates/servicemonitor.yaml
@@ -10,6 +10,12 @@ metadata:
     {{- if .Values.metrics.serviceMonitor.additionalLabels }}
     {{- include "wordpress.tplValue" (dict "value" .Values.metrics.serviceMonitor.additionalLabels "context" $) | nindent 4 }}
     {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "wordpress.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "wordpress.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   endpoints:
     - port: metrics

--- a/bitnami/wordpress/templates/svc.yaml
+++ b/bitnami/wordpress/templates/svc.yaml
@@ -3,8 +3,17 @@ kind: Service
 metadata:
   name: {{ template "wordpress.fullname" . }}
   labels: {{- include "wordpress.labels" . | nindent 4 }}
-  {{- if .Values.service.annotations }}
-  annotations: {{- include "wordpress.tplValue" (dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "wordpress.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.service.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.service.annotations }}
+    {{- include "wordpress.tplValue" (dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "wordpress.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/bitnami/wordpress/templates/tls-secrets.yaml
+++ b/bitnami/wordpress/templates/tls-secrets.yaml
@@ -1,13 +1,35 @@
 {{- if .Values.ingress.enabled }}
+{{- if .Values.ingress.secrets }}
 {{- range .Values.ingress.secrets }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .name }}
   labels: {{- include "wordpress.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "wordpress.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "wordpress.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .certificate | b64enc }}
   tls.key: {{ .key | b64enc }}
+---
+{{- end }}
+{{- else if and .Values.ingress.tls (not .Values.ingress.certManager) }}
+{{- $ca := genCA "wordpress-ca" 365 }}
+{{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-tls" .Values.ingress.hostname }}
+  labels: {{- include "wordpress.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $cert.Cert | b64enc | quote }}
+  tls.key: {{ $cert.Key | b64enc | quote }}
+  ca.crt: {{ $ca.Cert | b64enc | quote }}
 {{- end }}
 {{- end }}

--- a/bitnami/wordpress/values-production.yaml
+++ b/bitnami/wordpress/values-production.yaml
@@ -38,6 +38,18 @@ image:
 ##
 # fullnameOverride:
 
+## Kubernetes Cluster Domain
+##
+clusterDomain: cluster.local
+
+## Add labels to all the deployed resources
+##
+commonLabels: {}
+
+## Add annotations to all the deployed resources
+##
+commonAnnotations: {}
+
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
 ##
@@ -84,6 +96,31 @@ wordpressScheme: http
 ##
 wordpressSkipInstall: false
 
+## Set to `false` to allow the container to be started with blank passwords
+## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
+##
+allowEmptyPassword: true
+
+## Set Apache allowOverride to None
+## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
+##
+allowOverrideNone: false
+
+## Persist the custom changes of the htaccess. It depends on the value of
+## `.Values.allowOverrideNone`, when `yes` it will persist `/opt/bitnami/wordpress/wordpress-htaccess.conf`
+## if `no` it will persist `/opt/bitnami/wordpress/.htaccess`
+##
+htaccessPersistenceEnabled: false
+
+## ConfigMap with custom wordpress-htaccess.conf file (requires allowOverrideNone to true)
+##
+customHTAccessCM:
+
+## Command and args for running the container (set to default if not set). Use array form
+##
+command: []
+args: []
+
 ## Set up update strategy for wordpress installation. Set to Recreate if you use persistent volume that cannot be mounted by more than one pods to makesure the pods is destroyed first.
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
 ## Example:
@@ -95,26 +132,6 @@ wordpressSkipInstall: false
 ##
 updateStrategy:
   type: RollingUpdate
-
-## Set to `false` to allow the container to be started with blank passwords
-## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
-##
-allowEmptyPassword: true
-
-## Set Apache allowOverride to None
-## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
-##
-allowOverrideNone: true
-
-## Persist the custom changes of the htaccess. It depends on the value of
-## `.Values.allowOverrideNone`, when `yes` it will persist `/opt/bitnami/wordpress/wordpress-htaccess.conf`
-## if `no` it will persist `/opt/bitnami/wordpress/.htaccess`
-##
-htaccessPersistenceEnabled: false
-
-## ConfigMap with custom wordpress-htaccess.conf file (requires allowOverrideNone to true)
-##
-customHTAccessCM:
 
 ## Use an alternate scheduler, e.g. "stork".
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
@@ -167,6 +184,8 @@ extraVolumes: []
 ##
 resources:
   limits: {}
+  #   cpu: 500m
+  #   memory: 1Gi
   requests:
     memory: 512Mi
     cpu: 300m

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -38,6 +38,18 @@ image:
 ##
 # fullnameOverride:
 
+## Kubernetes Cluster Domain
+##
+clusterDomain: cluster.local
+
+## Add labels to all the deployed resources
+##
+commonLabels: {}
+
+## Add annotations to all the deployed resources
+##
+commonAnnotations: {}
+
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
 ##
@@ -84,18 +96,6 @@ wordpressScheme: http
 ##
 wordpressSkipInstall: false
 
-## Set up update strategy for wordpress installation. Set to Recreate if you use persistent volume that cannot be mounted by more than one pods to makesure the pods is destroyed first.
-## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
-## Example:
-## updateStrategy:
-##  type: RollingUpdate
-##  rollingUpdate:
-##    maxSurge: 25%
-##    maxUnavailable: 25%
-##
-updateStrategy:
-  type: RollingUpdate
-
 ## Set to `false` to allow the container to be started with blank passwords
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
 ##
@@ -115,6 +115,23 @@ htaccessPersistenceEnabled: false
 ## ConfigMap with custom wordpress-htaccess.conf file (requires allowOverrideNone to true)
 ##
 customHTAccessCM:
+
+## Command and args for running the container (set to default if not set). Use array form
+##
+command: []
+args: []
+
+## Set up update strategy for wordpress installation. Set to Recreate if you use persistent volume that cannot be mounted by more than one pods to makesure the pods is destroyed first.
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+## Example:
+## updateStrategy:
+##  type: RollingUpdate
+##  rollingUpdate:
+##    maxSurge: 25%
+##    maxUnavailable: 25%
+##
+updateStrategy:
+  type: RollingUpdate
 
 ## Use an alternate scheduler, e.g. "stork".
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
@@ -167,6 +184,8 @@ extraVolumes: []
 ##
 resources:
   limits: {}
+  #   cpu: 500m
+  #   memory: 1Gi
   requests:
     memory: 512Mi
     cpu: 300m
@@ -199,10 +218,6 @@ securityContext:
   fsGroup: 1001
   runAsUser: 1001
 
-## Allow health checks to be pointed at the https port
-##
-healthcheckHttps: false
-
 ## WordPress pod extra options for liveness and readiness probes
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 ##
@@ -220,6 +235,10 @@ readinessProbe:
   timeoutSeconds: 5
   failureThreshold: 6
   successThreshold: 1
+
+## Allow health checks to be pointed at the https port
+##
+healthcheckHttps: false
 
 ## Custom liveness and readiness probes, it overrides the default one (evaluated as a template)
 ##


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>
Credits to @lwj5 for bringing this up and provide the solution for liveness probes.

**Description of the change**

This PR documents a known limitation when running the WP with the production values related to the maintenance mode. It also uses a better endpoint for liveness probes so the container is not restarted when performing operations such as updating a plugin.

On the other hand, it adds some common useful parameters that were missing in the chart.

**Possible drawbacks**

None

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

