### PR TITLE
[bitnami/influxdb] Fix indentation for ServiceMonitor namespaceSelector

### DIFF
--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.6.4
+version: 0.6.5
 appVersion: 1.8.1
 description: InfluxDB is an open source time-series database designed to handle large write and read loads in real-time.
 engine: gotpl

--- a/bitnami/influxdb/templates/influxdb/servicemonitor.yaml
+++ b/bitnami/influxdb/templates/influxdb/servicemonitor.yaml
@@ -25,7 +25,7 @@ spec:
       {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
       {{- end }}
-    namespaceSelector:
-      matchNames:
-        - {{ .Release.Namespace }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
 {{- end }}


### PR DESCRIPTION
**Description of the change**

Fix indentation for ServiceMonitor namespaceSelector

**Benefits**

You can now set serviceMonitor.enabled = true

**Possible drawbacks**

Not sure of any

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)