### PR TITLE
[bitnami/nginx-ingress-controller] Make default backend health check path configurable

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress-controller
-version: 5.5.1
+version: 5.5.2
 appVersion: 0.35.0
 description: Chart for the nginx Ingress controller
 keywords:

--- a/bitnami/nginx-ingress-controller/templates/default-backend-deployment.yaml
+++ b/bitnami/nginx-ingress-controller/templates/default-backend-deployment.yaml
@@ -63,7 +63,7 @@ spec:
             runAsUser: {{ .Values.securityContext.runAsUser }}
           livenessProbe:
             httpGet:
-              path: /
+              path: {{ .Values.defaultBackend.livenessProbe.path }}
               port: {{ .Values.defaultBackend.port }}
               scheme: HTTP
             initialDelaySeconds: {{ .Values.defaultBackend.livenessProbe.initialDelaySeconds }}
@@ -73,7 +73,7 @@ spec:
             failureThreshold: {{ .Values.defaultBackend.livenessProbe.failureThreshold }}
           readinessProbe:
             httpGet:
-              path: /
+              path: {{ .Values.defaultBackend.readinessProbe.path }}
               port: {{ .Values.defaultBackend.port }}
               scheme: HTTP
             initialDelaySeconds: {{ .Values.defaultBackend.readinessProbe.initialDelaySeconds }}

--- a/bitnami/nginx-ingress-controller/values-production.yaml
+++ b/bitnami/nginx-ingress-controller/values-production.yaml
@@ -447,12 +447,14 @@ defaultBackend:
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
   ##
   livenessProbe:
+    path: /
     failureThreshold: 3
     initialDelaySeconds: 30
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 5
   readinessProbe:
+    path: /
     failureThreshold: 6
     initialDelaySeconds: 0
     periodSeconds: 5

--- a/bitnami/nginx-ingress-controller/values.yaml
+++ b/bitnami/nginx-ingress-controller/values.yaml
@@ -447,12 +447,14 @@ defaultBackend:
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
   ##
   livenessProbe:
+    path: /
     failureThreshold: 3
     initialDelaySeconds: 30
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 5
   readinessProbe:
+    path: /
     failureThreshold: 6
     initialDelaySeconds: 0
     periodSeconds: 5


### PR DESCRIPTION
**Description of the change**

This change makes the liveness and readiness probe paths configurable for a custom default backend. 

The default is unchanged (still `/`) so this will not be a breaking change for anyone.

**Benefits**

When using an image such as `quay.io/kubernetes-ingress-controller/custom-error-pages-amd64` (among others), the health check is served at `/healthz` according to what the ingress-controller docs specify. The image can't be deployed with this chart without manually modifying the health check after deployment since `/` will serve a 404 by default (thus failing the health checks).

**Possible drawbacks**

None

**Applicable issues**

None

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
