### PR TITLE
[bitnami/spark] Add bitnami/common subchart and update components

### DIFF
--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 2.0.2
+version: 3.0.0
 appVersion: 3.0.0
 description: Spark is a fast and general-purpose cluster computing system.
 name: spark

--- a/bitnami/spark/README.md
+++ b/bitnami/spark/README.md
@@ -280,4 +280,4 @@ security.ssl.needClientAuth=true
 
 - Spark container images are updated to use Hadoop `3.2.x`: [Notable Changes: 3.0.0-debian-10-r44](https://github.com/bitnami/bitnami-docker-spark#300-debian-10-r44)
 
-> Note: There is no backwards compatibility due to the above mentioned changes.
+> Note: Backwards compatibility is not guaranteed due to the above mentioned changes. Please make sure your workloads are compatible with the new version of Hadoop before upgrading. Backups are always recommended before any upgrade operation.

--- a/bitnami/spark/README.md
+++ b/bitnami/spark/README.md
@@ -280,4 +280,4 @@ security.ssl.needClientAuth=true
 
 - Spark container images are updated to use Hadoop `3.2.x`: [Notable Changes: 3.0.0-debian-10-r44](https://github.com/bitnami/bitnami-docker-spark#300-debian-10-r44)
 
-> Note: There is no backwards compatibility due to the above mentioned changes. It's necessary to install a new release of the chart, and migrate the existing TSDB data to the new Prometheus instances.
+> Note: There is no backwards compatibility due to the above mentioned changes.

--- a/bitnami/spark/README.md
+++ b/bitnami/spark/README.md
@@ -56,8 +56,8 @@ The following tables lists the configurable parameters of the spark chart and th
 | `image.tag`                                 | spark Image tag                                                                                                                            | `{TAG_NAME}`                                            |
 | `image.pullPolicy`                          | spark image pull policy                                                                                                                    | `IfNotPresent`                                          |
 | `image.pullSecrets`                         | Specify docker-registry secret names as an array                                                                                           | `[]` (does not add image pull secrets to deployed pods) |
-| `nameOverride`                              | String to partially override spark.fullname template with a string (will prepend the release name)                                         | `nil`                                                   |
-| `fullnameOverride`                          | String to fully override spark.fullname template with a string                                                                             | `nil`                                                   |
+| `nameOverride`                              | String to partially override common.names.fullname template with a string (will prepend the release name)                                  | `nil`                                                   |
+| `fullnameOverride`                          | String to fully override common.names.fullname template with a string                                                                      | `nil`                                                   |
 | `master.debug`                              | Specify if debug values should be set on the master                                                                                        | `false`                                                 |
 | `master.webPort`                            | Specify the port where the web interface will listen on the master                                                                         | `8080`                                                  |
 | `master.clusterPort`                        | Specify the port where the master listens to communicate with workers                                                                      | `7077`                                                  |
@@ -271,3 +271,13 @@ security.ssl.needClientAuth=true
 ```
 
 > Be aware that currently is not possible to submit an application to a standalone cluster if RPC authentication is configured. More info about the issue [here](https://issues.apache.org/jira/browse/SPARK-25078).
+
+## Upgrading
+
+### To 3.0.0
+
+- This version introduces `bitnami/common`, a [library chart](https://helm.sh/docs/topics/library_charts/#helm) as a dependency. More documentation about this new utility could be found [here](https://github.com/bitnami/charts/tree/master/bitnami/common#bitnami-common-library-chart). Please, make sure that you have updated the chart dependencies before executing any upgrade.
+
+- Spark container images are updated to use Hadoop `3.2.x`: [Notable Changes: 3.0.0-debian-10-r44](https://github.com/bitnami/bitnami-docker-spark#300-debian-10-r44)
+
+> Note: There is no backwards compatibility due to the above mentioned changes. It's necessary to install a new release of the chart, and migrate the existing TSDB data to the new Prometheus instances.

--- a/bitnami/spark/requirements.lock
+++ b/bitnami/spark/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 0.6.2
+digest: sha256:e30fa2c3364d51b5e0b1d5ee81d6c9d5d94e4c1f430ee6a3210192d1850b118d
+generated: "2020-09-02T10:39:15.841297589+02:00"

--- a/bitnami/spark/requirements.yaml
+++ b/bitnami/spark/requirements.yaml
@@ -1,0 +1,6 @@
+dependencies:
+  - name: common
+    version: "0.x.x"
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common

--- a/bitnami/spark/templates/NOTES.txt
+++ b/bitnami/spark/templates/NOTES.txt
@@ -1,7 +1,7 @@
 1. Get the Spark master WebUI URL by running these commands:
 {{- if .Values.ingress.enabled }}
 
-  export HOSTNAME=$(kubectl get ingress --namespace {{ .Release.Namespace }} {{ include "spark.fullname" . }}-ingress -o jsonpath='{.spec.rules[0].host}')
+  export HOSTNAME=$(kubectl get ingress --namespace {{ .Release.Namespace }} {{ include "common.names.fullname" . }}-ingress -o jsonpath='{.spec.rules[0].host}')
   echo "Spark-master URL: http://$HOSTNAME/"
 
 {{- else -}}
@@ -37,12 +37,12 @@
   Run the commands below to obtain the master IP and submit your application.
 {{- end }}
 
-  export EXAMPLE_JAR=$(kubectl exec -ti --namespace {{ .Release.Namespace }} {{ include "spark.fullname" . }}-worker-0 -- find examples/jars/ -name 'spark-example*\.jar' | tr -d '\r')
+  export EXAMPLE_JAR=$(kubectl exec -ti --namespace {{ .Release.Namespace }} {{ include "common.names.fullname" . }}-worker-0 -- find examples/jars/ -name 'spark-example*\.jar' | tr -d '\r')
 {{- if eq "NodePort" .Values.service.type }}
   export SUBMIT_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[?(@.name=='cluster')].nodePort}" services {{ include "spark.master.service.name" . }})
   export SUBMIT_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
 
-  kubectl run --namespace {{ .Release.Namespace }} {{ template "spark.fullname" . }}-client --rm --tty -i --restart='Never' \
+  kubectl run --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }}-client --rm --tty -i --restart='Never' \
     --image {{ template "spark.image" . }} \
     -- spark-submit --master spark://$SUBMIT_IP:$SUBMIT_PORT \
     --class org.apache.spark.examples.SparkPi \
@@ -52,7 +52,7 @@
 {{- else if eq "LoadBalancer" .Values.service.type }}
   export SUBMIT_IP=$(kubectl get --namespace {{ .Release.Namespace }} svc {{ include "spark.master.service.name" . }} -o jsonpath="{.status.loadBalancer.ingress[0]['ip', 'hostname'] }")
 
-  kubectl run --namespace {{ .Release.Namespace }} {{ template "spark.fullname" . }}-client --rm --tty -i --restart='Never' \
+  kubectl run --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }}-client --rm --tty -i --restart='Never' \
     --image {{ template "spark.image" . }} \
     -- spark-submit --master spark://$SUBMIT_IP:{{ .Values.service.clusterPort }} \
     --deploy-mode cluster \
@@ -61,7 +61,7 @@
 
 {{- else }}
 
-  kubectl exec -ti --namespace {{ .Release.Namespace }} {{ include "spark.fullname" . }}-worker-0 -- spark-submit --master spark://{{ include "spark.master.service.name" . }}:{{ .Values.service.clusterPort }} \
+  kubectl exec -ti --namespace {{ .Release.Namespace }} {{ include "common.names.fullname" . }}-worker-0 -- spark-submit --master spark://{{ include "spark.master.service.name" . }}:{{ .Values.service.clusterPort }} \
     --class org.apache.spark.examples.SparkPi \
     $EXAMPLE_JAR 5
 
@@ -73,6 +73,6 @@
 
 ** Please be patient while the chart is being deployed **
 
-{{ include "spark.rollingTags.warning" . }}
+{{ include "spark.checkRollingTags" . }}
 
 {{ include "spark.validateValues" . }}

--- a/bitnami/spark/templates/_helpers.tpl
+++ b/bitnami/spark/templates/_helpers.tpl
@@ -1,110 +1,38 @@
 {{- /* vim: set filetype=mustache: */}}
-{{- /*
-Expand the name of the chart.
-*/}}
-{{- define "spark.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
 {{/*
 Return the proper Spark image name
 */}}
 {{- define "spark.image" -}}
-{{- $registryName := .Values.image.registry -}}
-{{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
-{{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-{{- end -}}
+{{- include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) -}}
 {{- end -}}
 
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "spark.imagePullSecrets" -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.image) "global" .Values.global) -}}
+{{- end -}}
 
 {{- /*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "spark.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{- /* 
-As we use a headless service we need to append -master-svc to 
-the service name. 
+As we use a headless service we need to append -master-svc to
+the service name.
 */ -}}
 {{- define "spark.master.service.name" -}}
-{{ include "spark.fullname" . }}-master-svc
+{{ include "common.names.fullname" . }}-master-svc
 {{- end -}}
 
-{{- /*
-Create chart name and version as used by the chart label.
-*/}}
-{{- define "spark.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Common labels
-*/}}
-{{- define "spark.labels" -}}
-app.kubernetes.io/name: {{ include "spark.name" . }}
-helm.sh/chart: {{ include "spark.chart" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end -}}
-
-{{/*
-Labels to use on deploy.spec.selector.matchLabels and svc.spec.selector
-*/}}
-{{- define "spark.matchLabels" -}}
-app.kubernetes.io/name: {{ include "spark.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end -}}
-
-{{- define "spark.imagePullSecrets" -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
-Also, we can not use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets:
-{{- range .Values.global.imagePullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- else if .Values.image.pullSecrets }}
-imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
+{{/* Get the secret for paswords */}}
+{{- define "spark.passwordsSecretName" -}}
+{{- if .Values.security.passwordsSecretName -}}
+  {{- printf "%s" .Values.security.passwordsSecretName -}}
+{{- else }}
+  {{- printf "%s-secret" (include "common.names.fullname" .) -}}
 {{- end }}
 {{- end -}}
-{{- else if .Values.image.pullSecrets }}
-imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end -}}
+
+{{/* Check if there are rolling tags in the images */}}
+{{- define "spark.checkRollingTags" -}}
+{{- include "common.warnings.rollingTag" .Values.image -}}
 {{- end -}}
 
 {{/* Validate values of Spark - Incorrect extra volume settings */}}
@@ -116,6 +44,15 @@ spark: missing-worker-extra-volume-mounts
 {{- end -}}
 {{- end -}}
 
+{/* Validate values of Spark - number of workers must be greater than 0 */}}
+{{- define "spark.validateValues.workerCount" -}}
+{{- $replicaCount := int .Values.worker.replicaCount }}
+{{- if lt $replicaCount 1 -}}
+spark: workerCount
+    Worker replicas must be greater than 0!!
+    Please set a valid worker count size (--set worker.replicaCount=X)
+{{- end -}}
+{{- end -}}
 
 {{/*
 Compile all warnings into a single message, and call fail.
@@ -130,45 +67,4 @@ Compile all warnings into a single message, and call fail.
 {{- if $message -}}
 {{-   printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
 {{- end -}}
-{{- end -}}
-
-{/* Validate values of Spark - number of workers must be greater than 0 */}}
-{{- define "spark.validateValues.workerCount" -}}
-{{- $replicaCount := int .Values.worker.replicaCount }}
-{{- if lt $replicaCount 1 -}}
-spark: workerCount
-    Worker replicas must be greater than 0!!
-    Please set a valid worker count size (--set worker.replicaCount=X)
-{{- end -}}
-{{- end -}}
-
-
-{{/* Get the secret for paswords */}}
-{{- define "spark.get.passwordSecretName" -}}
-{{- if .Values.security.passwordsSecretName -}}
-  {{- printf "%s" .Values.security.passwordsSecretName -}}
-{{- else }}
-  {{- printf "%s-secret" (include "spark.fullname" .) -}}
-{{- end }}
-{{- end -}}
-
-{{/* Warning for rolling tags */}}
-{{- define "spark.rollingTags.warning" -}}
-{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
-WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
-+info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
-{{- end -}}
-{{- end -}}
-
-{{/*
-Renders a value that contains template.
-Usage:
-{{ include "spark.tplValue" (dict "value" .Values.path.to.the.Value "context" $) }}
-*/}}
-{{- define "spark.tplValue" -}}
-    {{- if typeIs "string" .value }}
-        {{- tpl .value .context }}
-    {{- else }}
-        {{- tpl (.value | toYaml) .context }}
-    {{- end }}
 {{- end -}}

--- a/bitnami/spark/templates/headless-svc.yaml
+++ b/bitnami/spark/templates/headless-svc.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "spark.fullname" . }}-headless
-  labels: {{- include "spark.labels" . | nindent 4 }}
+  name: {{ template "common.names.fullname" . }}-headless
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   type: ClusterIP
   clusterIP: None
-  selector: {{- include "spark.matchLabels" . | nindent 4 }}
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/spark/templates/hpa-worker.yaml
+++ b/bitnami/spark/templates/hpa-worker.yaml
@@ -2,14 +2,14 @@
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
-  labels: {{- include "spark.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: worker-autoscaler
-  name: {{ include "spark.fullname" . }}-autoscaler
+  name: {{ include "common.names.fullname" . }}-autoscaler
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: statefulset
-    name: {{ include "spark.fullname" . }}-worker
+    name: {{ include "common.names.fullname" . }}-worker
   minReplicas: {{ .Values.worker.replicaCount }}
   maxReplicas: {{ .Values.worker.autoscaling.replicasMax }}
   metrics:

--- a/bitnami/spark/templates/ingress.yaml
+++ b/bitnami/spark/templates/ingress.yaml
@@ -2,8 +2,8 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ include "spark.fullname" . }}-ingress
-  labels: {{- include "spark.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}-ingress
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: ingress
   annotations:
     {{- if .Values.ingress.certManager }}

--- a/bitnami/spark/templates/secret.yaml
+++ b/bitnami/spark/templates/secret.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "spark.fullname" . }}-secret
-  labels: {{- include "spark.labels" . | nindent 4 }}
+  name: {{ template "spark.passwordsSecretName" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
 type: Opaque
 data:
   {{- if .Values.security.rpc.authenticationEnabled }}

--- a/bitnami/spark/templates/statefulset-master.yaml
+++ b/bitnami/spark/templates/statefulset-master.yaml
@@ -1,32 +1,32 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "spark.fullname" . }}-master
-  labels: {{- include "spark.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}-master
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: master
 spec:
-  serviceName: {{ template "spark.fullname" . }}-headless
+  serviceName: {{ template "common.names.fullname" . }}-headless
   replicas: 1
   selector:
-    matchLabels: {{- include "spark.matchLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: master
   template:
     metadata:
-      labels: {{- include "spark.labels" . | nindent 8 }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: master
       {{- if .Values.master.podAnnotations }}
-      annotations: {{- include "spark.tplValue" (dict "value" .Values.master.podAnnotations "context" $) | nindent 8 }}
-      {{- end }}        
+      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.master.podAnnotations "context" $) | nindent 8 }}
+      {{- end }}
     spec:
 {{- include "spark.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.master.affinity }}
-      affinity: {{- include "spark.tplValue" (dict "value" .Values.master.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.master.affinity "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.master.nodeSelector }}
-      nodeSelector: {{- include "spark.tplValue" (dict "value" .Values.master.nodeSelector "context" $) | nindent 8 }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.master.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.master.tolerations }}
-      tolerations: {{- include "spark.tplValue" (dict "value" .Values.master.tolerations "context" $) | nindent 8 }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.master.tolerations "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.master.securityContext.enabled }}
       securityContext:
@@ -83,11 +83,7 @@ spec:
             - name: SPARK_RPC_AUTHENTICATION_SECRET
               valueFrom:
                 secretKeyRef:
-                  {{- if .Values.security.passwordsSecretName }}
-                  name: {{ .Values.security.passwordsSecretName }}
-                  {{- else }}
-                  name: {{ include "spark.fullname" . }}-secret
-                  {{- end }}
+                  name: {{ template "spark.passwordsSecretName" . }}
                   key: rpc-authentication-secret
             {{- end }}
             {{- if .Values.security.rpc.encryptionEnabled }}
@@ -104,17 +100,17 @@ spec:
             - name: SPARK_SSL_KEY_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "spark.get.passwordSecretName" . }}
+                  name: {{ template "spark.passwordsSecretName" . }}
                   key: ssl-key-password
             - name: SPARK_SSL_KEYSTORE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "spark.get.passwordSecretName" . }}
+                  name: {{ template "spark.passwordsSecretName" . }}
                   key: ssl-keystore-password
             - name: SPARK_SSL_TRUSTSTORE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "spark.get.passwordSecretName" . }}
+                  name: {{ template "spark.passwordsSecretName" . }}
                   key: ssl-truststore-password
             - name: SPARK_SSL_NEED_CLIENT_AUTH
               value: {{ .Values.security.ssl.needClientAuth | quote }}

--- a/bitnami/spark/templates/statefulset-worker.yaml
+++ b/bitnami/spark/templates/statefulset-worker.yaml
@@ -1,32 +1,32 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "spark.fullname" . }}-worker
-  labels: {{- include "spark.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}-worker
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: worker
 spec:
-  serviceName: {{ template "spark.fullname" . }}-headless
+  serviceName: {{ template "common.names.fullname" . }}-headless
   replicas: {{ .Values.worker.replicaCount }}
   selector:
-    matchLabels: {{- include "spark.matchLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: worker
   template:
     metadata:
-      labels: {{- include "spark.labels" . | nindent 8 }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: worker
       {{- if .Values.worker.podAnnotations }}
-      annotations: {{- include "spark.tplValue" (dict "value" .Values.worker.podAnnotations "context" $) | nindent 8 }}
-      {{- end }}        
+      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.worker.podAnnotations "context" $) | nindent 8 }}
+      {{- end }}
     spec:
 {{- include "spark.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.worker.affinity }}
-      affinity: {{- include "spark.tplValue" (dict "value" .Values.worker.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.worker.affinity "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.worker.nodeSelector }}
-      nodeSelector: {{- include "spark.tplValue" (dict "value" .Values.worker.nodeSelector "context" $) | nindent 8 }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.worker.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.worker.tolerations }}
-      tolerations: {{- include "spark.tplValue" (dict "value" .Values.worker.tolerations "context" $) | nindent 8 }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.worker.tolerations "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.worker.securityContext.enabled }}
       securityContext:
@@ -101,11 +101,7 @@ spec:
             - name: SPARK_RPC_AUTHENTICATION_SECRET
               valueFrom:
                 secretKeyRef:
-                  {{- if .Values.security.passwordsSecretName }}
-                  name: {{ .Values.security.passwordsSecretName }}
-                  {{- else }}
-                  name: {{ include "spark.fullname" . }}-secret
-                  {{- end }}
+                  name: {{ template "spark.passwordsSecretName" . }}
                   key: rpc-authentication-secret
             {{- end }}
             {{- if .Values.security.rpc.encryptionEnabled }}
@@ -122,17 +118,17 @@ spec:
             - name: SPARK_SSL_KEY_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "spark.get.passwordSecretName" . }}
+                  name: {{ template "spark.passwordsSecretName" . }}
                   key: ssl-key-password
             - name: SPARK_SSL_KEYSTORE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "spark.get.passwordSecretName" . }}
+                  name: {{ template "spark.passwordsSecretName" . }}
                   key: ssl-keystore-password
             - name: SPARK_SSL_TRUSTSTORE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "spark.get.passwordSecretName" . }}
+                  name: {{ template "spark.passwordsSecretName" . }}
                   key: ssl-truststore-password
             - name: SPARK_SSL_NEED_CLIENT_AUTH
               value: {{ .Values.security.ssl.needClientAuth | quote }}

--- a/bitnami/spark/templates/svc-master.yaml
+++ b/bitnami/spark/templates/svc-master.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "spark.master.service.name" . }}
-  labels: {{- include "spark.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.service.annotations }}
-  annotations: {{- include "spark.tplValue" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
@@ -29,5 +29,5 @@ spec:
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
-  selector: {{- include "spark.matchLabels" . | nindent 4 }}
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: master

--- a/bitnami/spark/values-production.yaml
+++ b/bitnami/spark/values-production.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/spark
-  tag: 3.0.0-debian-10-r36
+  tag: 3.0.0-debian-10-r45
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/spark/values-production.yaml
+++ b/bitnami/spark/values-production.yaml
@@ -29,11 +29,11 @@ image:
   ## ref:  https://github.com/bitnami/minideb-extras/#turn-on-bash-debugging
   debug: false
 
-## String to partially override spark.fullname template (will maintain the release name)
+## String to partially override common.names.fullname template (will maintain the release name)
 ##
 # nameOverride:
 
-## String to fully override spark.fullname template
+## String to fully override common.names.fullname template
 ##
 # fullnameOverride:
 

--- a/bitnami/spark/values.yaml
+++ b/bitnami/spark/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/spark
-  tag: 3.0.0-debian-10-r36
+  tag: 3.0.0-debian-10-r45
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/spark/values.yaml
+++ b/bitnami/spark/values.yaml
@@ -29,11 +29,11 @@ image:
   ## ref:  https://github.com/bitnami/minideb-extras/#turn-on-bash-debugging
   debug: false
 
-## String to partially override spark.fullname template (will maintain the release name)
+## String to partially override common.names.fullname template (will maintain the release name)
 ##
 # nameOverride:
 
-## String to fully override spark.fullname template
+## String to fully override common.names.fullname template
 ##
 # fullnameOverride:
 


### PR DESCRIPTION
Signed-off-by: Andrés Bono <andresbono@vmware.com>

**Description of the change**

- Start using [bitnami/common](https://github.com/bitnami/charts/tree/master/bitnami/common).
- Update components. Major change in the images: Spark is now using Hadoop `3.2.x`.

**Applicable issues**

  - Related to https://github.com/bitnami/bitnami-docker-spark/issues/3.

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)