### PR TITLE
[bitnami/common] fix: mariadb checks secret fields after check enabled

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: common
 # Please make sure that version and appVersion are always the same.
-version: 0.6.0
-appVersion: 0.6.0
+version: 0.6.1
+appVersion: 0.6.1
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 keywords:
   - common

--- a/bitnami/common/templates/_validations.tpl
+++ b/bitnami/common/templates/_validations.tpl
@@ -65,23 +65,25 @@ Validate value params:
   - secret - String - Required. Name of the secret where mysql values are stored, e.g: "mysql-passwords-secret"
 */}}
 {{- define "common.validations.values.mariadb.passwords" -}}
-  {{- if and (not .context.Values.mariadb.existingSecret) .context.Values.mariadb.enabled .context.Values.mariadb.secret.requirePasswords -}}
+  {{- if and (not .context.Values.mariadb.existingSecret) .context.Values.mariadb.enabled -}}
     {{- $requiredPasswords := list -}}
 
-    {{- $requiredRootMariadbPassword := dict "valueKey" "mariadb.rootUser.password" "secret" .secretName "field" "mariadb-root-password" -}}
-    {{- $requiredPasswords = append $requiredPasswords $requiredRootMariadbPassword -}}
+    {{- if .context.Values.mariadb.secret.requirePasswords -}}
+      {{- $requiredRootMariadbPassword := dict "valueKey" "mariadb.rootUser.password" "secret" .secretName "field" "mariadb-root-password" -}}
+      {{- $requiredPasswords = append $requiredPasswords $requiredRootMariadbPassword -}}
 
-    {{- if not (empty .context.Values.mariadb.db.user) -}}
-        {{- $requiredMariadbPassword := dict "valueKey" "mariadb.db.password" "secret" .secretName "field" "mariadb-password" -}}
-        {{- $requiredPasswords = append $requiredPasswords $requiredMariadbPassword -}}
+      {{- if not (empty .context.Values.mariadb.db.user) -}}
+          {{- $requiredMariadbPassword := dict "valueKey" "mariadb.db.password" "secret" .secretName "field" "mariadb-password" -}}
+          {{- $requiredPasswords = append $requiredPasswords $requiredMariadbPassword -}}
+      {{- end -}}
+
+      {{- if .context.Values.mariadb.replication.enabled -}}
+          {{- $requiredReplicationPassword := dict "valueKey" "mariadb.replication.password" "secret" .secretName "field" "mariadb-replication-password" -}}
+          {{- $requiredPasswords = append $requiredPasswords $requiredReplicationPassword -}}
+      {{- end -}}
+
+      {{- include "common.validations.values.multiple.empty" (dict "required" $requiredPasswords "context" .context) -}}
     {{- end -}}
-
-    {{- if .context.Values.mariadb.replication.enabled -}}
-        {{- $requiredReplicationPassword := dict "valueKey" "mariadb.replication.password" "secret" .secretName "field" "mariadb-replication-password" -}}
-        {{- $requiredPasswords = append $requiredPasswords $requiredReplicationPassword -}}
-    {{- end -}}
-
-    {{- include "common.validations.values.multiple.empty" (dict "required" $requiredPasswords "context" .context) -}}
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Signed-off-by: darteaga <darteaga@vmware.com>
 
**Description of the change**

As described in #3547, there was a bug in the `common.validations.values.mariadb.passwords` helpers, we need to check if MariaDB is enabled first and then check if the passwords are required.

**Benefits**

We can use mariadb as a sub chart in combination with `mariadb.enabled=false`

**Possible drawbacks**

N/A

**Applicable issues**

  - fixes #3547

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
