### PR TITLE
[bitnami/grafana] Introduce .Release.Namespace in metadata

### DIFF
--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 3.3.5
+version: 3.4.0
 appVersion: 7.1.3
 description: Grafana is an open source, feature rich metrics dashboard and graph editor for Graphite, Elasticsearch, OpenTSDB, Prometheus and InfluxDB.
 keywords:

--- a/bitnami/grafana/templates/configmap.yaml
+++ b/bitnami/grafana/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "grafana.fullname" . }}-envvars
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "grafana.labels" . | nindent 4 }}
     app.kubernetes.io/component: grafana
 data:

--- a/bitnami/grafana/templates/dashboard-provider.yaml
+++ b/bitnami/grafana/templates/dashboard-provider.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "grafana.fullname" . }}-provider
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "grafana.labels" . | nindent 4 }}
     app.kubernetes.io/component: grafana
 data:

--- a/bitnami/grafana/templates/deployment.yaml
+++ b/bitnami/grafana/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "grafana.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "grafana.labels" . | nindent 4 }}
     app.kubernetes.io/component: grafana
 spec:

--- a/bitnami/grafana/templates/image-renderer-deployment.yaml
+++ b/bitnami/grafana/templates/image-renderer-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "grafana.fullname" . }}-image-renderer
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "grafana.labels" . | nindent 4 }}
     app.kubernetes.io/component: image-renderer
 spec:

--- a/bitnami/grafana/templates/image-renderer-service.yaml
+++ b/bitnami/grafana/templates/image-renderer-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "grafana.fullname" . }}-image-renderer
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "grafana.labels" . | nindent 4 }}
     app.kubernetes.io/component: image-renderer
   {{- if and .Values.imageRenderer.metrics.enabled .Values.imageRenderer.metrics.annotations }}

--- a/bitnami/grafana/templates/image-renderer-servicemonitor.yaml
+++ b/bitnami/grafana/templates/image-renderer-servicemonitor.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "grafana.fullname" . }}-image-renderer
   {{- if .Values.imageRenderer.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.imageRenderer.metrics.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
   {{- end }}
   labels: {{- include "grafana.labels" . | nindent 4 }}
     app.kubernetes.io/component: image-renderer

--- a/bitnami/grafana/templates/ingress.yaml
+++ b/bitnami/grafana/templates/ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ template "grafana.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "grafana.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "grafana.labels" . | nindent 4 }}
     app.kubernetes.io/component: grafana
   annotations:

--- a/bitnami/grafana/templates/pvc.yaml
+++ b/bitnami/grafana/templates/pvc.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "grafana.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "grafana.labels" . | nindent 4 }}
     app.kubernetes.io/component: grafana
 spec:

--- a/bitnami/grafana/templates/secret.yaml
+++ b/bitnami/grafana/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "grafana.fullname" . }}-admin
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "grafana.labels" . | nindent 4 }}
     app.kubernetes.io/component: grafana
 type: Opaque

--- a/bitnami/grafana/templates/service.yaml
+++ b/bitnami/grafana/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "grafana.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "grafana.labels" . | nindent 4 }}
     app.kubernetes.io/component: grafana
   {{- if or (and .Values.metrics.enabled .Values.metrics.service.annotations) .Values.service.annotations }}

--- a/bitnami/grafana/templates/serviceaccount.yaml
+++ b/bitnami/grafana/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "grafana.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "grafana.labels" . | nindent 4 }}
   {{- if .Values.serviceAccount.annotations }}
   annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}

--- a/bitnami/grafana/templates/servicemonitor.yaml
+++ b/bitnami/grafana/templates/servicemonitor.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "grafana.fullname" . }}
   {{- if .Values.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
   {{- end }}
   labels: {{- include "grafana.labels" . | nindent 4 }}
     app.kubernetes.io/component: grafana

--- a/bitnami/grafana/templates/smtp-secret.yaml
+++ b/bitnami/grafana/templates/smtp-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "grafana.fullname" . }}-smtp
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "grafana.labels" . | nindent 4 }}
     app.kubernetes.io/component: grafana
 type: Opaque


### PR DESCRIPTION
**Description of the change**

Hi,

The PR is connected with issue #2006
and follows the same scheme as:
#2156
#2159
#2177
#2316
#3186 

this time for grafana

**Benefits**

TLDR; ability to deploy the helm chart in gitops-friendly way, for details read the issue here: #2006

Possible drawbacks
Not known

Applicable issues

#2006


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
