### PR TITLE
[bitnami/fluentd] Add fluentd priorityClassName

### DIFF
--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fluentd
-version: 1.3.0
+version: 1.4.0
 appVersion: 1.11.2
 description: Fluentd is an open source data collector for unified logging layer
 keywords:

--- a/bitnami/fluentd/README.md
+++ b/bitnami/fluentd/README.md
@@ -51,7 +51,7 @@ The command removes all the Kubernetes components associated with the chart and 
 The following tables lists the configurable parameters of the fluentd chart and their default values.
 
 | Parameter                                       | Description                                                                                                    | Default                                                                                                 |
-| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+|-------------------------------------------------|----------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
 | `global.imageRegistry`                          | Global Docker image registry                                                                                   | `nil`                                                                                                   |
 | `global.imagePullSecrets`                       | Global Docker registry secret names as an array                                                                | `[]` (does not add image pull secrets to deployed pods)                                                 |
 | `image.registry`                                | Fluentd image registry                                                                                         | `docker.io`                                                                                             |
@@ -71,6 +71,7 @@ The following tables lists the configurable parameters of the fluentd chart and 
 | `forwarder.configFile`                          | Name of the config file that will be used by Fluentd at launch under the `/opt/bitnami/fluentd/conf` directory | `fluentd.conf`                                                                                          |
 | `forwarder.configMap`                           | Name of the config map that contains the Fluentd configuration files                                           | `nil`                                                                                                   |
 | `forwarder.extraArgs`                           | Extra arguments for the Fluentd command line                                                                   | `nil`                                                                                                   |
+| `forwarder.priorityClassName`                   | Set Pods Priority Class                                                                                        | `nil`                                                                                                   |
 | `forwarder.extraEnv`                            | Extra environment variables to pass to the container                                                           | `[]`                                                                                                    |
 | `forwarder.containerPorts`                      | Ports the forwarder containers will listen on                                                                  | `Check values.yaml`                                                                                     |
 | `forwarder.service.type`                        | Kubernetes service type (`ClusterIP`, `NodePort`, or `LoadBalancer`) for the forwarders                        | `ClusterIP`                                                                                             |
@@ -99,7 +100,6 @@ The following tables lists the configurable parameters of the fluentd chart and 
 | `forwarder.podAnnotations`                      | Pod annotations                                                                                                | `{}`                                                                                                    |
 | `forwarder.extraVolumes`                        | Extra volumes                                                                                                  | `nil`                                                                                                   |
 | `forwarder.extraVolumeMounts`                   | Mount extra volume(s),                                                                                         | `nil`                                                                                                   |
-| `forwarder.priorityClassName`                   | Set Pods Priority Class                                                                                        | `nil`                                                                                                   |
 | `aggregator.enabled`                            | Enable Fluentd aggregator                                                                                      | `true`                                                                                                  |
 | `aggregator.replicaCount`                       | Number of aggregator pods to deploy in the Stateful Set                                                        | `2`                                                                                                     |
 | `aggregator.securityContext.enabled`            | Enable security context for aggregator pods                                                                    | `true`                                                                                                  |
@@ -158,7 +158,6 @@ The following tables lists the configurable parameters of the fluentd chart and 
 | `tls.serverCertificate`                         | Server certificate                                                                                             | Server certificate content                                                                              |
 | `tls.serverKey`                                 | Server Key                                                                                                     | Server private key content                                                                              |
 | `tls.existingSecret`                            | Existing secret with certificate content                                                                       | `nil`                                                                                                   |
-
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
@@ -189,14 +188,12 @@ Bitnami will release a new chart updating its containers if a new version of the
 This chart includes a `values-production.yaml` file where you can find some parameters oriented to production configuration in comparison to the regular `values.yaml`. You can use this file instead of the default one.
 
 - Number of aggregator nodes:
-
 ```diff
 - aggregator.replicaCount: 1
 + aggregator.replicaCount: 2
 ```
 
 - Enable prometheus to access fluentd metrics endpoint:
-
 ```diff
 - metrics.enabled: false
 + metrics.enabled: true

--- a/bitnami/fluentd/README.md
+++ b/bitnami/fluentd/README.md
@@ -51,7 +51,7 @@ The command removes all the Kubernetes components associated with the chart and 
 The following tables lists the configurable parameters of the fluentd chart and their default values.
 
 | Parameter                                       | Description                                                                                                    | Default                                                                                                 |
-|-------------------------------------------------|----------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `global.imageRegistry`                          | Global Docker image registry                                                                                   | `nil`                                                                                                   |
 | `global.imagePullSecrets`                       | Global Docker registry secret names as an array                                                                | `[]` (does not add image pull secrets to deployed pods)                                                 |
 | `image.registry`                                | Fluentd image registry                                                                                         | `docker.io`                                                                                             |
@@ -99,6 +99,7 @@ The following tables lists the configurable parameters of the fluentd chart and 
 | `forwarder.podAnnotations`                      | Pod annotations                                                                                                | `{}`                                                                                                    |
 | `forwarder.extraVolumes`                        | Extra volumes                                                                                                  | `nil`                                                                                                   |
 | `forwarder.extraVolumeMounts`                   | Mount extra volume(s),                                                                                         | `nil`                                                                                                   |
+| `forwarder.priorityClassName`                   | Set Pods Priority Class                                                                                        | `nil`                                                                                                   |
 | `aggregator.enabled`                            | Enable Fluentd aggregator                                                                                      | `true`                                                                                                  |
 | `aggregator.replicaCount`                       | Number of aggregator pods to deploy in the Stateful Set                                                        | `2`                                                                                                     |
 | `aggregator.securityContext.enabled`            | Enable security context for aggregator pods                                                                    | `true`                                                                                                  |
@@ -157,6 +158,7 @@ The following tables lists the configurable parameters of the fluentd chart and 
 | `tls.serverCertificate`                         | Server certificate                                                                                             | Server certificate content                                                                              |
 | `tls.serverKey`                                 | Server Key                                                                                                     | Server private key content                                                                              |
 | `tls.existingSecret`                            | Existing secret with certificate content                                                                       | `nil`                                                                                                   |
+
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
@@ -187,12 +189,14 @@ Bitnami will release a new chart updating its containers if a new version of the
 This chart includes a `values-production.yaml` file where you can find some parameters oriented to production configuration in comparison to the regular `values.yaml`. You can use this file instead of the default one.
 
 - Number of aggregator nodes:
+
 ```diff
 - aggregator.replicaCount: 1
 + aggregator.replicaCount: 2
 ```
 
 - Enable prometheus to access fluentd metrics endpoint:
+
 ```diff
 - metrics.enabled: false
 + metrics.enabled: true

--- a/bitnami/fluentd/templates/forwarder-daemonset.yaml
+++ b/bitnami/fluentd/templates/forwarder-daemonset.yaml
@@ -28,6 +28,7 @@ spec:
     spec:
 {{- include "fluentd.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ template "fluentd.serviceAccountName" . }}
+      priorityClassName: {{ .Values.forwarder.priorityClassName | quote }}
       {{- if .Values.forwarder.affinity }}
       affinity: {{- include "fluentd.tplValue" (dict "value" .Values.forwarder.affinity "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/fluentd/values-production.yaml
+++ b/bitnami/fluentd/values-production.yaml
@@ -453,16 +453,17 @@ metrics:
     ## Namespace in which Prometheus is running
     ##
     # namespace: monitoring
+
     ## Interval at which metrics should be scraped.
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
     ##
-
     # interval: 10s
+
     ## Timeout after which the scrape is ended
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
     ##
-    
     # scrapeTimeout: 10s
+
     ## ServiceMonitor selector labels
     ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
     ##

--- a/bitnami/fluentd/values-production.yaml
+++ b/bitnami/fluentd/values-production.yaml
@@ -456,10 +456,12 @@ metrics:
     ## Interval at which metrics should be scraped.
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
     ##
+
     # interval: 10s
     ## Timeout after which the scrape is ended
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
     ##
+    
     # scrapeTimeout: 10s
     ## ServiceMonitor selector labels
     ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration

--- a/bitnami/fluentd/values-production.yaml
+++ b/bitnami/fluentd/values-production.yaml
@@ -73,6 +73,11 @@ forwarder:
   ##
   extraArgs: ""
 
+  ## Set Priority Class Name to allow priority control over other pods
+  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  ##
+  priorityClassName: ""
+
   ## Extra environment variables to pass to the container
   ## extraEnv:
   ##   - name: MY_ENV_VAR
@@ -448,17 +453,14 @@ metrics:
     ## Namespace in which Prometheus is running
     ##
     # namespace: monitoring
-
     ## Interval at which metrics should be scraped.
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
     ##
     # interval: 10s
-
     ## Timeout after which the scrape is ended
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
     ##
     # scrapeTimeout: 10s
-
     ## ServiceMonitor selector labels
     ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
     ##

--- a/bitnami/fluentd/values.yaml
+++ b/bitnami/fluentd/values.yaml
@@ -212,7 +212,6 @@ forwarder:
   ## Extra labels to add to Pod
   podLabels: {}
 
-
   ## Extra volumes to mount
   ## Example Use Case: mount systemd journal volume
   # extraVolumes:

--- a/bitnami/fluentd/values.yaml
+++ b/bitnami/fluentd/values.yaml
@@ -212,6 +212,7 @@ forwarder:
   ## Extra labels to add to Pod
   podLabels: {}
 
+
   ## Extra volumes to mount
   ## Example Use Case: mount systemd journal volume
   # extraVolumes:
@@ -260,6 +261,11 @@ aggregator:
   ## ref: https://docs.fluentd.org/deployment/command-line-option
   ##
   extraArgs: ""
+
+  ## Set Priority Class Name to allow priority control over other pods
+  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  ##
+  priorityClassName: ""
 
   ## Extra environment variables to pass to the container
   ## extraEnv:


### PR DESCRIPTION
**Description of the change**
Allow the use of priorityClassName within Kubernetes. 

**Benefits**
Allow further control of DaemonSets over other pods.

**Possible drawbacks**
None

**Applicable issues**
None

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
