### PR TITLE
[bitnami/spring-cloud-dataflow] feat: add composed task runner image

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: spring-cloud-dataflow
-version: 0.6.2
+version: 0.7.0
 appVersion: 2.6.1
 description: Spring Cloud Data Flow is a microservices-based toolkit for building streaming and batch data processing pipelines in Cloud Foundry and Kubernetes.
 keywords:

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -48,231 +48,234 @@ The following tables lists the configurable parameters of the Spring Cloud Data 
 
 ### Global parameters
 
-| Parameter                                       | Description                                                | Default                                                 |
-|-------------------------------------------------|------------------------------------------------------------|---------------------------------------------------------|
-| `global.imageRegistry`                          | Global Docker image registry                               | `nil`                                                   |
-| `global.imagePullSecrets`                       | Global Docker registry secret names as an array            | `[]` (does not add image pull secrets to deployed pods) |
-| `global.storageClass`                           | Global storage class for dynamic provisioning              | `nil`                                                   |
+| Parameter                                    | Description                                                                                            | Default                                                 |
+|----------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `global.imageRegistry`                       | Global Docker image registry                                                                           | `nil`                                                   |
+| `global.imagePullSecrets`                    | Global Docker registry secret names as an array                                                        | `[]` (does not add image pull secrets to deployed pods) |
+| `global.storageClass`                        | Global storage class for dynamic provisioning                                                          | `nil`                                                   |
 
 ### Common parameters
 
-| Parameter                                       | Description                                                | Default                                                 |
-|-------------------------------------------------|------------------------------------------------------------|---------------------------------------------------------|
-| `nameOverride`                                  | String to partially override scdf.fullname                 | `nil`                                                   |
-| `fullnameOverride`                              | String to fully override scdf.fullname                     | `nil`                                                   |
-| `clusterDomain`                                 | Default Kubernetes cluster domain                          | `cluster.local`                                         |
-| `deployer.resources.limits`                     | Streaming applications resource limits                     | `{ cpu: "500m", memory: "1024Mi" }`                     |
-| `deployer.resources.requests`                   | Streaming applications resource requests                   | `{}`                                                    |
-| `deployer.resources.readinessProbe`             | Streaming applications readiness probes requests           | Check `values.yaml` file                                |
-| `deployer.resources.livenessProbe`              | Streaming applications liveness probes  requests           | Check `values.yaml` file                                |
-| `deployer.nodeSelector`                         | Streaming applications nodeSelector                        | `""`                                                    |
-| `deployer.tolerations`                          | Streaming applications tolerations                         | `{}`                                                    |
-| `deployer.volumeMounts`                         | Streaming applications extra volume mounts                 | `{}`                                                    |
-| `deployer.volumes`                              | Streaming applications extra volumes                       | `{}`                                                    |
-| `deployer.environmentVariables`                 | Streaming applications environment variables               | `""`                                                    |
+| Parameter                                    | Description                                                                                            | Default                                                 |
+|----------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `nameOverride`                               | String to partially override scdf.fullname                                                             | `nil`                                                   |
+| `fullnameOverride`                           | String to fully override scdf.fullname                                                                 | `nil`                                                   |
+| `clusterDomain`                              | Default Kubernetes cluster domain                                                                      | `cluster.local`                                         |
+| `deployer.resources.limits`                  | Streaming applications resource limits                                                                 | `{ cpu: "500m", memory: "1024Mi" }`                     |
+| `deployer.resources.requests`                | Streaming applications resource requests                                                               | `{}`                                                    |
+| `deployer.resources.readinessProbe`          | Streaming applications readiness probes requests                                                       | Check `values.yaml` file                                |
+| `deployer.resources.livenessProbe`           | Streaming applications liveness probes  requests                                                       | Check `values.yaml` file                                |
+| `deployer.nodeSelector`                      | Streaming applications nodeSelector                                                                    | `""`                                                    |
+| `deployer.tolerations`                       | Streaming applications tolerations                                                                     | `{}`                                                    |
+| `deployer.volumeMounts`                      | Streaming applications extra volume mounts                                                             | `{}`                                                    |
+| `deployer.volumes`                           | Streaming applications extra volumes                                                                   | `{}`                                                    |
+| `deployer.environmentVariables`              | Streaming applications environment variables                                                           | `""`                                                    |
 
 ### Dataflow Server parameters
 
