### PR TITLE
[bitnami/kube-state-metrics] Introduce .Release.Namespace in metadata

### DIFF
--- a/bitnami/kube-state-metrics/Chart.yaml
+++ b/bitnami/kube-state-metrics/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.9.7
 description: kube-state-metrics is a simple service that listens to the Kubernetes API server and generates metrics about the state of the objects.
 name: kube-state-metrics
-version: 0.4.3
+version: 0.5.0
 keywords:
   - prometheus
   - kube-state-metrics

--- a/bitnami/kube-state-metrics/templates/deployment.yaml
+++ b/bitnami/kube-state-metrics/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kube-state-metrics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "kube-state-metrics.labels" . | nindent 4 }}
 spec:
   selector:

--- a/bitnami/kube-state-metrics/templates/service.yaml
+++ b/bitnami/kube-state-metrics/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kube-state-metrics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     {{- if not .Values.serviceMonitor.enabled }}
     prometheus.io/scrape: "true"

--- a/bitnami/kube-state-metrics/templates/serviceaccount.yaml
+++ b/bitnami/kube-state-metrics/templates/serviceaccount.yaml
@@ -3,5 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "kube-state-metrics.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "kube-state-metrics.labels" . | nindent 4 }}
 {{- end }}

--- a/bitnami/kube-state-metrics/templates/servicemonitor.yaml
+++ b/bitnami/kube-state-metrics/templates/servicemonitor.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ template "kube-state-metrics.fullname" . }}
   {{- if .Values.serviceMonitor.namespace }}
   namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
   {{- end }}
   labels: {{- include "kube-state-metrics.labels" . | nindent 4 }}
     {{- range $key, $value := .Values.serviceMonitor.selector }}


### PR DESCRIPTION
**Description of the change**

Hi,

The PR is connected with issue #2006
and follows the same scheme as:
#2156
#2159
#2177
#2316
#3186 

this time for kube-state-metrics

**Benefits**

TLDR; ability to deploy the helm chart in gitops-friendly way, for details read the issue here: #2006

Possible drawbacks
Not known

Applicable issues

#2006

Additional information

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
