### PR TITLE
[bitnami/aspnet-core] Fix Ingress extra hosts

### DIFF
--- a/bitnami/aspnet-core/Chart.yaml
+++ b/bitnami/aspnet-core/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: aspnet-core
-version: 0.1.3
+version: 0.1.4
 appVersion: 3.1.7
 description: ASP.NET Core is an open-source framework created by Microsoft for building cloud-enabled, modern applications.
 keywords:

--- a/bitnami/aspnet-core/templates/ingress.yaml
+++ b/bitnami/aspnet-core/templates/ingress.yaml
@@ -34,7 +34,7 @@ spec:
         paths:
           - path: {{ default "/" .path }}
             backend:
-              serviceName: {{ include "aspnet-core.fullname" . }}
+              serviceName: {{ include "aspnet-core.fullname" $ }}
               servicePort: http
     {{- end }}
   {{- if or .Values.ingress.tls .Values.ingress.extraTls .Values.ingress.hosts }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR addresses the issue below when setting extra hosts to be defined in the ingress rule:

```console
error calling include: template: aspnet-core/charts/common/templates/_names.tpl:22:14: 
executing "common.names.fullname" at <.Values.fullnameOverride>: nil pointer evaluating interface {}.fullnameOverride
```

**Benefits**

Users can add custom hostnames to the ingress rule.

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/3436

**Additional information**

You can reproduce the issue using the values.yaml below:

```yaml
ingress:
  enabled: true
  extraHosts:
    - name: my.second.hostname
      path: /foo
    - name: my.third.hostname
      path: /bar
```

```console
$ helm template -f values.yaml aspnet-core bitnami/aspnet-core
```

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

