### PR TITLE
[bitnami/moodle] Fix issue when rendering ingress.hosts[]

### DIFF
--- a/bitnami/moodle/Chart.yaml
+++ b/bitnami/moodle/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: moodle
-version: 8.1.1
+version: 8.1.2
 appVersion: 3.9.1
 description: Moodle is a learning platform designed to provide educators, administrators and learners with a single robust, secure and integrated system to create personalised learning environments
 keywords:

--- a/bitnami/moodle/templates/ingress.yaml
+++ b/bitnami/moodle/templates/ingress.yaml
@@ -26,15 +26,15 @@ spec:
           backend:
             serviceName: {{ include "moodle.fullname" $ }}
             servicePort: 80
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .name }}
-      http:
-        paths:
-        - path: {{ default "/" .path }}
-          backend:
-            serviceName: {{ include "moodle.fullname" $ }}
-            servicePort: http
-    {{- end }}
+  {{- range .Values.ingress.hosts }}
+  - host: {{ .name }}
+    http:
+      paths:
+      - path: {{ default "/" .path }}
+        backend:
+          serviceName: {{ include "moodle.fullname" $ }}
+          servicePort: http
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls: {{- toYaml .Values.ingress.tls | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
**Description of the change**
When setting extra hosts via `ingress.hosts[0].*` the following render error appears:
```
Error: YAML parse error on moodle/templates/ingress.yaml: error converting YAML to JSON: yaml: line 20: did not find expected key
helm.go:84: [debug] error converting YAML to JSON: yaml: line 20: did not find expected key
YAML parse error on moodle/templates/ingress.yaml
```

**Applicable issues**
  - fixes #3617

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files