### PR TITLE
[bitnami/thanos] Fix - Move ruler rules to separate folder

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 2.0.0
+version: 2.0.1
 appVersion: 0.14.0
 description: Thanos is a highly available metrics system that can be added on top of existing Prometheus deployments, providing a global query view across all Prometheus installations.
 engine: gotpl

--- a/bitnami/thanos/templates/bucketweb/deployment.yaml
+++ b/bitnami/thanos/templates/bucketweb/deployment.yaml
@@ -83,7 +83,6 @@ spec:
               mountPath: /conf
               {{- else }}
               mountPath: /conf/objstore.yml
-              subPath: objstore.yml
               {{- end }}
       volumes:
         - name: objstore-config

--- a/bitnami/thanos/templates/compactor/deployment.yaml
+++ b/bitnami/thanos/templates/compactor/deployment.yaml
@@ -101,7 +101,6 @@ spec:
               mountPath: /conf
               {{- else }}
               mountPath: /conf/objstore.yml
-              subPath: objstore.yml
               {{- end }}
             - name: data
               mountPath: /data

--- a/bitnami/thanos/templates/querier/deployment.yaml
+++ b/bitnami/thanos/templates/querier/deployment.yaml
@@ -110,7 +110,6 @@ spec:
       {{- if or (include "thanos.querier.createSDConfigmap" .) .Values.querier.existingSDConfigmap }}
             - name: sd-config
               mountPath: /conf/servicediscovery.yml
-              subPath: servicediscovery.yml
       {{- end }}
       {{- if .Values.querier.grpcTLS.server.secure }}
             - name: tls-server

--- a/bitnami/thanos/templates/ruler/statefulset.yaml
+++ b/bitnami/thanos/templates/ruler/statefulset.yaml
@@ -88,7 +88,7 @@ spec:
             - --label=ruler_cluster="{{ .Values.ruler.clusterName }}"
             - --alert.label-drop="replica"
             - --objstore.config-file=/conf/objstore.yml
-            - --rule-file=/conf/ruler.yml
+            - --rule-file=/conf/rules/ruler.yml
             {{- range .Values.ruler.queries }}
             - --query={{ . }}
             {{- end }}
@@ -118,14 +118,12 @@ spec:
           {{- end }}
           volumeMounts:
             - name: ruler-config
-              mountPath: /conf/ruler.yml
-              subPath: ruler.yml
+              mountPath: /conf/rules/ruler.yml
             - name: objstore-config
               {{- if .Values.existingObjstoreSecretItems }}
               mountPath: /conf
               {{- else }}
               mountPath: /conf/objstore.yml
-              subPath: objstore.yml
               {{- end }}
             - name: data
               mountPath: /data

--- a/bitnami/thanos/templates/storegateway/statefulset.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset.yaml
@@ -102,7 +102,6 @@ spec:
               mountPath: /conf
               {{- else }}
               mountPath: /conf/objstore.yml
-              subPath: objstore.yml
               {{- end }}
             - name: data
               mountPath: /data


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

GKE doesn't play nicely with `subPath` in VolumeMounts. Needed to move the `ruler.yml` to a separate folder inside of the conf folder so it wouldn't have issues with the objstore-config. This way I could delete the `subPath` from the deployment.

Error that was generated when deploying current chart/pod:

```shell
OCI runtime create failed: container_linux.go:349: starting container process caused "process_linux.go:449: 
container init caused \"rootfs_linux.go:58: mounting \\\
"/var/lib/kubelet/pods/281a145a-f287-4afa-804d-044855ce9e87/volume-subpaths/ruler-config/ruler/0
\\\" to rootfs 
\\\"/var/lib/docker/overlay2/3579a2bf3b39d7b13f9a4c0c885e38e1d8c07a86c746d061fabe9680befee096/merged
\\\" at \\\"/var/lib/docker/overlay2/3579a2bf3b39d7b13f9a4c0c885e38e1d8c07a86c746d061fabe9680befee096/merged/conf/ruler.yml
\\\" caused 
\\\"not a directory
\\\"\"": unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type
```

Removed subPath in all deployment to reduce any further issues.

**Benefits**

Fixed the helm chart for GKE cluster deployments.

**Possible drawbacks**

Might break on other clouds? Don't think it will.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x ] Variables are documented in the README.md
- [ x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
