### PR TITLE
[bitnami/zookeeper] Fix probes when using CentOS images

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zookeeper
-version: 5.21.0
+version: 5.21.1
 appVersion: 3.6.1
 description: A centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services for distributed applications.
 keywords:

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -233,7 +234,7 @@ spec:
           livenessProbe:
             exec:
               {{- if not .Values.service.tls.disable_base_client_port }}
-              command: ['/bin/bash', '-c', 'echo "ruok" | nc -w {{ .Values.livenessProbe.probeCommandTimeout }} -q {{ .Values.livenessProbe.probeCommandTimeout }} localhost {{ .Values.service.port }} | grep imok']
+              command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.livenessProbe.probeCommandTimeout }} nc -w {{ .Values.livenessProbe.probeCommandTimeout }} localhost {{ .Values.service.port }} | grep imok']
               {{- else }}
               command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.livenessProbe.probeCommandTimeout }} openssl s_client -quiet -crlf -connect localhost:{{ .Values.service.tls.client_port }} | grep imok']
               {{- end }}
@@ -247,7 +248,7 @@ spec:
           readinessProbe:
             exec:
               {{- if not .Values.service.tls.disable_base_client_port }}
-              command: ['/bin/bash', '-c', 'echo "ruok" | nc -w {{ .Values.readinessProbe.probeCommandTimeout }} -q {{ .Values.readinessProbe.probeCommandTimeout }} localhost {{ .Values.service.port }} | grep imok']
+              command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.livenessProbe.probeCommandTimeout }} nc -w {{ .Values.readinessProbe.probeCommandTimeout }} localhost {{ .Values.service.port }} | grep imok']
               {{- else }}
               command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.readinessProbe.probeCommandTimeout }} openssl s_client -quiet -crlf -connect localhost:{{ .Values.service.tls.client_port }} | grep imok']
               {{- end }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

The option `-q` is not supported on CentOS netcat, while the option `-w` is shared: 

- Debian:

```console
$ nc -h
[v1.10-41.1]
connect to somewhere:	nc [-options] hostname port[s] [ports] ...
listen for inbound:	nc -l -p port [-options] [hostname] [port]
options:
	...
	-q secs			quit after EOF on stdin and delay of secs
	...
	-w secs			timeout for connects and final net reads
```

- CentOS:

```console
$ nc -h
Ncat 7.50 ( https://nmap.org/ncat )
Usage: ncat [options] [hostname] [port]
  ...
  -w, --wait <time>          Connect timeout
  ...
```

We can obtain a similar effect (quitting after N seconds) using the `timeout` command.

**Benefits**

You can replace default image with a "centos based" one.

**Possible drawbacks**

None

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

