### PR TITLE
[bitnami/wildfly] Bugfix: extra volume is created in the init container instead of the container

### DIFF
--- a/bitnami/wildfly/Chart.yaml
+++ b/bitnami/wildfly/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wildfly
-version: 4.3.1
+version: 4.3.2
 appVersion: 20.0.1
 description: Chart for Wildfly
 keywords:

--- a/bitnami/wildfly/templates/deployment.yaml
+++ b/bitnami/wildfly/templates/deployment.yaml
@@ -51,9 +51,6 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /bitnami/wildfly
-            {{- if .Values.extraVolumeMounts }}
-            {{- include "wildfly.tplValue" ( dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
-            {{- end }}
       {{- end }}
       containers:
         - name: wildfly
@@ -106,6 +103,9 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /bitnami/wildfly
+            {{- if .Values.extraVolumeMounts }}
+            {{- include "wildfly.tplValue" ( dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
         {{- if .Values.sidecars }}
         {{- include "wildfly.tplValue" (dict "value" .Values.sidecars "context" $) | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
**Description of the change**

Fixes a bug where the extra volume is created in the init container instead of the container

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
