### PR TITLE
[bitnami/thanos] fix thanos ruler alert label drop

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 2.3.2
+version: 2.3.3
 appVersion: 0.14.0
 description: Thanos is a highly available metrics system that can be added on top of existing Prometheus deployments, providing a global query view across all Prometheus installations.
 engine: gotpl

--- a/bitnami/thanos/templates/ruler/statefulset.yaml
+++ b/bitnami/thanos/templates/ruler/statefulset.yaml
@@ -86,7 +86,7 @@ spec:
             {{- end }}
             - --label=replica="$(POD_NAME)"
             - --label=ruler_cluster="{{ .Values.ruler.clusterName }}"
-            - --alert.label-drop="replica"
+            - --alert.label-drop=replica
             - --objstore.config-file=/conf/objstore/objstore.yml
             - --rule-file=/conf/rules/ruler.yml
             {{- range .Values.ruler.queries }}


### PR DESCRIPTION
**Description of the change**

With the quotes in place the alert drop doesn't work and the label is included in the data sent to alert manager.

**Benefits**

will be able to drop the de-dupe alerts when running thanos ruler in HA

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
