### PR TITLE
[bitnami/grafana] Fix grafana-admin command when using existing secrets

### DIFF
--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 3.3.0
+version: 3.3.1
 appVersion: 7.1.1
 description: Grafana is an open source, feature rich metrics dashboard and graph editor for Graphite, Elasticsearch, OpenTSDB, Prometheus and InfluxDB.
 keywords:

--- a/bitnami/grafana/templates/NOTES.txt
+++ b/bitnami/grafana/templates/NOTES.txt
@@ -25,7 +25,7 @@
 2. Get the admin credentials:
 
     echo "User: {{ .Values.admin.user }}"
-    echo "Password: $(kubectl get secret {{ include "grafana.fullname" . }}-admin --namespace {{ .Release.Namespace }} -o jsonpath="{.data.{{ include "grafana.adminSecretPasswordKey" . }}}" | base64 --decode)"
+    echo "Password: $(kubectl get secret {{ include "grafana.adminSecretName" . }}-admin --namespace {{ .Release.Namespace }} -o jsonpath="{.data.{{ include "grafana.adminSecretPasswordKey" . }}}" | base64 --decode)"
 
 {{ include "grafana.checkRollingTags" . }}
 {{ include "grafana.validateValues" . }}

--- a/bitnami/grafana/templates/NOTES.txt
+++ b/bitnami/grafana/templates/NOTES.txt
@@ -25,7 +25,7 @@
 2. Get the admin credentials:
 
     echo "User: {{ .Values.admin.user }}"
-    echo "Password: $(kubectl get secret {{ include "grafana.fullname" . }}-admin --namespace {{ .Release.Namespace }} -o jsonpath="{.data.GF_SECURITY_ADMIN_PASSWORD}" | base64 --decode)"
+    echo "Password: $(kubectl get secret {{ include "grafana.fullname" . }}-admin --namespace {{ .Release.Namespace }} -o jsonpath="{.data.{{ include "grafana.adminSecretPasswordKey" . }}}" | base64 --decode)"
 
 {{ include "grafana.checkRollingTags" . }}
 {{ include "grafana.validateValues" . }}

--- a/bitnami/grafana/templates/NOTES.txt
+++ b/bitnami/grafana/templates/NOTES.txt
@@ -25,7 +25,7 @@
 2. Get the admin credentials:
 
     echo "User: {{ .Values.admin.user }}"
-    echo "Password: $(kubectl get secret {{ include "grafana.adminSecretName" . }}-admin --namespace {{ .Release.Namespace }} -o jsonpath="{.data.{{ include "grafana.adminSecretPasswordKey" . }}}" | base64 --decode)"
+    echo "Password: $(kubectl get secret {{ include "grafana.adminSecretName" . }} --namespace {{ .Release.Namespace }} -o jsonpath="{.data.{{ include "grafana.adminSecretPasswordKey" . }}}" | base64 --decode)"
 
 {{ include "grafana.checkRollingTags" . }}
 {{ include "grafana.validateValues" . }}

--- a/bitnami/grafana/values-production.yaml
+++ b/bitnami/grafana/values-production.yaml
@@ -337,10 +337,10 @@ ingress:
 
       ## Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
       extraPaths: []
-        # - path: /*
-        #   backend:
-        #     serviceName: ssl-redirect
-        #     servicePort: use-annotation
+      # - path: /*
+      #   backend:
+      #     serviceName: ssl-redirect
+      #     servicePort: use-annotation
 
       ## Set this to true in order to enable TLS on the ingress record
       tls: false

--- a/bitnami/grafana/values.yaml
+++ b/bitnami/grafana/values.yaml
@@ -337,10 +337,10 @@ ingress:
 
       ## Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
       extraPaths: []
-        # - path: /*
-        #   backend:
-        #     serviceName: ssl-redirect
-        #     servicePort: use-annotation
+      # - path: /*
+      #   backend:
+      #     serviceName: ssl-redirect
+      #     servicePort: use-annotation
 
       ## Set this to true in order to enable TLS on the ingress record
       tls: false


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

The grafana-admin command is not correct when using existingSecrets.

**Benefits**

<!-- What benefits will be realized by the code change? -->

The user is instructed to use a proper grafana-admin command.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

None

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #3247

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

```console
$ helm install mygrafana1 .
    ...
    echo "Password: $(kubectl get secret mygrafana1-admin --namespace default -o jsonpath="{.data.GF_SECURITY_ADMIN_PASSWORD}" | base64 --decode)"
$ helm install mygrafana2 --set admin.existingSecret=mysecret .
    ...
    echo "Password: $(kubectl get secret mysecret --namespace default -o jsonpath="{.data.password}" | base64 --decode)"
```

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
