### PR TITLE
[bitnami/cassandra ]Fix volume definition for initDB secret

### DIFF
--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cassandra
-version: 5.6.3
+version: 5.6.4
 appVersion: 3.11.8
 description: Apache Cassandra is a free and open-source distributed database management system designed to handle large amounts of data across many commodity servers, providing high availability with no single point of failure. Cassandra offers robust support for clusters spanning multiple datacenters, with asynchronous masterless replication allowing low latency operations for all clients.
 keywords:

--- a/bitnami/cassandra/templates/statefulset.yaml
+++ b/bitnami/cassandra/templates/statefulset.yaml
@@ -256,8 +256,8 @@ spec:
         {{- end }}
         {{- if .Values.initDBSecret }}
         - name: init-db-secret
-          configMap:
-            name: {{ tpl .Values.initDBSecret $ }}
+          secret:
+            secretName: {{ tpl .Values.initDBSecret $ }}
         {{- end }}
 {{- if not .Values.persistence.enabled }}
         - name: data


### PR DESCRIPTION
As described in #3605, secret is mount uncorrectly.
This PR fixes the chart.