### PR TITLE
[bitnami/thanos]Hotfix. Didn't remove filename in mountPath

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 2.1.0
+version: 2.1.1
 appVersion: 0.14.0
 description: Thanos is a highly available metrics system that can be added on top of existing Prometheus deployments, providing a global query view across all Prometheus installations.
 engine: gotpl

--- a/bitnami/thanos/templates/ruler/statefulset.yaml
+++ b/bitnami/thanos/templates/ruler/statefulset.yaml
@@ -118,7 +118,7 @@ spec:
           {{- end }}
           volumeMounts:
             - name: ruler-config
-              mountPath: /conf/rules/ruler.yml
+              mountPath: /conf/rules
             - name: objstore-config
               {{- if .Values.existingObjstoreSecretItems }}
               mountPath: /conf


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

File name was not removed from mountPath, this puts the pod in a crashloop. Both with `ruler.existingConfigmap` and `ruler.config`.

**Benefits**

Working Thanos-Ruler.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
