### PR TITLE
[bitnami/prometheus-operator] Bump node-exporter subchart major version

### DIFF
--- a/bitnami/prometheus-operator/Chart.yaml
+++ b/bitnami/prometheus-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.41.0
 description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 name: prometheus-operator
-version: 0.27.1
+version: 0.28.0
 keywords:
   - prometheus
   - alertmanager

--- a/bitnami/prometheus-operator/requirements.lock
+++ b/bitnami/prometheus-operator/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: node-exporter
   repository: https://charts.bitnami.com/bitnami
-  version: 0.2.14
+  version: 1.0.2
 - name: kube-state-metrics
   repository: https://charts.bitnami.com/bitnami
   version: 0.4.2
-digest: sha256:5ac56d4a609ee6183d12ed61eb6b4e2cbba7cc34d91c3e1589c9b321bb5e6b79
-generated: "2020-07-30T14:33:56.975352239Z"
+digest: sha256:8d94e711170d0871898f4ab82f67cbd844735603fe09b285613b5474340b96de
+generated: "2020-08-03T12:48:37.978901046Z"

--- a/bitnami/prometheus-operator/requirements.yaml
+++ b/bitnami/prometheus-operator/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
   - name: node-exporter
     repository: https://charts.bitnami.com/bitnami
-    version: 0.x.x
+    version: 1.x.x
     condition: exporters.enabled,exporters.node-exporter.enabled
   - name: kube-state-metrics
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
Change node-exporter dependency version from `0.X.X` to `1.X.X`, there are no breaking changes, just a version update some days ago #2858