### PR TITLE
[bitnami/nginx] Fix inability to create single ingress rule with path

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx
-version: 6.0.2
+version: 6.0.3
 appVersion: 1.19.1
 description: Chart for the nginx server
 keywords:

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -338,7 +338,13 @@ ingress:
 
   ## When the ingress is enabled, a host pointing to this will be created
   ##
-  hostname: example.local
+  # hostname: example.local
+
+  ## The list of hosts and paths to be covered into ingress rules if more than one hosts
+  ## or only a host with a path is needed, this is an array
+  ## hosts:
+  ## - name: example.local
+  ##   path: /
 
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
@@ -348,12 +354,6 @@ ingress:
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
   annotations: {}
   #  kubernetes.io/ingress.class: nginx
-
-  ## The list of additional hostnames to be covered with this ingress record.
-  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
-  ## hosts:
-  ## - name: example.local
-  ##   path: /
 
   ## The tls configuration for the ingress
   ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls


### PR DESCRIPTION
**Description of the change**

Remove default value for the ingress hostname

**Benefits**

It allows creating ingress with a single rule containing a path

**Possible drawbacks**

**Applicable issues**

  - fixes #3264

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
