### PR TITLE
[bitnami/grafana] Made persistence volume optional

### DIFF
--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 3.3.3
+version: 3.3.4
 appVersion: 7.1.2
 description: Grafana is an open source, feature rich metrics dashboard and graph editor for Graphite, Elasticsearch, OpenTSDB, Prometheus and InfluxDB.
 keywords:

--- a/bitnami/grafana/templates/deployment.yaml
+++ b/bitnami/grafana/templates/deployment.yaml
@@ -83,8 +83,10 @@ spec:
               mountPath: /opt/bitnami/grafana/conf/grafana.ini
               subPath: grafana.ini
             {{- end }}
+            {{- if .Values.persistence.enabled }}
             - name: data
               mountPath: /opt/bitnami/grafana/data
+            {{- end }}
             {{- if .Values.dashboardsProvider.enabled }}
             - name: dashboards-provider
               mountPath: /opt/bitnami/grafana/conf/provisioning/dashboards
@@ -145,8 +147,8 @@ spec:
         {{- include "grafana.tplValue" (dict "value" .Values.sidecars "context" $) | nindent 8 }}
         {{- end }}
       volumes:
-        - name: data
         {{- if .Values.persistence.enabled }}
+        - name: data
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.existingClaim | default (include "grafana.fullname" .) }}
         {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Made persistence volume "data" optional. If `persistence.enabled=false` the "data" volume should not exist at all, rather than the default
```
volumes:
- name: data
- [...]
```

This behaviour is consistent with other Bitnami charts

**Benefits**

This allows the `/opt/bitnami/grafana/data` folder to be mounted using the extraVolumes values, without needing to use PVs and PVCs

This is useful for k8s platforms that don't have a storage provider

**Possible drawbacks**

If `persistence.enabled=false` and no alternative mount for `/opt/bitnami/grafana/data` is present, the grafana database and plugin files will be stored in the overlay filesystem instead of the default ext4 `emptyDir`

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