-| Parameter                                      | Description                                                         | Default                                                 |
-|------------------------------------------------|---------------------------------------------------------------------|---------------------------------------------------------|
-| `server.image.registry`                        | Spring Cloud Dataflow image registry                                | `docker.io`                                             |
-| `server.image.repository`                      | Spring Cloud Dataflow image name                                    | `bitnami/spring-cloud-dataflow`                         |
-| `server.image.tag`                             | Spring Cloud Dataflow image tag                                     | `{TAG_NAME}`                                            |
-| `server.image.pullPolicy`                      | Spring Cloud Dataflow image pull policy                             | `IfNotPresent`                                          |
-| `server.image.pullSecrets`                     | Specify docker-registry secret names as an array                    | `[]` (does not add image pull secrets to deployed pods) |
-| `server.configuration.streamingEnabled`        | Enables or disables streaming data processing                       | `true`                                                  |
-| `server.configuration.batchEnabled`            | Enables or disables bath data (tasks and schedules) processing      | `true`                                                  |
-| `server.configuration.accountName`             | The name of the account to configure for the Kubernetes platform    | `default`                                               |
-| `server.configuration.trustK8sCerts`           | Trust K8s certificates when querying the Kubernetes API             | `false`                                                 |
-| `server.configuration.containerRegistries`     | Container registries configuration                                  | `{}` (check `values.yaml` for more information)         |
-| `server.existingConfigmap`                     | Name of existing ConfigMap with Dataflow server configuration       | `nil`                                                   |
-| `server.extraEnvVars`                          | Extra environment variables to be set on Dataflow server container  | `{}`                                                    |
-| `server.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars                | `nil`                                                   |
-| `server.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars                   | `nil`                                                   |
-| `server.replicaCount`                          | Number of Dataflow server replicas to deploy                        | `1`                                                     |
-| `server.strategyType`                          | Deployment Strategy Type                                            | `RollingUpdate`                                         |
-| `server.affinity`                              | Affinity for pod assignment                                         | `{}` (evaluated as a template)                          |
-| `server.nodeSelector`                          | Node labels for pod assignment                                      | `{}` (evaluated as a template)                          |
-| `server.tolerations`                           | Tolerations for pod assignment                                      | `[]` (evaluated as a template)                          |
-| `server.priorityClassName`                     | Controller priorityClassName                                        | `nil`                                                   |
-| `server.podSecurityContext`                    | Dataflow server pods' Security Context                              | `{ fsGroup: "1001" }`                                   |
-| `server.containerSecurityContext`              | Dataflow server containers' Security Context                        | `{ runAsUser: "1001" }`                                 |
-| `server.resources.limits`                      | The resources limits for the Dataflow server container              | `{}`                                                    |
-| `server.resources.requests`                    | The requested resources for the Dataflow server container           | `{}`                                                    |
-| `server.podAnnotations`                        | Annotations for Dataflow server pods                                | `{}`                                                    |
-| `server.livenessProbe`                         | Liveness probe configuration for Dataflow server                    | Check `values.yaml` file                                |
-| `server.readinessProbe`                        | Readiness probe configuration for Dataflow server                   | Check `values.yaml` file                                |
-| `server.customLivenessProbe`                   | Override default liveness probe                                     | `nil`                                                   |
-| `server.customReadinessProbe`                  | Override default readiness probe                                    | `nil`                                                   |
-| `server.service.type`                          | Kubernetes service type                                             | `ClusterIP`                                             |
-| `server.service.port`                          | Service HTTP port                                                   | `8080`                                                  |
-| `server.service.nodePort`                      | Service HTTP node port                                              | `nil`                                                   |
-| `server.service.clusterIP`                     | Dataflow server service clusterIP IP                                | `None`                                                  |
-| `server.service.externalTrafficPolicy`         | Enable client source IP preservation                                | `Cluster`                                               |
-| `server.service.loadBalancerIP`                | loadBalancerIP if service type is `LoadBalancer`                    | `nil`                                                   |
-| `server.service.loadBalancerSourceRanges`      | Address that are allowed when service is LoadBalancer               | `[]`                                                    |
-| `server.service.annotations`                   | Annotations for Dataflow server service                             | `{}`                                                    |
-| `server.ingress.enabled`                       | Enable ingress controller resource                                  | `false`                                                 |
-| `server.ingress.certManager`                   | Add annotations for cert-manager                                    | `false`                                                 |
-| `server.ingress.hostname`                      | Default host for the ingress resource                               | `dataflow.local`                                        |
-| `server.ingress.annotations`                   | Ingress annotations                                                 | `[]`                                                    |
-| `server.ingress.extraHosts[0].name`            | Additional hostnames to be covered                                  | `nil`                                                   |
-| `server.ingress.extraHosts[0].path`            | Additional hostnames to be covered                                  | `nil`                                                   |
-| `server.ingress.extraTls[0].hosts[0]`          | TLS configuration for additional hostnames to be covered            | `nil`                                                   |
-| `server.ingress.extraTls[0].secretName`        | TLS configuration for additional hostnames to be covered            | `nil`                                                   |
-| `server.ingress.secrets[0].name`               | TLS Secret Name                                                     | `nil`                                                   |
-| `server.ingress.secrets[0].certificate`        | TLS Secret Certificate                                              | `nil`                                                   |
-| `server.ingress.secrets[0].key`                | TLS Secret Key                                                      | `nil`                                                   |
-| `server.initContainers`                        | Add additional init containers to the Dataflow server pods          | `{}` (evaluated as a template)                          |
-| `server.sidecars`                              | Add additional sidecar containers to the Dataflow server pods       | `{}` (evaluated as a template)                          |
-| `server.pdb.create`                            | Enable/disable a Pod Disruption Budget creation                     | `false`                                                 |
-| `server.pdb.minAvailable`                      | Minimum number/percentage of pods that should remain scheduled      | `1`                                                     |
-| `server.pdb.maxUnavailable`                    | Maximum number/percentage of pods that may be made unavailable      | `nil`                                                   |
-| `server.autoscaling.enabled`                   | Enable autoscaling for Dataflow server                              | `false`                                                 |
-| `server.autoscaling.minReplicas`               | Minimum number of Dataflow server replicas                          | `nil`                                                   |
-| `server.autoscaling.maxReplicas`               | Maximum number of Dataflow server replicas                          | `nil`                                                   |
-| `server.autoscaling.targetCPU`                 | Target CPU utilization percentage                                   | `nil`                                                   |
-| `server.autoscaling.targetMemory`              | Target Memory utilization percentage                                | `nil`                                                   |
-| `server.jdwp.enabled`                          | Enable Java Debug Wire Protocol (JDWP)                              | `false`                                                 |
-| `server.jdwp.port`                             | JDWP TCP port                                                       | `5005`                                                  |
+| Parameter                                    | Description                                                                                            | Default                                                 |
+|----------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `server.image.registry`                      | Spring Cloud Dataflow image registry                                                                   | `docker.io`                                             |
+| `server.image.repository`                    | Spring Cloud Dataflow image name                                                                       | `bitnami/spring-cloud-dataflow`                         |
+| `server.image.tag`                           | Spring Cloud Dataflow image tag                                                                        | `{TAG_NAME}`                                            |
+| `server.image.pullPolicy`                    | Spring Cloud Dataflow image pull policy                                                                | `IfNotPresent`                                          |
+| `server.image.pullSecrets`                   | Specify docker-registry secret names as an array                                                       | `[]` (does not add image pull secrets to deployed pods) |
+| `server.composedTaskRunner.image.registry`   | Spring Cloud Dataflow Composed Task Runner image registry                                              | `docker.io`                                             |
+| `server.composedTaskRunner.image.repository` | Spring Cloud Dataflow Composed Task Runner image name                                                  | `bitnami/spring-cloud-dataflow-composed-task-runner`    |
+| `server.composedTaskRunner.image.tag`        | Spring Cloud Dataflow Composed Task Runner image tag                                                   | `{TAG_NAME}`                                            |
+| `server.configuration.streamingEnabled`      | Enables or disables streaming data processing                                                          | `true`                                                  |
+| `server.configuration.batchEnabled`          | Enables or disables bath data (tasks and schedules) processing                                         | `true`                                                  |
+| `server.configuration.accountName`           | The name of the account to configure for the Kubernetes platform                                       | `default`                                               |
+| `server.configuration.trustK8sCerts`         | Trust K8s certificates when querying the Kubernetes API                                                | `false`                                                 |
+| `server.configuration.containerRegistries`   | Container registries configuration                                                                     | `{}` (check `values.yaml` for more information)         |
+| `server.existingConfigmap`                   | Name of existing ConfigMap with Dataflow server configuration                                          | `nil`                                                   |
+| `server.extraEnvVars`                        | Extra environment variables to be set on Dataflow server container                                     | `{}`                                                    |
+| `server.extraEnvVarsCM`                      | Name of existing ConfigMap containing extra env vars                                                   | `nil`                                                   |
+| `server.extraEnvVarsSecret`                  | Name of existing Secret containing extra env vars                                                      | `nil`                                                   |
+| `server.replicaCount`                        | Number of Dataflow server replicas to deploy                                                           | `1`                                                     |
+| `server.strategyType`                        | Deployment Strategy Type                                                                               | `RollingUpdate`                                         |
+| `server.affinity`                            | Affinity for pod assignment                                                                            | `{}` (evaluated as a template)                          |
+| `server.nodeSelector`                        | Node labels for pod assignment                                                                         | `{}` (evaluated as a template)                          |
+| `server.tolerations`                         | Tolerations for pod assignment                                                                         | `[]` (evaluated as a template)                          |
+| `server.priorityClassName`                   | Controller priorityClassName                                                                           | `nil`                                                   |
+| `server.podSecurityContext`                  | Dataflow server pods' Security Context                                                                 | `{ fsGroup: "1001" }`                                   |
+| `server.containerSecurityContext`            | Dataflow server containers' Security Context                                                           | `{ runAsUser: "1001" }`                                 |
+| `server.resources.limits`                    | The resources limits for the Dataflow server container                                                 | `{}`                                                    |
+| `server.resources.requests`                  | The requested resources for the Dataflow server container                                              | `{}`                                                    |
+| `server.podAnnotations`                      | Annotations for Dataflow server pods                                                                   | `{}`                                                    |
+| `server.livenessProbe`                       | Liveness probe configuration for Dataflow server                                                       | Check `values.yaml` file                                |
+| `server.readinessProbe`                      | Readiness probe configuration for Dataflow server                                                      | Check `values.yaml` file                                |
+| `server.customLivenessProbe`                 | Override default liveness probe                                                                        | `nil`                                                   |
+| `server.customReadinessProbe`                | Override default readiness probe                                                                       | `nil`                                                   |
+| `server.service.type`                        | Kubernetes service type                                                                                | `ClusterIP`                                             |
+| `server.service.port`                        | Service HTTP port                                                                                      | `8080`                                                  |
+| `server.service.nodePort`                    | Service HTTP node port                                                                                 | `nil`                                                   |
+| `server.service.clusterIP`                   | Dataflow server service clusterIP IP                                                                   | `None`                                                  |
+| `server.service.externalTrafficPolicy`       | Enable client source IP preservation                                                                   | `Cluster`                                               |
+| `server.service.loadBalancerIP`              | loadBalancerIP if service type is `LoadBalancer`                                                       | `nil`                                                   |
+| `server.service.loadBalancerSourceRanges`    | Address that are allowed when service is LoadBalancer                                                  | `[]`                                                    |
+| `server.service.annotations`                 | Annotations for Dataflow server service                                                                | `{}`                                                    |
+| `server.ingress.enabled`                     | Enable ingress controller resource                                                                     | `false`                                                 |
+| `server.ingress.certManager`                 | Add annotations for cert-manager                                                                       | `false`                                                 |
+| `server.ingress.hostname`                    | Default host for the ingress resource                                                                  | `dataflow.local`                                        |
+| `server.ingress.annotations`                 | Ingress annotations                                                                                    | `[]`                                                    |
+| `server.ingress.extraHosts[0].name`          | Additional hostnames to be covered                                                                     | `nil`                                                   |
+| `server.ingress.extraHosts[0].path`          | Additional hostnames to be covered                                                                     | `nil`                                                   |
+| `server.ingress.extraTls[0].hosts[0]`        | TLS configuration for additional hostnames to be covered                                               | `nil`                                                   |
+| `server.ingress.extraTls[0].secretName`      | TLS configuration for additional hostnames to be covered                                               | `nil`                                                   |
+| `server.ingress.secrets[0].name`             | TLS Secret Name                                                                                        | `nil`                                                   |
+| `server.ingress.secrets[0].certificate`      | TLS Secret Certificate                                                                                 | `nil`                                                   |
+| `server.ingress.secrets[0].key`              | TLS Secret Key                                                                                         | `nil`                                                   |
+| `server.initContainers`                      | Add additional init containers to the Dataflow server pods                                             | `{}` (evaluated as a template)                          |
+| `server.sidecars`                            | Add additional sidecar containers to the Dataflow server pods                                          | `{}` (evaluated as a template)                          |
+| `server.pdb.create`                          | Enable/disable a Pod Disruption Budget creation                                                        | `false`                                                 |
+| `server.pdb.minAvailable`                    | Minimum number/percentage of pods that should remain scheduled                                         | `1`                                                     |
+| `server.pdb.maxUnavailable`                  | Maximum number/percentage of pods that may be made unavailable                                         | `nil`                                                   |
+| `server.autoscaling.enabled`                 | Enable autoscaling for Dataflow server                                                                 | `false`                                                 |
+| `server.autoscaling.minReplicas`             | Minimum number of Dataflow server replicas                                                             | `nil`                                                   |
+| `server.autoscaling.maxReplicas`             | Maximum number of Dataflow server replicas                                                             | `nil`                                                   |
+| `server.autoscaling.targetCPU`               | Target CPU utilization percentage                                                                      | `nil`                                                   |
+| `server.autoscaling.targetMemory`            | Target Memory utilization percentage                                                                   | `nil`                                                   |
+| `server.jdwp.enabled`                        | Enable Java Debug Wire Protocol (JDWP)                                                                 | `false`                                                 |
+| `server.jdwp.port`                           | JDWP TCP port                                                                                          | `5005`                                                  |
 
 ### Dataflow Skipper parameters
 
