### PR TITLE
[bitnami/ejbca] Fix externalDatabase.port render and remove unused parameter from the README

### DIFF
--- a/bitnami/ejbca/Chart.yaml
+++ b/bitnami/ejbca/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ejbca
-version: 0.3.0
+version: 0.3.1
 appVersion: 6.15.2-6
 description: Enterprise class PKI Certificate Authority built on JEE technology.
 icon: https://bitnami.com/assets/stacks/ejbca/img/ejbca-stack-220x234.png

--- a/bitnami/ejbca/README.md
+++ b/bitnami/ejbca/README.md
@@ -108,7 +108,6 @@ The following table lists the configurable parameters of the EJBCA chart and the
 | `ejbcaAdminPassword`                      | EJBCA administrator password                                                          | _random 10 character long alphanumeric string_               |
 | `existingSecret`                          | Name of an existing secret containing EJBCA admin password ('ejbca-admin-password' key) | `nil`                                                      |
 | `ejbcaJavaOpts`                           | Options used to launch the WildFly server                                             | `nil`                                                        |
-| `ejbcaHttpsServerHostname`                | Hostname of the server when using HTTPS                                               | `hostname`                                                   |
 | `ejbcaCA.name`                            | Name of the CA EJBCA will instantiate by default                                      | `ManagementCA`                                               |
 | `ejbcaCA.baseDN`                          | Base DomainName of the CA EJBCA will instantiate by default                           | `nil`                                                        |
 | `ejbcaKeystoreExistingSecret`             | Existing Secret containing a Keystore to be imported by EBJCA                         | `nil`                                                        |

--- a/bitnami/ejbca/templates/_helpers.tpl
+++ b/bitnami/ejbca/templates/_helpers.tpl
@@ -117,7 +117,7 @@ Return the MariaDB Port
 {{- if .Values.mariadb.enabled }}
     {{- printf "3306" | quote -}}
 {{- else -}}
-    {{- printf "%d" (.Values.externalDatabase.port | quote ) -}}
+    {{- printf "%s" (.Values.externalDatabase.port | quote ) -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
**Description of the change**

Fix the render of the external database port when assigned to an env. variable in the _deployment.yaml_. In the same way, this PR also removes an unused leftover parameter from the _README.md_
```
helm template ejbca . --debug \
--set mariadb.enabled=false \ 
--set externalDatabase.host: mysql.local.xyz \
--set externalDatabase.user: ejbca_user \
--set externalDatabase.database: ejbca \
--set externalDatabase.port: 3306
```
```yaml
env:
  - name: EJBCA_DATABASE_PORT
    value: %!d(string="3306")
```
VS
```yaml
env:
  - name: EJBCA_DATABASE_PORT
    value: "3306"
```

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #3584

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)