### PR TITLE
[bitnami/consul] fix: use the service DNS instead pod DNS for joinning

### DIFF
--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: consul
-version: 7.1.6
+version: 7.1.7
 appVersion: 1.8.3
 description: Highly available and distributed service discovery and key-value store designed with support for the modern data center to make distributed systems and configuration easy.
 home: https://github.com/bitnami/charts/tree/master/bitnami/consul

--- a/bitnami/consul/templates/_helpers.tpl
+++ b/bitnami/consul/templates/_helpers.tpl
@@ -205,3 +205,16 @@ Usage:
         {{- tpl (.value | toYaml) .context }}
     {{- end }}
 {{- end -}}
+
+{{/*
+Return retry_join endpoint for members to join the cluster
+Usage:
+{{ include "consul.retryjoin.endpoint" . }}
+*/}}
+{{- define "consul.retryjoin.endpoint" -}}
+    {{- $name := include "consul.fullname" . -}}
+    {{- $domain := .Values.clusterDomain -}}
+    {{- $namespace := .Release.Namespace -}}
+
+    {{- printf "%s.%s.svc.%s" $name $namespace $domain -}}
+{{- end -}}

--- a/bitnami/consul/templates/consul-configmap.yaml
+++ b/bitnami/consul/templates/consul-configmap.yaml
@@ -9,6 +9,6 @@ data:
   config.json: {{- toYaml .Values.configmap | nindent 4}}
   connection.json: |
     {
-      "retry_join": ["{{ template "consul.fullname" . }}-0.{{ template "consul.fullname" . }}.{{ .Release.Namespace }}.svc"]
+      "retry_join": ["{{ include "consul.retryjoin.endpoint" . }}"]
     }
 {{- end }}

--- a/bitnami/consul/templates/statefulset.yaml
+++ b/bitnami/consul/templates/statefulset.yaml
@@ -98,7 +98,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: CONSUL_RETRY_JOIN
-              value: {{ printf "%s-0.%s.%s.svc.%s" $consulFullName $consulHeadlessSvcName .Release.Namespace $clusterDomain | quote }}
+              value: {{ include "consul.retryjoin.endpoint" . | quote }}
             - name: CONSUL_DISABLE_KEYRING_FILE
               value: "true"
             - name: CONSUL_BOOTSTRAP_EXPECT

--- a/bitnami/consul/templates/statefulset.yaml
+++ b/bitnami/consul/templates/statefulset.yaml
@@ -88,9 +88,6 @@ spec:
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
           env:
-            {{- $consulFullName := include "consul.fullname" . }}
-            {{- $consulHeadlessSvcName := include "consul.fullname" . }}
-            {{- $clusterDomain := .Values.clusterDomain }}
             - name: BITNAMI_DEBUG
               value: {{ ternary "true" "false" .Values.image.debug | quote }}
             - name: CONSUL_NODE_NAME


### PR DESCRIPTION
Signed-off-by: darteaga <darteaga@vmware.com>

**Description of the change**

Change the DNS used by members for joining the cluster. 

Before: it was using pods DNS
After: it will use service DNS

**Benefits**

Member 0 of the cluster will be able to join the cluster after a restart. 

**Possible drawbacks**

N/A

**Applicable issues**

  - fixes #3626

**Additional information**


**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