-| Parameter                                  | Description                                                         | Default                                                 |
-|--------------------------------------------|---------------------------------------------------------------------|---------------------------------------------------------|
-| `skipper.enabled`                          | Enable Spring Cloud Skipper component                               | `true`                                                  |
-| `skipper.image.registry`                   | Spring Cloud Skipper image registry                                 | `docker.io`                                             |
-| `skipper.image.repository`                 | Spring Cloud Skipper image name                                     | `bitnami/spring-cloud-dataflow`                         |
-| `skipper.image.tag`                        | Spring Cloud Skipper image tag                                      | `{TAG_NAME}`                                            |
-| `skipper.image.pullPolicy`                 | Spring Cloud Skipper image pull policy                              | `IfNotPresent`                                          |
-| `skipper.image.pullSecrets`                | Specify docker-registry secret names as an array                    | `[]` (does not add image pull secrets to deployed pods) |
-| `skipper.configuration.accountName`        | The name of the account to configure for the Kubernetes platform    | `default`                                               |
-| `skipper.configuration.trustK8sCerts`      | Trust K8s certificates when querying the Kubernetes API             | `false`                                                 |
-| `skipper.existingConfigmap`                | Name of existing ConfigMap with Skipper server configuration        | `nil`                                                   |
-| `skipper.extraEnvVars`                     | Extra environment variables to be set on Skipper server container   | `{}`                                                    |
-| `skipper.extraEnvVarsCM`                   | Name of existing ConfigMap containing extra env vars                | `nil`                                                   |
-| `skipper.extraEnvVarsSecret`               | Name of existing Secret containing extra env vars                   | `nil`                                                   |
-| `skipper.replicaCount`                     | Number of Skipper server replicas to deploy                         | `1`                                                     |
-| `skipper.strategyType`                     | Deployment Strategy Type                                            | `RollingUpdate`                                         |
-| `skipper.affinity`                         | Affinity for pod assignment                                         | `{}` (evaluated as a template)                          |
-| `skipper.nodeSelector`                     | Node labels for pod assignment                                      | `{}` (evaluated as a template)                          |
-| `skipper.tolerations`                      | Tolerations for pod assignment                                      | `[]` (evaluated as a template)                          |
-| `skipper.priorityClassName`                | Controller priorityClassName                                        | `nil`                                                   |
-| `skipper.podSecurityContext`               | Skipper server pods' Security Context                               | `{ fsGroup: "1001" }`                                   |
-| `skipper.containerSecurityContext`         | Skipper server containers' Security Context                         | `{ runAsUser: "1001" }`                                 |
-| `skipper.resources.limits`                 | The resources limits for the Skipper server container               | `{}`                                                    |
-| `skipper.resources.requests`               | The requested resources for the Skipper server container            | `{}`                                                    |
-| `skipper.podAnnotations`                   | Annotations for Skipper server pods                                 | `{}`                                                    |
-| `skipper.livenessProbe`                    | Liveness probe configuration for Skipper server                     | Check `values.yaml` file                                |
-| `skipper.readinessProbe`                   | Readiness probe configuration for Skipper server                    | Check `values.yaml` file                                |
-| `skipper.customLivenessProbe`              | Override default liveness probe                                     | `nil`                                                   |
-| `skipper.customReadinessProbe`             | Override default readiness probe                                    | `nil`                                                   |
-| `skipper.service.type`                     | Kubernetes service type                                             | `ClusterIP`                                             |
-| `skipper.service.port`                     | Service HTTP port                                                   | `8080`                                                  |
-| `skipper.service.nodePort`                 | Service HTTP node port                                              | `nil`                                                   |
-| `skipper.service.clusterIP`                | Skipper server service clusterIP IP                                 | `None`                                                  |
-| `skipper.service.externalTrafficPolicy`    | Enable client source IP preservation                                | `Cluster`                                               |
-| `skipper.service.loadBalancerIP`           | loadBalancerIP if service type is `LoadBalancer`                    | `nil`                                                   |
-| `skipper.service.loadBalancerSourceRanges` | Address that are allowed when service is LoadBalancer               | `[]`                                                    |
-| `skipper.service.annotations`              | Annotations for Skipper server service                              | `{}`                                                    |
-| `skipper.initContainers`                   | Add additional init containers to the Skipper pods                  | `{}` (evaluated as a template)                          |
-| `skipper.sidecars`                         | Add additional sidecar containers to the Skipper pods               | `{}` (evaluated as a template)                          |
-| `skipper.pdb.create`                       | Enable/disable a Pod Disruption Budget creation                     | `false`                                                 |
-| `skipper.pdb.minAvailable`                 | Minimum number/percentage of pods that should remain scheduled      | `1`                                                     |
-| `skipper.pdb.maxUnavailable`               | Maximum number/percentage of pods that may be made unavailable      | `nil`                                                   |
-| `skipper.autoscaling.enabled`              | Enable autoscaling for Skipper server                               | `false`                                                 |
-| `skipper.autoscaling.minReplicas`          | Minimum number of Skipper server replicas                           | `nil`                                                   |
-| `skipper.autoscaling.maxReplicas`          | Maximum number of Skipper server replicas                           | `nil`                                                   |
-| `skipper.autoscaling.targetCPU`            | Target CPU utilization percentage                                   | `nil`                                                   |
-| `skipper.autoscaling.targetMemory`         | Target Memory utilization percentage                                | `nil`                                                   |
-| `skipper.jdwp.enabled`                     | Enable Java Debug Wire Protocol (JDWP)                              | `false`                                                 |
-| `skipper.jdwp.port`                        | JDWP TCP port                                                       | `5005`                                                  |
-| `externalSkipper.host`                     | Host of a external Skipper Server                                   | `localhost`                                             |
-| `externalSkipper.port`                     | External Skipper Server port number                                 | `7577`                                                  |
+| Parameter                                    | Description                                                                                            | Default                                                 |
+|----------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `skipper.enabled`                            | Enable Spring Cloud Skipper component                                                                  | `true`                                                  |
+| `skipper.image.registry`                     | Spring Cloud Skipper image registry                                                                    | `docker.io`                                             |
+| `skipper.image.repository`                   | Spring Cloud Skipper image name                                                                        | `bitnami/spring-cloud-dataflow`                         |
+| `skipper.image.tag`                          | Spring Cloud Skipper image tag                                                                         | `{TAG_NAME}`                                            |
+| `skipper.image.pullPolicy`                   | Spring Cloud Skipper image pull policy                                                                 | `IfNotPresent`                                          |
+| `skipper.image.pullSecrets`                  | Specify docker-registry secret names as an array                                                       | `[]` (does not add image pull secrets to deployed pods) |
+| `skipper.configuration.accountName`          | The name of the account to configure for the Kubernetes platform                                       | `default`                                               |
+| `skipper.configuration.trustK8sCerts`        | Trust K8s certificates when querying the Kubernetes API                                                | `false`                                                 |
+| `skipper.existingConfigmap`                  | Name of existing ConfigMap with Skipper server configuration                                           | `nil`                                                   |
+| `skipper.extraEnvVars`                       | Extra environment variables to be set on Skipper server container                                      | `{}`                                                    |
+| `skipper.extraEnvVarsCM`                     | Name of existing ConfigMap containing extra env vars                                                   | `nil`                                                   |
+| `skipper.extraEnvVarsSecret`                 | Name of existing Secret containing extra env vars                                                      | `nil`                                                   |
+| `skipper.replicaCount`                       | Number of Skipper server replicas to deploy                                                            | `1`                                                     |
+| `skipper.strategyType`                       | Deployment Strategy Type                                                                               | `RollingUpdate`                                         |
+| `skipper.affinity`                           | Affinity for pod assignment                                                                            | `{}` (evaluated as a template)                          |
+| `skipper.nodeSelector`                       | Node labels for pod assignment                                                                         | `{}` (evaluated as a template)                          |
+| `skipper.tolerations`                        | Tolerations for pod assignment                                                                         | `[]` (evaluated as a template)                          |
+| `skipper.priorityClassName`                  | Controller priorityClassName                                                                           | `nil`                                                   |
+| `skipper.podSecurityContext`                 | Skipper server pods' Security Context                                                                  | `{ fsGroup: "1001" }`                                   |
+| `skipper.containerSecurityContext`           | Skipper server containers' Security Context                                                            | `{ runAsUser: "1001" }`                                 |
+| `skipper.resources.limits`                   | The resources limits for the Skipper server container                                                  | `{}`                                                    |
+| `skipper.resources.requests`                 | The requested resources for the Skipper server container                                               | `{}`                                                    |
+| `skipper.podAnnotations`                     | Annotations for Skipper server pods                                                                    | `{}`                                                    |
+| `skipper.livenessProbe`                      | Liveness probe configuration for Skipper server                                                        | Check `values.yaml` file                                |
+| `skipper.readinessProbe`                     | Readiness probe configuration for Skipper server                                                       | Check `values.yaml` file                                |
+| `skipper.customLivenessProbe`                | Override default liveness probe                                                                        | `nil`                                                   |
+| `skipper.customReadinessProbe`               | Override default readiness probe                                                                       | `nil`                                                   |
+| `skipper.service.type`                       | Kubernetes service type                                                                                | `ClusterIP`                                             |
+| `skipper.service.port`                       | Service HTTP port                                                                                      | `8080`                                                  |
+| `skipper.service.nodePort`                   | Service HTTP node port                                                                                 | `nil`                                                   |
+| `skipper.service.clusterIP`                  | Skipper server service clusterIP IP                                                                    | `None`                                                  |
+| `skipper.service.externalTrafficPolicy`      | Enable client source IP preservation                                                                   | `Cluster`                                               |
+| `skipper.service.loadBalancerIP`             | loadBalancerIP if service type is `LoadBalancer`                                                       | `nil`                                                   |
+| `skipper.service.loadBalancerSourceRanges`   | Address that are allowed when service is LoadBalancer                                                  | `[]`                                                    |
+| `skipper.service.annotations`                | Annotations for Skipper server service                                                                 | `{}`                                                    |
+| `skipper.initContainers`                     | Add additional init containers to the Skipper pods                                                     | `{}` (evaluated as a template)                          |
+| `skipper.sidecars`                           | Add additional sidecar containers to the Skipper pods                                                  | `{}` (evaluated as a template)                          |
+| `skipper.pdb.create`                         | Enable/disable a Pod Disruption Budget creation                                                        | `false`                                                 |
+| `skipper.pdb.minAvailable`                   | Minimum number/percentage of pods that should remain scheduled                                         | `1`                                                     |
+| `skipper.pdb.maxUnavailable`                 | Maximum number/percentage of pods that may be made unavailable                                         | `nil`                                                   |
+| `skipper.autoscaling.enabled`                | Enable autoscaling for Skipper server                                                                  | `false`                                                 |
+| `skipper.autoscaling.minReplicas`            | Minimum number of Skipper server replicas                                                              | `nil`                                                   |
+| `skipper.autoscaling.maxReplicas`            | Maximum number of Skipper server replicas                                                              | `nil`                                                   |
+| `skipper.autoscaling.targetCPU`              | Target CPU utilization percentage                                                                      | `nil`                                                   |
+| `skipper.autoscaling.targetMemory`           | Target Memory utilization percentage                                                                   | `nil`                                                   |
+| `skipper.jdwp.enabled`                       | Enable Java Debug Wire Protocol (JDWP)                                                                 | `false`                                                 |
+| `skipper.jdwp.port`                          | JDWP TCP port                                                                                          | `5005`                                                  |
+| `externalSkipper.host`                       | Host of a external Skipper Server                                                                      | `localhost`                                             |
+| `externalSkipper.port`                       | External Skipper Server port number                                                                    | `7577`                                                  |
 
 ### RBAC parameters
 
