### PR TITLE
[bitnami/redis] Fixed various yaml render issues with redis chart

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 10.9.0
+version: 10.9.1
 appVersion: 6.0.8
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/bitnami/redis/templates/redis-master-statefulset.yaml
+++ b/bitnami/redis/templates/redis-master-statefulset.yaml
@@ -219,8 +219,10 @@ spec:
               mountPath: /opt/bitnami/redis/secrets/
             {{- end }}
             - name: redis-data
-              mountPath: {{ .Values.master.persistence.path }}
-              subPath: {{ .Values.master.persistence.subPath }}
+              mountPath: {{ .Values.master.persistence.path | quote }}
+              {{- if .Values.master.persistence.subPath }}
+              subPath: {{ .Values.master.persistence.subPath | quote }}
+              {{- end }}
             - name: config
               mountPath: /opt/bitnami/redis/mounted-etc
             - name: redis-tmp-conf
@@ -332,7 +334,7 @@ spec:
           {{- else if .Values.sentinel.customLivenessProbe }}
           livenessProbe: {{- toYaml .Values.sentinel.customLivenessProbe | nindent 12 }}
           {{- end }}
-          {{- if .Values.sentinel.readinessProbe.enabled}}
+          {{- if .Values.sentinel.readinessProbe.enabled }}
           readinessProbe:
             initialDelaySeconds: {{ .Values.sentinel.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.sentinel.readinessProbe.periodSeconds }}
@@ -347,7 +349,9 @@ spec:
           {{- else if .Values.sentinel.customReadinessProbe }}
           readinessProbe: {{- toYaml .Values.sentinel.customReadinessProbe | nindent 12 }}
           {{- end }}
