### PR TITLE
[bitnami/prometheus-operator] Re-enable subpaths when persistent

### DIFF
--- a/bitnami/prometheus-operator/Chart.yaml
+++ b/bitnami/prometheus-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.41.0
 description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 name: prometheus-operator
-version: 0.30.0
+version: 0.31.0
 keywords:
   - prometheus
   - alertmanager

--- a/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -231,7 +231,7 @@ spec:
       volumeMounts:
         - mountPath: /prometheus
           name: prometheus-{{ template "prometheus-operator.prometheus.fullname" . }}-db
-          {{- if not (.Values.prometheus.storageSpec.disableMountSubPath | default true) }}
+          {{- if not (.Values.prometheus.storageSpec.disableMountSubPath | default (not .Values.prometheus.persistence.enabled)) }}
           subPath: prometheus-db
           {{- end }}
     {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

The upstream change regarding mount subpaths only applied to `emptyDir` volume mounts, so fix our defaults to accomodate.

**Benefits**

<!-- What benefits will be realized by the code change? -->

Fixes a regression where #3122 would break persistent clusters.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

None that I'm aware of.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - Fixes #3299 
  - Fixes #3391

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

This is based off 3d7ab406fecd64f1af25f53e7d27f03ec95b29a4 rather than master, because ba873c363674c6618909dc205c177133d8693930's upgrade to prom-op 0.41.0 creates an inoperable cluster thanks to missing CRDs (and corresponding permissions): #3297.

I haven't bumped any chart versions because it's impossible to test this before #3297 is fixed.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)