### PR TITLE
[bitnami/postgresql-ha] Fix postgresql-ha chart prometheus annotations

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql-ha
-version: 3.5.3
+version: 3.5.4
 appVersion: 11.8.0
 description: Chart for PostgreSQL with HA architecture (using Replication Manager (repmgr) and Pgpool).
 keywords:

--- a/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
@@ -25,8 +25,14 @@ spec:
         {{- if .Values.postgresql.podLabels }}
         {{- include "postgresql-ha.tplValue" (dict "value" .Values.postgresql.podLabels "context" $) | nindent 8 }}
         {{- end }}
+      {{- if or .Values.postgresql.podAnnotations (and .Values.metrics.enabled .Values.metrics.annotations) }}
+      annotations:
       {{- if .Values.postgresql.podAnnotations }}
-      annotations: {{- include "postgresql-ha.tplValue" (dict "value" .Values.postgresql.podAnnotations "context" $) | nindent 8 }}
+      {{- include "postgresql-ha.tplValue" (dict "value" .Values.postgresql.podAnnotations "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if and .Values.metrics.enabled .Values.metrics.annotations }}
+      {{- include "postgresql-ha.tplValue" (dict "value" .Values.metrics.annotations "context" $) | nindent 8 }}
+      {{- end }}
       {{- end }}
     spec:
 {{- include "postgresql-ha.imagePullSecrets" . | indent 6 }}


### PR DESCRIPTION
In `postgresql-ha` chart when we want to use the Prometheus exporter, The annotations that we have In values file for exporter don't set.
This PR is for fixing this issue.