### PR TITLE
[bitnami/kafka] Fix typo in kafka.tplValue usage for common labels and annotations

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 11.7.0
+version: 11.7.1
 appVersion: 2.5.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/templates/configmap.yaml
+++ b/bitnami/kafka/templates/configmap.yaml
@@ -5,10 +5,10 @@ metadata:
   name: {{ template "kafka.fullname" . }}-configuration
   labels: {{- include "kafka.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
-    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
   server.properties: |-

--- a/bitnami/kafka/templates/jaas-secret.yaml
+++ b/bitnami/kafka/templates/jaas-secret.yaml
@@ -5,10 +5,10 @@ metadata:
   name: {{ template "kafka.fullname" . }}-jaas
   labels: {{- include "kafka.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
-    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 type: Opaque
 data:

--- a/bitnami/kafka/templates/jks-secret.yaml
+++ b/bitnami/kafka/templates/jks-secret.yaml
@@ -5,10 +5,10 @@ metadata:
   name: {{ template "kafka.fullname" . }}-jks
   labels: {{- include "kafka.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
-    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 type: Opaque
 data:

--- a/bitnami/kafka/templates/jmx-configmap.yaml
+++ b/bitnami/kafka/templates/jmx-configmap.yaml
@@ -5,10 +5,10 @@ metadata:
   name: {{ template "kafka.fullname" . }}-jmx-configuration
   labels: {{- include "kafka.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
-    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
   jmx-kafka-prometheus.yml: |-

--- a/bitnami/kafka/templates/jmx-metrics-svc.yaml
+++ b/bitnami/kafka/templates/jmx-metrics-svc.yaml
@@ -6,7 +6,7 @@ metadata:
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
     {{- if .Values.commonLabels }}
-    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if or .Values.metrics.jmx.service.annotations .Values.commonAnnotations }}
   annotations:
@@ -14,7 +14,7 @@ metadata:
     {{ include "kafka.tplValue" ( dict "value" .Values.metrics.jmx.service.annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
-    {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:

--- a/bitnami/kafka/templates/kafka-metrics-deployment.yaml
+++ b/bitnami/kafka/templates/kafka-metrics-deployment.yaml
@@ -11,10 +11,10 @@ metadata:
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics
     {{- if .Values.commonLabels }}
-    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   replicas: 1

--- a/bitnami/kafka/templates/kafka-metrics-svc.yaml
+++ b/bitnami/kafka/templates/kafka-metrics-svc.yaml
@@ -6,7 +6,7 @@ metadata:
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics
     {{- if .Values.commonLabels }}
-    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if or .Values.metrics.kafka.service.annotations .Values.commonAnnotations }}
   annotations:
@@ -14,7 +14,7 @@ metadata:
     {{ include "kafka.tplValue" ( dict "value" .Values.metrics.kafka.service.annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
-    {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:

--- a/bitnami/kafka/templates/log4j-configmap.yaml
+++ b/bitnami/kafka/templates/log4j-configmap.yaml
@@ -5,10 +5,10 @@ metadata:
   name: {{ include "kafka.log4j.configMapName" . }}
   labels: {{- include "kafka.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
-    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
   log4j.properties: |-

--- a/bitnami/kafka/templates/poddisruptionbudget.yaml
+++ b/bitnami/kafka/templates/poddisruptionbudget.yaml
@@ -7,10 +7,10 @@ metadata:
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
     {{- if .Values.commonLabels }}
-    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   {{- if .Values.pdb.minAvailable }}

--- a/bitnami/kafka/templates/role.yaml
+++ b/bitnami/kafka/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
     {{- if .Values.commonLabels }}
-    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 rules:
   - apiGroups:

--- a/bitnami/kafka/templates/rolebinding.yaml
+++ b/bitnami/kafka/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
     {{- if .Values.commonLabels }}
-    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 roleRef:
   kind: Role

--- a/bitnami/kafka/templates/scripts-configmap.yaml
+++ b/bitnami/kafka/templates/scripts-configmap.yaml
@@ -4,10 +4,10 @@ metadata:
   name: {{ template "kafka.fullname" . }}-scripts
   labels: {{- include "kafka.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
-    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
   {{- $fullname := include "kafka.fullname" . }}

--- a/bitnami/kafka/templates/serviceaccount.yaml
+++ b/bitnami/kafka/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
     {{- if .Values.commonLabels }}
-    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/bitnami/kafka/templates/servicemonitor-jmx-metrics.yaml
+++ b/bitnami/kafka/templates/servicemonitor-jmx-metrics.yaml
@@ -12,10 +12,10 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- if .Values.commonLabels }}
-    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   selector:

--- a/bitnami/kafka/templates/servicemonitor-metrics.yaml
+++ b/bitnami/kafka/templates/servicemonitor-metrics.yaml
@@ -12,10 +12,10 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- if .Values.commonLabels }}
-    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   selector:

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -15,10 +15,10 @@ metadata:
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
     {{- if .Values.commonLabels }}
-    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   podManagementPolicy: Parallel

--- a/bitnami/kafka/templates/svc-external-access.yaml
+++ b/bitnami/kafka/templates/svc-external-access.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/component: kafka
     pod: {{ $targetPod }}
     {{- if $root.Values.commonLabels }}
-    {{- include "kafka.tplvalue" ( dict "value" $root.Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplValue" ( dict "value" $root.Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if or $root.Values.externalAccess.service.annotations $root.Values.commonAnnotations }}
   annotations:
@@ -22,7 +22,7 @@ metadata:
     {{ include "kafka.tplValue" ( dict "value" $root.Values.externalAccess.service.annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if $root.Values.commonAnnotations }}
-    {{- include "kafka.tplvalue" ( dict "value" $root.Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplValue" ( dict "value" $root.Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:

--- a/bitnami/kafka/templates/svc-headless.yaml
+++ b/bitnami/kafka/templates/svc-headless.yaml
@@ -5,10 +5,10 @@ metadata:
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
     {{- if .Values.commonLabels }}
-    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "kafka.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   type: ClusterIP

--- a/bitnami/kafka/templates/svc.yaml
+++ b/bitnami/kafka/templates/svc.yaml
@@ -5,7 +5,7 @@ metadata:
   labels: {{- include "kafka.labels" . | nindent 4 }}
     app.kubernetes.io/component: kafka
     {{- if .Values.commonLabels }}
-    {{- include "kafka.tplvalue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if or .Values.service.annotations .Values.commonAnnotations }}
   annotations:
@@ -13,7 +13,7 @@ metadata:
     {{ include "kafka.tplValue" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
-    {{- include "kafka.tplvalue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- include "kafka.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:


### PR DESCRIPTION
**Description of the change**
Fixing a typo in recently added includes of `kafka.tplValue` for common annotations and labels (lower-case `v` should be an upper-case `V`). 

**Benefits**
When I tried to use `commonLabels` the chart failed to render with this error:

```
Error: template: kafka/templates/svc.yaml:8:8: executing "kafka/templates/svc.yaml" at <include "kafka.tplvalue" (dict "value" .Values.commonLabels "context" $)>: error calling include: template: no template "kafka.tplvalue" associated with template "gotpl"
```

After this change the chart renders properly.

**Possible drawbacks**


**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
