### PR TITLE
[bitnami/phpmyadmin]Add allowArbitraryServer environment variable

### DIFF
--- a/bitnami/phpmyadmin/Chart.yaml
+++ b/bitnami/phpmyadmin/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: phpmyadmin
-version: 6.3.4
+version: 6.4.0
 appVersion: 5.0.2
 description: phpMyAdmin is an mysql administration frontend
 keywords:

--- a/bitnami/phpmyadmin/Chart.yaml
+++ b/bitnami/phpmyadmin/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: phpmyadmin
-version: 6.3.3
+version: 6.3.4
 appVersion: 5.0.2
 description: phpMyAdmin is an mysql administration frontend
 keywords:

--- a/bitnami/phpmyadmin/README.md
+++ b/bitnami/phpmyadmin/README.md
@@ -59,6 +59,7 @@ The following table lists the configurable parameters of the phpMyAdmin chart an
 | `fullnameOverride`           | String to fully override phpmyadmin.fullname template with a string                                     | `nil`                                                        |
 | `service.type`               | Type of service for phpMyAdmin frontend                                                                 | `ClusterIP`                                                  |
 | `service.port`               | Port to expose service                                                                                  | `80`                                                         |
+| `db.allowArbitraryServer`    | Enable connection to arbitrary MySQL server                                                             | `true`                                                       |
 | `db.port`                    | Database port to use to connect                                                                         | `3306`                                                       |
 | `db.chartName`               | Database suffix if included in the same release                                                         | `nil`                                                        |
 | `db.host`                    | Database host to connect to                                                                             | `nil`                                                        |

--- a/bitnami/phpmyadmin/templates/deployment.yaml
+++ b/bitnami/phpmyadmin/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
             - name: PHPMYADMIN_ALLOW_NO_PASSWORD
               value: "true"
             - name: PHPMYADMIN_ALLOW_ARBITRARY_SERVER
-              value: "true"
+              value: {{ .Values.db.allowArbitraryServer | quote }}
             {{- else }}
             - name: PHPMYADMIN_ALLOW_NO_PASSWORD
               value: "false"

--- a/bitnami/phpmyadmin/values.yaml
+++ b/bitnami/phpmyadmin/values.yaml
@@ -39,6 +39,10 @@ service:
   port: 80
 
 db:
+  ## If you do not want the user to be able to specify an arbitrary MySQL server
+  ## at login time, set this to false
+  allowArbitraryServer: true
+
   ## Database port
   ##
   port: 3306


### PR DESCRIPTION

**Description of the change**

Add _allowArbitraryServer_ environment variable to be able to modify via **values.yaml** the variable _PHPMYADMIN_ALLOW_ARBITRARY_SERVER_ currently set to "true" in **deployment.yaml** . The default value for _allowArbitraryServer_ remains "true" so the default behavior doesn't change.

**Benefits**

Being able to access _PHPMYADMIN_ALLOW_ARBITRARY_SERVER_ without modifying **deployment.yaml**.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

