### PR TITLE
[bitnami/kafka] Fix kafka_jaas.conf filepath in KAFKA_OPTS

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 11.8.1
+version: 11.8.2
 appVersion: 2.6.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -192,7 +192,7 @@ spec:
               value: {{ ternary "yes" "no" (or .Values.auth.enabled .Values.allowPlaintextListener) | quote }}
             {{- if or (include "kafka.client.saslAuthentication" .) (include "kafka.interBroker.saslAuthentication" .) }}
             - name: KAFKA_OPTS
-              value: "-Djava.security.auth.login.config=/opt/bitnami/kafka/conf/kafka_jaas.conf"
+              value: "-Djava.security.auth.login.config=/opt/bitnami/kafka/config/kafka_jaas.conf"
             {{- if (include "kafka.client.saslAuthentication" .) }}
             - name: KAFKA_CLIENT_USERS
               value: {{ join "," .Values.auth.jaas.clientUsers | quote }}


### PR DESCRIPTION
Signed-off-by: Vignesh Subramanian <vignesh.subramanian93@gmail.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
This change fixes the issue raised in #3491. Kindly refer to this issue for details of the bug.
Updated the `KAFKA_OPTS` env var with correct filepath to `kafka_jaas.conf` as below,

```
            - name: KAFKA_OPTS
              value: "-Djava.security.auth.login.config=/opt/bitnami/kafka/config/kafka_jaas.conf"
```

**Benefits**

<!-- What benefits will be realized by the code change? -->
This allows Kafka CLI operations to find the kafka_jaas.conf file at the correct location for authentication.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
None AFAIK

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #3491 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
