### PR TITLE
[bitnami/mongodb-sharded] Add ServiceAccount (#3432)

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb-sharded
-version: 2.0.0
+version: 2.1.0
 appVersion: 4.4.0
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications. Sharded topology.
 keywords:

--- a/bitnami/mongodb-sharded/README.md
+++ b/bitnami/mongodb-sharded/README.md
@@ -82,6 +82,8 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `common.mongodbMaxWaitTimeout`                | Maximum time (in seconds) for MongoDB nodes to wait for another MongoDB node to be ready                                                                  | `120`                                                    |
 | `common.podLabels`                            | Extra labels for all pods in the cluster (evaluated as a template)                                                                                        | `{}`                                                     |
 | `common.podAnnotations`                       | Extra annotations for all pods in the cluster (evaluated as a template)                                                                                   | `{}`                                                     |
+| `common.serviceAccount.name`                  | Name of a Service Account to be used by all Pods                                                                                                          | `nil`                                                    |
+| `common.serviceAccount.create`                | Whether to create a Service Account for all pods automatically                                                                                            | `false`                                                  |
 | `common.sidecars`                             | Attach additional containers to all pods in the cluster (evaluated as a template)                                                                         | `nil`                                                    |
 | `common.useHostnames`                         | Enable DNS hostnames in the replica set config                                                                                                            | `true`                                                   |
 | `common.initContainers`                       | Add additional init containers to all pods in the cluster (evaluated as a template)                                                                       | `nil`                                                    |
@@ -162,6 +164,8 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `configsvr.external.rootPassword`           | Root passworrd of the external config server replicaset                                                                                                                              | `nil`                                                     |
 | `configsvr.external.replicasetName`           | Replicaset name of an external config server                                                                                                                              | `nil`                                                     |
 | `configsvr.external.replicasetKey`           | Replicaset key of an external config server                                                                                                                              | `nil`                                                     |
+| `configsvr.serviceAccount.name`                 | Name of a Service Account to be used by configsvr                                                                                                            | `nil`                                                    |
+| `configsvr.serviceAccount.create`               | Whether to create a Service Account for configsvr automatically                                                                                              | `false`                                                  |
 
 ### Mongos configuration
 
@@ -190,6 +194,8 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `mongos.extraEnvVarsSecret`                   | Secret containing extra env vars (evaluated as a template)                                                                                                | `nil`                                                    |
 | `mongos.extraVolumes`                         | Array of extra volumes (evaluated as template). Requires setting `common.extraVolumeMounts`                                                               | `nil`                                                    |
 | `mongos.extraVolumeMounts`                    | Array of extra volume mounts (evaluated as template). Normally used with `common.extraVolumes`.                                                           | `nil`                                                    |
+| `mongos.serviceAccount.name`                  | Name of a Service Account to be used by mongos                                                                                                            | `nil`                                                    |
+| `mongos.serviceAccount.create`                | Whether to create a Service Account for mongos automatically                                                                                              | `false`                                                  |
 
 ### Shard configuration: Data nodes
 
@@ -219,6 +225,8 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `shardsvr.dataNode.extraEnvVarsSecret`        | Secret containing extra env vars (evaluated as a template)                                                                                                | `nil`                                                    |
 | `shardsvr.dataNode.extraVolumes`              | Array of extra volumes (evaluated as template). Requires setting `common.extraVolumeMounts`                                                               | `nil`                                                    |
 | `shardsvr.dataNode.extraVolumeMounts`         | Array of extra volume mounts (evaluated as template). Normally used with `common.extraVolumes`.                                                           | `nil`                                                    |
+| `shardsvr.dataNode.serviceAccount.name`       | Name of a Service Account to be used by shardsvr data pods                                                                                                | `nil`                                                    |
+| `shardsvr.dataNode.serviceAccount.create`     | Whether to create a Service Account for shardsvr data pods automatically                                                                                  | `false`                                                  |
 | `shardsvr.persistence.enabled`                | Use a PVC to persist data                                                                                                                                 | `true`                                                   |
 | `shardsvr.persistence.mountPath`              | Path to mount the volume at                                                                                                                               | `/bitnami/mongodb`                                       |
 | `shardsvr.persistence.subPath`                | Subdirectory of the volume to mount at                                                                                                                    | `""`                                                     |
@@ -252,6 +260,8 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `shardsvr.arbiter.extraEnvVarsSecret`         | Secret containing extra env vars (evaluated as a template)                                                                                                | `nil`                                                    |
 | `shardsvr.arbiter.extraVolumes`               | Array of extra volumes (evaluated as template). Requires setting `common.extraVolumeMounts`                                                               | `nil`                                                    |
 | `shardsvr.arbiter.extraVolumeMounts`          | Array of extra volume mounts (evaluated as template). Normally used with `common.extraVolumes`.                                                           | `nil`                                                    |
+| `shardsvr.arbiter.serviceAccount.name`        | Name of a Service Account to be used by shardsvr arbiter pods                                                                                             | `nil`                                                    |
+| `shardsvr.arbiter.serviceAccount.create`      | Whether to create a Service Account for shardsvr arbiter pods automatically                                                                               | `false`                                                  |
 
 ### Metrics exporter
 

--- a/bitnami/mongodb-sharded/templates/_helpers.tpl
+++ b/bitnami/mongodb-sharded/templates/_helpers.tpl
@@ -38,6 +38,40 @@ Usage:
 {{- end -}}
 
 {{/*
+Returns a ServiceAccount name for specified path or falls back to `common.serviceAccount.name`
+if `common.serviceAccount.create` is set to true. Falls back to Chart's fullname otherwise.
+
+Usage:
+{{ include "mongodb-sharded.serviceAccountName" (dict "value" .Values.path.to.serviceAccount "context" $) }}
+*/}}
+{{- define "mongodb-sharded.serviceAccountName" -}}
+{{- if .value.create }}
+    {{- default (include "mongodb-sharded.fullname" .context) .value.name | quote }}
+{{- else if .context.Values.common.serviceAccount.create }}
+    {{- default (include "mongodb-sharded.fullname" .context) .context.Values.common.serviceAccount.name | quote }}
+{{- else -}}
+    {{- default "default" .value.name | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Renders a ServiceAccount for specified name.
+Usage:
+{{ include "mongodb-sharded.serviceaccount" (dict "value" .Values.path.to.serviceAccount "context" $) }}
+*/}}
+{{- define "mongodb-sharded.serviceaccount" -}}
+{{- if .value.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mongodb-sharded.serviceAccountName" (dict "value" .value "context" .context) }}
+  labels:
+    {{- include "mongodb-sharded.labels" .context | nindent 4 }}
+---
+{{ end -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
@@ -36,6 +36,7 @@ spec:
       {{- if .Values.common.schedulerName }}
       schedulerName: {{ .Values.common.schedulerName | quote }}
       {{- end }}
+      serviceAccountName: {{ include "mongodb-sharded.serviceAccountName" (dict "value" .Values.configsvr.serviceAccount "context" $) }}
       nodeSelector: {{- include "mongodb-sharded.tplValue" ( dict "value" .Values.configsvr.nodeSelector "context" $ ) | nindent 8 }}
       affinity: {{- include "mongodb-sharded.tplValue" ( dict "value" .Values.configsvr.affinity "context" $ ) | nindent 8 }}
       tolerations: {{- include "mongodb-sharded.tplValue" ( dict "value" .Values.configsvr.tolerations "context" $ ) | nindent 8 }}

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-deployment.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-deployment.yaml
@@ -33,6 +33,7 @@ spec:
       {{- if .Values.common.schedulerName }}
       schedulerName: {{ .Values.common.schedulerName | quote }}
       {{- end }}
+      serviceAccountName: {{ include "mongodb-sharded.serviceAccountName" (dict "value" $.Values.mongos.serviceAccount "context" $) }}
       nodeSelector: {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.mongos.nodeSelector "context" $ ) | nindent 8 }}
       affinity: {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.mongos.affinity "context" $ ) | nindent 8 }}
       tolerations: {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.mongos.tolerations "context" $ ) | nindent 8 }}

