### PR TITLE
[bitnami/kafka] Fix typo in helpers

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 11.7.1
+version: 11.7.2
 appVersion: 2.5.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/templates/_helpers.tpl
+++ b/bitnami/kafka/templates/_helpers.tpl
@@ -512,7 +512,7 @@ kafka: auth.clientProtocol auth.interBrokerProtocol
 {{- $nodePortListLength := len .Values.externalAccess.service.nodePorts }}
 {{- if and .Values.externalAccess.enabled (not .Values.externalAccess.autoDiscovery.enabled) (not (eq $replicaCount $nodePortListLength )) (eq .Values.externalAccess.service.type "NodePort") -}}
 kafka: .Values.externalAccess.service.nodePorts
-    Number of replicas and nodePort array length must be the same.
+    Number of replicas and nodePort array length must be the same. Currently: replicaCount = {{ $replicaCount }} and nodePorts = {{ $nodePortListLength }}
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/kafka/templates/_helpers.tpl
+++ b/bitnami/kafka/templates/_helpers.tpl
@@ -511,7 +511,7 @@ kafka: auth.clientProtocol auth.interBrokerProtocol
 {{- $replicaCount := int .Values.replicaCount }}
 {{- $nodePortListLength := len .Values.externalAccess.service.nodePorts }}
 {{- if and .Values.externalAccess.enabled (not .Values.externalAccess.autoDiscovery.enabled) (not (eq $replicaCount $nodePortListLength )) (eq .Values.externalAccess.service.type "NodePort") -}}
-kafka: .Values.externalAccess.service.nodePort
+kafka: .Values.externalAccess.service.nodePorts
     Number of replicas and nodePort array length must be the same.
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
**Description of the change**

Some months ago the parameter `externalAccess.service.nodePort` was renamed as `externalAccess.service.nodePorts` since we are using an array of ports instead of a single port. Changes were introduced in [this PR](https://github.com/bitnami/charts/pull/2098), also the change in this specific parameter name was documented in the [notable changes section of the README](https://github.com/bitnami/charts/tree/master/bitnami/kafka#to-900).

As the length must be the same as replicaCount, we also added the following check in the `_helpers.tpl`
```
{{/* Validate values of Kafka - number of replicas must be the same than NodePort list */}}
{{- define "kafka.validateValues.nodePortListLength" -}}
{{- $replicaCount := int .Values.replicaCount }}
{{- $nodePortListLength := len .Values.externalAccess.service.nodePorts }}
{{- if and .Values.externalAccess.enabled (not .Values.externalAccess.autoDiscovery.enabled) (not (eq $replicaCount $nodePortListLength )) (eq .Values.externalAccess.service.type "NodePort") -}}
kafka: .Values.externalAccess.service.nodePort
Number of replicas and nodePort array length must be the same.
{{- end -}}
{{- end -}}
```

In the above code block, we are calculating the length of node ports using the correct parameter (`.Values.externalAccess.service.nodePorts`) but we are printing the old one `.Values.externalAccess.service.nodePort`

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files