### PR TITLE
[bitnami/redis-cluster] Add instructions to README to verify the StorageClass is configured to WaitForFirstConsumer

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis-cluster
-version: 3.2.4
+version: 3.2.5
 appVersion: 6.0.8
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/bitnami/redis-cluster/README.md
+++ b/bitnami/redis-cluster/README.md
@@ -5,7 +5,7 @@
 
 ## TL;DR
 
-Verify the default or Kubernetes StorageClass to use has `VolumeBindingMode` set to `WaitForFirstConsumer`, if it does not then skip to [full installation](#installing-the-chart) instructions.
+Verify the Kubernetes StorageClass to use has `VolumeBindingMode` set to `WaitForFirstConsumer`, if not then skip to the [full installation](#installing-the-chart) instructions.
 
 ```bash
 $ kubectl get storageclass -o wide
@@ -67,7 +67,7 @@ NAME                         PROVISIONER                 RECLAIMPOLICY   VOLUMEB
 do-block-storage (default)   dobs.csi.digitalocean.com   Delete          Immediate              true                   26d
 ```
 
-Create a new StorageClass in file `storage-class.yaml` with contents as followed, making sure you edit the `provisioner` field to match that of your Kubernetes cloud provider.
+Create a new StorageClass in file `storage-class.yaml` with contents as followed, make sure you edit the `provisioner` field to match that of your Kubernetes cloud provider.
 
 ```yaml
 apiVersion: storage.k8s.io/v1


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

The installation instructions on the README have been edited to include configuration notes related to the StorageClass. As per the Issue #3653 Kubernetes default StorageClass mode is set to `volumeBindingMode: Immediate` which causes the installation of the Pods to enter status `Waiting: CrashLoopBack` due to redis error;

```
sed: can't read /bitnami/redis/data/nodes.conf: No such file or directory
```

**Benefits**

New users to this chart should now avoid experiencing a failed deployment.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #3653

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