--- a/bitnami/mongodb-sharded/templates/serviceaccount.yaml
+++ b/bitnami/mongodb-sharded/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+{{ include "mongodb-sharded.serviceaccount" (dict "value" .Values.common.serviceAccount "context" $) }}
+{{ include "mongodb-sharded.serviceaccount" (dict "value" .Values.mongos.serviceAccount "context" $) }}
+{{ include "mongodb-sharded.serviceaccount" (dict "value" .Values.configsvr.serviceAccount "context" $) }}
+{{ include "mongodb-sharded.serviceaccount" (dict "value" .Values.shardsvr.arbiter.serviceAccount "context" $) }}
+{{ include "mongodb-sharded.serviceaccount" (dict "value" .Values.shardsvr.dataNode.serviceAccount "context" $) }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
@@ -36,6 +36,7 @@ spec:
         {{- end }}
       {{- end }}
     spec:
+      serviceAccountName: {{ include "mongodb-sharded.serviceAccountName" (dict "value" $.Values.shardsvr.arbiter.serviceAccount "context" $) }}
       {{- if $.Values.common.schedulerName }}
       schedulerName: {{ $.Values.common.schedulerName | quote }}
       {{- end }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -42,6 +42,7 @@ spec:
       nodeSelector: {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.dataNode.nodeSelector "context" $ ) | nindent 8 }}
       affinity: {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.dataNode.affinity "context" (set $ "dataNodeLoopId" $i) ) | nindent 8 }}
       tolerations: {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.dataNode.tolerations "context" $ ) | nindent 8 }}
