### PR TITLE
[bitnami/prometheus-operator] Pull container references into a configmap for easier overriding.

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.42.1
 description: kube-prometheus collects Kubernetes manifests to provide easy to operate end-to-end Kubernetes cluster monitoring with Prometheus using the Prometheus Operator.
 name: kube-prometheus
-version: 2.2.0
+version: 2.2.1
 keywords:
   - prometheus
   - alertmanager

--- a/bitnami/kube-prometheus/templates/prometheus-operator/configmap.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.operator.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "kube-prometheus.operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "kube-prometheus.operator.labels" . | nindent 4 }}
+data:
+  config-reloader-image: {{ template "kube-prometheus.configmapReload.image" . }}
+  prometheus-config-reloader: {{ template "kube-prometheus.prometheusConfigReloader.image" . }}
+{{- end }}

--- a/bitnami/kube-prometheus/templates/prometheus-operator/deployment.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/deployment.yaml
@@ -62,6 +62,17 @@ spec:
         - name: prometheus-operator
           image: {{ template "kube-prometheus.image" . }}
           imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
+          env:
+          - name: CONFIG_RELOADER_IMAGE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "kube-prometheus.operator.fullname" . }}
+                key: config-reloader-image
+          - name: PROMETHEUS_CONFIG_RELOADER
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "kube-prometheus.operator.fullname" . }}
+                key: prometheus-config-reloader
           args:
             {{- if .Values.operator.kubeletService.enabled }}
             - --kubelet-service={{ .Values.operator.kubeletService.namespace }}/{{ template "kube-prometheus.fullname" . }}-kubelet
@@ -74,8 +85,8 @@ spec:
             {{- end }}
             - --logtostderr=true
             - --localhost=127.0.0.1
-            - --config-reloader-image={{ template "kube-prometheus.configmapReload.image" . }}
-            - --prometheus-config-reloader={{ template "kube-prometheus.prometheusConfigReloader.image" . }}
+            - --config-reloader-image=$(CONFIG_RELOADER_IMAGE)
+            - --prometheus-config-reloader=$(PROMETHEUS_CONFIG_RELOADER)
           {{- if .Values.operator.configReloaderCpu }}
             - --config-reloader-cpu={{ .Values.operator.configReloaderCpu }}
           {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This moves references to container images into a configmap, my hope is to have a follow-on PR to allow overriding this configmap.

**Benefits**

Relocating images from an internet connected environment into an air-gapped environment requires proper coordination of changing image references, there are tools that do this efficiently by searching into configmaps or similar constructs; however, they don't work as great with `args` passed in a deployment.

**Possible drawbacks**

Requires a configmap to exist and adds another object that must be maintained.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
