### PR TITLE
[bitnami/apache] Add resources for git container

### DIFF
--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: apache
-version: 7.3.23
+version: 7.3.24
 appVersion: 2.4.46
 description: Chart for Apache HTTP Server
 keywords:

--- a/bitnami/apache/README.md
+++ b/bitnami/apache/README.md
@@ -74,6 +74,7 @@ The following tables lists the configurable parameters of the Apache chart and t
 | `cloneHtdocsFromGit.repository`  | Repository to clone static content from                 | `nil`                                                        |
 | `cloneHtdocsFromGit.branch`      | Branch inside the git repository                        | `nil`                                                        |
 | `cloneHtdocsFromGit.interval`    | Interval for sidecar container pull from the repository | `60`                                                         |
+| `cloneHtdocsFromGit.resources`   | Init container git resource requests/limit              | `{}`                                                         |
 | `podAnnotations`                 | Pod annotations                                         | `{}`                                                         |
 | `livenessProbe.enabled`          | Enable liveness probe                                   | `true`                                                       |
 | `livenessProbe.path`             | Path to access on the HTTP server                       | `/`                                                          |

--- a/bitnami/apache/templates/deployment.yaml
+++ b/bitnami/apache/templates/deployment.yaml
@@ -44,6 +44,7 @@ spec:
             - -ec
             - |
               git clone {{ .Values.cloneHtdocsFromGit.repository }} --branch {{ .Values.cloneHtdocsFromGit.branch }} /app
+          resources: {{- toYaml .Values.cloneHtdocsFromGit.resources | nindent 12 }}
           volumeMounts:
             - name: htdocs
               mountPath: /app
@@ -59,6 +60,7 @@ spec:
                   cd /app && git pull origin {{ .Values.cloneHtdocsFromGit.branch }}
                   sleep {{ .Values.cloneHtdocsFromGit.interval }}
               done
+          resources: {{- toYaml .Values.cloneHtdocsFromGit.resources | nindent 12 }}
           volumeMounts:
             - name: htdocs
               mountPath: /app

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -79,6 +79,7 @@ cloneHtdocsFromGit:
   # repository:
   # branch:
   interval: 60
+  resources: {}
 
 ## Name of a config map with the server static content
 ##


### PR DESCRIPTION


**Description of the change**
Currently on git init containers you can not set any resources
**Benefits**
support for resources on git init container

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
