### PR TITLE
[bitnami/prometheus-operator] Revert "Adjust thanos-sidecar for prom-op no longer using mount subpaths (#3122)"

### DIFF
--- a/bitnami/prometheus-operator/Chart.yaml
+++ b/bitnami/prometheus-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.41.0
 description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 name: prometheus-operator
-version: 0.27.1
+version: 0.27.2
 keywords:
   - prometheus
   - alertmanager

--- a/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -220,9 +220,7 @@ spec:
       volumeMounts:
         - mountPath: /prometheus
           name: prometheus-{{ template "prometheus-operator.prometheus.fullname" . }}-db
-          {{- if not (.Values.prometheus.storageSpec.disableMountSubPath | default true) }}
           subPath: prometheus-db
-          {{- end }}
     {{- end }}
     {{- if .Values.prometheus.containers }}
     {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.containers "context" $) | nindent 4 }}


### PR DESCRIPTION
This reverts commit ad72b27091f2b7ee29e22c236463c6a8a1b4e6b7.

The change is breaking Thanos due to disableMountSubPath option not
existing to the Prometheus CRD

```
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data:
ValidationError(Prometheus.spec.storage): unknown field "disableMountSubPath" in com.coreos.monitoring.v1.Prometheus.spec.storage
```

Which is actually true since the CRD installed by Bitnami does not have
this option in the spec

https://github.com/bitnami/charts/blob/master/bitnami/prometheus-operator/crds/crd-prometheus.yaml

As such there is no way to set this option to the values.yaml file

However, the message in the original commit is rather confusing as the
option hasn't changed its default value upstream

https://github.com/coreos/prometheus-operator/blob/release-0.40/pkg/prometheus/statefulset.go#L947

The operator will still return 'prometheus-db' subpath by default. Also
this option was not documented at all in the README file so it's not
clear what its intention is.

Having said that, not being able to override it in the values.yaml file,
means that Thanos sidecar is unable to mount the subpath no matter what
and there is no straight way to recover this apart from editing the live
objects.

As such, I suggest we revert this in order to restore functionality as
it was until it's clear what problem we are trying to solve.


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
