### PR TITLE
[kube-prometheus] Set Prometheus Operator container name to 'prometheus-operator'

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.41.1
 description: kube-prometheus collects Kubernetes manifests to provide easy to operate end-to-end Kubernetes cluster monitoring with Prometheus using the Prometheus Operator.
 name: kube-prometheus
-version: 1.0.1
+version: 1.0.2
 keywords:
   - prometheus
   - alertmanager

--- a/bitnami/kube-prometheus/templates/prometheus-operator/deployment.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/deployment.yaml
@@ -59,7 +59,7 @@ spec:
         podAffinity: {{- include "common.tplvalues.render" (dict "value" .Values.operator.podAffinity "context" $) | nindent 10 }}
         {{- end }}
       containers:
-        - name: {{ template "kube-prometheus.name" . }}
+        - name: prometheus-operator
           image: {{ template "kube-prometheus.image" . }}
           imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
           args:


### PR DESCRIPTION
**Description of the change**

Hardcodes the Prometheus Operator container name since it doesn't add any value to auto-generate it, and it does not make any sense to use a name based on the release name for the container.

**Possible drawbacks**

None

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

