### PR TITLE
[bitnami/kafka] fix: use the proper loadBalancerSourceRanges

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 11.8.0
+version: 11.8.1
 appVersion: 2.6.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/templates/svc-external-access.yaml
+++ b/bitnami/kafka/templates/svc-external-access.yaml
@@ -32,7 +32,7 @@ spec:
   loadBalancerIP: {{ index $root.Values.externalAccess.service.loadBalancerIPs $i }}
   {{- end }}
   {{- if $root.Values.externalAccess.service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges: {{- toYaml $root.Values.service.loadBalancerSourceRanges | nindent 4 }}
+  loadBalancerSourceRanges: {{- toYaml $root.Values.externalAccess.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
   {{- end }}
   ports:


### PR DESCRIPTION
Signed-off-by: darteaga <darteaga@vmware.com>

**Description of the change**

The external access service was using `.Values.service.loadBalancerSourceRangesload`, this PR change it to `.Values.externalAccess.service.loadBalancerSourceRangesload`

**Benefits**

We can use loadBalancerSourceRangesload for external access

**Possible drawbacks**

N/A

**Applicable issues**

  - fixes #3434

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
