### PR TITLE
[bitnami/harbor] Update max_connections value for postgresql

### DIFF
--- a/.github/ct-install.yaml
+++ b/.github/ct-install.yaml
@@ -11,4 +11,5 @@ excluded-charts:
   - mariadb-galera
   - discourse
   - ejbca
+  - harbor
 remote: origin

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: harbor
-version: 7.1.0
+version: 7.1.1
 appVersion: 2.0.2
 description: Harbor is an an open source trusted cloud native registry project that stores, signs, and scans content
 keywords:

--- a/bitnami/harbor/README.md
+++ b/bitnami/harbor/README.md
@@ -638,6 +638,7 @@ The following tables list the configurable parameters of the Harbor chart and th
 | `postgresql.nameOverride`               | String to partially override common.names.fullname template with a string (will prepend the release name) | `nil`                            |
 | `postgresql.postgresqlUsername`         | Postgresql username                                                                                       | `postgres`                       |
 | `postgresql.postgresqlPassword`         | Postgresql password                                                                                       | `not-a-secure-database-password` |
+| `postgresql.postgresqlExtendedConf`     | Extended runtime config parameters (appended to main or default configuration)                            | `{"maxConnections": "1024"}`     |
 | `postgresql.replication.enabled`        | Enable replicated postgresql                                                                              | `false`                          |
 | `postgresql.persistence.enabled`        | Enable persistence for PostgreSQL                                                                         | `true`                           |
 | `postgresql.initdbScripts`              | Initdb scripts to create Harbor databases                                                                 | `See values.yaml file`           |

--- a/bitnami/harbor/values-production.yaml
+++ b/bitnami/harbor/values-production.yaml
@@ -2258,6 +2258,8 @@ postgresql:
   nameOverride:
   postgresqlUsername: postgres
   postgresqlPassword: not-secure-database-password
+  postgresqlExtendedConf:
+    maxConnections: 1024
   replication:
     enabled: false
   persistence:

--- a/bitnami/harbor/values.yaml
+++ b/bitnami/harbor/values.yaml
@@ -2257,6 +2257,8 @@ postgresql:
   nameOverride:
   postgresqlUsername: postgres
   postgresqlPassword: not-secure-database-password
+  postgresqlExtendedConf:
+    maxConnections: 1024
   replication:
     enabled: false
   persistence:


### PR DESCRIPTION
Signed-off-by: Andrés Bono <andresbono@vmware.com>

**Description of the change**

PostgreSQL `max_connections` setting should be set to `1024` as per Harbor recommendation.

**Applicable issues**

  - fixes #3505

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
