### PR TITLE
[bitnami/orangehrm] Add extra env vars parameters

### DIFF
--- a/bitnami/orangehrm/Chart.yaml
+++ b/bitnami/orangehrm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: orangehrm
 version: 7.1.0
-appVersion: 4.4.0-0
+appVersion: 4.5.0-0
 description: OrangeHRM is a free HR management system that offers a wealth of modules
   to suit the needs of your business.
 keywords:

--- a/bitnami/orangehrm/Chart.yaml
+++ b/bitnami/orangehrm/Chart.yaml
@@ -1,23 +1,23 @@
 apiVersion: v1
 name: orangehrm
-version: 7.0.22
-appVersion: 4.5.0-0
+version: 7.1.0
+appVersion: 4.4.0-0
 description: OrangeHRM is a free HR management system that offers a wealth of modules
   to suit the needs of your business.
 keywords:
-- orangehrm
-- http
-- https
-- web
-- application
-- php
-- human resources
+  - orangehrm
+  - http
+  - https
+  - web
+  - application
+  - php
+  - human resources
 home: https://www.orangehrm.com
 sources:
-- https://github.com/bitnami/bitnami-docker-orangehrm
+  - https://github.com/bitnami/bitnami-docker-orangehrm
 maintainers:
-- name: Bitnami
-  email: containers@bitnami.com
+  - name: Bitnami
+    email: containers@bitnami.com
 engine: gotpl
 icon: https://bitnami.com/assets/stacks/orangehrm/img/orangehrm-stack-110x117.png
 annotations:

--- a/bitnami/orangehrm/README.md
+++ b/bitnami/orangehrm/README.md
@@ -48,74 +48,106 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Parameters
 
-The following table lists the configurable parameters of the OrangeHRM chart and their default values.
+The following table lists the configurable parameters of the OrangeHRM chart and their default values per section/component:
 
