### PR TITLE
[bitnami/postgresql-ha] Add TLS support in PgPool

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql-ha
-version: 3.5.10
+version: 3.6.0
 appVersion: 11.9.0
 description: Chart for PostgreSQL with HA architecture (using Replication Manager (repmgr) and Pgpool).
 keywords:

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -311,7 +311,7 @@ For example:
     pgpool.tls.certKeyFilename="cert.key"
     ```
 
-    > Note TLS and VolumePermissions: PgPool requires certain permissions on sensitive files (such as certificate keys) to start up. Due to an on-going [issue](https://github.com/kubernetes/kubernetes/issues/57923) regarding kubernetes permissions and the use of `securityContext.runAsUser`, you must enable `volumePermissions` to ensure everything works as expected.
+    > Note TLS and VolumePermissions: PgPool requires certain permissions on sensitive files (such as certificate keys) to start up. Due to an on-going [issue](https://github.com/kubernetes/kubernetes/issues/57923) regarding kubernetes permissions and the use of `securityContext.runAsUser`, the `volumePermissions` init container will ensure everything works as expected.
 
 ### LDAP
 

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -154,7 +154,7 @@ The following table lists the configurable parameters of the PostgreSQL HA chart
 | `pgpool.configuration`                         | Content of pgpool.conf                                                                                                                                               | `nil`                                                        |
 | `pgpool.configurationCM`                       | ConfigMap with the Pgpool configuration file (Note: Overrides `pgpol.configuration`). The file used must be named `pgpool.conf`.                                     | `nil` (The value is evaluated as a template)                 |
 | `pgpool.useLoadBalancing`                      | If true, use Pgpool Load-Balancing                                                                                                                                   | `true`                                                       |
-| `pgpool.tls.enabled`                                 | Enable TLS traffic support                                                                                                                                                | `false`                                                       |
+| `pgpool.tls.enabled`                                 | Enable TLS traffic support for end-client connections                                                                                                                                               | `false`                                                       |
 | `pgpool.tls.preferServerCiphers`                     | Whether to use the server's TLS cipher preferences rather than the client's                                                                                               | `true`                                                        |
 | `pgpool.tls.certificatesSecret`                      | Name of an existing secret that contains the certificates                                                                                                                 | `nil`                                                         |
 | `pgpool.tls.certFilename`                            | Certificate filename                                                                                                                                                      | `""`                                                          |
@@ -287,7 +287,7 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 
 ### Securing Pgpool traffic using TLS
 
-TLS support can be enabled in the chart by specifying the `pgpool.tls.` parameters while creating a release. The following parameters should be configured to properly enable the TLS support in the chart:
+TLS for end-client connections can be enabled in the chart by specifying the `pgpool.tls.` parameters while creating a release. The following parameters should be configured to properly enable the TLS support in the chart:
 
 - `pgpool.tls.enabled`: Enable TLS support. Defaults to `false`
 - `pgpool.tls.certificatesSecret`: Name of an existing secret that contains the certificates. No defaults.
@@ -305,7 +305,6 @@ For example:
 * Then, use the following parameters:
 
     ```console
-    volumePermissions.enabled=true
     pgpool.tls.enabled=true
     pgpool.tls.certificatesSecret="certificates-pgpool.tls.secret"
     pgpool.tls.certFilename="cert.crt"

--- a/bitnami/postgresql-ha/templates/_helpers.tpl
+++ b/bitnami/postgresql-ha/templates/_helpers.tpl
@@ -618,7 +618,6 @@ Also, we can't use a single if because lazy evaluation is not an option
 {{- end -}}
 {{- end -}}
 
-
 {{/*
 Return the LDAP credentials secret.
 */}}
@@ -814,4 +813,25 @@ pool_passwd file.
 {{- else -}}
 {{- printf "%s-custom-users" (include "postgresql-ha.pgpool" .) -}}
 {{- end -}}
