### PR TITLE
[bitnami/mongodb] fix required ReplicaSetKey when auth.enabled=false

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb
-version: 9.0.0
+version: 9.0.1
 appVersion: 4.4.0
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/bitnami/mongodb/templates/NOTES.txt
+++ b/bitnami/mongodb/templates/NOTES.txt
@@ -172,7 +172,7 @@ Then, open the obtained URL in a browser.
 {{- $secretName := include "mongodb.fullname" . -}}
 {{- $requiredPasswords := list -}}
 
-{{- if .Values.auth.enabled }}
+{{- if and .Values.auth.enabled (not .Values.auth.existingSecret) }}
 
 {{- $requiredRootPassword := dict "valueKey" "auth.rootPassword" "secret" $secretName "field" "mongodb-root-password" "context" $ -}}
 {{- $requiredPasswords = append $requiredPasswords $requiredRootPassword -}}

--- a/bitnami/mongodb/templates/NOTES.txt
+++ b/bitnami/mongodb/templates/NOTES.txt
@@ -181,7 +181,7 @@ Then, open the obtained URL in a browser.
   {{- $requiredDBPassword := dict "valueKey" "auth.password" "secret" $secretName "field" "mongodb-password" "context" $ -}}
   {{- $requiredPasswords = append $requiredPasswords $requiredDBPassword -}}
 {{- end -}}
-{{- end }}
+
 
 {{- if eq .Values.architecture "replicaset" }}
   {{- $requiredReplicaSetKey := dict "valueKey" "auth.replicaSetKey" "secret" $secretName "field" "mongodb-replica-set-key" "context" $ -}}
@@ -190,3 +190,4 @@ Then, open the obtained URL in a browser.
 
 {{- $requiredPasswordValidationErrors := include "common.validations.values.multiple.empty" (dict "required" $requiredPasswords "context" $) -}}
 {{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" (list $requiredPasswordValidationErrors) "context" $) -}}
+{{- end }}


### PR DESCRIPTION
**Description of the change**

update NOTES.txt to remove check for replicaset key when auth.enabled=false

**Benefits**

allow upgrade of chart when auth.enabled=false

**Applicable issues**

  - fixes #3425 

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files