### PR TITLE
[bitnami/thanos] Fixes for Ingresses of Querier and Bucketweb in Thanos Chart

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 2.3.4
+version: 2.3.5
 appVersion: 0.15.0
 description: Thanos is a highly available metrics system that can be added on top of existing Prometheus deployments, providing a global query view across all Prometheus installations.
 engine: gotpl

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 2.3.5
+version: 2.4.0
 appVersion: 0.15.0
 description: Thanos is a highly available metrics system that can be added on top of existing Prometheus deployments, providing a global query view across all Prometheus installations.
 engine: gotpl

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -576,6 +576,22 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 
 ## Upgrading
 
+### To 2.4.0
+
+The Ingress API object name for Querier changes from:
+
+```yaml
+{{ include "thanos.fullname" . }}
+```
+
+> **NOTE**: Which in most cases (depending on any set values in `fullnameOverride` or `nameOverride`) resolves to the used Helm release name (`.Release.Name`).
+
+To:
+
+```yaml
+{{ include "thanos.fullname" . }}-querier
+```
+
 ### To 2.0.0
 
 The format of the chart's `extraFlags` option has been updated to be an array (instead of an object), to support passing multiple flags with the same name to Thanos.

--- a/bitnami/thanos/templates/bucketweb/ingress.yaml
+++ b/bitnami/thanos/templates/bucketweb/ingress.yaml
@@ -33,7 +33,7 @@ spec:
     {{- end }}
   {{- if or .Values.bucketweb.ingress.tls .Values.bucketweb.ingress.extraTls .Values.bucketweb.ingress.hosts }}
   tls:
-    {{- if .Values.bucketweb.ingress.tls }}
+    {{- if .Values.bucketweb.ingress.secrets }}
     - hosts:
         - {{ .Values.bucketweb.ingress.hostname }}
       secretName: {{ printf "%s-tls" .Values.bucketweb.ingress.hostname }}