-| Parameter                | Description                                                                          | Default                                       |
-|------------------------- |--------------------------------------------------------------------------------------|---------------------------------------------- |
-| `serviceAccount.create`  | Enable the creation of a ServiceAccount for Dataflow server and Skipper server pods  | `true`                                        |
-| `serviceAccount.name`    | Name of the created serviceAccount                                                   | Generated using the `scdf.fullname` template  |
-| `rbac.create`            | Weather to create & use RBAC resources or not                                        | `true`                                        |
+| Parameter                                    | Description                                                                                            | Default                                                 |
+|----------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `serviceAccount.create`                      | Enable the creation of a ServiceAccount for Dataflow server and Skipper server pods                    | `true`                                                  |
+| `serviceAccount.name`                        | Name of the created serviceAccount                                                                     | Generated using the `scdf.fullname` template            |
+| `rbac.create`                                | Weather to create & use RBAC resources or not                                                          | `true`                                                  |
 
 ### Metrics parameters
 
-| Parameter                                       | Description                                                                                            | Default                                                 |
-|-------------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `metrics.metrics`                               | Enable the export of Prometheus metrics                                                                | `false`                                                 |
-| `metrics.image.registry`                        | Prometheus Rsocket Proxy image registry                                                                | `docker.io`                                             |
-| `metrics.image.repository`                      | Prometheus Rsocket Proxy image name                                                                    | `bitnami/prometheus-rsocket-proxy`                      |
-| `metrics.image.tag`                             | Prometheus Rsocket Proxy image tag                                                                     | `{TAG_NAME}`                                            |
-| `metrics.image.pullPolicy`                      | Prometheus Rsocket Proxy image pull policy                                                             | `IfNotPresent`                                          |
-| `metrics.image.pullSecrets`                     | Specify docker-registry secret names as an array                                                       | `[]` (does not add image pull secrets to deployed pods) |
-| `metrics.kafka.service.httpPort`                | Prometheus Rsocket Proxy HTTP port                                                                     | `8080`                                                  |
-| `metrics.kafka.service.rsocketPort`             | Prometheus Rsocket Proxy Rsocket port                                                                  | `8080`                                                  |
-| `metrics.kafka.service.annotations`             | Annotations for Prometheus Rsocket Proxy service                                                       | `Check values.yaml file`                                |
-| `metrics.serviceMonitor.enabled`                | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`) | `false`                                                 |
-| `metrics.serviceMonitor.namespace`              | Namespace in which Prometheus is running                                                               | `nil`                                                   |
-| `metrics.serviceMonitor.interval`               | Interval at which metrics should be scraped.                                                           | `nil` (Prometheus Operator default value)               |
-| `metrics.serviceMonitor.scrapeTimeout`          | Timeout after which the scrape is ended                                                                | `nil` (Prometheus Operator default value)               |
+| Parameter                                    | Description                                                                                            | Default                                                 |
+|----------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `metrics.metrics`                            | Enable the export of Prometheus metrics                                                                | `false`                                                 |
+| `metrics.image.registry`                     | Prometheus Rsocket Proxy image registry                                                                | `docker.io`                                             |
+| `metrics.image.repository`                   | Prometheus Rsocket Proxy image name                                                                    | `bitnami/prometheus-rsocket-proxy`                      |
+| `metrics.image.tag`                          | Prometheus Rsocket Proxy image tag                                                                     | `{TAG_NAME}`                                            |
+| `metrics.image.pullPolicy`                   | Prometheus Rsocket Proxy image pull policy                                                             | `IfNotPresent`                                          |
+| `metrics.image.pullSecrets`                  | Specify docker-registry secret names as an array                                                       | `[]` (does not add image pull secrets to deployed pods) |
+| `metrics.kafka.service.httpPort`             | Prometheus Rsocket Proxy HTTP port                                                                     | `8080`                                                  |
+| `metrics.kafka.service.rsocketPort`          | Prometheus Rsocket Proxy Rsocket port                                                                  | `8080`                                                  |
+| `metrics.kafka.service.annotations`          | Annotations for Prometheus Rsocket Proxy service                                                       | `Check values.yaml file`                                |
+| `metrics.serviceMonitor.enabled`             | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`) | `false`                                                 |
+| `metrics.serviceMonitor.namespace`           | Namespace in which Prometheus is running                                                               | `nil`                                                   |
+| `metrics.serviceMonitor.interval`            | Interval at which metrics should be scraped.                                                           | `nil` (Prometheus Operator default value)               |
+| `metrics.serviceMonitor.scrapeTimeout`       | Timeout after which the scrape is ended                                                                | `nil` (Prometheus Operator default value)               |
 
 ### Init Container parameters
 
