### PR TITLE
[bitnami/redis] Fix matchLabels for PDB

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 10.7.14
+version: 10.7.15
 appVersion: 6.0.6
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/bitnami/redis/templates/pdb.yaml
+++ b/bitnami/redis/templates/pdb.yaml
@@ -17,4 +17,5 @@ spec:
     matchLabels:
       app: {{ template "redis.name" . }}
       chart: {{ template "redis.chart" . }}
+      release: {{ .Release.Name }}
 {{- end }}


### PR DESCRIPTION
**Description of the change**

Make the PodDisruptionBudget for Redis use `release` for node selection.

**Benefits**

PodDisruptionBudget now behaves correctly if multiple releases are installed in the same namespace.

**Possible drawbacks**

**Applicable issues**
  - fixes #3294 

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