--- a/bitnami/thanos/templates/bucketweb/tls-secrets.yaml
+++ b/bitnami/thanos/templates/bucketweb/tls-secrets.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.bucketweb.ingress.enabled }}
+{{- range .Values.bucketweb.ingress.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "thanos.fullname" . }}-bucketweb
+  labels: {{- include "thanos.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .certificate | b64enc }}
+  tls.key: {{ .key | b64enc }}
+---
+{{- end }}
+{{- end }}

--- a/bitnami/thanos/templates/querier/ingress.yaml
+++ b/bitnami/thanos/templates/querier/ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ include "thanos.fullname" . }}
+  name: {{ include "thanos.fullname" . }}-querier
   labels: {{- include "thanos.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.querier.ingress.certManager }}
@@ -33,7 +33,7 @@ spec:
     {{- end }}
   {{- if or .Values.querier.ingress.tls .Values.querier.ingress.extraTls .Values.querier.ingress.hosts }}
   tls:
-    {{- if .Values.querier.ingress.tls }}
+    {{- if .Values.querier.ingress.secrets }}
     - hosts:
         - {{ .Values.querier.ingress.hostname }}
       secretName: {{ printf "%s-tls" .Values.querier.ingress.hostname }}

--- a/bitnami/thanos/templates/querier/tls-secrets.yaml
+++ b/bitnami/thanos/templates/querier/tls-secrets.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.querier.ingress.enabled }}
+{{- range .Values.querier.ingress.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "thanos.fullname" . }}-querier
+  labels: {{- include "thanos.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .certificate | b64enc }}
+  tls.key: {{ .key | b64enc }}
+---
+{{- end }}
+{{- end }}

--- a/bitnami/thanos/values-production.yaml
+++ b/bitnami/thanos/values-production.yaml
@@ -188,7 +188,7 @@ querier:
   ## to configure --grpc-server-tls-cert, --grpc-server-tls-key, --grpc-server-tls-client-ca, --grpc-client-tls-secure, --grpc-client-tls-cert, --grpc-client-tls-key, --grpc-client-tls-ca, --grpc-client-server-name
   ## ref: https://github.com/thanos-io/thanos/blob/master/docs/components/query.md#flags
   grpcTLS:
-    # TLS server side 
+    # TLS server side
     server:
       # Enable TLS for GRPC server
       secure: false
@@ -296,16 +296,16 @@ querier:
 
     ## The list of additional hostnames to be covered with this ingress record.
     ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
-    ## extraHosts:
-    ## - name: thanos.local
-    ##   path: /
+    # extraHosts:
+    # - name: thanos.local
+    #   path: /
 
     ## The tls configuration for additional hostnames to be covered with this ingress record.
     ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
-    ## extraTls:
-    ## - hosts:
-    ##     - thanos.local
-    ##   secretName: thanos.local-tls
+    # extraTls:
+    # - hosts:
+    #     - thanos.local
+    #   secretName: thanos.local-tls
 
     ## If you're providing your own certificates, please use this to add the certificates as secrets
     ## key and certificate should start with -----BEGIN CERTIFICATE----- or
@@ -318,8 +318,9 @@ querier:
     ## Please see README.md for more information
     ##
     secrets: []
-    ## - name: thanos.local-tls
-    ##   key:
+    # - name: thanos.local-tls
+    #   key:
+    #   certificate:
 
     ## Create an ingress object for the GRPC service. This requires an HTTP/2
     ## capable Ingress controller (eg. traefik using AWS NLB). Example annotations
@@ -336,23 +337,33 @@ querier:
       hostname: thanos-grpc.local
       annotations: {}
 
-      ## - hosts:
-      ##     - thanos.local
-      ##   secretName: thanos-grpc.local-tls
+      ## The list of additional hostnames to be covered with this ingress record.
+      ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+      # extraHosts:
+      # - name: thanos-grpc.local
+      #   path: /
 
-      ## extraHosts:
-      ## - name: thanos-grpc.local
-      ##   path: /
+      ## The tls configuration for additional hostnames to be covered with this ingress record.
+      ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+      # extraTls:
+      # - hosts:
+      #     - thanos-grpc.local
+      #   secretName: thanos-grpc.local-tls
 
-      ## extraTls:
-      ## - hosts:
-      ##     - thanos-grpc.local
-      ##   secretName: thanos-grpc.local-tls
-
+      ## If you're providing your own certificates, please use this to add the certificates as secrets
+      ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+      ## -----BEGIN RSA PRIVATE KEY-----
+      ##
+      ## name should line up with a tlsSecret set further up
+      ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+      ##
+      ## It is also possible to create and manage the certificates outside of this helm chart
+      ## Please see README.md for more information
+      ##
       secrets: []
-      ## - name: thanos-grpc.local-tls
-      ##   key:
-      ##   certificate:
+      # - name: thanos-grpc.local-tls
+      #   key:
+      #   certificate:
 
 ## Thanos Bucket Web parameters
 ##
@@ -531,16 +542,16 @@ bucketweb:
 
     ## The list of additional hostnames to be covered with this ingress record.
     ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
-    ## extraHosts:
-    ## - name: thanos-bucketweb.local
-    ##   path: /
+    # extraHosts:
+    # - name: thanos-bucketweb.local
+    #   path: /
 
     ## The tls configuration for additional hostnames to be covered with this ingress record.
     ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
-    ## extraTls:
-    ## - hosts:
-    ##     - thanos-bucketweb.local
-    ##   secretName: thanos-bucketweb.local-tls
+    # extraTls:
+    # - hosts:
+    #     - thanos-bucketweb.local
+    #   secretName: thanos-bucketweb.local-tls
 
     ## If you're providing your own certificates, please use this to add the certificates as secrets
     ## key and certificate should start with -----BEGIN CERTIFICATE----- or
@@ -553,8 +564,8 @@ bucketweb:
     ## Please see README.md for more information
     ##
     secrets: []
-    ## - name: thanos-bucketweb.local-tls
-    ##   key:
+    # - name: thanos-bucketweb.local-tls
+    #   key:
 
 ## Thanos Compactor parameters
 ##

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -306,16 +306,16 @@ querier:
 
     ## The list of additional hostnames to be covered with this ingress record.
     ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
-    ## extraHosts:
-    ## - name: thanos.local
-    ##   path: /
+    # extraHosts:
+    # - name: thanos.local
+    #   path: /
 
     ## The tls configuration for additional hostnames to be covered with this ingress record.
     ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
-    ## extraTls:
-    ## - hosts:
-    ##     - thanos.local
-    ##   secretName: thanos.local-tls
+    # extraTls:
+    # - hosts:
+    #     - thanos.local
+    #   secretName: thanos.local-tls
 
     ## If you're providing your own certificates, please use this to add the certificates as secrets
     ## key and certificate should start with -----BEGIN CERTIFICATE----- or
@@ -328,9 +328,9 @@ querier:
     ## Please see README.md for more information
     ##
     secrets: []
-    ## - name: thanos.local-tls
-    ##   key:
-    ##   certificate:
+    # - name: thanos.local-tls
+    #   key:
+    #   certificate:
 
     ## Create an ingress object for the GRPC service. This requires an HTTP/2
     ## capable Ingress controller (eg. traefik using AWS NLB). Example annotations
@@ -347,23 +347,33 @@ querier:
       hostname: thanos-grpc.local
       annotations: {}
 
-      ## - hosts:
-      ##     - thanos.local
-      ##   secretName: thanos-grpc.local-tls
+      ## The list of additional hostnames to be covered with this ingress record.
+      ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+      # extraHosts:
+      # - name: thanos-grpc.local
+      #   path: /
 
-      ## extraHosts:
-      ## - name: thanos-grpc.local
-      ##   path: /
+      ## The tls configuration for additional hostnames to be covered with this ingress record.
+      ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+      # extraTls:
+      # - hosts:
+      #     - thanos-grpc.local
+      #   secretName: thanos-grpc.local-tls
 
-      ## extraTls:
-      ## - hosts:
-      ##     - thanos-grpc.local
-      ##   secretName: thanos-grpc.local-tls
-
+      ## If you're providing your own certificates, please use this to add the certificates as secrets
+      ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+      ## -----BEGIN RSA PRIVATE KEY-----
+      ##
+      ## name should line up with a tlsSecret set further up
+      ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+      ##
+      ## It is also possible to create and manage the certificates outside of this helm chart
+      ## Please see README.md for more information
+      ##
       secrets: []
-      ## - name: thanos-grpc.local-tls
-      ##   key:
-      ##   certificate:
+      # - name: thanos-grpc.local-tls
+      #   key:
+      #   certificate:
 
 ## Thanos Bucket Web parameters
 ##
@@ -542,16 +552,16 @@ bucketweb:
 
     ## The list of additional hostnames to be covered with this ingress record.
     ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
-    ## extraHosts:
-    ## - name: thanos-bucketweb.local
-    ##   path: /
+    # extraHosts:
+    # - name: thanos-bucketweb.local
+    #   path: /
 
     ## The tls configuration for additional hostnames to be covered with this ingress record.
     ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
-    ## extraTls:
-    ## - hosts:
-    ##     - thanos-bucketweb.local
-    ##   secretName: thanos-bucketweb.local-tls
+    # extraTls:
+    # - hosts:
+    #     - thanos-bucketweb.local
+    #   secretName: thanos-bucketweb.local-tls
 
     ## If you're providing your own certificates, please use this to add the certificates as secrets
     ## key and certificate should start with -----BEGIN CERTIFICATE----- or
@@ -564,9 +574,9 @@ bucketweb:
     ## Please see README.md for more information
     ##
     secrets: []
-    ## - name: thanos-bucketweb.local-tls
-    ##   key:
-    ##   certificate:
+    # - name: thanos-bucketweb.local-tls
+    #   key:
+    #   certificate:
 
 ## Thanos Compactor parameters
 ##


### PR DESCRIPTION
**Description of the change**

Fixes for the Ingress API objects of Querier and Bucketweb in the Thanos chart.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
