### PR TITLE
[bitnami/node-exporter] Introduce .Release.Namespace in metadata

### DIFF
--- a/bitnami/node-exporter/Chart.yaml
+++ b/bitnami/node-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.1
 description: Prometheus exporter for hardware and OS metrics exposed by UNIX kernels, with pluggable metric collectors.
 name: node-exporter
-version: 1.0.3
+version: 1.1.0
 keywords:
   - prometheus
   - node-exporter

--- a/bitnami/node-exporter/templates/daemonset.yaml
+++ b/bitnami/node-exporter/templates/daemonset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "node-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "node-exporter.labels" . | nindent 4 }}
 spec:
   selector:

--- a/bitnami/node-exporter/templates/service.yaml
+++ b/bitnami/node-exporter/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "node-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     {{- if .Values.service.addPrometheusScrapeAnnotation }}
     prometheus.io/scrape: "true"

--- a/bitnami/node-exporter/templates/serviceaccount.yaml
+++ b/bitnami/node-exporter/templates/serviceaccount.yaml
@@ -3,5 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "node-exporter.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "node-exporter.labels" . | nindent 4 }}
 {{- end }}

--- a/bitnami/node-exporter/templates/servicemonitor.yaml
+++ b/bitnami/node-exporter/templates/servicemonitor.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ template "node-exporter.fullname" . }}
   {{- if .Values.serviceMonitor.namespace }}
   namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
   {{- end }}
   labels: {{- include "node-exporter.labels" . | nindent 4 }}
     {{- range $key, $value := .Values.serviceMonitor.selector }}


### PR DESCRIPTION
**Description of the change**

Hi,

The PR is connected with issue #2006
and follows the same scheme as:
#2156
#2159
#2177
#2316
#3186 

this time for node-exporter

**Benefits**

TLDR; ability to deploy the helm chart in gitops-friendly way, for details read the issue here: #2006

Possible drawbacks
Not known

Applicable issues

#2006

Additional information

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