+      serviceAccountName: {{ include "mongodb-sharded.serviceAccountName" (dict "value" $.Values.shardsvr.dataNode.serviceAccount "context" $) }}
       {{- if $.Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ $.Values.securityContext.fsGroup }}

--- a/bitnami/mongodb-sharded/values-production.yaml
+++ b/bitnami/mongodb-sharded/values-production.yaml
@@ -209,6 +209,17 @@ shardsvr:
       ## Use 0 to disable
       ##
       maxUnavailable: 1
+    ## K8s Service Account.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+    ##
+    serviceAccount:
+      ## Specifies whether a ServiceAccount should be created.
+      ##
+      create: true
+      ## The name of the ServiceAccount to use.
+      ## If not set and create is true, a name is generated using the XXX.fullname template
+      ##
+      name: mongo-shard-data
 
   ## Properties for arbiter nodes
   ## ref: https://docs.mongodb.com/manual/tutorial/add-replica-set-arbiter/
@@ -312,6 +323,17 @@ shardsvr:
     ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
     ##
     schedulerName:
+    ## K8s Service Account.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+    ##
+    serviceAccount:
+      ## Specifies whether a ServiceAccount should be created.
+      ##
+      create: true
+      ## The name of the ServiceAccount to use.
+      ## If not set and create is true, a name is generated using the XXX.fullname template
+      ##
+      name: mongo-arbiter
   ## Enable persistence using Persistent Volume Claims
   ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
   ##
@@ -489,6 +511,17 @@ configsvr:
     ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
     ##
     annotations: {}
+  ## K8s Service Account.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  ##
+  serviceAccount:
+    ## Specifies whether a ServiceAccount should be created.
+    ##
+    create: true
+    ## The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the XXX.fullname template
+    ##
+    name: mongo-configsvr
 
   ## Use a external config server instead of deploying one
   ##
@@ -614,6 +647,17 @@ mongos:
     ## Use 0 to disable
     ##
     maxUnavailable: 1
