### PR TITLE
[bitnami/spring-cloud-dataflow] feat: add url to grafana

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: spring-cloud-dataflow
-version: 0.4.3
+version: 0.5.0
 appVersion: 2.5.3
 description: Spring Cloud Data Flow is a microservices-based toolkit for building streaming and batch data processing pipelines in Cloud Foundry and Kubernetes.
 keywords:

--- a/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
@@ -77,6 +77,10 @@ data:
                         port: {{ $rsocketPort }}
             {{- end }}
           {{- end }}
+          {{- if .Values.server.configuration.grafanaInfo }}
+          grafana-info:
+            url: {{ .Values.server.configuration.grafanaInfo }}
+          {{- end }}
       {{- $hibernateDialect := include "scdf.database.hibernate.dialect" .  }}
       {{- if $hibernateDialect }}
       jpa:

--- a/bitnami/spring-cloud-dataflow/values-production.yaml
+++ b/bitnami/spring-cloud-dataflow/values-production.yaml
@@ -67,6 +67,9 @@ server:
     ##     authorization-type: dockeroauth2
     ##
     containerRegistries: {}
+    ## Endpoint to the grafana instance
+    ##
+    grafanaInfo:
 
   ## ConfigMap with Spring Cloud Dataflow Server Configuration
   ## NOTE: When it's set the server.configuration.* and deployer.*
@@ -587,7 +590,7 @@ deployer:
   ## The node selectors to apply to the streaming applications deployments in "key:value" format.
   ## Multiple node selectors are comma separated.
   ##
-  nodeSelector: ""
+  nodeSelector: ''
   tolerations: {}
   ## Extra volume mounts.
   ##
@@ -597,7 +600,7 @@ deployer:
   volumes: {}
   ## List of environment variables to set for any deployed app container. Multiple values are comma separated.
   ##
-  environmentVariables: ""
+  environmentVariables: ''
 
 ## Init containers parameters:
 ## wait-for-backends: Wait for the database and other services (such as Kafka or RabbitMQ) used when enabling streaming

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -590,7 +590,7 @@ deployer:
   ## The node selectors to apply to the streaming applications deployments in "key:value" format.
   ## Multiple node selectors are comma separated.
   ##
-  nodeSelector: ""
+  nodeSelector: ''
   tolerations: {}
   ## Extra volume mounts.
   ##
@@ -601,7 +601,7 @@ deployer:
   ## List of extra environment variables to set for any deployed app container. These environments will not override
   ## RabbitMQ/Kafka envs. Multiple values are comma separated.
   ##
-  environmentVariables: ""
+  environmentVariables: ''
 
 ## Init containers parameters:
 ## wait-for-backends: Wait for the database and other services (such as Kafka or RabbitMQ) used when enabling streaming

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -67,6 +67,9 @@ server:
     ##     authorization-type: dockeroauth2
     ##
     containerRegistries: {}
+    ## Endpoint to the grafana instance
+    ##
+    grafanaInfo:
 
   ## ConfigMap with Spring Cloud Dataflow Server Configuration
   ## NOTE: When it's set the server.configuration.* and deployer.*


### PR DESCRIPTION
**Description of the change**

Add a new value to supply grafana info to dataflow server configuration

**Benefits**

We will see a link to grafana.

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