-| Parameter                                       | Description                                                                                            | Default                                                 |
-|-------------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `waitForBackends.enabled`                       | Wait for the database and other services (such as Kafka or RabbitMQ) used when enabling streaming      | `true`                                                  |
-| `waitForBackends.image.registry`                | Init container wait-for-backend image registry                                                         | `docker.io`                                             |
-| `waitForBackends.image.repository`              | Init container wait-for-backend image name                                                             | `bitnami/kubectl`                                       |
-| `waitForBackends.image.tag`                     | Init container wait-for-backend image tag                                                              | `{TAG_NAME}`                                            |
-| `waitForBackends.image.pullPolicy`              | Init container wait-for-backend image pull policy                                                      | `IfNotPresent`                                          |
-| `waitForBackends.image.pullSecrets`             | Specify docker-registry secret names as an array                                                       | `[]` (does not add image pull secrets to deployed pods) |
-| `waitForBackends.resources.limits`              | Init container wait-for-backend resource  limits                                                       | `{}`                                                    |
-| `waitForBackends.resources.requests`            | Init container wait-for-backend resource  requests                                                     | `{}`                                                    |
+| Parameter                                    | Description                                                                                            | Default                                                 |
+|----------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `waitForBackends.enabled`                    | Wait for the database and other services (such as Kafka or RabbitMQ) used when enabling streaming      | `true`                                                  |
+| `waitForBackends.image.registry`             | Init container wait-for-backend image registry                                                         | `docker.io`                                             |
+| `waitForBackends.image.repository`           | Init container wait-for-backend image name                                                             | `bitnami/kubectl`                                       |
+| `waitForBackends.image.tag`                  | Init container wait-for-backend image tag                                                              | `{TAG_NAME}`                                            |
+| `waitForBackends.image.pullPolicy`           | Init container wait-for-backend image pull policy                                                      | `IfNotPresent`                                          |
+| `waitForBackends.image.pullSecrets`          | Specify docker-registry secret names as an array                                                       | `[]` (does not add image pull secrets to deployed pods) |
+| `waitForBackends.resources.limits`           | Init container wait-for-backend resource  limits                                                       | `{}`                                                    |
+| `waitForBackends.resources.requests`         | Init container wait-for-backend resource  requests                                                     | `{}`                                                    |
 
 ### Database parameters
 
