### PR TITLE
[bitnami/postgresql] Fix slave' statefulset when persistence is disabled

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 9.3.2
+version: 9.3.3
 appVersion: 11.9.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/bitnami/postgresql/templates/statefulset-slaves.yaml
+++ b/bitnami/postgresql/templates/statefulset-slaves.yaml
@@ -305,7 +305,7 @@ spec:
             medium: Memory
             sizeLimit: 1Gi
         {{- end }}
-        {{- if not .Values.persistence.enabled }}
+        {{- if or (not .Values.persistence.enabled) (not .Values.slave.persistence.enabled) }}
         - name: data
           emptyDir: {}
         {{- end }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

It's possible to disable persistence on slaves, while keeping it for master nodes. However, it's not working properly since the emptyDir section is not added and pods can't created due to unbind volumes. This PR fixes this issue.

**Benefits**

Disable persistence on slaves works properly.

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/3516

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)