### PR TITLE
[bitnami/kube-prometheus] Bump thanos sidecar to 0.15

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.41.1
 description: kube-prometheus collects Kubernetes manifests to provide easy to operate end-to-end Kubernetes cluster monitoring with Prometheus using the Prometheus Operator.
 name: kube-prometheus
-version: 2.0.0
+version: 2.1.0
 keywords:
   - prometheus
   - alertmanager

--- a/bitnami/kube-prometheus/values-production.yaml
+++ b/bitnami/kube-prometheus/values-production.yaml
@@ -691,7 +691,7 @@ prometheus:
     image:
       registry: docker.io
       repository: bitnami/thanos
-      tag: 0.14.0-scratch-r3
+      tag: 0.15.0-scratch-r0
       ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
       ##

--- a/bitnami/kube-prometheus/values.yaml
+++ b/bitnami/kube-prometheus/values.yaml
@@ -691,7 +691,7 @@ prometheus:
     image:
       registry: docker.io
       repository: bitnami/thanos
-      tag: 0.14.0-scratch-r3
+      tag: 0.15.0-scratch-r0
       ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
       ##


### PR DESCRIPTION
Thanos chart was bumped to use the 0.15 version of Thanos so we should
do the same with Prometheus.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files