### PR TITLE
[bitnami/zookeeper] Add missing properties to production values

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zookeeper
-version: 5.21.1
+version: 5.21.2
 appVersion: 3.6.1
 description: A centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services for distributed applications.
 keywords:

--- a/bitnami/zookeeper/values-production.yaml
+++ b/bitnami/zookeeper/values-production.yaml
@@ -148,6 +148,14 @@ listenOnAllIPs: false
 ##
 allowAnonymousLogin: true
 
+autopurge:
+  ## Retains the snapRetainCount most recent snapshots and the corresponding transaction logs and deletes the rest
+  ##
+  snapRetainCount: 3
+  ## The time interval in hours for which the purge task has to be triggered. Set to a positive integer (1 and above) to enable the auto purging.
+  ##
+  purgeInterval: 0
+
 auth:
   ## Use existing secret (ignores previous password)
   ##
@@ -176,6 +184,8 @@ heapSize: 1024
 ##
 logLevel: ERROR
 
+## Data log directory. Specifying this option will direct zookeeper to write the transaction log to the dataLogDir rather than the dataDir.
+## This allows a dedicated log device to be used, and helps avoid competition between logging and snaphots.
 ## Example:
 ## dataLogDir: /bitnami/zookeeper/dataLog
 ##
@@ -418,4 +428,3 @@ metrics:
     #    for: 5m
     #    labels:
     #      severity: critical
-


### PR DESCRIPTION
Signed-off-by: joancafom <jcarmona@bitnami.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Added missing properties in `values-production.yaml` that were available in `values.yaml` :

https://github.com/bitnami/charts/blob/ce863f02dfbce68fc69be3765cec458de5edbde3/bitnami/zookeeper/values.yaml#L146-L152

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
Both `values.yaml` and `values-production.yaml` contain now the same properties, and running `helm lint` over any of them results in success.

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
None
<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #3283

**Additional information**
PR #1984 introduced changes regarding `autopurge`, but only updated `values.yaml`.
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
