### PR TITLE
[bitnami/mongodb-sharded] Bump major version due to new major in the app

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb-sharded
-version: 1.6.7
+version: 2.0.0
 appVersion: 4.4.0
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications. Sharded topology.
 keywords:


### PR DESCRIPTION
**Description of the change**

The new MongoDB 4.4 should have bumped the chart version in a major, but it was not the case due to a weird race condition, see https://github.com/bitnami/charts/commit/18311369fa24d3c220ba1d4386d023cd2dd1f923

The upgrade notes were already placed in the README, see https://github.com/bitnami/charts/tree/master/bitnami/mongodb-sharded#to-200 so this PR is only bumping the chart version as the CI/CD should have done automatically
