### PR TITLE
[bitnami/common] missing $ in required values helper

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: common
 # Please make sure that version and appVersion are always the same.
-version: 0.5.0
-appVersion: 0.5.0
+version: 0.5.1
+appVersion: 0.5.1
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 keywords:
   - common

--- a/bitnami/common/templates/_validations.tpl
+++ b/bitnami/common/templates/_validations.tpl
@@ -36,7 +36,7 @@ Validate value params:
   {{- $latestObj := $.context.Values -}}
   {{- range $valueKeyArray -}}
     {{- if not $latestObj -}}
-      {{- printf "please review the entire path of '%s' exists in values" .valueKey | fail -}}
+      {{- printf "please review the entire path of '%s' exists in values" $.valueKey | fail -}}
     {{- end -}}
 
     {{- $value = ( index $latestObj . ) -}}


### PR DESCRIPTION
**Description of the change**

Add the proper context `$` which is missing when trying to evaluate a field.

**Benefits**

We can report to the user when the value is empty.

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
