### PR TITLE
[bitnami/kube-state-metrics] Fix setting service.annotations (#3582)

### DIFF
--- a/bitnami/kube-state-metrics/Chart.yaml
+++ b/bitnami/kube-state-metrics/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.9.7
 description: kube-state-metrics is a simple service that listens to the Kubernetes API server and generates metrics about the state of the objects.
 name: kube-state-metrics
-version: 0.5.0
+version: 0.5.1
 keywords:
   - prometheus
   - kube-state-metrics

--- a/bitnami/kube-state-metrics/templates/service.yaml
+++ b/bitnami/kube-state-metrics/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- if not .Values.serviceMonitor.enabled }}
     prometheus.io/scrape: "true"
     {{- end }}
-    {{- with .Values.service.annotations }}
+    {{- if .Values.service.annotations }}
     {{- include "kube-state-metrics.tplValue" (dict "value" .Values.service.annotations "context" $) | nindent 4 }}
     {{- end }}
   labels: {{- include "kube-state-metrics.labels" . | nindent 4 }}


### PR DESCRIPTION
**Description of the change**

As described in #3582, currently bitnami/kube-state-metrics does not allow to set "service.annotations" due to a bug

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #3582 

**Additional information**
Test with:
```
# helm install -n default my-release bitnami/kube-state-metrics --set service.annotations."prometheus\.io/path"=/metrics
```
previous result:
```
Error: template: kube-state-metrics/templates/service.yaml:11:67: executing "kube-state-metrics/templates/service.yaml" at <.Values.service.annotations>: nil pointer evaluating interface {}.service
```

fix result:
```
NAME: my-release
LAST DEPLOYED: Thu Sep  3 12:22:31 2020
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
...
```

**Checklist**
* [x]  Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
* [x]  Variables are documented in the README.md
* [x]  Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
* [x]  If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