-| Parameter                                       | Description                                                             | Default                             |
-|-------------------------------------------------|-------------------------------------------------------------------------|-------------------------------------|
-| `mariadb.enabled`                               | Enable/disable MariaDB chart installation                               | `true`                              |
-| `mariadb.replication.enabled`                   | MariaDB replication enabled                                             | `false`                             |
-| `mariadb.db.name`                               | Name for new database to create                                         | `dataflow`                          |
-| `mariadb.db.user`                               | Username of new user to create                                          | `dataflow`                          |
-| `mariadb.db.password`                           | Password for the new user                                               | `change-me`_                        |
-| `mariadb.initdbScripts`                         | Dictionary of initdb scripts                                            | Check `values.yaml` file            |
-| `externalDatabase.host`                         | Host of the external database                                           | `localhost`                         |
-| `externalDatabase.port`                         | External database port number                                           | `3306`                              |
-| `externalDatabase.password`                     | Password for the above username                                         | `""`                                |
-| `externalDatabase.existingPasswordSecret`       | Existing secret with database password                                  | `""`                                |
-| `externalDatabase.dataflow.user`                | Existing username in the external db to be used by Dataflow server      | `dataflow`                          |
-| `externalDatabase.dataflow.database`            | Name of the existing database to be used by Dataflow server             | `dataflow`                          |
-| `externalDatabase.skipper.user`                 | Existing username in the external db to be used by Skipper server       | `skipper`                           |
-| `externalDatabase.skipper.database`             | Name of the existing database to be used by Skipper server              | `skipper`                           |
-| `externalDatabase.hibernateDialect`             | Hibernate Dialect used by Dataflow/Skipper servers                      | `""`                                |
+| Parameter                                    | Description                                                                                            | Default                                                 |
+|----------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `mariadb.enabled`                            | Enable/disable MariaDB chart installation                                                              | `true`                                                  |
+| `mariadb.replication.enabled`                | MariaDB replication enabled                                                                            | `false`                                                 |
+| `mariadb.db.name`                            | Name for new database to create                                                                        | `dataflow`                                              |
+| `mariadb.db.user`                            | Username of new user to create                                                                         | `dataflow`                                              |
+| `mariadb.db.password`                        | Password for the new user                                                                              | `change-me`_                                            |
+| `mariadb.initdbScripts`                      | Dictionary of initdb scripts                                                                           | Check `values.yaml` file                                |
+| `externalDatabase.host`                      | Host of the external database                                                                          | `localhost`                                             |
+| `externalDatabase.port`                      | External database port number                                                                          | `3306`                                                  |
+| `externalDatabase.password`                  | Password for the above username                                                                        | `""`                                                    |
+| `externalDatabase.existingPasswordSecret`    | Existing secret with database password                                                                 | `""`                                                    |
+| `externalDatabase.dataflow.user`             | Existing username in the external db to be used by Dataflow server                                     | `dataflow`                                              |
+| `externalDatabase.dataflow.database`         | Name of the existing database to be used by Dataflow server                                            | `dataflow`                                              |
+| `externalDatabase.skipper.user`              | Existing username in the external db to be used by Skipper server                                      | `skipper`                                               |
+| `externalDatabase.skipper.database`          | Name of the existing database to be used by Skipper server                                             | `skipper`                                               |
+| `externalDatabase.hibernateDialect`          | Hibernate Dialect used by Dataflow/Skipper servers                                                     | `""`                                                    |
 
 ### RabbitMQ chart parameters
 
