### PR TITLE
[bitnami/prometheus-operator] Introduce .Release.Namespace in metadata

### DIFF
--- a/bitnami/prometheus-operator/Chart.yaml
+++ b/bitnami/prometheus-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.41.0
 description: The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 name: prometheus-operator
-version: 0.29.4
+version: 0.30.0
 keywords:
   - prometheus
   - alertmanager

--- a/bitnami/prometheus-operator/templates/alertmanager/alertmanager.yaml
+++ b/bitnami/prometheus-operator/templates/alertmanager/alertmanager.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: Alertmanager
 metadata:
   name: {{ template "prometheus-operator.alertmanager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "prometheus-operator.alertmanager.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.alertmanager.replicaCount }}

--- a/bitnami/prometheus-operator/templates/alertmanager/ingress.yaml
+++ b/bitnami/prometheus-operator/templates/alertmanager/ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ template "prometheus-operator.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "prometheus-operator.alertmanager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "prometheus-operator.alertmanager.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.alertmanager.ingress.certManager }}

--- a/bitnami/prometheus-operator/templates/alertmanager/pdb.yaml
+++ b/bitnami/prometheus-operator/templates/alertmanager/pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus-operator.alertmanager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "prometheus-operator.alertmanager.labels" . | nindent 4 }}
 spec:
   selector:

--- a/bitnami/prometheus-operator/templates/alertmanager/secrets.yaml
+++ b/bitnami/prometheus-operator/templates/alertmanager/secrets.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: alertmanager-{{ template "prometheus-operator.alertmanager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "prometheus-operator.alertmanager.labels" . | nindent 4 }}
 data:
   alertmanager.yaml: {{ toYaml .Values.alertmanager.config | b64enc | quote }}

--- a/bitnami/prometheus-operator/templates/alertmanager/service.yaml
+++ b/bitnami/prometheus-operator/templates/alertmanager/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "prometheus-operator.alertmanager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "prometheus-operator.alertmanager.labels" . | nindent 4 }}
   {{- with .Values.alertmanager.service.annotations }}
   annotations: {{- toYaml . | nindent 4 }}

--- a/bitnami/prometheus-operator/templates/alertmanager/serviceaccount.yaml
+++ b/bitnami/prometheus-operator/templates/alertmanager/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "prometheus-operator.alertmanager.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "prometheus-operator.alertmanager.labels" . | nindent 4 }}
   {{- if index .Values.alertmanager.serviceAccount "annotations" }}
   annotations: {{- include "prometheus-operator.tplValue" (dict "value" .Values.alertmanager.serviceAccount.annotations "context" $) | nindent 4 }}

--- a/bitnami/prometheus-operator/templates/alertmanager/servicemonitor.yaml
+++ b/bitnami/prometheus-operator/templates/alertmanager/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-operator.alertmanager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "prometheus-operator.alertmanager.labels" . | nindent 4 }}
 spec:
   selector:

--- a/bitnami/prometheus-operator/templates/exporters/kube-apiserver/servicemonitor.yaml
+++ b/bitnami/prometheus-operator/templates/exporters/kube-apiserver/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-apiserver
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "prometheus-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: apiserver
 spec:

--- a/bitnami/prometheus-operator/templates/exporters/kubelet/servicemonitor.yaml
+++ b/bitnami/prometheus-operator/templates/exporters/kubelet/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-operator.fullname" . }}-kubelet
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "prometheus-operator.labels" . | nindent 4 }}
     app.kubernetes.io/component: kubelet
 spec:

--- a/bitnami/prometheus-operator/templates/prometheus-operator/deployment.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ template "prometheus-operator.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "prometheus-operator.operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "prometheus-operator.operator.labels" . | nindent 4 }}
 spec:
   replicas: 1

--- a/bitnami/prometheus-operator/templates/prometheus-operator/service.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "prometheus-operator.operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "prometheus-operator.operator.labels" . | nindent 4 }}
   {{- with .Values.operator.service.annotations }}
   annotations: {{- toYaml . | nindent 4 }}

--- a/bitnami/prometheus-operator/templates/prometheus-operator/serviceaccount.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "prometheus-operator.operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "prometheus-operator.operator.labels" . | nindent 4 }}
 {{- include "prometheus-operator.operator.imagePullSecrets" . }}
 {{- end }}

--- a/bitnami/prometheus-operator/templates/prometheus-operator/servicemonitor.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus-operator/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-operator.operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "prometheus-operator.operator.labels" . | nindent 4 }}
 spec:
   endpoints:

--- a/bitnami/prometheus-operator/templates/prometheus/ingress.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ template "prometheus-operator.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "prometheus-operator.prometheus.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "prometheus-operator.prometheus.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.prometheus.ingress.certManager }}

--- a/bitnami/prometheus-operator/templates/prometheus/pdb.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus-operator.prometheus.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "prometheus-operator.prometheus.labels" . | nindent 4 }}
 spec:
   selector:

--- a/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
 metadata:
   name: {{ template "prometheus-operator.prometheus.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "prometheus-operator.prometheus.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.prometheus.replicaCount }}

--- a/bitnami/prometheus-operator/templates/prometheus/service.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "prometheus-operator.prometheus.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "prometheus-operator.prometheus.labels" . | nindent 4 }}
   {{- if .Values.prometheus.service.annotations }}
   annotations: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.service.annotations "context" $) | nindent 4 }}

--- a/bitnami/prometheus-operator/templates/prometheus/serviceaccount.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "prometheus-operator.prometheus.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "prometheus-operator.prometheus.labels" . | nindent 4 }}
   {{- if index .Values.prometheus.serviceAccount "annotations" }}
   annotations: {{- include "prometheus-operator.tplValue" (dict "value" .Values.prometheus.serviceAccount.annotations "context" $) | nindent 4 }}

--- a/bitnami/prometheus-operator/templates/prometheus/servicemonitor.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-operator.prometheus.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "prometheus-operator.prometheus.labels" . | nindent 4 }}
 spec:
   selector:

--- a/bitnami/prometheus-operator/templates/prometheus/thanos-service.yaml
+++ b/bitnami/prometheus-operator/templates/prometheus/thanos-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "prometheus-operator.prometheus.fullname" . }}-thanos
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "prometheus-operator.prometheus.labels" . | nindent 4 }}
     app.kubernetes.io/subcomponent: thanos
   {{- if .Values.prometheus.thanos.service.annotations }}


### PR DESCRIPTION
**Description of the change**

Hi,

The PR is connected with issue #2006
and follows the same scheme as:
#2156
#2159
#2177
#2316
#3186 

this time for prometheus-operator

**Benefits**

TLDR; ability to deploy the helm chart in gitops-friendly way, for details read the issue here: #2006

Possible drawbacks
Not known

Applicable issues

#2006

Additional information

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
