### PR TITLE
[bitnami/mongodb-sharded] Update example for multiple variables in --set

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb-sharded
-version: 1.6.5
+version: 1.6.6
 appVersion: 4.2.9
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications. Sharded topology.
 keywords:

--- a/bitnami/mongodb-sharded/README.md
+++ b/bitnami/mongodb-sharded/README.md
@@ -288,11 +288,11 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 
 ```bash
 $ helm install my-release \
-  --set mongodbRootPassword=secretpassword,mongodbUsername=my-user,mongodbPassword=my-password,mongodbDatabase=my-database \
+  --set shards=4,configsvr.replicas=3,shardsvr.dataNode.replicas=2 \
     bitnami/mongodb-sharded
 ```
 
-The above command sets the MongoDB `root` account password to `secretpassword`. Additionally, it creates a standard database user named `my-user`, with the password `my-password`, who has access to a database named `my-database`.
+The above command sets the number of shards to 4, the number of replicas for the config servers to 3 and number of replicas for data nodes to 2.
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 


### PR DESCRIPTION
**Description of the change**

While playing around with this chart I noticed that the example for multiple values in --set use variables which where patched out in PR #1883 / commit 1ae572b82c890866c45f90207f5d06691573666c.
Therefore this example doesn't work currently.

**Benefits**

The example in the documentation actually works if it's just copied and pasted.

**Possible drawbacks**

. / .

**Applicable issues**

. / .

**Additional information**

I know there were already discussion about fixing the underling problem (bring back these vars), but I prefer that examples work with the version they're documented in.

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