-| Parameter                                       | Description                                                             | Default                                                 |
-|-------------------------------------------------|-------------------------------------------------------------------------|---------------------------------------------------------|
-| `rabbitmq.enabled`                              | Enable/disable RabbitMQ chart installation                              | `true`                                                  |
-| `rabbitmq.auth.username`                        | RabbitMQ username                                                       | `user`                                                  |
-| `rabbitmq.auth.password`                        | RabbitMQ password                                                       | _random 40 character alphanumeric string_               |
-| `externalRabbitmq.enabled`                      | Enable/disable external RabbitMQ                                        | `false`                                                 |
-| `externalRabbitmq.host`                         | Host of the external RabbitMQ                                           | `localhost`                                             |
-| `externalRabbitmq.port`                         | External RabbitMQ port number                                           | `5672`                                                  |
-| `externalRabbitmq.username`                     | External RabbitMQ username                                              | `guest`                                                 |
-| `externalRabbitmq.password`                     | External RabbitMQ password                                              | `guest`                                                 |
-| `externalRabbitmq.vhost`                        | External RabbitMQ virtual host                                          | `/`                                                     |
-| `externalRabbitmq.existingPasswordSecret`       | Existing secret with RabbitMQ password                                  | `""`                                                    |
+| Parameter                                    | Description                                                                                            | Default                                                 |
+|----------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `rabbitmq.enabled`                           | Enable/disable RabbitMQ chart installation                                                             | `true`                                                  |
+| `rabbitmq.auth.username`                     | RabbitMQ username                                                                                      | `user`                                                  |
+| `rabbitmq.auth.password`                     | RabbitMQ password                                                                                      | _random 40 character alphanumeric string_               |
+| `externalRabbitmq.enabled`                   | Enable/disable external RabbitMQ                                                                       | `false`                                                 |
+| `externalRabbitmq.host`                      | Host of the external RabbitMQ                                                                          | `localhost`                                             |
+| `externalRabbitmq.port`                      | External RabbitMQ port number                                                                          | `5672`                                                  |
+| `externalRabbitmq.username`                  | External RabbitMQ username                                                                             | `guest`                                                 |
+| `externalRabbitmq.password`                  | External RabbitMQ password                                                                             | `guest`                                                 |
+| `externalRabbitmq.vhost`                     | External RabbitMQ virtual host                                                                         | `/`                                                     |
+| `externalRabbitmq.existingPasswordSecret`    | Existing secret with RabbitMQ password                                                                 | `""`                                                    |
 
 ### Kafka chart parameters
 
