### PR TITLE
[bitnami/prometheus-operator] Provide https-metrics port for kube-proxy ServiceMonitor

### DIFF
--- a/bitnami/prometheus-operator/Chart.yaml
+++ b/bitnami/prometheus-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.41.0
 description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 name: prometheus-operator
-version: 0.29.4
+version: 0.29.5
 keywords:
   - prometheus
   - alertmanager

--- a/bitnami/prometheus-operator/README.md
+++ b/bitnami/prometheus-operator/README.md
@@ -348,6 +348,8 @@ The following table lists the configurable parameters of the Prometheus Operator
 | `kubeProxy.service.enabled`                        | Whether or not to create a Service object for kube-proxy     | `true`        |
 | `kubeProxy.service.port`                           | Listening port of the kube-proxy Service object              | `10249`       |
 | `kubeProxy.service.targetPort`                     | Port to target on the kube-proxy Pods. This should be the port that kube-proxy is listening on | `10249`       |
+| `kubeProxy.service.httpsPort`                      | Listening https port of the kube-proxy Service object              | `10250`       |
+| `kubeProxy.service.httpsTargetPort`                | Https Port to target on the kube-proxy Pods. This should be the port that kube-proxy is listening on | `10250`       |
 | `kubeProxy.service.selector`                       | Service label selector to discover the kube-proxy Pods       | `{}`          |
 | `kubeProxy.serviceMonitor.enabled`                 | Create a ServiceMonitor object                               | `true`        |
 | `kubeProxy.serviceMonitor.interval`                | Scrape interval (use by default, falling back to Prometheus' default) | `""`          |

--- a/bitnami/prometheus-operator/templates/exporters/kube-proxy/service.yaml
+++ b/bitnami/prometheus-operator/templates/exporters/kube-proxy/service.yaml
@@ -13,6 +13,10 @@ spec:
       port: {{ .Values.kubeProxy.service.port }}
       protocol: TCP
       targetPort: {{ .Values.kubeProxy.service.targetPort }}
+    - name: https-metrics
+      port: {{ .Values.kubeProxy.service.httpsPort }}
+      protocol: TCP
+      targetPort: {{ .Values.kubeProxy.service.httpsTargetPort }}
 {{- if .Values.kubeProxy.endpoints }}{{- else }}
   selector:
     {{- if .Values.kubeProxy.service.selector }}

--- a/bitnami/prometheus-operator/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/bitnami/prometheus-operator/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -15,20 +15,37 @@ spec:
     matchNames:
       - {{ .Values.kubeProxy.namespace }}
   endpoints:
-    - port: http-metrics
+    {{- if .Values.kubeProxy.serviceMonitor.https }}
+    - port: https-metrics
       {{- if .Values.kubeProxy.serviceMonitor.interval }}
       interval: {{ .Values.kubeProxy.serviceMonitor.interval }}
       {{- end }}
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      {{- if .Values.kubeProxy.serviceMonitor.https }}
       scheme: https
       tlsConfig:
         caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-      {{- end}}
+        serverName: kubernetes
+        insecureSkipVerify: true
       {{- if .Values.kubeProxy.serviceMonitor.metricRelabelings }}
       metricRelabelings: {{- toYaml .Values.kubeProxy.serviceMonitor.metricRelabelings | nindent 8 }}
       {{- end }}
       {{- if .Values.kubeProxy.serviceMonitor.relabelings }}
       relabelings: {{- toYaml .Values.kubeProxy.serviceMonitor.relabelings | nindent 8 }}
       {{- end }}
+    {{- else }}
+    - port: http-metrics
+      scheme: http
+      tlsConfig:
+        insecureSkipVerify: false
+      {{- if .Values.kubeProxy.serviceMonitor.interval }}
+      interval: {{ .Values.kubeProxy.serviceMonitor.interval }}
+      {{- end }}
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      {{- if .Values.kubeProxy.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- toYaml .Values.kubeProxy.serviceMonitor.metricRelabelings | nindent 8 }}
+      {{- end }}
+      {{- if .Values.kubeProxy.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml .Values.kubeProxy.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
+    {{- end }}
 {{- end }}

--- a/bitnami/prometheus-operator/values-production.yaml
+++ b/bitnami/prometheus-operator/values-production.yaml
@@ -1104,6 +1104,8 @@ kubeProxy:
     enabled: true
     port: 10249
     targetPort: 10249
+    httpsPort: 10250
+    httpsTargetPort: 10250
     # selector:
     #   k8s-app: kube-proxy
 

--- a/bitnami/prometheus-operator/values.yaml
+++ b/bitnami/prometheus-operator/values.yaml
@@ -1105,6 +1105,8 @@ kubeProxy:
     enabled: true
     port: 10249
     targetPort: 10249
+    httpsPort: 10250
+    httpsTargetPort: 10250
     # selector:
     #   k8s-app: kube-proxy
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This change allows setting up a https-port for the kube-proxy service monitor scraper. Some cluster setups will force using https on the `kube-system` namespace.

The change is implemented to be similar to the `kubelet` ServiceMonitor 

**Benefits**

Provides more options in configuring https for the `kube-proxy` ServiceMonitor

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

I hope this is a valid approach to achieve scraping from a https port for the kube-proxy services. I mainly just copied the setup from the kubelet ServiceMontior.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
