### PR TITLE
[bitnami/wordpress] Add extra config content env var

### DIFF
--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 9.4.4
+version: 9.5.0
 appVersion: 5.5.0
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -87,6 +87,7 @@ The following table lists the configurable parameters of the WordPress chart and
 | `wordpressBlogName`                       | Blog name                                                                             | `User's Blog!`                                               |
 | `wordpressTablePrefix`                    | Table prefix                                                                          | `wp_`                                                        |
 | `wordpressScheme`                         | Scheme to generate application URLs [`http`, `https`]                                 | `http`                                                       |
+| `wordpressExtraConfigContent`             | Add extra content to the configuration file                                           | `""`                                                           |
 | `allowEmptyPassword`                      | Allow DB blank passwords                                                              | `true`                                                       |
 | `allowOverrideNone`                       | Set Apache AllowOverride directive to None                                            | `false`                                                      |
 | `htaccessPersistenceEnabled`              | Make `.htaccess` persistence so that it can be customized. [See](#disabling-htaccess) | `false`                                                      |

--- a/bitnami/wordpress/templates/deployment.yaml
+++ b/bitnami/wordpress/templates/deployment.yaml
@@ -109,6 +109,8 @@ spec:
               value: {{ .Values.wordpressTablePrefix | quote }}
             - name: WORDPRESS_SCHEME
               value: {{ .Values.wordpressScheme | quote }}
+            - name: WORDPRESS_EXTRA_WP_CONFIG_CONTENT
+              value: {{ .Values.wordpressExtraConfigContent | quote }}
             {{- if .Values.smtpHost }}
             - name: SMTP_HOST
               value: {{ .Values.smtpHost | quote }}

--- a/bitnami/wordpress/values-production.yaml
+++ b/bitnami/wordpress/values-production.yaml
@@ -96,6 +96,10 @@ wordpressScheme: http
 ##
 wordpressSkipInstall: false
 
+## Add extra content to the default configuration file
+##
+wordpressExtraConfigContent: ""
+
 ## Set to `false` to allow the container to be started with blank passwords
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
 ##

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -96,6 +96,10 @@ wordpressScheme: http
 ##
 wordpressSkipInstall: false
 
+## Add extra content to the default configuration file
+##
+wordpressExtraConfigContent: ""
+
 ## Set to `false` to allow the container to be started with blank passwords
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
 ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
This PR adds the option to provide extra content to the wp-config.php file.

As an example, you can install the using:
```
helm install wordpress . --set wordpressExtraConfigContent="if ( isset( \$_SERVER['HTTP_X_FORWARDED_PROTO'] ) && 'https' ==\$_SERVER['HTTP_X_FORWARDED_PROTO'] ) {
    \$_SERVER['HTTPS'] = 'on';
}"
```
An the configuration file will have those lines at the end.
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #3466

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
