### PR TITLE
[bitnami/rabbitmq] Change documentation about 'load_definitions'

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 7.6.3
+version: 7.6.4
 appVersion: 3.8.7
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/bitnami/rabbitmq/README.md
+++ b/bitnami/rabbitmq/README.md
@@ -403,7 +403,7 @@ stringData:
     }
 ```
 
-Then, specify the `management.load_definitions` property as an `extraConfiguration` pointing to the load definition file path within the container (i.e. `/app/load_definition.json`) and set `loadDefinition.enable` to `true`. Any load definitions specified will be available within in the container at `/app`.
+Then, specify the `load_definitions` property as an `extraConfiguration` pointing to the load definition file path within the container (i.e. `/app/load_definition.json`) and set `loadDefinition.enable` to `true`. Any load definitions specified will be available within in the container at `/app`.
 
 > Loading a definition will take precedence over any configuration done through [Helm values](#parameters).
 
@@ -424,7 +424,7 @@ loadDefinition:
   enabled: true
   existingSecret: load-definition
 extraConfiguration: |
-  management.load_definitions = /app/load_definition.json
+  load_definitions = /app/load_definition.json
 ```
 
 ### LDAP

--- a/bitnami/rabbitmq/values-production.yaml
+++ b/bitnami/rabbitmq/values-production.yaml
@@ -233,7 +233,7 @@ configuration: |-
 extraConfiguration: |-
   #default_vhost = {{ .Release.Namespace }}-vhost
   #disk_free_limit.absolute = 50MB
-  #management.load_definitions = /app/load_definition.json
+  #load_definitions = /app/load_definition.json
 
 ## Configuration file content: advanced configuration
 ## Use this as additional configuraton in classic config format (Erlang term configuration format)

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -234,7 +234,7 @@ configuration: |-
 extraConfiguration: |-
   #default_vhost = {{ .Release.Namespace }}-vhost
   #disk_free_limit.absolute = 50MB
-  #management.load_definitions = /app/load_definition.json
+  #load_definitions = /app/load_definition.json
 
 ## Configuration file content: advanced configuration
 ## Use this as additional configuraton in classic config format (Erlang term configuration format)


### PR DESCRIPTION
**Description of the change**
Change documentation in REAME.md, values.yaml and values-production.yaml about `load_definitions` as indicated in issue #3464

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #3464 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