-| Parameter                                       | Description                                                             | Default                                                 |
-|-------------------------------------------------|-------------------------------------------------------------------------|---------------------------------------------------------|
-| `kafka.enabled`                                 | Enable/disable Kafka chart installation                                 | `false`                                                 |
-| `kafka.replicaCount`                            | Number of Kafka brokers                                                 | `1`                                                     |
-| `kafka.offsetsTopicReplicationFactor`           | Kafka Secret Key                                                        | `1`                                                     |
-| `kafka.zookeeper.enabled`                       | Enable/disable Zookeeper chart installation                             | `nil`                                                   |
-| `kafka.zookeeper.replicaCount`                  | Number of Zookeeper replicas                                            | `1`                                                     |
+| Parameter                                    | Description                                                                                            | Default                                                 |
+|----------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `kafka.enabled`                              | Enable/disable Kafka chart installation                                                                | `false`                                                 |
+| `kafka.replicaCount`                         | Number of Kafka brokers                                                                                | `1`                                                     |
+| `kafka.offsetsTopicReplicationFactor`        | Kafka Secret Key                                                                                       | `1`                                                     |
+| `kafka.zookeeper.enabled`                    | Enable/disable Zookeeper chart installation                                                            | `nil`                                                   |
+| `kafka.zookeeper.replicaCount`               | Number of Zookeeper replicas                                                                           | `1`                                                     |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/spring-cloud-dataflow/templates/NOTES.txt
+++ b/bitnami/spring-cloud-dataflow/templates/NOTES.txt
@@ -64,6 +64,7 @@ To access Spring Cloud Data Flow dashboard from outside the cluster execute the 
 2. Open a browser and access the Data Flow dashboard using the obtained URL.
 
 {{- include "common.warnings.rollingTag" .Values.server.image }}
+{{- include "common.warnings.rollingTag" .Values.server.composedTaskRunner.image }}
 {{- include "common.warnings.rollingTag" .Values.skipper.image }}
 {{- include "common.warnings.rollingTag" .Values.waitForBackends.image }}
 {{- include "scdf.validateValues" . }}

--- a/bitnami/spring-cloud-dataflow/templates/server/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/deployment.yaml
@@ -126,6 +126,8 @@ spec:
             - name: JAVA_TOOL_OPTIONS
               value: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address={{ .Values.server.jdwp.port }}"
             {{- end }}
+            - name: SPRING_CLOUD_DATAFLOW_TASK_COMPOSED_TASK_RUNNER_URI
+              value: 'docker://{{ include "common.images.image" (dict "imageRoot" .Values.server.composedTaskRunner.image) }}'
             {{- range $key, $value := .Values.server.extraEnvVars }}
             - name: {{ $key }}
               value: "{{ $value }}"

--- a/bitnami/spring-cloud-dataflow/values-production.yaml
+++ b/bitnami/spring-cloud-dataflow/values-production.yaml
@@ -44,6 +44,15 @@ server:
     ##
     debug: false
 
+  composedTaskRunner:
+    ## Bitnami Spring Cloud Dataflow Composed Task Runner image
+    ## ref: https://hub.docker.com/r/bitnami/spring-cloud-dataflow/tags/
+    ##
+    image:
+      registry: docker.io
+      repository: bitnami/spring-cloud-dataflow-composed-task-runner
+      tag: 2.6.1-debian-10-r0
+
   ## Spring Cloud Dataflow Server configuration parameters
   ##
   configuration:

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -44,6 +44,15 @@ server:
     ##
     debug: false
 
+  composedTaskRunner:
+    ## Bitnami Spring Cloud Dataflow Composed Task Runner image
+    ## ref: https://hub.docker.com/r/bitnami/spring-cloud-dataflow/tags/
+    ##
+    image:
+      registry: docker.io
+      repository: bitnami/spring-cloud-dataflow-composed-task-runner
+      tag: 2.6.1-debian-10-r0
+
   ## Spring Cloud Dataflow Server configuration parameters
   ##
   configuration:


### PR DESCRIPTION
**Description of the change**

This PR adds an environment variable that is set to point to an image containing the CTR `bitnami/spring-cloud-dataflow-composed-task-runner`.

**Benefits**

With those changes, we are going to be able to run a composed task in our dataflow deployments

**Possible drawbacks**

N/A

**Applicable issues**

  - fixes #3571

**Additional information**

- `bitnami/spring-cloud-dataflow-composed-task-runner` is being developed at the same time as this PR which shouldn't be merged until the image is properly released.

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