+  ## K8s Service Account.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  ##
+  serviceAccount:
+    ## Specifies whether a ServiceAccount should be created for mongos.
+    ##
+    create: true
+    ## The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the XXX.fullname template
+    ##
+    name: mongo-mongos
 
 ## Properties for all of the pods in the cluster (shards, config servers and mongos)
 ##
@@ -692,6 +736,17 @@ common:
   ## Array to add extra mounts (normally used with extraVolumes)
   ##
   extraVolumeMounts:
+  ## K8s Service Account.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  ##
+  serviceAccount:
+    ## Specifies whether a ServiceAccount should be created.
+    ##
+    create: false
+    ## The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the XXX.fullname template
+    ##
+    # name:
 
 ## Init containers parameters:
 ## volumePermissions: Change the owner and group of the persistent volume mountpoint to runAsUser:fsGroup values from the securityContext section.

--- a/bitnami/mongodb-sharded/values.yaml
+++ b/bitnami/mongodb-sharded/values.yaml
@@ -189,6 +189,17 @@ shardsvr:
       ## Use 0 to disable
       ##
       maxUnavailable: 1
+    ## K8s Service Account.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+    ##
+    serviceAccount:
+      ## Specifies whether a ServiceAccount should be created for shardsvr.
+      ##
+      create: false
+      ## The name of the ServiceAccount to use.
+      ## If not set and create is true, a name is generated using the XXX.fullname template
+      ##
+      # name:
 
   ## Properties for arbiter nodes
   ## ref: https://docs.mongodb.com/manual/tutorial/add-replica-set-arbiter/
@@ -292,6 +303,17 @@ shardsvr:
     ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
     ##
     schedulerName:
+    ## K8s Service Account.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+    ##
+    serviceAccount:
+      ## Specifies whether a ServiceAccount should be created for shardsvr arbiter nodes.
+      ##
+      create: false
+      ## The name of the ServiceAccount to use.
+      ## If not set and create is true, a name is generated using the XXX.fullname template
+      ##
+      # name:
   ## Enable persistence using Persistent Volume Claims
   ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
   ##
@@ -469,6 +491,17 @@ configsvr:
     ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
     ##
     annotations: {}
+  ## K8s Service Account.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  ##
+  serviceAccount:
+    ## Specifies whether a ServiceAccount should be created for configsvr.
+    ##
+    create: false
+    ## The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the XXX.fullname template
+    ##
+    # name:
 
   ## Use a external config server instead of deploying one
   ##
@@ -594,6 +627,17 @@ mongos:
     ## Use 0 to disable
     ##
     maxUnavailable: 1
+  ## K8s Service Account.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  ##
+  serviceAccount:
+    ## Specifies whether a ServiceAccount should be created for mongos.
+    ##
+    create: false
+    ## The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the XXX.fullname template
+    ##
+    # name:
 
 ## Properties for all of the pods in the cluster (shards, config servers and mongos)
 ##
@@ -672,6 +716,17 @@ common:
   ## Array to add extra mounts (normally used with extraVolumes)
   ##
   extraVolumeMounts: []
+  ## K8s Service Account.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  ##
+  serviceAccount:
+    ## Specifies whether a ServiceAccount should be created for all Pods.
+    ##
+    create: false
+    ## The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the XXX.fullname template
+    ##
+    # name:
 
 ## Init containers parameters:
 ## volumePermissions: Change the owner and group of the persistent volume mountpoint to runAsUser:fsGroup values from the securityContext section.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
ServiceAccount added to all StatefulSets/Deployments. You can now set (and create automatically) a ServiceAccount globally, or just for specific StatefulSet/Deployment, i.e. to `mongos`.

**Benefits**
You can add ServiceAccount to all pods in `mongodb-sharded` chart, or to just specific ones. Adding ServiceAccount to mongos allows it to work with additional injected sidecar containers, such as Consul Connect and/or Vault Agent.

**Possible drawbacks**
You can't set annotations on, or further customize ServiceAccounts created by the module. You can, however use external service accounts if this implementation limits you.

**Applicable issues**

  - resolves #3432

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
