### PR TITLE
[bitnami/wordpress] Allowing usage of existing secrets for WordPress, MariaDB and SMTP

### DIFF
--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 9.5.6
+version: 9.5.7
 appVersion: 5.5.1
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 9.5.5
+version: 9.5.6
 appVersion: 5.5.1
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 9.5.7
+version: 9.6.6
 appVersion: 5.5.1
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 9.6.6
+version: 9.6.0
 appVersion: 5.5.1
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -80,6 +80,7 @@ The following table lists the configurable parameters of the WordPress chart and
 | `image.debug`                             | Specify if debug logs should be enabled                                               | `false`                                                      |
 | `wordpressSkipInstall`                    | Skip wizard installation when the external db already contains data from a previous WordPress installation [see](https://github.com/bitnami/bitnami-docker-wordpress#connect-wordpress-docker-container-to-an-existing-database) | `false`                                                      |
 | `wordpressUsername`                       | User of the application                                                               | `user`                                                       |
+| `existingSecret`                          | Name of the existing Wordpress Secret Object                                          | `nil`               |
 | `wordpressPassword`                       | Application password                                                                  | _random 10 character long alphanumeric string_               |
 | `wordpressEmail`                          | Admin email                                                                           | `user@example.com`                                           |
 | `wordpressFirstName`                      | First name                                                                            | `FirstName`                                                  |
@@ -98,6 +99,7 @@ The following table lists the configurable parameters of the WordPress chart and
 | `smtpPassword`                            | SMTP password                                                                         | `nil`                                                        |
 | `smtpUsername`                            | User name for SMTP emails                                                             | `nil`                                                        |
 | `smtpProtocol`                            | SMTP protocol [`tls`, `ssl`, `none`]                                                  | `nil`                                                        |
+| `smtpExistingPassword`                    | Existing secret containing SMTP password in key `smtp-password`                        | `nil`                                                        |
 | `command`                                 | Override default container command (useful when using custom images)                  | `nil`                                                        |
 | `args`                                    | Override default container args (useful when using custom images)                     | `nil`                                                        |
 | `extraEnv`                                | Additional container environment variables                                            | `[]`                                                         |
@@ -183,6 +185,7 @@ The following table lists the configurable parameters of the WordPress chart and
 | `mariadb.master.persistence.size`         | Database Persistent Volume Size                                                       | `8Gi`                                                        |
 | `externalDatabase.host`                   | Host of the external database                                                         | `localhost`                                                  |
 | `externalDatabase.user`                   | Existing username in the external db                                                  | `bn_wordpress`                                               |
+| `externalDatabase.existingSecret`         | Name of the database existing Secret Object                                           | `nil`                                                        |
 | `externalDatabase.password`               | Password for the above username                                                       | `nil`                                                        |
 | `externalDatabase.database`               | Name of the existing database                                                         | `bitnami_wordpress`                                          |
 | `externalDatabase.port`                   | Database port number                                                                  | `3306`                                                       |

--- a/bitnami/wordpress/requirements.lock
+++ b/bitnami/wordpress/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 7.10.0
-digest: sha256:a61b0a96b1493f082762e9850cd5edeb1ed6e98e8f24f5d23048f8bcec785bf2
-generated: "2020-09-17T06:59:44.839350946Z"
+  version: 7.10.1
+digest: sha256:a3d9836286bbd2c40252c7c02abb6eec9ced6ce33a74ee7d8c7c5b9ea0ca643a
+generated: "2020-09-17T13:25:24.303462417Z"

--- a/bitnami/wordpress/templates/_helpers.tpl
+++ b/bitnami/wordpress/templates/_helpers.tpl
@@ -259,13 +259,37 @@ Return the MariaDB User
 {{- end -}}
 
 {{/*
-Return the MariaDB User
+Return the MariaDB Secret Name
 */}}
 {{- define "wordpress.databaseSecretName" -}}
 {{- if .Values.mariadb.enabled }}
     {{- printf "%s" (include "mariadb.fullname" .) -}}
+{{- else if .Values.externalDatabase.existingSecret -}}
+    {{- printf "%s" .Values.externalDatabase.existingSecret -}}
 {{- else -}}
     {{- printf "%s-%s" .Release.Name "externaldb" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the WordPress Secret Name
+*/}}
+{{- define "wordpress.secretName" -}}
+{{- if .Values.existingSecret }}
+    {{- printf "%s" .Values.existingSecret -}}
+{{- else -}}
+    {{- printf "%s" (include "wordpress.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the SMTP Secret Name
+*/}}
+{{- define "wordpress.smtpSecretName" -}}
+{{- if .Values.smtpExistingSecret }}
+    {{- printf "%s" .Values.smtpExistingSecret -}}
+{{- else -}}
+    {{- printf "%s" (include "wordpress.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/wordpress/templates/deployment.yaml
+++ b/bitnami/wordpress/templates/deployment.yaml
@@ -89,7 +89,7 @@ spec:
             - name: WORDPRESS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "wordpress.fullname" . }}
+                  name: {{ include "wordpress.secretName" . }}
                   key: wordpress-password
             - name: WORDPRESS_EMAIL
               value: {{ .Values.wordpressEmail | quote }}
@@ -123,11 +123,11 @@ spec:
             - name: SMTP_USER
               value: {{ .Values.smtpUser | quote }}
             {{- end }}
-            {{- if .Values.smtpPassword }}
+            {{- if (or .Values.smtpPassword .Values.smtpExistingSecret) }}
             - name: SMTP_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "wordpress.fullname" . }}
+                  name: {{ include "wordpress.smtpSecretName" . }}
                   key: smtp-password
             {{- end }}
             {{- if .Values.smtpUsername }}

--- a/bitnami/wordpress/templates/externaldb-secrets.yaml
+++ b/bitnami/wordpress/templates/externaldb-secrets.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.mariadb.enabled }}
+{{- if (not (or .Values.mariadb.enabled .Values.externalDatabase.existingSecret)) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/bitnami/wordpress/templates/secrets.yaml
+++ b/bitnami/wordpress/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if or (not .Values.existingSecret) (and (not .Values.smtpExistingSecret) .Values.smtpPassword) -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,11 +12,16 @@ metadata:
   {{- end }}
 type: Opaque
 data:
+  {{- if not .Values.existingSecret }}
   {{- if .Values.wordpressPassword }}
   wordpress-password: {{ .Values.wordpressPassword | b64enc | quote }}
   {{- else }}
   wordpress-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
+  {{- end }}
+  {{- if not .Values.smtpExistingSecret }}
   {{- if .Values.smtpPassword }}
   smtp-password: {{ .Values.smtpPassword | b64enc | quote }}
   {{- end }}
+  {{- end }}
+{{- end -}}

--- a/bitnami/wordpress/templates/secrets.yaml
+++ b/bitnami/wordpress/templates/secrets.yaml
@@ -19,7 +19,7 @@ data:
   wordpress-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
   {{- end }}
-  {{- if not .Values.smtpExistingSecret }}
+  {{- if and .Values.smtpPassword (not .Values.smtpExistingSecret) }}
   {{- if .Values.smtpPassword }}
   smtp-password: {{ .Values.smtpPassword | b64enc | quote }}
   {{- end }}

--- a/bitnami/wordpress/values-production.yaml
+++ b/bitnami/wordpress/values-production.yaml
@@ -458,6 +458,13 @@ externalDatabase:
   ##
   password: ""
 
+  ## Use existing secret (ignores previous password)
+  # existingSecret:
+
+  ## Password key to be retrieved from secret if not `mariadb-password`
+  ##
+  # existingSecretPasswordKey:
+
   ## Database name
   ##
   database: bitnami_wordpress

--- a/bitnami/wordpress/values-production.yaml
+++ b/bitnami/wordpress/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/wordpress
-  tag: 5.5.1-debian-10-r11
+  tag: 5.5.1-debian-10-r12
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/wordpress/values-production.yaml
+++ b/bitnami/wordpress/values-production.yaml
@@ -50,6 +50,11 @@ commonLabels: {}
 ##
 commonAnnotations: {}
 
+## Use existing secret (does not create the WordPress Secret object)
+## Must contain key `wordpress-secret`
+## NOTE: When it's set, the `wordpressPassword` parameter is ignored
+# existingSecret:
+
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
 ##
@@ -145,6 +150,13 @@ updateStrategy:
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress/#smtp-configuration
 ##
+
+## Use an existing secret for the SMTP Password
+## Can be the same secret as existingSecret
+## Must contain key `smtp-password`
+## NOTE: When it's set, the `smtpPassword` parameter is ignored
+# smtpExistingSecret:
+
 # smtpHost:
 # smtpPort:
 # smtpUser:
@@ -446,6 +458,11 @@ mariadb:
 ## All of these values are only used when mariadb.enabled is set to false
 ##
 externalDatabase:
+  ## Use existing secret (ignores previous password)
+  ## must contain key `mariadb-password`
+  ## NOTE: When it's set, the `externalDatabase.password` parameter is ignored
+  # existingSecret:
+
   ## Database host
   ##
   host: localhost
@@ -457,13 +474,6 @@ externalDatabase:
   ## Database password
   ##
   password: ""
-
-  ## Use existing secret (ignores previous password)
-  # existingSecret:
-
-  ## Password key to be retrieved from secret if not `mariadb-password`
-  ##
-  # existingSecretPasswordKey:
 
   ## Database name
   ##

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -50,6 +50,10 @@ commonLabels: {}
 ##
 commonAnnotations: {}
 
+## Use existing secret (does not create the WordPress Secret object)
+## must contain key `wordpress-secret`
+# existingSecret:
+
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
 ##
@@ -151,6 +155,11 @@ updateStrategy:
 # smtpPassword:
 # smtpUsername:
 # smtpProtocol:
+## Use an existing secret for the SMTP Password
+## Can be the same secret as existingSecret
+## Must contain the key `smtp-password`
+# smtpExistingSecret:
+
 
 replicaCount: 1
 
@@ -451,6 +460,10 @@ externalDatabase:
   ## Database password
   ##
   password: ""
+  
+  ## Use existing secret (ignores previous password)
+  ## must contain key `mariadb-password`
+  # existingSecret:
 
   ## Database name
   ##

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/wordpress
-  tag: 5.5.1-debian-10-r11
+  tag: 5.5.1-debian-10-r12
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -51,7 +51,8 @@ commonLabels: {}
 commonAnnotations: {}
 
 ## Use existing secret (does not create the WordPress Secret object)
-## must contain key `wordpress-secret`
+## Must contain key `wordpress-secret`
+## NOTE: When it's set, the `wordpressPassword` parameter is ignored
 # existingSecret:
 
 ## User of the application
@@ -149,17 +150,19 @@ updateStrategy:
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress/#smtp-configuration
 ##
+
+## Use an existing secret for the SMTP Password
+## Can be the same secret as existingSecret
+## Must contain key `smtp-password`
+## NOTE: When it's set, the `smtpPassword` parameter is ignored
+# smtpExistingSecret:
+
 # smtpHost:
 # smtpPort:
 # smtpUser:
 # smtpPassword:
 # smtpUsername:
 # smtpProtocol:
-## Use an existing secret for the SMTP Password
-## Can be the same secret as existingSecret
-## Must contain the key `smtp-password`
-# smtpExistingSecret:
-
 
 replicaCount: 1
 
@@ -449,6 +452,11 @@ mariadb:
 ## All of these values are only used when mariadb.enabled is set to false
 ##
 externalDatabase:
+  ## Use existing secret (ignores previous password)
+  ## must contain key `mariadb-password`
+  ## NOTE: When it's set, the `externalDatabase.password` parameter is ignored
+  # existingSecret:
+
   ## Database host
   ##
   host: localhost
@@ -460,10 +468,6 @@ externalDatabase:
   ## Database password
   ##
   password: ""
-
-  ## Use existing secret (ignores previous password)
-  ## must contain key `mariadb-password`
-  # existingSecret:
 
   ## Database name
   ##

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -460,7 +460,7 @@ externalDatabase:
   ## Database password
   ##
   password: ""
-  
+
   ## Use existing secret (ignores previous password)
   ## must contain key `mariadb-password`
   # existingSecret:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
This change will make possible the usage of an existing Secret in the Wordpress Chart. The current version is forcing the creation of a secret for every new WordPress deployment, and does not allow the usage of an existing Secret to handle the `externalDatabase` password, forcing users to hardcode the database password into the repo when using Helm with any GitOps CI/CD tool, in case we don't opt to have the Chart create the database.
 
**Benefits**

<!-- What benefits will be realized by the code change? -->
Another benefit this change provide is allowing us to use Bitnami's [SealedSecrets](https://github.com/bitnami-labs/sealed-secrets), making this Chart more secure.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - No issues have been opened related to this fix.

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
