### PR TITLE
[bitnami/discourse] Changes to tls-secrets template to use global scope for the objects referenced in the range loop

### DIFF
--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: discourse
 description: A Helm chart for deploying Discourse to Kubernetes
-version: 0.3.3
+version: 0.3.4
 appVersion: 2.5.0
 engine: gotpl
 home: https://www.discourse.org/

--- a/bitnami/discourse/templates/tls-secrets.yaml
+++ b/bitnami/discourse/templates/tls-secrets.yaml
@@ -4,11 +4,11 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .name }}
-  labels: {{- include "discourse.labels" . | nindent 4 }}
-  {{- if .Values.commonLabels }}
+  labels: {{- include "discourse.labels" $ | nindent 4 }}
+  {{- if $.Values.commonLabels }}
   {{- include "discourse.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- end }}
-  {{- if .Values.commonAnnotations }}
+  {{- if $.Values.commonAnnotations }}
   annotations: {{- include "discourse.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 type: kubernetes.io/tls


### PR DESCRIPTION

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

There was an issue in the tls-secrets.yaml template of the discourse chart that prevented the installation of the chart in the case in which you wanted to managed the secrets with helm, via the values file. the chart didn't install because some of the objects needed from the .Values and .Chart namespaces were not in the scope of the range loop within which they were needed. I made changes to make sure the scope is correct and the template executes.

**Benefits**

TLS secret can now be created by the chart

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