+          {{- if .Values.sentinel.resources }}
           resources: {{- toYaml .Values.sentinel.resources | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: health
               mountPath: /health
@@ -356,8 +360,10 @@ spec:
               mountPath: /opt/bitnami/redis/secrets/
             {{- end }}
             - name: redis-data
-              mountPath: {{ .Values.master.persistence.path }}
-              subPath: {{ .Values.master.persistence.subPath }}
+              mountPath: {{ .Values.master.persistence.path | quote }}
+              {{- if .Values.master.persistence.subPath }}
+              subPath: {{ .Values.master.persistence.subPath | quote }}
+              {{- end }}
             - name: config
               mountPath: /opt/bitnami/redis-sentinel/mounted-etc
             - name: sentinel-tmp-conf
@@ -396,6 +402,7 @@ spec:
             - name: REDIS_EXPORTER_TLS_CLIENT_CERT_FILE
               value: {{ template "redis.tlsCert" . }}
             {{- end }}
+          {{- if or .Values.usePasswordFile .Values.tls.enabled }}
           volumeMounts:
             {{- if .Values.usePasswordFile }}
             - name: redis-password
@@ -406,10 +413,13 @@ spec:
               mountPath: /opt/bitnami/redis/certs
               readOnly: true
             {{- end }}
+          {{- end }}
           ports:
             - name: metrics
               containerPort: 9121
+          {{- if .Values.metrics.resources }}
           resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
+          {{- end }}
   {{- end }}
       {{- $needsVolumePermissions := and .Values.volumePermissions.enabled (and ( and .Values.master.persistence.enabled (not .Values.persistence.existingClaim) ) .Values.securityContext.enabled) }}
       {{- if or $needsVolumePermissions .Values.sysctlImage.enabled }}
@@ -424,8 +434,10 @@ spec:
         resources: {{- toYaml .Values.volumePermissions.resources | nindent 10 }}
         volumeMounts:
           - name: redis-data
-            mountPath: {{ .Values.master.persistence.path }}
-            subPath: {{ .Values.master.persistence.subPath }}
+            mountPath: {{ .Values.master.persistence.path | quote }}
+            {{- if .Values.master.persistence.subPath }}
+            subPath: {{ .Values.master.persistence.subPath | quote }}
+            {{- end }}
       {{- end }}
       {{- if .Values.sysctlImage.enabled }}
       - name: init-sysctl
@@ -504,6 +516,7 @@ spec:
           requests:
             storage: {{ .Values.master.persistence.size | quote }}
         {{ include "redis.master.storageClass" . }}
+        {{- if or .Values.master.persistence.matchLabels .Values.master.persistence.matchExpressions }}
         selector:
         {{- if .Values.master.persistence.matchLabels }}
           matchLabels: {{- toYaml .Values.master.persistence.matchLabels | nindent 12 }}
@@ -511,6 +524,7 @@ spec:
         {{- if .Values.master.persistence.matchExpressions }}
           matchExpressions: {{- toYaml .Values.master.persistence.matchExpressions | nindent 12 }}
         {{- end -}}
+        {{- end }}
   {{- end }}
   updateStrategy:
     type: {{ .Values.master.statefulset.updateStrategy }}

--- a/bitnami/redis/templates/redis-slave-statefulset.yaml
+++ b/bitnami/redis/templates/redis-slave-statefulset.yaml
@@ -359,7 +359,7 @@ spec:
           {{- else if .Values.sentinel.customLivenessProbe }}
           livenessProbe: {{- toYaml .Values.sentinel.customLivenessProbe | nindent 12 }}
           {{- end }}
-          {{- if .Values.sentinel.readinessProbe.enabled}}
+          {{- if .Values.sentinel.readinessProbe.enabled }}
           readinessProbe:
             initialDelaySeconds: {{ .Values.sentinel.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.sentinel.readinessProbe.periodSeconds }}
@@ -374,7 +374,9 @@ spec:
           {{- else if .Values.sentinel.customReadinessProbe }}
           readinessProbe: {{- toYaml .Values.sentinel.customReadinessProbe | nindent 12 }}
           {{- end }}
+          {{- if .Values.sentinel.resources }}
           resources: {{- toYaml .Values.sentinel.resources | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: health
               mountPath: /health
@@ -383,8 +385,10 @@ spec:
               mountPath: /opt/bitnami/redis/secrets/
             {{- end }}
             - name: redis-data
-              mountPath: {{ .Values.master.persistence.path }}
-              subPath: {{ .Values.master.persistence.subPath }}
+              mountPath: {{ .Values.master.persistence.path | quote }}
+              {{- if .Values.master.persistence.subPath }}
+              subPath: {{ .Values.master.persistence.subPath | quote }}
+              {{- end }}
             - name: config
               mountPath: /opt/bitnami/redis-sentinel/mounted-etc
             - name: sentinel-tmp-conf
@@ -423,6 +427,7 @@ spec:
             - name: REDIS_EXPORTER_TLS_CLIENT_CERT_FILE
               value: {{ template "redis.tlsCert" . }}
             {{- end }}
+          {{- if or .Values.usePasswordFile .Values.tls.enabled }}
           volumeMounts:
             {{- if .Values.usePasswordFile }}
             - name: redis-password
@@ -433,10 +438,13 @@ spec:
               mountPath: /opt/bitnami/redis/certs
               readOnly: true
             {{- end }}
+          {{- end }}
           ports:
             - name: metrics
               containerPort: 9121
+          {{- if .Values.metrics.resources }}
           resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
+          {{- end }}
   {{- end }}
       {{- $needsVolumePermissions := and .Values.volumePermissions.enabled (and .Values.slave.persistence.enabled .Values.securityContext.enabled) }}
       {{- if or $needsVolumePermissions .Values.sysctlImage.enabled }}
@@ -452,7 +460,9 @@ spec:
           volumeMounts:
             - name: redis-data
               mountPath: {{ .Values.slave.persistence.path }}
+              {{- if .Values.slave.persistence.subPath }}
               subPath: {{ .Values.slave.persistence.subPath }}
+              {{- end }}
         {{- end }}
         {{- if .Values.sysctlImage.enabled }}
         - name: init-sysctl
@@ -522,6 +532,7 @@ spec:
           requests:
             storage: {{ .Values.slave.persistence.size | quote }}
         {{ include "redis.slave.storageClass" . }}
+        {{- if or .Values.slave.persistence.matchLabels .Values.slave.persistence.matchExpressions }}
         selector:
         {{- if .Values.slave.persistence.matchLabels }}
           matchLabels: {{- toYaml .Values.slave.persistence.matchLabels | nindent 12 }}
@@ -529,6 +540,7 @@ spec:
         {{- if .Values.slave.persistence.matchExpressions }}
           matchExpressions: {{- toYaml .Values.slave.persistence.matchExpressions | nindent 12 }}
         {{- end -}}
+        {{- end }}
   {{- end }}
   updateStrategy:
     type: {{ .Values.slave.statefulset.updateStrategy }}


### PR DESCRIPTION
**Description of the change**

There are some render issues, which lead to invalid yaml when specific values are omitted, as well as empty strings.

Examples of broken rendered fragments that will be fixed with this PR:

Subpath empty (not quoted, also not omitted when not set):
```
          ...
          volumeMounts:
            - name: redis-data
              mountPath: /data
              subPath: 
            - name: config
          ...
```

Written `null` in resources when not set:
```
          ...
          resources:
            null
          volumeMounts:
          ...
```


volumeMounts empty :
```
          ...
          volumeMounts:
          ports:
          ...
```

selector empty :
```
          ...
        selector:
  updateStrategy:
          ...
```

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Correct yaml

**Possible drawbacks**

None

**Applicable issues**

Improved behaviour when values are omitted. IDEs and tools do not complain.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