+{{- end -}}
+
+{{/*
+Return the path to the cert file.
+*/}}
+{{- define "postgresql-ha.pgpool.tlsCert" -}}
+{{- required "Certificate filename is required when TLS in enabled" .Values.pgpool.tls.certFilename | printf "/opt/bitnami/pgpool/certs/%s" -}}
+{{- end -}}
+
+{{/*
+Return the path to the cert key file.
+*/}}
+{{- define "postgresql-ha.pgpool.tlsCertKey" -}}
+{{- required "Certificate Key filename is required when TLS in enabled" .Values.pgpool.tls.certKeyFilename | printf "/opt/bitnami/pgpool/certs/%s" -}}
+{{- end -}}
+
+{{/*
+Return the path to the CA cert file.
+*/}}
+{{- define "postgresql-ha.pgpool.tlsCACert" -}}
+{{- printf "/opt/bitnami/pgpool/certs/%s" .Values.pgpool.tls.certCAFilename -}}
 {{- end -}}

--- a/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
@@ -50,7 +50,7 @@ spec:
       {{- if .Values.pgpool.tls.enabled }}
         - name: init-chmod-data
           image: {{ template "postgresql-ha.volumePermissionsImage" . }}
-          imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
+          imagePullPolicy: {{ .Values.volumePermissionsImage.pullPolicy | quote }}
           command:
             - /bin/sh
             - -cx