-| Parameter                            | Description                                                                                            | Default                                                      |
-|--------------------------------------|--------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `global.imageRegistry`               | Global Docker image registry                                                                           | `nil`                                                        |
-| `global.imagePullSecrets`            | Global Docker registry secret names as an array                                                        | `[]` (does not add image pull secrets to deployed pods)      |
-| `global.storageClass`                | Global storage class for dynamic provisioning                                                          | `nil`                                                        |
-| `image.registry`                     | OrangeHRM image registry                                                                               | `docker.io`                                                  |
-| `image.repository`                   | OrangeHRM Image name                                                                                   | `bitnami/orangehrm`                                          |
-| `image.tag`                          | OrangeHRM Image tag                                                                                    | `{TAG_NAME}`                                                 |
-| `image.pullPolicy`                   | Image pull policy                                                                                      | `IfNotPresent`                                               |
-| `image.pullSecrets`                  | Specify docker-registry secret names as an array                                                       | `[]` (does not add image pull secrets to deployed pods)      |
-| `nameOverride`                       | String to partially override orangehrm.fullname template with a string (will prepend the release name) | `nil`                                                        |
-| `fullnameOverride`                   | String to fully override orangehrm.fullname template with a string                                     | `nil`                                                        |
-| `orangehrmUsername`                  | User of the application                                                                                | `user`                                                       |
-| `orangehrmPassword`                  | Application password                                                                                   | _random 10 character long alphanumeric string_               |
-| `smtpHost`                           | SMTP host                                                                                              | `nil`                                                        |
-| `smtpPort`                           | SMTP port                                                                                              | `nil`                                                        |
-| `smtpUser`                           | SMTP user                                                                                              | `nil`                                                        |
-| `smtpPassword`                       | SMTP password                                                                                          | `nil`                                                        |
-| `smtpProtocol`                       | SMTP protocol [`ssl`, `none`]                                                                          | `nil`                                                        |
-| `service.type`                       | Kubernetes Service type                                                                                | `LoadBalancer`                                               |
-| `service.port`                       | Service HTTP port                                                                                      | `80`                                                         |
-| `service.httpsPort`                  | Service HTTPS port                                                                                     | `443`                                                        |
-| `service.externalTrafficPolicy`      | Enable client source IP preservation                                                                   | `Cluster`                                                    |
-| `service.nodePorts.http`             | Kubernetes http node port                                                                              | `""`                                                         |
-| `service.nodePorts.https`            | Kubernetes https node port                                                                             | `""`                                                         |
-| `ingress.enabled`                    | Enable ingress controller resource                                                                     | `false`                                                      |
-| `ingress.annotations`                | Ingress annotations                                                                                    | `[]`                                                         |
-| `ingress.certManager`                | Add annotations for cert-manager                                                                       | `false`                                                      |
-| `ingress.hosts[0].name`              | Hostname to your OrangeHRM installation                                                                | `orangehrm.local`                                            |
-| `ingress.hosts[0].path`              | Path within the url structure                                                                          | `/`                                                          |
-| `ingress.hosts[0].tls`               | Utilize TLS backend in ingress                                                                         | `false`                                                      |
-| `ingress.hosts[0].tlsHosts`          | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`)                   | `nil`                                                        |
-| `ingress.hosts[0].tlsSecret`         | TLS Secret (certificates)                                                                              | `orangehrm.local-tls-secret`                                 |
-| `ingress.secrets[0].name`            | TLS Secret Name                                                                                        | `nil`                                                        |
-| `ingress.secrets[0].certificate`     | TLS Secret Certificate                                                                                 | `nil`                                                        |
-| `ingress.secrets[0].key`             | TLS Secret Key                                                                                         | `nil`                                                        |
-| `resources`                          | CPU/Memory resource requests/limits                                                                    | Memory: `512Mi`, CPU: `300m`                                 |
-| `persistence.enabled`                | Enable persistence using PVC                                                                           | `true`                                                       |
-| `persistence.orangehrm.storageClass` | PVC Storage Class for OrangeHRM volume                                                                 | `nil` (uses alpha storage class annotation)                  |
-| `persistence.orangehrm.accessMode`   | PVC Access Mode for OrangeHRM volume                                                                   | `ReadWriteOnce`                                              |
-| `persistence.orangehrm.size`         | PVC Storage Request for OrangeHRM volume                                                               | `8Gi`                                                        |
-| `allowEmptyPassword`                 | Allow DB blank passwords                                                                               | `yes`                                                        |
-| `externalDatabase.host`              | Host of the external database                                                                          | `nil`                                                        |
-| `externalDatabase.port`              | Port of the external database                                                                          | `3306`                                                       |
-| `externalDatabase.user`              | Existing username in the external db                                                                   | `bn_orangehrm`                                               |
-| `externalDatabase.password`          | Password for the above username                                                                        | `nil`                                                        |
-| `externalDatabase.database`          | Name of the existing database                                                                          | `bitnami_orangehrm`                                          |
-| `mariadb.enabled`                    | Whether to use the MariaDB chart                                                                       | `true`                                                       |
-| `mariadb.db.name`                    | Database name to create                                                                                | `bitnami_orangehrm`                                          |
-| `mariadb.db.user`                    | Database user to create                                                                                | `bn_orangehrm`                                               |
-| `mariadb.db.password`                | Password for the database                                                                              | `nil`                                                        |
-| `mariadb.rootUser.password`          | MariaDB admin password                                                                                 | `nil`                                                        |
-| `mariadb.persistence.enabled`        | Enable MariaDB persistence using PVC                                                                   | `true`                                                       |
-| `mariadb.persistence.storageClass`   | PVC Storage Class for MariaDB volume                                                                   | `nil` (uses alpha storage class annotation)                  |
-| `mariadb.persistence.accessMode`     | PVC Access Mode for MariaDB volume                                                                     | `ReadWriteOnce`                                              |
-| `mariadb.persistence.size`           | PVC Storage Request for MariaDB volume                                                                 | `8Gi`                                                        |
-| `podAnnotations`                     | Pod annotations                                                                                        | `{}`                                                         |
-| `affinity`                           | Map of node/pod affinities                                                                             | `{}`                                                         |
-| `metrics.enabled`                    | Start a side-car prometheus exporter                                                                   | `false`                                                      |
-| `metrics.image.registry`             | Apache exporter image registry                                                                         | `docker.io`                                                  |
-| `metrics.image.repository`           | Apache exporter image name                                                                             | `bitnami/apache-exporter`                                    |
-| `metrics.image.tag`                  | Apache exporter image tag                                                                              | `{TAG_NAME}`                                                 |
-| `metrics.image.pullPolicy`           | Image pull policy                                                                                      | `IfNotPresent`                                               |
-| `metrics.image.pullSecrets`          | Specify docker-registry secret names as an array                                                       | `[]` (does not add image pull secrets to deployed pods)      |
-| `metrics.podAnnotations`             | Additional annotations for Metrics exporter pod                                                        | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
-| `metrics.resources`                  | Exporter resource requests/limit                                                                       | {}                                                           |
+### Global parameters
+
+| Parameter                               | Description                                                | Default                                                 |
+|-----------------------------------------|------------------------------------------------------------|---------------------------------------------------------|
+| `global.imageRegistry`                  | Global Docker image registry                               | `nil`                                                   |
+| `global.imagePullSecrets`               | Global Docker registry secret names as an array            | `[]` (does not add image pull secrets to deployed pods) |
+| `global.storageClass`                   | Global storage class for dynamic provisioning              | `nil`                                                   |
+
+### Common parameters
+
+| Parameter                               | Description                                                | Default                                                 |
+|-----------------------------------------|------------------------------------------------------------|---------------------------------------------------------|
+| `nameOverride`                          | String to partially override aspnet-core.fullname          | `nil`                                                   |
+| `fullnameOverride`                      | String to fully override aspnet-core.fullname              | `nil`                                                   |
+
+### OrangeHRM parameters
+
+| Parameter                               | Description                                                                              | Default                                                 |
+|-----------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `image.registry`                        | OrangeHRM image registry                                                                 | `docker.io`                                             |
+| `image.repository`                      | OrangeHRM Image name                                                                     | `bitnami/orangehrm`                                     |
+| `image.tag`                             | OrangeHRM Image tag                                                                      | `{TAG_NAME}`                                            |
+| `image.pullPolicy`                      | Image pull policy                                                                        | `IfNotPresent`                                          |
+| `image.pullSecrets`                     | Specify docker-registry secret names as an array                                         | `[]` (does not add image pull secrets to deployed pods) |
+| `allowEmptyPassword`                    | Allow DB blank passwords                                                                 | `yes`                                                   |
+| `orangehrmUsername`                     | User of the application                                                                  | `user`                                                  |
+| `orangehrmPassword`                     | Application password                                                                     | _random 10 character long alphanumeric string_          |
+| `smtpHost`                              | SMTP host                                                                                | `nil`                                                   |
+| `smtpPort`                              | SMTP port                                                                                | `nil`                                                   |
+| `smtpUser`                              | SMTP user                                                                                | `nil`                                                   |
+| `smtpPassword`                          | SMTP password                                                                            | `nil`                                                   |
+| `smtpProtocol`                          | SMTP protocol [`ssl`, `none`]                                                            | `nil`                                                   |
+| `extraEnvVars`                          | Extra environment variables to be set on OrangeHRM container                             | `{}`                                                    |
+| `extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars                                     | `nil`                                                   |
+| `extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars                                        | `nil`                                                   |
+| `podAnnotations`                        | Pod annotations                                                                          | `{}`                                                    |
+| `affinity`                              | Map of node/pod affinities                                                               | `{}`                                                    |
+| `resources.limits`                      | The resources limits for the OrangeHRM container                                         | `{}`                                                    |
+| `resources.requests`                    | The requested resources for the OrangeHRM container                                      | `{"Memory": "512Mi", "CPU": "300m"}`                    |
+| `persistence.enabled`                   | Enable persistence using PVC                                                             | `true`                                                  |
+| `persistence.orangehrm.storageClass`    | PVC Storage Class for OrangeHRM volume                                                   | `nil` (uses alpha storage class annotation)             |
+| `persistence.orangehrm.accessMode`      | PVC Access Mode for OrangeHRM volume                                                     | `ReadWriteOnce`                                         |
+| `persistence.orangehrm.size`            | PVC Storage Request for OrangeHRM volume                                                 | `8Gi`                                                   |
+
+### Exposure parameters
+
+| Parameter                               | Description                                                                              | Default                                                 |
+|-----------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `service.type`                          | Kubernetes Service type                                                                  | `LoadBalancer`                                          |
+| `service.port`                          | Service HTTP port                                                                        | `80`                                                    |
+| `service.httpsPort`                     | Service HTTPS port                                                                       | `443`                                                   |
+| `service.externalTrafficPolicy`         | Enable client source IP preservation                                                     | `Cluster`                                               |
+| `service.nodePorts.http`                | Kubernetes http node port                                                                | `""`                                                    |
+| `service.nodePorts.https`               | Kubernetes https node port                                                               | `""`                                                    |
+| `ingress.enabled`                       | Enable ingress controller resource                                                       | `false`                                                 |
+| `ingress.annotations`                   | Ingress annotations                                                                      | `[]`                                                    |
+| `ingress.certManager`                   | Add annotations for cert-manager                                                         | `false`                                                 |
+| `ingress.hosts[0].name`                 | Hostname to your OrangeHRM installation                                                  | `orangehrm.local`                                       |
+| `ingress.hosts[0].path`                 | Path within the url structure                                                            | `/`                                                     |
+| `ingress.hosts[0].tls`                  | Utilize TLS backend in ingress                                                           | `false`                                                 |
+| `ingress.hosts[0].tlsHosts`             | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`)     | `nil`                                                   |
+| `ingress.hosts[0].tlsSecret`            | TLS Secret (certificates)                                                                | `orangehrm.local-tls-secret`                            |
+| `ingress.secrets[0].name`               | TLS Secret Name                                                                          | `nil`                                                   |
+| `ingress.secrets[0].certificate`        | TLS Secret Certificate                                                                   | `nil`                                                   |
+| `ingress.secrets[0].key`                | TLS Secret Key                                                                           | `nil`                                                   |
+
+### Database parameters
+
+| Parameter                               | Description                                                                              | Default                                                 |
+|-----------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `externalDatabase.host`                 | Host of the external database                                                            | `nil`                                                   |
+| `externalDatabase.port`                 | Port of the external database                                                            | `3306`                                                  |
+| `externalDatabase.user`                 | Existing username in the external db                                                     | `bn_orangehrm`                                          |
+| `externalDatabase.password`             | Password for the above username                                                          | `nil`                                                   |
+| `externalDatabase.database`             | Name of the existing database                                                            | `bitnami_orangehrm`                                     |
+| `mariadb.enabled`                       | Whether to use the MariaDB chart                                                         | `true`                                                  |
+| `mariadb.db.name`                       | Database name to create                                                                  | `bitnami_orangehrm`                                     |
+| `mariadb.db.user`                       | Database user to create                                                                  | `bn_orangehrm`                                          |
+| `mariadb.db.password`                   | Password for the database                                                                | `nil`                                                   |
+| `mariadb.rootUser.password`             | MariaDB admin password                                                                   | `nil`                                                   |
+| `mariadb.persistence.enabled`           | Enable MariaDB persistence using PVC                                                     | `true`                                                  |
+| `mariadb.persistence.storageClass`      | PVC Storage Class for MariaDB volume                                                     | `nil` (uses alpha storage class annotation)             |
+| `mariadb.persistence.accessMode`        | PVC Access Mode for MariaDB volume                                                       | `ReadWriteOnce`                                         |
+| `mariadb.persistence.size`              | PVC Storage Request for MariaDB volume                                                   | `8Gi`                                                   |
+
+### Metrics parameters
+
+| Parameter                               | Description                                                                         | Default                                                      |
+|-----------------------------------------|-------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `metrics.enabled`                       | Start a side-car prometheus exporter                                                | `false`                                                      |
+| `metrics.image.registry`                | Apache exporter image registry                                                      | `docker.io`                                                  |
+| `metrics.image.repository`              | Apache exporter image name                                                          | `bitnami/apache-exporter`                                    |
+| `metrics.image.tag`                     | Apache exporter image tag                                                           | `{TAG_NAME}`                                                 |
+| `metrics.image.pullPolicy`              | Image pull policy                                                                   | `IfNotPresent`                                               |
+| `metrics.image.pullSecrets`             | Specify docker-registry secret names as an array                                    | `[]` (does not add image pull secrets to deployed pods)      |
+| `metrics.podAnnotations`                | Additional annotations for Metrics exporter pod                                     | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
+| `metrics.resources.limits`              | The resources limits for the Sidecar exporter container                             | `{}`                                                         |
+| `metrics.resources.requests`            | The requested resources for the Sidecar exporter container                          | `{}`                                                         |
 
 The above parameters map to the env variables defined in [bitnami/orangehrm](http://github.com/bitnami/bitnami-docker-orangehrm). For more information please refer to the [bitnami/orangehrm](http://github.com/bitnami/bitnami-docker-orangehrm) image documentation.
 

--- a/bitnami/orangehrm/requirements.lock
+++ b/bitnami/orangehrm/requirements.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 7.9.2
 digest: sha256:85df321ec48770c8c415a1e4177e874f1c91ee63e3b514fc4070413d1724840c
-generated: "2020-08-27T15:35:35.376753354Z"
+generated: "2020-08-28T07:55:03.688732+02:00"

--- a/bitnami/orangehrm/requirements.yaml
+++ b/bitnami/orangehrm/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
-- name: mariadb
-  version: 7.x.x
-  repository: https://charts.bitnami.com/bitnami
-  condition: mariadb.enabled
+  - name: mariadb
+    version: 7.x.x
+    repository: https://charts.bitnami.com/bitnami
+    condition: mariadb.enabled

--- a/bitnami/orangehrm/templates/deployment.yaml
+++ b/bitnami/orangehrm/templates/deployment.yaml
@@ -18,129 +18,145 @@ spec:
         app: {{ template "orangehrm.fullname" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
-{{- if or .Values.podAnnotations .Values.metrics.enabled }}
+      {{- if or .Values.podAnnotations .Values.metrics.enabled }}
       annotations:
-  {{- if .Values.podAnnotations }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
-  {{- end }}
-  {{- if .Values.metrics.podAnnotations }}
-{{ toYaml .Values.metrics.podAnnotations | indent 8 }}
-  {{- end }}
-{{- end }}
-    spec:
-{{- include "orangehrm.imagePullSecrets" . | indent 6 }}
-      hostAliases:
-      - ip: "127.0.0.1"
-        hostnames:
-        - "status.localhost"
-      containers:
-      - name: {{ template "orangehrm.fullname" . }}
-        image: {{ template "orangehrm.image" . }}
-        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-        env:
-        - name: ALLOW_EMPTY_PASSWORD
-          value: {{ .Values.allowEmptyPassword | quote }}
-        {{- if .Values.mariadb.enabled }}
-        - name: MARIADB_HOST
-          value: {{ template "orangehrm.mariadb.fullname" . }}
-        - name: MARIADB_PORT_NUMBER
-          value: "3306"
-        - name: ORANGEHRM_DATABASE_NAME
-          value: {{ .Values.mariadb.db.name | quote }}
-        - name: ORANGEHRM_DATABASE_USER
-          value: {{ .Values.mariadb.db.user | quote }}
-        - name: ORANGEHRM_DATABASE_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "orangehrm.mariadb.fullname" . }}
-              key: mariadb-password
-        {{- else }}
-        - name: MARIADB_HOST
-          value: {{ .Values.externalDatabase.host | quote }}
-        - name: MARIADB_PORT_NUMBER
-          value: {{ .Values.externalDatabase.port | quote }}
-        - name: ORANGEHRM_DATABASE_NAME
-          value: {{ .Values.externalDatabase.database | quote }}
-        - name: ORANGEHRM_DATABASE_USER
-          value: {{ .Values.externalDatabase.user | quote }}
-        - name: ORANGEHRM_DATABASE_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ printf "%s-%s" .Release.Name "externaldb" }}
-              key: db-password
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
-        - name: ORANGEHRM_USERNAME
-          value: {{ default "" .Values.orangehrmUsername | quote }}
-        - name: ORANGEHRM_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "orangehrm.fullname" . }}
-              key: orangehrm-password
-        - name: SMTP_HOST
-          value: {{ default "" .Values.smtpHost | quote }}
-        - name: SMTP_PORT
-          value: {{ default "" .Values.smtpPort | quote }}
-        - name: SMTP_USER
-          value: {{ default "" .Values.smtpUser | quote }}
-        - name: SMTP_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "orangehrm.fullname" . }}
-              key: smtp-password
-        - name: SMTP_PROTOCOL
-          value: {{ default "none" .Values.smtpProtocol | quote }}
-        ports:
-        - name: http
-          containerPort: 80
-        - name: https
-          containerPort: 443
-        livenessProbe:
-          httpGet:
-            path: /symfony/web/index.php
-            port: http
-          initialDelaySeconds: 120
-        readinessProbe:
-          httpGet:
-            path: /symfony/web/index.php
-            port: http
-          initialDelaySeconds: 30
-        resources:
-{{ toYaml .Values.resources | indent 10 }}
-        volumeMounts:
-        - name: orangehrm-data
-          mountPath: /bitnami/orangehrm
-{{- if .Values.metrics.enabled }}
-      - name: metrics
-        image: {{ template "orangehrm.metrics.image" . }}
-        imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
-        command: [ '/bin/apache_exporter', '--scrape_uri', 'http://status.localhost:80/server-status/?auto']
-        ports:
+        {{- if .Values.metrics.podAnnotations }}
+        {{- toYaml .Values.metrics.podAnnotations | nindent 8 }}
+        {{- end }}
+      {{- end }}
+    spec:
+      {{- include "orangehrm.imagePullSecrets" . | nindent 6 }}
+      hostAliases:
+        - ip: "127.0.0.1"
+          hostnames:
+            - "status.localhost"
+      {{- if .Values.affinity }}
+      affinity: {{- toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ template "orangehrm.fullname" . }}
+          image: {{ template "orangehrm.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          env:
+            - name: ALLOW_EMPTY_PASSWORD
+              value: {{ .Values.allowEmptyPassword | quote }}
+            {{- if .Values.mariadb.enabled }}
+            - name: MARIADB_HOST
+              value: {{ template "orangehrm.mariadb.fullname" . }}
+            - name: MARIADB_PORT_NUMBER
+              value: "3306"
+            - name: ORANGEHRM_DATABASE_NAME
+              value: {{ .Values.mariadb.db.name | quote }}
+            - name: ORANGEHRM_DATABASE_USER
+              value: {{ .Values.mariadb.db.user | quote }}
+            - name: ORANGEHRM_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "orangehrm.mariadb.fullname" . }}
+                  key: mariadb-password
+            {{- else }}
+            - name: MARIADB_HOST
+              value: {{ .Values.externalDatabase.host | quote }}
+            - name: MARIADB_PORT_NUMBER
+              value: {{ .Values.externalDatabase.port | quote }}
+            - name: ORANGEHRM_DATABASE_NAME
+              value: {{ .Values.externalDatabase.database | quote }}
+            - name: ORANGEHRM_DATABASE_USER
+              value: {{ .Values.externalDatabase.user | quote }}
+            - name: ORANGEHRM_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ printf "%s-%s" .Release.Name "externaldb" }}
+                  key: db-password
+            {{- end }}
+            - name: ORANGEHRM_USERNAME
+              value: {{ default "" .Values.orangehrmUsername | quote }}
+            - name: ORANGEHRM_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "orangehrm.fullname" . }}
+                  key: orangehrm-password
+            - name: SMTP_HOST
+              value: {{ default "" .Values.smtpHost | quote }}
+            - name: SMTP_PORT
+              value: {{ default "" .Values.smtpPort | quote }}
+            - name: SMTP_USER
+              value: {{ default "" .Values.smtpUser | quote }}
+            - name: SMTP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "orangehrm.fullname" . }}
+                  key: smtp-password
+            - name: SMTP_PROTOCOL
+              value: {{ default "none" .Values.smtpProtocol | quote }}
+            {{- range $key, $value := .Values.extraEnvVars }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
+          {{- if or .Values.extraEnvVarsCM .Values.extraEnvVarsSecret }}
+          envFrom:
+            {{- if .Values.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ tpl .Values.extraEnvVarsCM . | quote }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ tpl .Values.extraEnvVarsSecret . | quote }}
+            {{- end }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+            - name: https
+              containerPort: 443
+          livenessProbe:
+            httpGet:
+              path: /symfony/web/index.php
+              port: http
+            initialDelaySeconds: 120
+          readinessProbe:
+            httpGet:
+              path: /symfony/web/index.php
+              port: http
+            initialDelaySeconds: 30
+          {{- if .Values.resources }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: orangehrm-data
+              mountPath: /bitnami/orangehrm
+        {{- if .Values.metrics.enabled }}
         - name: metrics
-          containerPort: 9117
-        livenessProbe:
-          httpGet:
-            path: /metrics
-            port: metrics
-          initialDelaySeconds: 15
-          timeoutSeconds: 5
-        readinessProbe:
-          httpGet:
-            path: /metrics
-            port: metrics
-          initialDelaySeconds: 5
-          timeoutSeconds: 1
-        resources:
-  {{ toYaml .Values.metrics.resources | indent 10 }}
-{{- end }}
+          image: {{ template "orangehrm.metrics.image" . }}
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
+          command: [ '/bin/apache_exporter', '--scrape_uri', 'http://status.localhost:80/server-status/?auto']
+          ports:
+            - name: metrics
+              containerPort: 9117
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 15
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          {{- if .Values.metrics.resources }}
+          resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
+          {{- end }}
+        {{- end }}
       volumes:
-      - name: orangehrm-data
-      {{- if .Values.persistence.enabled }}
-        persistentVolumeClaim:
-          claimName: {{ template "orangehrm.fullname" . }}-orangehrm
-      {{- else }}
-        emptyDir: {}
-      {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-{{ toYaml . | indent 8 }}
-      {{- end }}
+        - name: orangehrm-data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ template "orangehrm.fullname" . }}-orangehrm
+          {{- else }}
+          emptyDir: {}
+          {{- end }}

--- a/bitnami/orangehrm/templates/ingress.yaml
+++ b/bitnami/orangehrm/templates/ingress.yaml
@@ -27,17 +27,17 @@ spec:
           servicePort: http
   {{- end }}
   tls:
-  {{- range .Values.ingress.hosts }}
-  {{- if .tls }}
-  - hosts:
-  {{- if .tlsHosts }}
-  {{- range $host := .tlsHosts }}
-    - {{ $host }}
-  {{- end }}
-  {{- else }}
-    - {{ .name }}
-  {{- end }}
-    secretName: {{ .tlsSecret }}
-  {{- end }}
-  {{- end }}
+    {{- range .Values.ingress.hosts }}
+    {{- if .tls }}
+    - hosts:
+    {{- if .tlsHosts }}
+    {{- range $host := .tlsHosts }}
+      - {{ $host }}
+    {{- end }}
+    {{- else }}
+      - {{ .name }}
+    {{- end }}
+      secretName: {{ .tlsSecret }}
+    {{- end }}
+    {{- end }}
 {{- end }}

--- a/bitnami/orangehrm/values.yaml
+++ b/bitnami/orangehrm/values.yaml
@@ -48,27 +48,8 @@ orangehrmUsername: admin
 
 ## Set to `yes` to allow the container to be started with blank passwords
 ## ref: https://github.com/bitnami/bitnami-docker-orangehrm#environment-variables
+##
 allowEmptyPassword: "yes"
-
-##
-## External database configuration
-##
-externalDatabase:
-  ## Database host
-  host:
-
-  ## Database host
-  port: 3306
-
-  ## Database user
-  user: bn_orangehrm
-
-  ## Database password
-  password:
-
-  ## Database name
-  database: bitnami_orangehrm
-
 
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/bitnami-docker-orangehrm/#smtp-configuration
@@ -77,6 +58,173 @@ externalDatabase:
 # smtpUser:
 # smtpPassword:
 # smtpProtocol:
+
+## Additional environment variables to set
+## E.g:
+## extraEnvVars:
+##   FOO: BAR
+##   BAZ: QUX
+##
+extraEnvVars: []
+
+## ConfigMap with extra environment variables
+##
+# extraEnvVarsCM:
+
+## Secret with extra environment variables
+##
+# extraEnvVarsSecret:
+
+## Pod annotations
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+
+## Affinity for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+affinity: {}
+
+## OrangeHRM containers' resource requests and limits.
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits: {}
+  #   cpu: 100m
+  #   memory: 128Mi
+  requests:
+    memory: 512Mi
+    cpu: 300m
+
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  enabled: true
+  orangehrm:
+    ## orangehrm data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    accessMode: ReadWriteOnce
+    size: 8Gi
+
+## Kubernetes configuration
+## For minikube, set this to NodePort, elsewhere use LoadBalancer or ClusterIP
+##
+service:
+  type: LoadBalancer
+  # HTTP Port
+  port: 80
+  # HTTPS Port
+  httpsPort: 443
+  ##
+  ## nodePorts:
+  ##   http: <to set explicitly, choose port between 30000-32767>
+  ##   https: <to set explicitly, choose port between 30000-32767>
+  nodePorts:
+    http: ""
+    https: ""
+  ## Enable client source IP preservation
+  ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+  ##
+  externalTrafficPolicy: Cluster
+
+## Configure the ingress resource that allows you to access the
+## OrangeHRM installation. Set up the URL
+## ref: http://kubernetes.io/docs/user-guide/ingress/
+##
+ingress:
+  ## Set to true to enable ingress record generation
+  enabled: false
+
+  ## Set this to true in order to add the corresponding annotations for cert-manager
+  certManager: false
+
+  ## Ingress annotations done as key:value pairs
+  ## For a full list of possible ingress annotations, please see
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ##
+  ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+  annotations:
+  #  kubernetes.io/ingress.class: nginx
+
+  ## The list of hostnames to be covered with this ingress record.
+  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
+  hosts:
+    - name: orangehrm.local
+      path: /
+
+      ## Set this to true in order to enable TLS on the ingress record
+      tls: false
+
+      ## Optionally specify the TLS hosts for the ingress record
+      ## Useful when the Ingress controller supports www-redirection
+      ## If not specified, the above host name will be used
+      # tlsHosts:
+      # - www.orangehrm.local
+      # - orangehrm.local
+
+      ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
+      tlsSecret: orangehrm.local-tls
+
+  secrets:
+  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+  ## -----BEGIN RSA PRIVATE KEY-----
+  ##
+  ## name should line up with a tlsSecret set further up
+  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+  ##
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  # - name: orangehrm.local-tls
+  #   key:
+  #   certificate:
+
+## Prometheus Exporter / Metrics
+##
+metrics:
+  enabled: false
+  image:
+    registry: docker.io
+    repository: bitnami/apache-exporter
+    tag: 0.8.0-debian-10-r129
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+  ## Metrics exporter pod Annotation and Labels
+  ##
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9117"
+  ## Metrics exporter resource requests and limits.
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+    requests: {}
+    #   cpu: 100m
+    #   memory: 128Mi
 
 ##
 ## MariaDB chart configuration
@@ -123,135 +271,21 @@ mariadb:
       accessMode: ReadWriteOnce
       size: 8Gi
 
-## Kubernetes configuration
-## For minikube, set this to NodePort, elsewhere use LoadBalancer or ClusterIP
 ##
-service:
-  type: LoadBalancer
-  # HTTP Port
-  port: 80
-  # HTTPS Port
-  httpsPort: 443
-  ##
-  ## nodePorts:
-  ##   http: <to set explicitly, choose port between 30000-32767>
-  ##   https: <to set explicitly, choose port between 30000-32767>
-  nodePorts:
-    http: ""
-    https: ""
-  ## Enable client source IP preservation
-  ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
-  ##
-  externalTrafficPolicy: Cluster
-
-## Enable persistence using Persistent Volume Claims
-## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+## External database configuration
 ##
-persistence:
-  enabled: true
-  orangehrm:
-    ## orangehrm data Persistent Volume Storage Class
-    ## If defined, storageClassName: <storageClass>
-    ## If set to "-", storageClassName: "", which disables dynamic provisioning
-    ## If undefined (the default) or set to null, no storageClassName spec is
-    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-    ##   GKE, AWS & OpenStack)
-    ##
-    # storageClass: "-"
-    accessMode: ReadWriteOnce
-    size: 8Gi
+externalDatabase:
+  ## Database host
+  host:
 
-## Configure resource requests and limits
-## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-##
-resources:
-  requests:
-    memory: 512Mi
-    cpu: 300m
+  ## Database host
+  port: 3306
 
-## Pod annotations
-## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-##
-podAnnotations: {}
+  ## Database user
+  user: bn_orangehrm
 
-## Configure the ingress resource that allows you to access the
-## OrangeHRM installation. Set up the URL
-## ref: http://kubernetes.io/docs/user-guide/ingress/
-##
-ingress:
-  ## Set to true to enable ingress record generation
-  enabled: false
+  ## Database password
+  password:
 
-  ## Set this to true in order to add the corresponding annotations for cert-manager
-  certManager: false
-
-  ## Ingress annotations done as key:value pairs
-  ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
-  ##
-  ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
-  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
-  annotations:
-  #  kubernetes.io/ingress.class: nginx
-
-  ## The list of hostnames to be covered with this ingress record.
-  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
-  hosts:
-  - name: orangehrm.local
-    path: /
-
-    ## Set this to true in order to enable TLS on the ingress record
-    tls: false
-
-    ## Optionally specify the TLS hosts for the ingress record
-    ## Useful when the Ingress controller supports www-redirection
-    ## If not specified, the above host name will be used
-    # tlsHosts:
-    # - www.orangehrm.local
-    # - orangehrm.local
-
-    ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
-    tlsSecret: orangehrm.local-tls
-
-  secrets:
-  ## If you're providing your own certificates, please use this to add the certificates as secrets
-  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
-  ## -----BEGIN RSA PRIVATE KEY-----
-  ##
-  ## name should line up with a tlsSecret set further up
-  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
-  ##
-  ## It is also possible to create and manage the certificates outside of this helm chart
-  ## Please see README.md for more information
-  # - name: orangehrm.local-tls
-  #   key:
-  #   certificate:
-
-## Affinity for pod assignment
-## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-##
-affinity: {}
-
-## Prometheus Exporter / Metrics
-##
-metrics:
-  enabled: false
-  image:
-    registry: docker.io
-    repository: bitnami/apache-exporter
-    tag: 0.8.0-debian-10-r129
-    pullPolicy: IfNotPresent
-    ## Optionally specify an array of imagePullSecrets.
-    ## Secrets must be manually created in the namespace.
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ##
-    # pullSecrets:
-    #   - myRegistryKeySecretName
-     ## Metrics exporter pod Annotation and Labels
-  podAnnotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9117"
-  ## Metrics exporter resource requests and limits
-  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-  ##
-  # resources: {}
+  ## Database name
+  database: bitnami_orangehrm


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Add the parameters **extraEnvVars**, **extraEnvVarsCM**, and **extraEnvVarsSecret** so users can add custom env. variables.

It also does some code refactoring, but it's needed much more. I did the minimal to pass the tests but we should work on standardising this chart.

**Benefits**

Customizations

**Possible drawbacks**

None


**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)