### PR TITLE
[bitnami/fluentd] Allow creation/configuration of dedicated ServiceAccount for fluentd aggregator

### DIFF
--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd
-version: 1.4.1
+version: 2.0.0
 appVersion: 1.11.2
 description: Fluentd is an open source data collector for unified logging layer
 keywords:

--- a/bitnami/fluentd/templates/_helpers.tpl
+++ b/bitnami/fluentd/templates/_helpers.tpl
@@ -91,13 +91,24 @@ imagePullSecrets:
 {{- end -}}
 
 {{/*
-Create the name of the service account to use
+Create the name of the forwarder service account to use
 */}}
-{{- define "fluentd.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-    {{ default (include "fluentd.fullname" .) .Values.serviceAccount.name }}
+{{- define "fluentd.forwarder.serviceAccountName" -}}
+{{- if .Values.forwarder.serviceAccount.create -}}
+    {{ default (printf "%s-forwarder" (include "fluentd.fullname" .)) .Values.forwarder.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
+    {{ default "default" .Values.forwarder.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the aggregator service account to use
+*/}}
+{{- define "fluentd.aggregator.serviceAccountName" -}}
+{{- if .Values.aggregator.serviceAccount.create -}}
+    {{ default (printf "%s-aggregator" (include "fluentd.fullname" .)) .Values.aggregator.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.aggregator.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 
@@ -116,6 +127,7 @@ Validate data
 {{- $messages := list -}}
 {{- $messages := append $messages (include "fluentd.validateValues.deployment" .) -}}
 {{- $messages := append $messages (include "fluentd.validateValues.rbac" .) -}}
+{{- $messages := append $messages (include "fluentd.validateValues.serviceAccount" .) -}}
 {{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}
  {{- if $message -}}
@@ -134,10 +146,34 @@ fluentd:
 
 {{/* Validate values of Fluentd - must create serviceAccount to create enable RBAC */}}
 {{- define "fluentd.validateValues.rbac" -}}
-{{- if and .Values.rbac.create (not .Values.serviceAccount.create) -}}
+{{- if not (typeIs "<nil>" .Values.rbac.create) -}}
 fluentd: rbac.create
-    A ServiceAccount is required ("rbac.create=true" is set)
-    Please create a ServiceAccount (--set serviceAccount.create=true)
+    Top-level rbac configuration has been removed, as it only applied to the forwarder.
+    Please migrate to forwarder.rbac.create
+{{- end -}}
+{{- if and .Values.forwarder.rbac.create (not .Values.forwarder.serviceAccount.create) }}
+fluentd: forwarder.rbac.create
+    A ServiceAccount is required ("forwarder.rbac.create=true" is set)
+    Please create a ServiceAccount (--set serviceAccount.forwarder.create=true)
+{{- end -}}
+{{- end -}}
+
+{{/* Validate values of Fluentd - prefer per component serviceAccounts to top-level definition */}}
+{{- define "fluentd.validateValues.serviceAccount" -}}
+{{- if not (typeIs "<nil>" .Values.serviceAccount.create) -}}
+fluentd: serviceAccount.create:
+    Top-level serviceAccount configuration has been removed, as it only applied to the forwarder.
+    Please migrate to forwarder.serviceAccount.create
+{{- end -}}
+{{- if .Values.serviceAccount.name }}
+fluentd: serviceAccount.name
+    Top-level serviceAccount configuration has been removed, as it only applied to the forwarder.
+    Please migrate to forwarder.serviceAccount.name
+{{- end -}}
+{{- if .Values.serviceAccount.annotations }}
+fluentd: serviceAccount.annotations
+    Top-level serviceAccount configuration has been removed, as it only applied to the forwarder.
+    Please migrate to forwarder.serviceAccount.annotations
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/fluentd/templates/aggregator-statefulset.yaml
+++ b/bitnami/fluentd/templates/aggregator-statefulset.yaml
@@ -29,6 +29,7 @@ spec:
         {{- end }}
     spec:
       {{- include "fluentd.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ template "fluentd.aggregator.serviceAccountName" . }}
       {{- if .Values.aggregator.securityContext.enabled }}
       securityContext:
         runAsUser: {{ .Values.aggregator.securityContext.runAsUser }}

--- a/bitnami/fluentd/templates/forwarder-clusterrole.yaml
+++ b/bitnami/fluentd/templates/forwarder-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccount.create .Values.rbac.create }}
+{{- if and .Values.forwarder.serviceAccount.create .Values.forwarder.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/bitnami/fluentd/templates/forwarder-clusterrolebinding.yaml
+++ b/bitnami/fluentd/templates/forwarder-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccount.create .Values.rbac.create }}
+{{- if and .Values.forwarder.serviceAccount.create .Values.forwarder.rbac.create }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -10,6 +10,6 @@ roleRef:
   name: {{ template "fluentd.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "fluentd.serviceAccountName" . }}
+    name: {{ template "fluentd.forwarder.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/bitnami/fluentd/templates/forwarder-daemonset.yaml
+++ b/bitnami/fluentd/templates/forwarder-daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         {{- end }}
     spec:
 {{- include "fluentd.imagePullSecrets" . | nindent 6 }}
-      serviceAccountName: {{ template "fluentd.serviceAccountName" . }}
+      serviceAccountName: {{ template "fluentd.forwarder.serviceAccountName" . }}
       priorityClassName: {{ .Values.forwarder.priorityClassName | quote }}
       {{- if .Values.forwarder.affinity }}
       affinity: {{- include "fluentd.tplValue" (dict "value" .Values.forwarder.affinity "context" $) | nindent 8 }}

--- a/bitnami/fluentd/templates/serviceaccount.yaml
+++ b/bitnami/fluentd/templates/serviceaccount.yaml
@@ -1,10 +1,24 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if and .Values.forwarder.serviceAccount.create .Values.forwarder.enabled }}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "fluentd.serviceAccountName" . }}
+  name: {{ include "fluentd.forwarder.serviceAccountName" . }}
   labels: {{- include "fluentd.labels" . | nindent 4 }}
-  {{- if .Values.serviceAccount.annotations }}
-  annotations: {{- include "fluentd.tplValue" (dict "value" .Values.serviceAccount.annotations "context" $) | nindent 4 }}
+    app.kubernetes.io/component: forwarder
+  {{- if .Values.forwarder.serviceAccount.annotations }}
+  annotations: {{- include "fluentd.tplValue" (dict "value" .Values.forwarder.serviceAccount.annotations "context" $) | nindent 4 }}
+  {{- end }}
+{{- end -}}
+{{- if and .Values.aggregator.serviceAccount.create .Values.aggregator.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "fluentd.aggregator.serviceAccountName" . }}
+  labels: {{- include "fluentd.labels" . | nindent 4 }}
+    app.kubernetes.io/component: aggregator
+  {{- if .Values.aggregator.serviceAccount.annotations }}
+  annotations: {{- include "fluentd.tplValue" (dict "value" .Values.aggregator.serviceAccount.annotations "context" $) | nindent 4 }}
   {{- end }}
 {{- end -}}

--- a/bitnami/fluentd/values-production.yaml
+++ b/bitnami/fluentd/values-production.yaml
@@ -217,6 +217,25 @@ forwarder:
   ## Extra labels to add to Pod
   podLabels: {}
 
+  ## Pods Service Account
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  serviceAccount:
+    ## Specifies whether a ServiceAccount should be created
+    ##
+    create: true
+    ## The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the fluentd.fullname template
+    # name:
+    ## Annotations for the Service Account (evaluated as a template)
+    ##
+    annotations: {}
+
+  ## Role Based Access
+  ## ref: https://kubernetes.io/docs/admin/authorization/rbac/
+  ##
+  rbac:
+    create: true
+
   ## Extra volumes to mount
   ## Example Use Case: mount systemd journal volume
   # extraVolumes:
@@ -389,6 +408,19 @@ aggregator:
   ## Extra labels to add to Pod
   podLabels: {}
 
+  ## Pods Service Account
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  serviceAccount:
+    ## Specifies whether a ServiceAccount should be created
+    ##
+    create: false
+    ## The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the fluentd.fullname template
+    # name:
+    ## Annotations for the Service Account (evaluated as a template)
+    ##
+    annotations: {}
+
   ## Persist data to a persistent volume
   persistence:
     enabled: false
@@ -405,22 +437,16 @@ aggregator:
 ## Pods Service Account
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 ##
-serviceAccount:
-  ## Specifies whether a ServiceAccount should be created
-  ##
-  create: true
-  ## The name of the ServiceAccount to use.
-  ## If not set and create is true, a name is generated using the fluentd.fullname template
-  # name:
-  ## Annotations for the Service Account (evaluated as a template)
-  ##
-  annotations: {}
+## This top-level global entry is DEPRECATED. Please use "forwarder.serviceAccount" instead. Only the
+## forwarder was affected by the historical usage here.
+serviceAccount: {}
 
 ## Role Based Access
 ## ref: https://kubernetes.io/docs/admin/authorization/rbac/
 ##
-rbac:
-  create: true
+## This top-level global entry is DEPRECATED. Please use "forwarder.rbac" instead. Only the
+## forwarder was affected by the historical usage here.
+rbac: {}
 
 ## Prometheus Exporter / Metrics
 ##

--- a/bitnami/fluentd/values.yaml
+++ b/bitnami/fluentd/values.yaml
@@ -212,6 +212,25 @@ forwarder:
   ## Extra labels to add to Pod
   podLabels: {}
 
+  ## Pods Service Account
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  serviceAccount:
+    ## Specifies whether a ServiceAccount should be created
+    ##
+    create: true
+    ## The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the fluentd.fullname template
+    # name:
+    ## Annotations for the Service Account (evaluated as a template)
+    ##
+    annotations: {}
+
+  ## Role Based Access
+  ## ref: https://kubernetes.io/docs/admin/authorization/rbac/
+  ##
+  rbac:
+    create: true
+
   ## Extra volumes to mount
   ## Example Use Case: mount systemd journal volume
   # extraVolumes:
@@ -389,6 +408,19 @@ aggregator:
   ## Extra labels to add to Pod
   podLabels: {}
 
+  ## Pods Service Account
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  serviceAccount:
+    ## Specifies whether a ServiceAccount should be created
+    ##
+    create: false
+    ## The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the fluentd.fullname template
+    # name:
+    ## Annotations for the Service Account (evaluated as a template)
+    ##
+    annotations: {}
+
   ## Persist data to a persistent volume
   persistence:
     enabled: false
@@ -405,22 +437,16 @@ aggregator:
 ## Pods Service Account
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 ##
-serviceAccount:
-  ## Specifies whether a ServiceAccount should be created
-  ##
-  create: true
-  ## The name of the ServiceAccount to use.
-  ## If not set and create is true, a name is generated using the fluentd.fullname template
-  # name:
-  ## Annotations for the Service Account (evaluated as a template)
-  ##
-  annotations: {}
+## This top-level global entry is DEPRECATED. Please use "forwarder.serviceAccount" instead. Only the
+## forwarder was affected by the historical usage here.
+serviceAccount: {}
 
 ## Role Based Access
 ## ref: https://kubernetes.io/docs/admin/authorization/rbac/
 ##
-rbac:
-  create: true
+## This top-level global entry is DEPRECATED. Please use "forwarder.rbac" instead. Only the
+## forwarder was affected by the historical usage here.
+rbac: {}
 
 ## Prometheus Exporter / Metrics
 ##


### PR DESCRIPTION
**Description of the change**

- Introduces ability to configure the aggregator `serviceAccount` via `.Values.aggregator.serviceAccount.*`
- Migrates the previous forwarder-only configuration of `.Values.serviceAccount` and `.Values.rbac` to `.Values.forwarder.*` values
- Adds validation errors to historical usage of `.Values.serviceAccount` and `.Values.rbac` to help users migrate to the new configuration points.

**Benefits**

There is currently no way to change the service account used by the aggregator's `StatefulSet`.

Since there is no `PodSecurityPolicy` assigned by this chart, having the aggregator run under a deterministic `ServiceAccount` allows wrapper charts to target a PSP at this `ServiceAccount`, as well as any custom RBAC/`ClusterRoleBinding`s they need.

Follow-up work could involve introducing pod/container `securityContext` and PSPs targeting each component.

**Possible drawbacks**

I couldn't find an elegant way to make this change backward compatible. This is because 
* the previous values of `serviceAccount.create` and `rbac.create` were `true`, making user-intention to disable the creation difficult to detect
* the chart supports `ServiceAccount` `name` and `annotations` customisation. Defaulting all these values and merging the annotation values from the old configuration location got messy, fast and made the chart confusing to configure.

I feel it was better to try and move to a more consistent configuration, as used by [the contour chart](https://github.com/bitnami/charts/tree/master/bitnami/contour) and help users get there by failing the template rendering if using the old configuration values.

**Applicable issues**

  - fixes #3292 

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
