### PR TITLE
[bitnami/etcd] Fix etcd deployment when disabling useAutoTLS in clien…

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: etcd
-version: 4.9.1
+version: 4.9.2
 appVersion: 3.4.10
 description: etcd is a distributed key value store that provides a reliable way to store data across a cluster of machines
 keywords:

--- a/bitnami/etcd/templates/_helpers.tpl
+++ b/bitnami/etcd/templates/_helpers.tpl
@@ -123,9 +123,9 @@ Return the proper etcdctl authentication options
 */}}
 {{- define "etcd.authOptions" -}}
 {{- $rbacOption := "--user root:$ETCD_ROOT_PASSWORD" -}}
-{{- $certsOption := " --cert=\"$ETCD_CERT_FILE\" --key=\"$ETCD_KEY_FILE\"" -}}
-{{- $autoCertsOption := " --cert=\"/bitnami/etcd/data/fixtures/client/cert.pem\" --key=\"/bitnami/etcd/data/fixtures/client/key.pem\"" -}}
-{{- $caOption := " --cacert=\"$ETCD_TRUSTED_CA_FILE\"" -}}
+{{- $certsOption := " --cert $ETCD_CERT_FILE --key $ETCD_KEY_FILE" -}}
+{{- $autoCertsOption := " --cert /bitnami/etcd/data/fixtures/client/cert.pem --key /bitnami/etcd/data/fixtures/client/key.pem" -}}
+{{- $caOption := " --cacert $ETCD_TRUSTED_CA_FILE" -}}
 {{- if .Values.auth.rbac.enabled -}}
 {{- printf "%s" $rbacOption -}}
 {{- end -}}


### PR DESCRIPTION
…t auth configuration

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This PR fixes `etcd.authOptions` data format so that when rendering `setup.sh` script, `AUTH_OPTIONS` constant is set properly.

Now `AUTH_OPTIONS` is defined as follows:

```
AUTH_OPTIONS="--user root:$ETCD_ROOT_PASSWORD --cert=\"$ETCD_CERT_FILE\" --key=\"$ETCD_KEY_FILE\" --cacert=\"$ETCD_TRUSTED_CA_FILE\""
```

The double quotes within the flags values caused `etcdctl` command in `setup.sh` script to fail as mentioned in #3278. This blocks Etcd deployments with custom auth client certificates (disabling `useAutoTLS`)

With this changes, `AUTH_OPTIONS` will be defined as follows:

```
AUTH_OPTIONS="--user root:$ETCD_ROOT_PASSWORD --cert $ETCD_CERT_FILE --key $ETCD_KEY_FILE --cacert $ETCD_TRUSTED_CA_FILE"
```

So that `etcdctl` commands  in `setup.sh` can work properly

**Benefits**

Etcd deployments with custom auth client certificates can be deployed

**Possible drawbacks**

None

**Applicable issues**

  - fixes #3278 

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)