### PR TITLE
bitnami/chart/redis-cluster Fixed on demand volume mount for tls certificates

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis-cluster
-version: 3.1.8
+version: 3.1.9
 appVersion: 6.0.6
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/bitnami/redis-cluster/templates/update-cluster.yaml
+++ b/bitnami/redis-cluster/templates/update-cluster.yaml
@@ -154,7 +154,7 @@ spec:
           {{- if .Values.updateJob.resources }}
           resources: {{- toYaml .Values.updateJob.resources | nindent 12 }}
           {{- end }}
-          
+          {{- if or .Values.tls.enabled .Values.updateJob.extraVolumeMounts }}
           volumeMounts:
             {{- if .Values.tls.enabled }}
             - name: redis-certificates
@@ -164,6 +164,7 @@ spec:
             {{- if .Values.updateJob.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.updateJob.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
+          {{- end }}
       restartPolicy: OnFailure
       volumes:
       {{- if .Values.tls.enabled }}

--- a/bitnami/redis-cluster/templates/update-cluster.yaml
+++ b/bitnami/redis-cluster/templates/update-cluster.yaml
@@ -154,10 +154,13 @@ spec:
           {{- if .Values.updateJob.resources }}
           resources: {{- toYaml .Values.updateJob.resources | nindent 12 }}
           {{- end }}
+          
           volumeMounts:
+            {{- if .Values.tls.enabled }}
             - name: redis-certificates
               mountPath: /opt/bitnami/redis/certs
               readOnly: true
+            {{- end }}
             {{- if .Values.updateJob.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.updateJob.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
**Description of the change**

Add a condition to mount the tls volume to update job.

**Benefits**

Fix for issue  https://github.com/bitnami/charts/issues/3326

**Possible drawbacks**

NA

**Applicable issues**

  - fixes #3326 
**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

