### PR TITLE
[bitnami/mariadb] Fix annotation for replica statefulset

### DIFF
--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb
-version: 7.9.2
+version: 7.9.3
 appVersion: 10.3.23
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/bitnami/mariadb/templates/master-statefulset.yaml
+++ b/bitnami/mariadb/templates/master-statefulset.yaml
@@ -25,9 +25,8 @@ spec:
     {{- end }}
   template:
     metadata:
-      {{- with .Values.master.annotations }}
-      annotations:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.master.annotations }}
+      annotations: {{- include "mariadb.tplValue" (dict "value" .Values.master.annotations "context" $) | nindent 8 }}
       {{- end }}
       labels:
         app: {{ template "mariadb.name" . }}

--- a/bitnami/mariadb/templates/slave-statefulset.yaml
+++ b/bitnami/mariadb/templates/slave-statefulset.yaml
@@ -26,9 +26,8 @@ spec:
     {{- end }}
   template:
     metadata:
-      {{- with .Values.slave.annotations }}
-      annotations:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.slave.annotations }}
+      annotations: {{- include "mariadb.tplValue" (dict "value" .Values.slave.annotations "context" $) | nindent 8 }}
       {{- end }}
       labels:
         app: {{ template "mariadb.name" . }}

--- a/bitnami/mariadb/templates/slave-statefulset.yaml
+++ b/bitnami/mariadb/templates/slave-statefulset.yaml
@@ -26,11 +26,9 @@ spec:
     {{- end }}
   template:
     metadata:
-      {{- if .Values.slave.annotations }}
+      {{- with .Values.slave.annotations }}
       annotations:
-        {{- range $key, $value := .Values.slave.annotations }}
-        {{ $key }}: {{ $value }}
-        {{- end }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
         app: {{ template "mariadb.name" . }}


### PR DESCRIPTION
**Description of the change**

Currently annotations are treated differently in the master vs slave statefulset template. This also causes issues with generating slave manifest when having annotations not using strict key: value format.

**Benefits**
No discrepancy in templating slave annotations vs master statefulsets and generating slave manifest works when for example using multi-line value.

**Possible drawbacks**

**Applicable issues**
**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

