### PR TITLE
[bitnami/redis-cluster] Service acount name needs to be set on jobs.

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis-cluster
-version: 3.2.2
+version: 3.2.3
 appVersion: 6.0.7
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/bitnami/redis-cluster/templates/init-cluster.yaml
+++ b/bitnami/redis-cluster/templates/init-cluster.yaml
@@ -52,6 +52,7 @@ spec:
           {{- toYaml .Values.podSecurityContext.sysctls | nindent 8 }}
         {{- end }}
       {{- end }}
+      serviceAccountName: {{ include "redis-cluster.serviceAccountName" . }}
       {{- if .Values.initJob.initContainers }}
       initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.initJob.initContainers "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/redis-cluster/templates/update-cluster.yaml
+++ b/bitnami/redis-cluster/templates/update-cluster.yaml
@@ -52,6 +52,7 @@ spec:
           {{- toYaml .Values.podSecurityContext.sysctls | nindent 8 }}
         {{- end }}
       {{- end }}
+      serviceAccountName: {{ include "redis-cluster.serviceAccountName" . }}
       {{- if .Values.updateJob.initContainers }}
       initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.updateJob.initContainers "context" $) | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Service account is mounted also on post install and post update jobs. 

**Benefits**

In very restrictive k8s cluster, default pod security policies can prevent chart from working. Your chart has great support for PSP, RBAC and service account, but unfortunately service account is only set on statefulset. So statefulset is working, but post-install and post-update job fail due to using PSP not created by chart. 

**Possible drawbacks**

/

**Applicable issues**

/

**Additional information**

Service account is now set to jobs the exact way as it is set on statefulset, so there should not be any issues with this minor change. 

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ X] Variables are documented in the README.md
- [ X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
