### PR TITLE
[bitnami/thanos] Add Xtigyro as Maintainer of Thanos

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 2.4.0
+version: 2.4.1
 appVersion: 0.15.0
 description: Thanos is a highly available metrics system that can be added on top of existing Prometheus deployments, providing a global query view across all Prometheus installations.
 engine: gotpl
@@ -13,6 +13,8 @@ keywords:
 maintainers:
   - name: Bitnami
     email: containers@bitnami.com
+  - name: Xtigyro
+    email: miroslav.hadzhiev@gmail.com
 name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos


### PR DESCRIPTION
**Description of the change**

Add Xtigyro as `maintainer` of the Thanos Helm chart.

**Additional information**

Lead author and maintainer of the [Puppet Server Helm chart](https://github.com/puppetlabs/puppetserver-helm-chart) and maintainer of the [Prometheus ](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus) and [Kube-Prometheus Stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) Helm charts.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