--- a/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       annotations: {{- include "postgresql-ha.tplValue" (dict "value" .Values.pgpool.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
     spec:
-{{- include "postgresql-ha.imagePullSecrets" . | indent 6 }}
+      {{- include "postgresql-ha.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.pgpool.affinity }}
       affinity: {{- include "postgresql-ha.tplValue" (dict "value" .Values.pgpool.affinity "context" $) | nindent 8 }}
       {{- end }}
@@ -45,6 +45,34 @@ spec:
       {{- if .Values.pgpool.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.pgpool.securityContext.fsGroup }}
+      {{- end }}
+      initContainers:
+      {{- if .Values.pgpool.tls.enabled }}
+        - name: init-chmod-data
+          image: {{ template "postgresql-ha.volumePermissionsImage" . }}
+          imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
+          command:
+            - /bin/sh
+            - -cx
+            - |
+              cp /tmp/certs/* /opt/bitnami/pgpool/certs/
+              {{- if eq ( toString ( .Values.volumePermissions.securityContext.runAsUser )) "auto" }}
+              chown -R `id -u`:`id -G | cut -d " " -f2` /opt/bitnami/pgpool/certs/
+              {{- else }}
+              chown -R {{ .Values.pgpool.securityContext.runAsUser }}:{{ .Values.pgpool.securityContext.fsGroup }} /opt/bitnami/pgpool/certs/
+              {{- end }}
+              chmod 600 {{ template "postgresql-ha.pgpool.tlsCertKey" . }}
+          {{- if eq ( toString ( .Values.volumePermissions.securityContext.runAsUser )) "auto" }}
+          securityContext:
+          {{- else }}
+          securityContext:
+            runAsUser: {{ .Values.volumePermissions.securityContext.runAsUser }}
+          {{- end }}
+          volumeMounts:
+            - name: raw-certificates
+              mountPath: /tmp/certs
+            - name: pgpool-certificates
+              mountPath: /opt/bitnami/pgpool/certs
       {{- end }}
       # Auxiliar vars to populate environment variables
       {{- $postgresqlReplicaCount := int .Values.postgresql.replicaCount }}
@@ -156,6 +184,20 @@ spec:
             - name: PGPOOL_NUM_INIT_CHILDREN
               value: {{ .Values.pgpool.numInitChildren | quote }}
             {{- end }}
+            - name: PGPOOL_ENABLE_TLS
+              value: {{ ternary "yes" "no" .Values.pgpool.tls.enabled | quote }}
+            {{- if .Values.pgpool.tls.enabled }}
+            - name: PGPOOL_TLS_PREFER_SERVER_CIPHERS
+              value: {{ ternary "yes" "no" .Values.pgpool.tls.preferServerCiphers | quote }}
+            - name: PGPOOL_TLS_CERT_FILE
+              value: {{ template "postgresql-ha.pgpool.tlsCert" . }}
+            - name: PGPOOL_TLS_KEY_FILE
+              value: {{ template "postgresql-ha.pgpool.tlsCertKey" . }}
+            {{- if .Values.pgpool.tls.certCAFilename }}
+            - name: PGPOOL_TLS_CA_FILE
+              value: {{ template "postgresql-ha.pgpool.tlsCACert" . }}
+            {{- end }}
+            {{- end }}
           ports:
             - name: postgresql
               containerPort: 5432
@@ -177,7 +219,7 @@ spec:
               command:
                 - bash
                 - -ec
-                - PGPASSWORD=${PGPOOL_POSTGRES_PASSWORD} psql -U {{ (include "postgresql-ha.postgresqlUsername" .) | quote }} {{- if not (empty (include "postgresql-ha.postgresqlDatabase" .)) }} -d {{ (include "postgresql-ha.postgresqlDatabase" .) | quote }}{{- end }} -h 127.0.0.1 -tA -c "SELECT 1" >/dev/null
+                - PGPASSWORD=${PGPOOL_POSTGRES_PASSWORD} psql -U {{ (include "postgresql-ha.postgresqlUsername" .) | quote }} {{- if not (empty (include "postgresql-ha.postgresqlDatabase" .)) }} -d {{ (include "postgresql-ha.postgresqlDatabase" .) | quote }}{{- end }} -h /opt/bitnami/pgpool/tmp -tA -c "SELECT 1" >/dev/null
             initialDelaySeconds: {{ .Values.pgpool.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.pgpool.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.pgpool.readinessProbe.timeoutSeconds }}
@@ -207,6 +249,10 @@ spec:
             {{- if .Values.pgpool.usePasswordFile }}
             - name: pgpool-password
               mountPath: /opt/bitnami/pgpool/secrets/
+            {{- end }}
+            {{- if .Values.pgpool.tls.enabled }}
+            - name: pgpool-certificates
+              mountPath: /opt/bitnami/pgpool/certs
             {{- end }}
       volumes:
         {{- if or (.Files.Glob "files/pgpool.conf") .Values.pgpool.configuration .Values.pgpool.configurationCM }}
@@ -241,4 +287,11 @@ spec:
             items:
               - key: admin-password
                 path: admin-password
+        {{- end }}
+        {{- if .Values.pgpool.tls.enabled }}
+        - name: raw-certificates
+          secret:
+            secretName: {{ required "A secret containing TLS certificates is required when TLS is enabled" .Values.pgpool.tls.certificatesSecret }}
+        - name: pgpool-certificates
+          emptyDir: {}
         {{- end }}

--- a/bitnami/postgresql-ha/values-production.yaml
+++ b/bitnami/postgresql-ha/values-production.yaml
@@ -51,7 +51,7 @@ postgresqlImage:
 pgpoolImage:
   registry: docker.io
   repository: bitnami/pgpool
-  tag: 4.1.3-debian-10-r19
+  tag: 4.1.3-debian-10-r21
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -309,7 +309,6 @@ postgresql:
 ## Pgpool parameters
 ##
 pgpool:
-
   ## Additional users that will be performing connections to the database using
   ## pgpool. Use this property in order to create new user/password entries that
   ## will be appended to the "pgpool_passwd" file
@@ -471,6 +470,36 @@ pgpool:
   ## Use Pgpool Load-Balancing
   ##
   useLoadBalancing: true
+
+  ##
+  ## TLS configuration
+  ##
+  tls:
+    ## Enable TLS traffic
+    ##
+    enabled: false
+    ##
+    ## Whether to use the server's TLS cipher preferences rather than the client's.
+    ##
+    preferServerCiphers: true
+    ##
+    ## Name of the Secret that contains the certificates
+    ##
+    certificatesSecret: ""
+    ##
+    ## Certificate filename
+    ##
+    certFilename: ""
+    ##
+    ## Certificate Key filename
+    ##
+    certKeyFilename: ""
+    ##
+    ## CA Certificate filename
+    ## If provided, PgPool will authenticate TLS/SSL clients by requesting them a certificate
+    ## ref: https://www.pgpool.net/docs/latest/en/html/runtime-ssl.html
+    ##
+    certCAFilename:
 
 ## LDAP parameters
 ##

--- a/bitnami/postgresql-ha/values.yaml
+++ b/bitnami/postgresql-ha/values.yaml
@@ -51,7 +51,7 @@ postgresqlImage:
 pgpoolImage:
   registry: docker.io
   repository: bitnami/pgpool
-  tag: 4.1.3-debian-10-r19
+  tag: 4.1.3-debian-10-r21
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##

--- a/bitnami/postgresql-ha/values.yaml
+++ b/bitnami/postgresql-ha/values.yaml
@@ -50,8 +50,8 @@ postgresqlImage:
 ##
 pgpoolImage:
   registry: docker.io
-  repository: bitnami/pgpool
-  tag: 4.1.3-debian-10-r19
+  repository: javsalgar/pgpool
+  tag: 4-debian-10
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -480,6 +480,36 @@ pgpool:
   ##
   useLoadBalancing: true
 
+  ##
+  ## TLS configuration
+  ##
+  tls:
+    ## Enable TLS traffic
+    ##
+    enabled: false
+    ##
+    ## Whether to use the server's TLS cipher preferences rather than the client's.
+    ##
+    preferServerCiphers: true
+    ##
+    ## Name of the Secret that contains the certificates
+    ##
+    certificatesSecret: ''
+    ##
+    ## Certificate filename
+    ##
+    certFilename: ''
+    ##
+    ## Certificate Key filename
+    ##
+    certKeyFilename: ''
+    ##
+    ## CA Certificate filename
+    ## If provided, PgPool will authenticate TLS/SSL clients by requesting them a certificate
+    ## ref: https://www.pgpool.net/docs/latest/en/html/runtime-ssl.html
+    ##
+    certCAFilename:
+
 ## LDAP parameters
 ##
 ldap:
@@ -519,6 +549,21 @@ volumePermissions:
     requests: {}
     #   cpu: 100m
     #   memory: 128Mi
+  image:
+    registry: docker.io
+    repository: bitnami/minideb
+    tag: buster
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: Always
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
 
 ## PostgreSQL Prometheus exporter parameters
 ##

--- a/bitnami/postgresql-ha/values.yaml
+++ b/bitnami/postgresql-ha/values.yaml
@@ -50,8 +50,8 @@ postgresqlImage:
 ##
 pgpoolImage:
   registry: docker.io
-  repository: javsalgar/pgpool
-  tag: 4-debian-10
+  repository: bitnami/pgpool
+  tag: 4.1.3-debian-10-r19
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##

--- a/bitnami/postgresql-ha/values.yaml
+++ b/bitnami/postgresql-ha/values.yaml
@@ -549,21 +549,6 @@ volumePermissions:
     requests: {}
     #   cpu: 100m
     #   memory: 128Mi
-  image:
-    registry: docker.io
-    repository: bitnami/minideb
-    tag: buster
-    ## Specify a imagePullPolicy
-    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-    ##
-    pullPolicy: Always
-    ## Optionally specify an array of imagePullSecrets.
-    ## Secrets must be manually created in the namespace.
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ##
-    # pullSecrets:
-    #   - myRegistryKeySecretName
 
 ## PostgreSQL Prometheus exporter parameters
 ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**


Add TLS support in the Pgpool deployment. The configuration is similar to the PostgreSQL chart.


**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
