### PR TITLE
[bitnami/ghost] Fix invalid deployment when podAnnotations value is set

### DIFF
--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ghost
-version: 10.1.7
+version: 10.1.8
 appVersion: 3.31.5
 description: A simple, powerful publishing platform that allows you to share your stories with the world
 keywords:

--- a/bitnami/ghost/templates/deployment.yaml
+++ b/bitnami/ghost/templates/deployment.yaml
@@ -12,7 +12,7 @@ spec:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
       {{- if .Values.podAnnotations }}
-      annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.podAnnotations "context" $ ) | nindent 6 }}
+      annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.podAnnotations "context" $ ) | nindent 8 }}
       {{- end }}
     spec:
       {{- include "ghost.imagePullSecrets" . | indent 6 }}

--- a/bitnami/ghost/templates/deployment.yaml
+++ b/bitnami/ghost/templates/deployment.yaml
@@ -11,9 +11,9 @@ spec:
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
-    {{- if .Values.podAnnotations }}
-    annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.podAnnotations "context" $ ) | nindent 6 }}
-    {{- end }}
+      {{- if .Values.podAnnotations }}
+      annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.podAnnotations "context" $ ) | nindent 6 }}
+      {{- end }}
     spec:
       {{- include "ghost.imagePullSecrets" . | indent 6 }}
       {{- if .Values.securityContext.enabled }}


### PR DESCRIPTION
**Description of the change**

When the `podAnnotations` value is set on the ghost helm chart, the resulting manifest for the chart's Deployment resource will be invalid, and Kubernetes won't be able to process it.

**Benefits**

Fixes deployment of the Helm chart. Allows for Istio-related annotations to be set.

**Possible drawbacks**

None that I can think of

**Applicable issues**

n/a

**Additional information**

Thanks for maintaining! Very handy chart to have available.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

