### PR TITLE
[bitnami/harbor] Bump postgresql subchart major version

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: harbor
-version: 6.0.11
+version: 7.0.0
 appVersion: 2.0.1
 description: Harbor is an an open source trusted cloud native registry project that stores, signs, and scans content
 keywords:

--- a/bitnami/harbor/README.md
+++ b/bitnami/harbor/README.md
@@ -828,6 +828,12 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 
 > NOTE: In you are upgrading an installation that contains a high amount of data, it is recommended to disable the liveness/readiness probes as the migration can take a substantial amount of time.
 
+## 7.0.0
+
+This major version include a major change in the PostgreSQL subchart labeling. Backwards compatibility from previous versions to this one is not guarantee during the upgrade.
+
+You can find more information about the changes in the PostgreSQL subchart and a way to workaround the `helm upgrade` issue in the ["Upgrade to 9.0.0"](https://github.com/bitnami/charts/tree/master/bitnami/postgresql#900) section of the PostgreSQL README.
+
 ## 6.0.0 to 6.0.2
 
 Due to an issue with Trivy volumeClaimTemplates, the upgrade needs to be done in two steps:

--- a/bitnami/harbor/requirements.lock
+++ b/bitnami/harbor/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 8.10.14
+  version: 9.1.2
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 10.7.12
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 0.3.1
-digest: sha256:78c30e9c5493667864cac449dbe61b1a1c8f1c08d00dc9f9e21ed9f19df01e40
-generated: "2020-08-02T21:50:14.039623615Z"
+digest: sha256:9bb479fcdc7da712e413fd65e8c6f554efadcf7ded51ac8a71946498576051ce
+generated: "2020-08-03T12:58:10.501578024Z"

--- a/bitnami/harbor/requirements.yaml
+++ b/bitnami/harbor/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: postgresql
-    version: 8.x.x
+    version: 9.x.x
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: redis


### PR DESCRIPTION
Bump the subchart major version produced in #3021, in order to include the latest postgresql images in the bundled subchart