### PR TITLE
[bitname/node] Fix missing "-binding" suffix in PVC declaration, breaking the persistency feature

### DIFF
--- a/bitnami/node/Chart.yaml
+++ b/bitnami/node/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node
-version: 13.0.1
+version: 13.0.2
 appVersion: 10.22.0
 description: Event-driven I/O server-side JavaScript environment based on V8
 keywords:

--- a/bitnami/node/templates/deployment.yaml
+++ b/bitnami/node/templates/deployment.yaml
@@ -179,7 +179,7 @@ spec:
         - name: data
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ template "node.fullname" . }}
+            claimName: {{ template "node.fullname" . }}-binding
           {{- else }}
           emptyDir: {}
           {{- end }}


### PR DESCRIPTION
**Description of the change**

"-binding" suffix is missing from the deployment volume declaration, while it is present in the PVC description. Adding the suffix fixes the persistency feature of this chart, that is otherwise broken.

**Benefits**

Persistency will work properly.

**Possible drawbacks**

IMHO none.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**
N/A
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

