### PR TITLE
[bitnami/nginx] New major version

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx
-version: 6.2.1
+version: 7.0.0
 appVersion: 1.19.2
 description: Chart for the nginx server
 keywords:

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -47,112 +47,162 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Parameters
 
-The following tables lists the configurable parameters of the NGINX Open Source chart and their default values.
+The following tables lists the configurable parameters of the NGINX chart and their default values per section/component:
 
-| Parameter                                  | Description                                                                                  | Default                                                      |
-|--------------------------------------------|----------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `global.imageRegistry`                     | Global Docker image registry                                                                 | `nil`                                                        |
-| `global.imagePullSecrets`                  | Global Docker registry secret names as an array                                              | `[]` (does not add image pull secrets to deployed pods)      |
-| `image.registry`                           | NGINX image registry                                                                         | `docker.io`                                                  |
-| `image.repository`                         | NGINX Image name                                                                             | `bitnami/nginx`                                              |
-| `image.tag`                                | NGINX Image tag                                                                              | `{TAG_NAME}`                                                 |
-| `image.pullPolicy`                         | NGINX image pull policy                                                                      | `IfNotPresent`                                               |
-| `image.pullSecrets`                        | Specify docker-registry secret names as an array                                             | `[]` (does not add image pull secrets to deployed pods)      |
-| `nameOverride`                             | String to partially override nginx.fullname template                                         | `nil`                                                        |
-| `fullnameOverride`                         | String to fully override nginx.fullname template                                             | `nil`                                                        |
-| `staticSiteConfigmap`                      | Name of existing ConfigMap with the server static content                                    | `nil`                                                        |
-| `staticSitePVC`                            | Name of existing PVC with the server static content                                          | `nil`                                                        |
-| `cloneStaticSiteFromGit.enabled`           | Get the server static content from a git repository                                          | `false`                                                      |
-| `cloneStaticSiteFromGit.image.registry`    | Git image registry                                                                           | `docker.io`                                                  |
-| `cloneStaticSiteFromGit.image.repository`  | Git image name                                                                               | `bitnami/git`                                                |
-| `cloneStaticSiteFromGit.image.tag`         | Git image tag                                                                                | `{TAG_NAME}`                                                 |
-| `cloneStaticSiteFromGit.image.pullPolicy`  | Git image pull policy                                                                        | `Always`                                                     |
-| `cloneStaticSiteFromGit.image.pullSecrets` | Specify docker-registry secret names as an array                                             | `[]` (does not add image pull secrets to deployed pods)      |
-| `cloneStaticSiteFromGit.repository`        | Repository to clone static content from                                                      | `nil`                                                        |
-| `cloneStaticSiteFromGit.branch`            | Branch inside the git repository                                                             | `nil`                                                        |
-| `cloneStaticSiteFromGit.interval`          | Interval for sidecar container pull from the repository                                      | `60`                                                         |
-| `serverBlock`                              | Custom NGINX server block                                                                    | `nil`                                                        |
-| `existingServerBlockConfigmap`             | Name of existing PVC with custom NGINX server block                                          | `nil`                                                        |
-| `replicaCount`                             | Number of replicas to deploy                                                                 | `1`                                                          |
-| `containerPort`                            | Deployment Container Port                                                                    | `8080`                                                       |
-| `containerTlsPort`                         | Deployment Container Tls Port                                                                | `nil`                                                        |
-| `podAnnotations`                           | Pod annotations                                                                              | `{}`                                                         |
-| `affinity`                                 | Map of node/pod affinities                                                                   | `{}` (The value is evaluated as a template)                  |
-| `nodeSelector`                             | Node labels for pod assignment                                                               | `{}` (The value is evaluated as a template)                  |
-| `tolerations`                              | Tolerations for pod assignment                                                               | `[]` (The value is evaluated as a template)                  |
-| `resources`                                | Resource requests/limit                                                                      | `{}`                                                         |
-| `livenessProbe`                            | Deployment Liveness Probe                                                                    | See `values.yaml`                                            |
-| `readinessProbe`                           | Deployment Readiness Probe                                                                   | See `values.yaml`                                            |
-| `service.type`                             | Kubernetes Service type                                                                      | `LoadBalancer`                                               |
-| `service.port`                             | Service HTTP port                                                                            | `80`                                                         |
-| `service.httpsPort`                        | Service HTTPS port                                                                           | `443`                                                        |
-| `service.nodePorts.http`                   | Kubernetes http node port                                                                    | `""`                                                         |
-| `service.nodePorts.https`                  | Kubernetes https node port
-| `service.targetPort.http`                  | Kubernetes http targetPort                                                                   | `http`                   |
-| `service.targetPort.https`                 | Kubernetes https targetPort                                                                  | `https`                  |
-| `service.externalTrafficPolicy`            | Enable client source IP preservation                                                         | `Cluster`                                                    |
-| `service.loadBalancerIP`                   | LoadBalancer service IP address                                                              | `""`                                                         |
-| `service.annotations`                      | Service annotations                                                                          | `{}`                                                         |
-| `ldapDaemon.enabled`                       | Enable LDAP Auth Daemon proxy                                                                | `false`                                                      |
-| `ldapDaemon.image.registry`                | LDAP AUth Daemon Image registry                                                              | `docker.io`                                                  |
-| `ldapDaemon.image.repository`              | LDAP Auth Daemon Image name                                                                  | `bitnami/nginx-ldap-auth-daemon`                             |
-| `ldapDaemon.image.tag`                     | LDAP Auth Daemon Image tag                                                                   | `{TAG_NAME}`                                                 |
-| `ldapDaemon.image.pullPolicy`              | LDAP Auth Daemon Image pull policy                                                           | `IfNotPresent`                                               |
-| `ldapDaemon.port`                          | LDAP Auth Daemon port                                                                        | `8888`                                                       |
-| `ldapDaemon.ldapConfig.uri`                | LDAP Server URI, `ldap[s]:/<hostname>:<port>`                                                | `""`                                                         |
-| `ldapDaemon.ldapConfig.baseDN`             | LDAP root DN to begin the search for the user                                                | `""`                                                         |
-| `ldapDaemon.ldapConfig.bindDN`             | DN of user to bind to LDAP                                                                   | `""`                                                         |
-| `ldapDaemon.ldapConfig.bindPassword`       | Password for the user to bind to LDAP                                                        | `""`                                                         |
-| `ldapDaemon.ldapConfig.filter`             | LDAP search filter for search+bind authentication                                            | `""`                                                         |
-| `ldapDaemon.ldapConfig.httpRealm`          | LDAP HTTP auth realm                                                                         | `""`                                                         |
-| `ldapDaemon.ldapConfig.httpCookieName`     | HTTP cookie name to be used in LDAP Auth                                                     | `""`                                                         |
-| `ldapDaemon.nginxServerBlock`              | NGINX server block that configures LDAP communication. Overrides `ldapDaemon.ldapConfig`     | See `values.yaml`                                            |
-| `ldapDaemon.existingNginxServerBlockSecret`| Name of existing Secret with a NGINX server block to use for LDAP communication              | `nil`                                                        |
-| `ldapDaemon.livenessProbe`                 | LDAP Auth Daemon Liveness Probe                                                              | See `values.yaml`                                            |
-| `ldapDaemon.readinessProbe`                | LDAP Auth Daemon Readiness Probe                                                             | See `values.yaml`                                            |
-| `ingress.enabled`                          | Enable ingress controller resource                                                           | `false`                                                      |
-| `ingress.certManager`                      | Add annotations for cert-manager                                                             | `false`                                                      |
-| `ingress.selectors`                        | Ingress selectors for labelSelector option                                                   | `[]`                                                         |
-| `ingress.annotations`                      | Ingress annotations                                                                          | `[]`                                                         |
-| `ingress.hosts[0].name`                    | Hostname to your NGINX installation                                                          | `nginx.local`                                                |
-| `ingress.hosts[0].path`                    | Path within the url structure                                                                | `/`                                                          |
-| `ingress.hosts[0].extraPaths`              | Ingress extra paths to prepend to every host configuration. Useful when configuring [custom actions with AWS ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/#actions). | `[]`                |
-| `ingress.tls[0].hosts[0]`                  | TLS hosts                                                                                    | `nginx.local`                                                |
-| `ingress.tls[0].secretName`                | TLS Secret (certificates)                                                                    | `nginx.local-tls`                                            |
-| `ingress.secrets[0].name`                  | TLS Secret Name                                                                              | `nil`                                                        |
-| `ingress.secrets[0].certificate`           | TLS Secret Certificate                                                                       | `nil`                                                        |
-| `ingress.secrets[0].key`                   | TLS Secret Key                                                                               | `nil`                                                        |
-| `healthIngress.enabled`                    | Enable health ingress controller resource                                                    | `false`                                                      |
-| `healthIngress.certManager`                | Add annotations for cert-manager                                                             | `false`                                                      |
-| `healthIngress.selectors`                  | Health Ingress selectors for labelSelector option                                            | `[]`                                                         |
-| `healthIngress.annotations`                | Health Ingress annotations                                                                   | `[]`                                                         |
-| `healthIngress.hosts[0].name`              | Hostname to your NGINX installation                                                          | `nginx.local`                                                |
-| `healthIngress.hosts[0].path`              | Path within the url structure                                                                | `/`                                                          |
-| `healthIngress.tls[0].hosts[0]`            | TLS hosts                                                                                    | `nginx.local`                                                |
-| `healthIngress.tls[0].secretName`          | TLS Secret (certificates)                                                                    | `nginx.local-tls`                                            |
-| `healthIngress.secrets[0].name`            | TLS Secret Name                                                                              | `nil`                                                        |
-| `healthIngress.secrets[0].certificate`     | TLS Secret Certificate                                                                       | `nil`                                                        |
-| `healthIngress.secrets[0].key`             | TLS Secret Key                                                                               | `nil`                                                        |
-| `metrics.enabled`                          | Start a side-car prometheus exporter                                                         | `false`                                                      |
-| `metrics.image.registry`                   | NGINX Prometheus exporter image registry                                                     | `docker.io`                                                  |
-| `metrics.image.repository`                 | NGINX Prometheus exporter image name                                                         | `bitnami/nginx-exporter`                                     |
-| `metrics.image.tag`                        | NGINX Prometheus exporter image tag                                                          | `{TAG_NAME}`                                                 |
-| `metrics.image.pullPolicy`                 | NGINX Prometheus exporter image pull policy                                                  | `IfNotPresent`                                               |
-| `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                                             | `[]` (does not add image pull secrets to deployed pods)      |
-| `metrics.podAnnotations`                   | Additional annotations for NGINX Prometheus exporter pod(s)                                  | `{prometheus.io/scrape: "true", prometheus.io/port: "9113"}` |
-| `metrics.resources`                        | NGINX Prometheus exporter resource requests/limit                                            | `{}`                                                         |
-| `metrics.serviceMonitor.enabled`           | Creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)  | `false`                                                      |
-| `metrics.serviceMonitor.namespace`         | Namespace in which Prometheus is running                                                     | `nil`                                                        |
-| `metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped.                                                 | `nil` (Prometheus Operator default value)                    |
-| `metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                                      | `nil` (Prometheus Operator default value)                    |
-| `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                          | `nil`                                                        |
-| `autoscaling.enabled`                      | Enable autoscaling for NGINX deployment                                                      | `false`                                                      |
-| `autoscaling.minReplicas`                  | Minimum number of replicas to scale back                                                     | `nil`                                                        |
-| `autoscaling.maxReplicas`                  | Maximum number of replicas to scale out                                                      | `nil`                                                        |
-| `autoscaling.targetCPU`                    | Target CPU utilization percentage                                                            | `nil`                                                        |
-| `autoscaling.targetMemory`                 | Target Memory utilization percentage                                                         | `nil`                                                        |
-| `extraVolumes`                             | Array to add extra volumes (evaluated as a template)                                         | `[]`                                                         |
-| `extraVolumeMounts`                        | Array to add extra mounts (normally used with extraVolumes, evaluated as a template)         | `[]`                                                         |
+### Global parameters
+
+| Parameter                               | Description                                                | Default                                                 |
+|-----------------------------------------|------------------------------------------------------------|---------------------------------------------------------|
+| `global.imageRegistry`                  | Global Docker image registry                               | `nil`                                                   |
+| `global.imagePullSecrets`               | Global Docker registry secret names as an array            | `[]` (does not add image pull secrets to deployed pods) |
+
+### Common parameters
+
+| Parameter                               | Description                                                | Default                                                 |
+|-----------------------------------------|------------------------------------------------------------|---------------------------------------------------------|
+| `nameOverride`                          | String to partially override nginx.fullname                | `nil`                                                   |
+| `fullnameOverride`                      | String to fully override nginx.fullname                    | `nil`                                                   |
+| `clusterDomain`                         | Default Kubernetes cluster domain                          | `cluster.local`                                         |
+| `commonLabels`                          | Labels to add to all deployed objects                      | `{}`                                                    |
+| `commonAnnotations`                     | Annotations to add to all deployed objects                 | `{}`                                                    |
+| `extraDeploy`                           | Array of extra objects to deploy with the release          | `[]` (evaluated as a template)                          |
+
+### NGINX parameters
+
+| Parameter                               | Description                                                                              | Default                                                 |
+|-----------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `image.registry`                        | NGINX image registry                                                                     | `docker.io`                                             |
+| `image.repository`                      | NGINX image name                                                                         | `bitnami/nginx`                                         |
+| `image.tag`                             | NGINX image tag                                                                          | `{TAG_NAME}`                                            |
+| `image.pullPolicy`                      | NGINX image pull policy                                                                  | `IfNotPresent`                                          |
+| `image.pullSecrets`                     | Specify docker-registry secret names as an array                                         | `[]` (does not add image pull secrets to deployed pods) |
+| `image.debug`                           | Set to true if you would like to see extra information on logs                           | `false`                                                 |
+| `command`                               | Override default container command (useful when using custom images)                     | `nil`                                                   |
+| `args`                                  | Override default container args (useful when using custom images)                        | `nil`                                                   |
+| `extraEnvVars`                          | Extra environment variables to be set on NGINX containers                                | `{}`                                                    |
+| `extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars                                     | `nil`                                                   |
+| `extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars                                        | `nil`                                                   |
+
+### NGINX deployment parameters
+
+| Parameter                               | Description                                                                              | Default                                                 |
+|-----------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `replicaCount`                          | Number of NGINX replicas to deploy                                                       | `1`                                                     |
+| `strategyType`                          | Deployment Strategy Type                                                                 | `RollingUpdate`                                         |
+| `affinity`                              | Affinity for pod assignment                                                              | `{}` (evaluated as a template)                          |
+| `nodeSelector`                          | Node labels for pod assignment                                                           | `{}` (evaluated as a template)                          |
+| `tolerations`                           | Tolerations for pod assignment                                                           | `[]` (evaluated as a template)                          |
+| `podLabels`                             | Additional labels for NGINX pods                                                         | `{}` (evaluated as a template)                          |
+| `podAnnotations`                        | Annotations for NGINX pods                                                               | `{}` (evaluated as a template)                          |
+| `podSecurityContext`                    | NGINX pods' Security Context                                                             | Check `values.yaml` file                                |
+| `containerSecurityContext`              | NGINX containers' Security Context                                                       | Check `values.yaml` file                                |
+| `containerPorts.http`                   | Sets http port inside NGINX container                                                    | `8080`                                                  |
+| `containerPorts.https`                  | Sets https port inside NGINX container                                                   | `nil`                                                   |
+| `resources.limits`                      | The resources limits for the NGINX container                                             | `{}`                                                    |
+| `resources.requests`                    | The requested resources for the NGINX container                                          | `{}`                                                    |
+| `livenessProbe`                         | Liveness probe configuration for NGINX                                                   | Check `values.yaml` file                                |
+| `readinessProbe`                        | Readiness probe configuration for NGINX                                                  | Check `values.yaml` file                                |
+| `customLivenessProbe`                   | Override default liveness probe                                                          | `nil`                                                   |
+| `customReadinessProbe`                  | Override default readiness probe                                                         | `nil`                                                   |
+| `autoscaling.enabled`                   | Enable autoscaling for NGINX deployment                                                  | `false`                                                 |
+| `autoscaling.minReplicas`               | Minimum number of replicas to scale back                                                 | `nil`                                                   |
+| `autoscaling.maxReplicas`               | Maximum number of replicas to scale out                                                  | `nil`                                                   |
+| `autoscaling.targetCPU`                 | Target CPU utilization percentage                                                        | `nil`                                                   |
+| `autoscaling.targetMemory`              | Target Memory utilization percentage                                                     | `nil`                                                   |
+| `extraVolumes`                          | Array to add extra volumes                                                               | `[]` (evaluated as a template)                          |
+| `extraVolumeMounts`                     | Array to add extra mount                                                                 | `[]` (evaluated as a template)                          |
+
+### Custom NGINX application parameters
+
+| Parameter                                         | Description                                                                    | Default                                                 |
+|---------------------------------------------------|--------------------------------------------------------------------------------|---------------------------------------------------------|
+| `cloneStaticSiteFromGit.enabled`                  | Get the server static content from a GIT repository                            | `false`                                                 |
+| `cloneStaticSiteFromGit.image.registry`           | GIT image registry                                                             | `docker.io`                                             |
+| `cloneStaticSiteFromGit.image.repository`         | GIT image name                                                                 | `bitnami/git`                                           |
+| `cloneStaticSiteFromGit.image.tag`                | GIT image tag                                                                  | `{TAG_NAME}`                                            |
+| `cloneStaticSiteFromGit.image.pullPolicy`         | GIT image pull policy                                                          | `Always`                                                |
+| `cloneStaticSiteFromGit.image.pullSecrets`        | Specify docker-registry secret names as an array                               | `[]` (does not add image pull secrets to deployed pods) |
+| `cloneStaticSiteFromGit.repository`               | GIT Repository to clone                                                        | `nil`                                                   |
+| `cloneStaticSiteFromGit.branch`                   | GIT revision to checkout                                                       | `nil`                                                   |
+| `cloneStaticSiteFromGit.interval`                 | Interval for sidecar container pull from the GIT repository                    | `60`                                                    |
+| `serverBlock`                                     | Custom NGINX server block                                                      | `nil`                                                   |
+| `existingServerBlockConfigmap`                    | Name of existing PVC with custom NGINX server block                            | `nil`                                                   |
+| `staticSiteConfigmap`                             | Name of existing ConfigMap with the server static content                      | `nil`                                                   |
+| `staticSitePVC`                                   | Name of existing PVC with the server static content                            | `nil`                                                   |
+
+### LDAP parameters
+
+| Parameter                                         | Description                                                                              | Default                                       |
+|---------------------------------------------------|------------------------------------------------------------------------------------------|-----------------------------------------------|
+| `ldapDaemon.enabled`                              | Enable LDAP Auth Daemon proxy                                                            | `false`                                       |
+| `ldapDaemon.image.registry`                       | LDAP AUth Daemon Image registry                                                          | `docker.io`                                   |
+| `ldapDaemon.image.repository`                     | LDAP Auth Daemon Image name                                                              | `bitnami/nginx-ldap-auth-daemon`              |
+| `ldapDaemon.image.tag`                            | LDAP Auth Daemon Image tag                                                               | `{TAG_NAME}`                                  |
+| `ldapDaemon.image.pullPolicy`                     | LDAP Auth Daemon Image pull policy                                                       | `IfNotPresent`                                |
+| `ldapDaemon.port`                                 | LDAP Auth Daemon port                                                                    | `8888`                                        |
+| `ldapDaemon.ldapConfig.uri`                       | LDAP Server URI, `ldap[s]:/<hostname>:<port>`                                            | `""`                                          |
+| `ldapDaemon.ldapConfig.baseDN`                    | LDAP root DN to begin the search for the user                                            | `""`                                          |
+| `ldapDaemon.ldapConfig.bindDN`                    | DN of user to bind to LDAP                                                               | `""`                                          |
+| `ldapDaemon.ldapConfig.bindPassword`              | Password for the user to bind to LDAP                                                    | `""`                                          |
+| `ldapDaemon.ldapConfig.filter`                    | LDAP search filter for search+bind authentication                                        | `""`                                          |
+| `ldapDaemon.ldapConfig.httpRealm`                 | LDAP HTTP auth realm                                                                     | `""`                                          |
+| `ldapDaemon.ldapConfig.httpCookieName`            | HTTP cookie name to be used in LDAP Auth                                                 | `""`                                          |
+| `ldapDaemon.nginxServerBlock`                     | NGINX server block that configures LDAP communication. Overrides `ldapDaemon.ldapConfig` | See `values.yaml`                             |
+| `ldapDaemon.existingNginxServerBlockSecret`       | Name of existing Secret with a NGINX server block to use for LDAP communication          | `nil`                                         |
+| `ldapDaemon.livenessProbe`                        | LDAP Auth Daemon Liveness Probe                                                          | See `values.yaml`                             |
+| `ldapDaemon.readinessProbe`                       | LDAP Auth Daemon Readiness Probe                                                         | See `values.yaml`                             |
+
+### Exposure parameters
+
+| Parameter                               | Description                                                                              | Default                                                 |
+|-----------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `service.type`                          | Kubernetes Service type                                                                  | `LoadBalancer`                                          |
+| `service.port`                          | Service HTTP port                                                                        | `80`                                                    |
+| `service.httpsPort`                     | Service HTTPS port                                                                       | `443`                                                   |
+| `service.nodePorts.http`                | Kubernetes http node port                                                                | `""`                                                    |
+| `service.nodePorts.https`               | Kubernetes https node port                                                               | `""`                                                    |
+| `service.targetPort.http`               | Kubernetes http targetPort                                                               | `http`                                                  |
+| `service.targetPort.https`              | Kubernetes https targetPort                                                              | `https`                                                 |
+| `service.externalTrafficPolicy`         | Enable client source IP preservation                                                     | `Cluster`                                               |
+| `service.loadBalancerIP`                | LoadBalancer service IP address                                                          | `""`                                                    |
+| `service.annotations`                   | Service annotations                                                                      | `{}`                                                    |
+| `ingress.enabled`                       | Enable ingress controller resource                                                       | `false`                                                 |
+| `ingress.certManager`                   | Add annotations for cert-manager                                                         | `false`                                                 |
+| `ingress.hostname`                      | Default host for the ingress resource                                                    | `example.local`                                         |
+| `ingress.tls`                           | Enable TLS configuration for the hostname defined at `ingress.hostname` parameter        | `false`                                                 |
+| `ingress.annotations`                   | Ingress annotations                                                                      | `[]`                                                    |
+| `ingress.extraHosts`                    | Additional hostnames to be covered                                                       | `[]`                                                    |
+| `ingress.extraTls`                      | TLS configuration for additional hostnames to be covered                                 | `[]`                                                    |
+| `ingress.secrets`                       | TLS Secret configuration                                                                 | `[]`                                                    |
+| `healthIngress.enabled`                 | Enable healthIngress controller resource                                                 | `false`                                                 |
+| `healthIngress.certManager`             | Add annotations for cert-manager                                                         | `false`                                                 |
+| `healthIngress.hostname`                | Default host for the healthIngress resource                                              | `example.local`                                         |
+| `healthIngress.tls`                     | Enable TLS configuration for the hostname defined at `healthIngress.hostname` parameter  | `false`                                                 |
+| `healthIngress.annotations`             | Ingress annotations                                                                      | `[]`                                                    |
+| `healthIngress.extraHosts`              | Additional hostnames to be covered                                                       | `[]`                                                    |
+| `healthIngress.extraTls`                | TLS configuration for additional hostnames to be covered                                 | `[]`                                                    |
+| `healthIngress.secrets`                 | TLS Secret configuration                                                                 | `[]`                                                    |
+
+### Metrics parameters
+
+| Parameter                               | Description                                                                                 | Default                                                      |
+|-----------------------------------------|---------------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `metrics.enabled`                       | Start a Prometheus exporter sidecar container                                               | `false`                                                      |
+| `metrics.image.registry`                | NGINX Prometheus exporter image registry                                                    | `docker.io`                                                  |
+| `metrics.image.repository`              | NGINX Prometheus exporter image name                                                        | `bitnami/nginx-exporter`                                     |
+| `metrics.image.tag`                     | NGINX Prometheus exporter image tag                                                         | `{TAG_NAME}`                                                 |
+| `metrics.image.pullPolicy`              | NGINX Prometheus exporter image pull policy                                                 | `IfNotPresent`                                               |
+| `metrics.image.pullSecrets`             | Specify docker-registry secret names as an array                                            | `[]` (does not add image pull secrets to deployed pods)      |
+| `metrics.podAnnotations`                | Additional annotations for NGINX Prometheus exporter pod(s)                                 | `{prometheus.io/scrape: "true", prometheus.io/port: "9113"}` |
+| `metrics.resources.limits`              | The resources limits for the NGINX Prometheus exporter container                            | `{}`                                                         |
+| `metrics.resources.requests`            | The requested resources for the NGINX Prometheus exporter container                         | `{}`                                                         |
+| `metrics.service.port`                  | NGINX Prometheus exporter service port                                                      | `9113`                                                       |
+| `metrics.service.annotations`           | Annotations for Jenkins Prometheus exporter service                                         | `{prometheus.io/scrape: "true", prometheus.io/port: "9113"}` |
+| `metrics.serviceMonitor.enabled`        | Creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`) | `false`                                                      |
+| `metrics.serviceMonitor.namespace`      | Namespace in which Prometheus is running                                                    | `nil`                                                        |
+| `metrics.serviceMonitor.interval`       | Interval at which metrics should be scraped.                                                | `nil` (Prometheus Operator default value)                    |
+| `metrics.serviceMonitor.scrapeTimeout`  | Timeout after which the scrape is ended                                                     | `nil` (Prometheus Operator default value)                    |
+| `metrics.serviceMonitor.selector`       | Prometheus instance selector labels                                                         | `nil`                                                        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -230,9 +280,47 @@ In order to enable LDAP authentication you can set the `ldapDaemon.enabled` prop
 
 2. Complete the aforementioned server block by specifying your LDAP Server connection details (see `values.yaml`). Alternatively, you can declare them using the property `ldapDaemon.ldapConfig`.
 
+### Adding extra environment variables
+
+In case you want to add extra environment variables (useful for advanced operations like custom init scripts), you can use the `extraEnvVars` property.
+
+```yaml
+extraEnvVars:
+  - name: LOG_LEVEL
+    value: error
+```
+
+Alternatively, you can use a ConfigMap or a Secret with the environment variables. To do so, use the `extraEnvVarsCM` or the `extraEnvVarsSecret` values.
+
+### Deploying extra resources
+
+There are cases where you may want to deploy extra objects, such a ConfigMap containing your app's configuration or some extra deployment with a micro service used by your app. For covering this case, the chart allows adding the full specification of other objects using the `extraDeploy` parameter.
+
+### Ingress
+
+This chart provides support for ingress resources. If you have an ingress controller installed on your cluster, such as [nginx-ingress-controller](https://github.com/bitnami/charts/tree/master/bitnami/nginx-ingress-controller) or [contour](https://github.com/bitnami/charts/tree/master/bitnami/contour) you can utilize the ingress controller to serve your application.
+
+To enable ingress integration, please set `ingress.enabled` to `true`.
+
+#### Hosts
+
+Most likely you will only want to have one hostname that maps to this NGINX installation. If that's your case, the property `ingress.hostname` will set it. However, it is possible to have more than one host. To facilitate this, the `ingress.extraHosts` object can be specified as an array. You can also use `ingress.extraTLS` to add the TLS configuration for extra hosts.
+
+For each host indicated at `ingress.extraHosts`, please indicate a `name`, `path`, and any `annotations` that you may want the ingress controller to know about.
+
+For annotations, please see [this document](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md). Not all annotations are supported by all ingress controllers, but this document does a good job of indicating which annotation is supported by many popular ingress controllers.
+
 ## Upgrading
 
+### 7.0.0
+
+- This version also introduces `bitnami/common`, a [library chart](https://helm.sh/docs/topics/library_charts/#helm) as a dependency. More documentation about this new utility could be found [here](https://github.com/bitnami/charts/tree/master/bitnami/common#bitnami-common-library-chart). Please, make sure that you have updated the chart dependencies before executing any upgrade.
+- Ingress configuration was also adapted to follow the Helm charts best practices.
+
+> Note: There is no backwards compatibility due to the above mentioned changes. It's necessary to install a new release of the chart, and migrate your existing application to the new NGINX instances.
+
 ### 5.6.0
+
 Added support for the use of LDAP.
 
 ### 5.0.0

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -193,11 +193,11 @@ The following tables lists the configurable parameters of the NGINX chart and th
 | `metrics.image.tag`                     | NGINX Prometheus exporter image tag                                                         | `{TAG_NAME}`                                                 |
 | `metrics.image.pullPolicy`              | NGINX Prometheus exporter image pull policy                                                 | `IfNotPresent`                                               |
 | `metrics.image.pullSecrets`             | Specify docker-registry secret names as an array                                            | `[]` (does not add image pull secrets to deployed pods)      |
-| `metrics.podAnnotations`                | Additional annotations for NGINX Prometheus exporter pod(s)                                 | `{prometheus.io/scrape: "true", prometheus.io/port: "9113"}` |
+| `metrics.podAnnotations`                | Additional annotations for NGINX Prometheus exporter pod(s)                                 | `{}`                                                         |
 | `metrics.resources.limits`              | The resources limits for the NGINX Prometheus exporter container                            | `{}`                                                         |
 | `metrics.resources.requests`            | The requested resources for the NGINX Prometheus exporter container                         | `{}`                                                         |
 | `metrics.service.port`                  | NGINX Prometheus exporter service port                                                      | `9113`                                                       |
-| `metrics.service.annotations`           | Annotations for Jenkins Prometheus exporter service                                         | `{prometheus.io/scrape: "true", prometheus.io/port: "9113"}` |
+| `metrics.service.annotations`           | Annotations for Jenkins Prometheus exporter service                                         | `{prometheus.io/scrape: true, prometheus.io/port: 9113}`     |
 | `metrics.serviceMonitor.enabled`        | Creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`) | `false`                                                      |
 | `metrics.serviceMonitor.namespace`      | Namespace in which Prometheus is running                                                    | `nil`                                                        |
 | `metrics.serviceMonitor.interval`       | Interval at which metrics should be scraped.                                                | `nil` (Prometheus Operator default value)                    |

--- a/bitnami/nginx/ci/values-with-ingress-metrics-and-serverblock.yaml
+++ b/bitnami/nginx/ci/values-with-ingress-metrics-and-serverblock.yaml
@@ -17,7 +17,7 @@ serverBlock: |-
 
 ingress:
   enabled: true
-  tls: []
+  tls: true
 
 metrics:
   enabled: true

--- a/bitnami/nginx/requirements.lock
+++ b/bitnami/nginx/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 0.6.2
+digest: sha256:e30fa2c3364d51b5e0b1d5ee81d6c9d5d94e4c1f430ee6a3210192d1850b118d
+generated: "2020-09-15T11:38:59.055715+02:00"

--- a/bitnami/nginx/requirements.yaml
+++ b/bitnami/nginx/requirements.yaml
@@ -1,0 +1,6 @@
+dependencies:
+  - name: common
+    version: 0.x.x
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common

--- a/bitnami/nginx/templates/NOTES.txt
+++ b/bitnami/nginx/templates/NOTES.txt
@@ -1,39 +1,49 @@
-Get the NGINX URL:
+** Please be patient while the chart is being deployed **
+
+NGINX can be accessed through the following DNS name from within your cluster:
+
+    {{ include "common.names.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} (port {{ .Values.service.port }})
+
+To access NGINX from outside the cluster, follow the steps below:
 
 {{- if .Values.ingress.enabled }}
 
-  You should be able to access your new NGINX installation through:
+1. Get the NGINX URL and associate its hostname to your cluster external IP:
 
-  {{- if .Values.ingress.hostname }}
-      - http://{{ .Values.ingress.hostname }}
-  {{- end }}
-  {{- range $host := .Values.ingress.hosts }}
-    {{- range .paths }}
-      - http://{{ $host.name }}{{ . }}
-    {{- end }}
-  {{- end }}
+   export CLUSTER_IP=$(minikube ip) # On Minikube. Use: `kubectl cluster-info` on others K8s clusters
+   echo "NGINX URL: http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.hostname }}"
+   echo "$CLUSTER_IP  {{ .Values.ingress.hostname }}" | sudo tee -a /etc/hosts
 
-{{- else if contains "LoadBalancer" .Values.service.type }}
-{{- $port:=.Values.service.port | toString }}
+{{- else }}
+
+1. Get the NGINX URL by running these commands:
+
+{{- if contains "LoadBalancer" .Values.service.type }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "nginx.fullname" . }}'
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ include "common.names.fullname" . }}'
 
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "nginx.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo "NGINX URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}/"
+    export SERVICE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].port}" services {{ include "common.names.fullname" . }})
+    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "common.names.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    echo "http://${SERVICE_IP}:${SERVICE_PORT}"
 
 {{- else if contains "ClusterIP"  .Values.service.type }}
 
-  echo "NGINX URL: http://127.0.0.1:8080/"
-  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "nginx.fullname" . }} 8080:{{ .Values.service.port }}
+    export SERVICE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].port}" services {{ include "common.names.fullname" . }})
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "common.names.fullname" . }} ${SERVICE_PORT}:${SERVICE_PORT} &
+    echo "http://127.0.0.1:${SERVICE_PORT}"
 
 {{- else if contains "NodePort" .Values.service.type }}
 
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "nginx.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo "NGINX URL: http://$NODE_IP:$NODE_PORT/"
+    export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "common.names.fullname" . }})
+    export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    echo "http://${NODE_IP}:${NODE_PORT}"
 
 {{- end }}
+{{- end }}
 
+{{- include "common.warnings.rollingTag" .Values.image }}
+{{- include "common.warnings.rollingTag" .Values.cloneStaticSiteFromGit.image }}
+{{- include "common.warnings.rollingTag" .Values.ldapDaemon.image }}
+{{- include "common.warnings.rollingTag" .Values.metrics.image }}
 {{- include "nginx.validateValues" . }}
-{{- include "nginx.checkRollingTags" . }}

--- a/bitnami/nginx/templates/_helpers.tpl
+++ b/bitnami/nginx/templates/_helpers.tpl
@@ -1,202 +1,37 @@
 {{/* vim: set filetype=mustache: */}}
 {{/*
-Expand the name of the chart.
-*/}}
-{{- define "nginx.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-*/}}
-{{- define "nginx.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
-{{- define "nginx.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Common labels
-*/}}
-{{- define "nginx.labels" -}}
-app.kubernetes.io/name: {{ include "nginx.name" . }}
-helm.sh/chart: {{ include "nginx.chart" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end -}}
-
-{{/*
-Labels to use on deploy.spec.selector.matchLabels and svc.spec.selector
-*/}}
-{{- define "nginx.matchLabels" -}}
-app.kubernetes.io/name: {{ include "nginx.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end -}}
-
-{{/*
 Return the proper NGINX image name
 */}}
 {{- define "nginx.image" -}}
-{{- $registryName := .Values.image.registry -}}
-{{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
-{{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-{{- end -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
 {{- end -}}
 
 {{/*
-Return the proper Git image name
+Return the proper GIT image name
 */}}
-{{- define "cloneStaticSiteFromGit.image" -}}
-{{- $registryName := .Values.cloneStaticSiteFromGit.image.registry -}}
-{{- $repositoryName := .Values.cloneStaticSiteFromGit.image.repository -}}
-{{- $tag := .Values.cloneStaticSiteFromGit.image.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
-{{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-{{- end -}}
+{{- define "nginx.cloneStaticSiteFromGit.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.cloneStaticSiteFromGit.image "global" .Values.global) }}
 {{- end -}}
 
 {{/*
-Return the proper image name (for the LDAP Auth Daemon image)
+Return the proper DAP Auth Daemon image name
 */}}
 {{- define "nginx.ldapDaemon.image" -}}
-{{- $registryName := .Values.ldapDaemon.image.registry -}}
-{{- $repositoryName := .Values.ldapDaemon.image.repository -}}
-{{- $tag := .Values.ldapDaemon.image.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
-{{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-{{- end -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.ldapDaemon.image "global" .Values.global) }}
 {{- end -}}
 
 {{/*
-Return the proper image name (for the metrics image)
+Return the proper Prometheus metrics image name
 */}}
 {{- define "nginx.metrics.image" -}}
-{{- $registryName := .Values.metrics.image.registry -}}
-{{- $repositoryName := .Values.metrics.image.repository -}}
-{{- $tag := .Values.metrics.image.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
-{{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-{{- end -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.metrics.image "global" .Values.global) }}
 {{- end -}}
 
 {{/*
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "nginx.imagePullSecrets" -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
-Also, we can not use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets:
-{{- range .Values.global.imagePullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- else if or .Values.image.pullSecrets .Values.metrics.image.pullSecrets .Values.cloneStaticSiteFromGit.image.pullSecrets }}
-imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- range .Values.cloneStaticSiteFromGit.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- range .Values.metrics.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end -}}
-{{- else if or .Values.image.pullSecrets .Values.metrics.image.pullSecrets .Values.cloneStaticSiteFromGit.image.pullSecrets }}
-imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- range .Values.cloneStaticSiteFromGit.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- range .Values.metrics.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Check if there are rolling tags in the images
-*/}}
-{{- define "nginx.checkRollingTags" -}}
-{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
-WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
-+info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
-{{- end }}
-{{- if and (contains "bitnami/" .Values.cloneStaticSiteFromGit.image.repository) (not (.Values.cloneStaticSiteFromGit.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
-WARNING: Rolling tag detected ({{ .Values.cloneStaticSiteFromGit.image.repository }}:{{ .Values.cloneStaticSiteFromGit.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
-+info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
-{{- end }}
-{{- if and (contains "bitnami/" .Values.metrics.image.repository) (not (.Values.metrics.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
-WARNING: Rolling tag detected ({{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
-+info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
-{{- end }}
+{{ include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.cloneStaticSiteFromGit.image .Values.ldapDaemon.image .Values.metrics.image) "global" .Values.global) }}
 {{- end -}}
 
 {{/*
@@ -230,7 +65,7 @@ Return the custom NGINX server block configmap.
 {{- if .Values.existingServerBlockConfigmap -}}
     {{- printf "%s" (tpl .Values.existingServerBlockConfigmap $) -}}
 {{- else -}}
-    {{- printf "%s-server-block" (include "nginx.fullname" .) -}}
+    {{- printf "%s-server-block" (include "common.names.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 
@@ -241,21 +76,8 @@ Return the custom NGINX server block secret for LDAP.
 {{- if .Values.ldapDaemon.existingNginxServerBlockSecret -}}
     {{- printf "%s" (tpl .Values.ldapDaemon.existingNginxServerBlockSecret $) -}}
 {{- else -}}
-    {{- printf "%s-ldap-daemon" (include "nginx.fullname" .) -}}
+    {{- printf "%s-ldap-daemon" (include "common.names.fullname" .) -}}
 {{- end -}}
-{{- end -}}
-
-{{/*
-Renders a value that contains template.
-Usage:
-{{ include "nginx.tplValue" (dict "value" .Values.path.to.the.Value "context" $) }}
-*/}}
-{{- define "nginx.tplValue" -}}
-    {{- if typeIs "string" .value }}
-        {{- tpl .value .context }}
-    {{- else }}
-        {{- tpl (.value | toYaml) .context }}
-    {{- end }}
 {{- end -}}
 
 {{/*

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -1,42 +1,55 @@
-apiVersion: apps/v1
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
-  name: {{ template "nginx.fullname" . }}
-  labels: {{- include "nginx.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
-  selector:
-    matchLabels: {{- include "nginx.matchLabels" . | nindent 6 }}
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
   template:
     metadata:
-      labels: {{- include "nginx.labels" . | nindent 8 }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
+        {{- end }}
       {{- if or .Values.podAnnotations (and .Values.metrics.enabled .Values.metrics.podAnnotations) (and .Values.serverBlock (not .Values.existingServerBlockConfigmap)) }}
       annotations:
         {{- if .Values.podAnnotations }}
-        {{- include "nginx.tplValue" ( dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
         {{- if and .Values.metrics.enabled .Values.metrics.podAnnotations }}
-        {{- include "nginx.tplValue" ( dict "value" .Values.metrics.podAnnotations "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
         {{- if and .Values.serverBlock (not .Values.existingServerBlockConfigmap) }}
         checksum/server-block-configuration: {{ include (print $.Template.BasePath "/server-block-configmap.yaml") . | sha256sum }}
         {{- end }}
       {{- end }}
     spec:
-{{- include "nginx.imagePullSecrets" . | indent 6 }}
+      {{- include "nginx.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.affinity }}
-      affinity: {{- include "nginx.tplValue" (dict "value" .Values.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.nodeSelector }}
-      nodeSelector: {{- include "nginx.tplValue" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.tolerations }}
-      tolerations: {{- include "nginx.tplValue" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.podSecurityContext.fsGroup }}
       {{- end }}
       {{- if .Values.cloneStaticSiteFromGit.enabled }}
       initContainers:
         - name: git-clone-repository
-          image: {{ include "cloneStaticSiteFromGit.image" . }}
+          image: {{ include "nginx.cloneStaticSiteFromGit.image" . }}
           imagePullPolicy: {{ .Values.cloneStaticSiteFromGit.image.pullPolicy | quote }}
           command:
             - /bin/bash
@@ -65,20 +78,65 @@ spec:
       containers:
       {{- end }}
         - name: nginx
-          image: {{ template "nginx.image" . }}
+          image: {{ include "nginx.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext:
+            runAsUser: {{ .Values.containerSecurityContext.runAsUser }}
+            runAsNonRoot: {{ .Values.containerSecurityContext.runAsNonRoot }}
+          {{- end }}
+          {{- if .Values.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.command "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 12 }}
+          {{- end }}
+          env:
+            - name: BITNAMI_DEBUG
+              value: {{ ternary "true" "false" .Values.image.debug | quote }}
+            {{- if .Values.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+          {{- if or .Values.extraEnvVarsCM .Values.extraEnvVarsSecret }}
+          envFrom:
+            {{- if .Values.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ tpl .Values.extraEnvVarsCM . | quote }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ tpl .Values.extraEnvVarsSecret . | quote }}
+            {{- end }}
+          {{- end }}
           ports:
             - name: http
-              containerPort: {{ .Values.containerPort }}
-            {{ if .Values.containerTlsPort }}
+              containerPort: {{ .Values.containerPorts.http }}
+            {{- if .Values.containerPorts.https }}
             - name: https
-              containerPort: {{ .Values.containerTlsPort }}
-            {{ end }}
-          {{- if .Values.livenessProbe }}
-          livenessProbe: {{- toYaml .Values.livenessProbe | nindent 12 }}
+              containerPort: {{ .Values.containerPorts.https }}
+            {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            tcpSocket:
+              port: http
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- else if .Values.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.readinessProbe }}
-          readinessProbe: {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- else if .Values.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
@@ -99,21 +157,12 @@ spec:
               mountPath: /app
             {{- end }}
             {{- if .Values.extraVolumeMounts }}
-            {{- include "nginx.tplValue" ( dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- include "common.tplvalues.render" ( dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
         {{- if .Values.ldapDaemon.enabled }}
         - name: ldap-daemon
-          image: {{ template "nginx.ldapDaemon.image" . }}
+          image: {{ include "nginx.ldapDaemon.image" . }}
           imagePullPolicy: {{ .Values.ldapDaemon.image.pullPolicy | quote }}
-          ports:
-            - name: ldap-daemon
-              containerPort: {{ .Values.ldapDaemon.port }}
-        {{- if .Values.ldapDaemon.livenessProbe }}
-          livenessProbe: {{- toYaml .Values.ldapDaemon.livenessProbe | nindent 12 }}
-        {{- end }}
-        {{- if .Values.ldapDaemon.readinessProbe }}
-          readinessProbe: {{- toYaml .Values.ldapDaemon.readinessProbe | nindent 12 }}
-        {{- end }}
           env:
             - name: NGINXLDAP_PORT_NUMBER
               value: {{ .Values.ldapDaemon.port | quote}}
@@ -126,7 +175,7 @@ spec:
             - name: NGINXLDAP_LDAP_BIND_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "nginx.fullname" . }}-ldap-daemon
+                  name: {{ template "common.names.fullname" . }}-ldap-daemon
                   key: ldap-daemon-ldap-bind-password
             - name: NGINXLDAP_LDAP_FILTER
               value: {{ .Values.ldapDaemon.ldapConfig.filter | quote }}
@@ -134,10 +183,36 @@ spec:
               value: {{ .Values.ldapDaemon.ldapConfig.httpRealm | quote }}
             - name: NGINXLDAP_HTTP_COOKIE_NAME
               value: {{ .Values.ldapDaemon.ldapConfig.httpCookieName | quote }}
+          ports:
+            - name: ldap-daemon
+              containerPort: {{ .Values.ldapDaemon.port }}
+          {{- if .Values.ldapDaemon.livenessProbe.enabled }}
+          livenessProbe:
+            tcpSocket:
+              port: ldap-daemon
+            periodSeconds: {{ .Values.ldapDaemon.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.ldapDaemon.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.ldapDaemon.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.ldapDaemon.livenessProbe.failureThreshold }}
+          {{- else if .Values.ldapDaemon.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ldapDaemon.customLivenessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.ldapDaemon.readinessProbe.enabled }}
+          readinessProbe:
+            tcpSocket:
+              port: ldap-daemon
+            initialDelaySeconds: {{ .Values.ldapDaemon.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.ldapDaemon.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.ldapDaemon.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.ldapDaemon.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.ldapDaemon.readinessProbe.failureThreshold }}
+          {{- else if .Values.ldapDaemon.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ldapDaemon.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
         {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
-          image: {{ template "nginx.metrics.image" . }}
+          image: {{ include "nginx.metrics.image" . }}
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
           command: ['/usr/bin/exporter', '-nginx.scrape-uri', 'http://127.0.0.1:8080/status']
           ports:
@@ -162,11 +237,11 @@ spec:
       volumes:
         - name: nginx-server-block-paths
           configMap:
-            name: {{ template "nginx.fullname" . }}-server-block
+            name: {{ template "common.names.fullname" . }}-server-block
             items:
               - key: server-blocks-paths.conf
                 path: server-blocks-paths.conf
-      {{- if or .Values.serverBlock .Values.existingServerBlockConfigmap .Values.extraVolumes (include "nginx.useStaticSite" .) }}
+        {{- if or .Values.serverBlock .Values.existingServerBlockConfigmap .Values.extraVolumes (include "nginx.useStaticSite" .) }}
         {{- if or .Values.serverBlock .Values.existingServerBlockConfigmap }}
         - name: nginx-server-block
           configMap:
@@ -181,12 +256,12 @@ spec:
         - name: staticsite
           {{- include "nginx.staticSiteVolume" . | nindent 10 }}
         {{- end }}
-      {{- if .Values.extraVolumes }}
-      {{- include "nginx.tplValue" ( dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
-      {{- end }}
-      {{- end }}
-      {{- if .Values.ldapDaemon.enabled }}
+        {{- if .Values.extraVolumes }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.ldapDaemon.enabled }}
         - name: nginx-server-block-ldap
           secret:
             secretName: {{ include "ldap.nginxServerBlockSecret" . }}
-      {{- end }}
+        {{- end }}

--- a/bitnami/nginx/templates/extra-list.yaml
+++ b/bitnami/nginx/templates/extra-list.yaml
@@ -1,0 +1,5 @@
+{{- if .Values.extraDeploy }}
+apiVersion: v1
+kind: List
+items: {{- include "common.tplvalues.render" (dict "value" .Values.extraDeploy "context" $) | nindent 2 }}
+{{- end }}

--- a/bitnami/nginx/templates/health-ingress.yaml
+++ b/bitnami/nginx/templates/health-ingress.yaml
@@ -1,15 +1,21 @@
 {{- if .Values.healthIngress.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: {{ include "nginx.fullname" . }}-health
-  labels: {{- include "nginx.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}-health
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   annotations:
     {{- if .Values.healthIngress.certManager }}
     kubernetes.io/tls-acme: "true"
     {{- end }}
-    {{- range $key, $value := .Values.healthIngress.annotations }}
-    {{ $key }}: {{ $value | quote }}
+    {{- if .Values.healthIngress.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.healthIngress.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
 spec:
   rules:
@@ -19,19 +25,27 @@ spec:
         paths:
           - path: /
             backend:
-              serviceName: "{{ template "nginx.fullname" $ }}"
+              serviceName: {{ template "common.names.fullname" . }}
               servicePort: http
     {{- end }}
-    {{- range .Values.healthIngress.hosts }}
+    {{- range .Values.healthIngress.extraHosts }}
     - host: {{ .name }}
       http:
         paths:
           - path: {{ default "/" .path }}
             backend:
-              serviceName: "{{ template "nginx.fullname" $ }}"
+              serviceName: {{ template "common.names.fullname" $ }}
               servicePort: http
     {{- end }}
-  {{- if .Values.healthIngress.tls }}
-  tls: {{- toYaml .Values.healthIngress.tls | nindent 4 }}
+  {{- if or .Values.healthIngress.tls .Values.healthIngress.extraTls }}
+  tls:
+    {{- if .Values.healthIngress.tls }}
+    - hosts:
+        - {{ .Values.healthIngress.hostname }}
+      secretName: {{ printf "%s-tls" .Values.healthIngress.hostname }}
+    {{- end }}
+    {{- if .Values.healthIngress.extraTls }}
+    {{- toYaml .Values.healthIngress.extraTls | nindent 4 }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/bitnami/nginx/templates/hpa.yaml
+++ b/bitnami/nginx/templates/hpa.yaml
@@ -2,13 +2,19 @@
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ template "nginx.fullname" . }}
-  labels: {{- include "nginx.labels" . | nindent 4 }}
+  name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1
+    apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
     kind: Deployment
-    name: {{ template "nginx.fullname" . }}
+    name: {{ template "common.names.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:

--- a/bitnami/nginx/templates/ingress.yaml
+++ b/bitnami/nginx/templates/ingress.yaml
@@ -1,15 +1,21 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: {{ include "nginx.fullname" . }}
-  labels: {{- include "nginx.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   annotations:
     {{- if .Values.ingress.certManager }}
     kubernetes.io/tls-acme: "true"
     {{- end }}
-    {{- range $key, $value := .Values.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
+    {{- if .Values.ingress.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
 spec:
   rules:
@@ -19,25 +25,27 @@ spec:
         paths:
           - path: /
             backend:
-              serviceName: "{{ template "nginx.fullname" $ }}"
+              serviceName: {{ template "common.names.fullname" . }}
               servicePort: http
     {{- end }}
-    {{- range .Values.ingress.hosts }}
+    {{- range .Values.ingress.extraHosts }}
     - host: {{ .name }}
       http:
         paths:
-        {{- range .extraPaths }}
-          - path: {{ .path }}
-            backend:
-              serviceName: {{ .backend.serviceName }}
-              servicePort: {{ .backend.servicePort }}
-        {{- end }}
           - path: {{ default "/" .path }}
             backend:
-              serviceName: "{{ template "nginx.fullname" $ }}"
+              serviceName: {{ template "common.names.fullname" $ }}
               servicePort: http
     {{- end }}
-  {{- if .Values.ingress.tls }}
-  tls: {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
+  tls:
+    {{- if .Values.ingress.tls }}
+    - hosts:
+        - {{ .Values.ingress.hostname }}
+      secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
+    {{- end }}
+    {{- if .Values.ingress.extraTls }}
+    {{- toYaml .Values.ingress.extraTls | nindent 4 }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/bitnami/nginx/templates/ldap-daemon-secrets.yaml
+++ b/bitnami/nginx/templates/ldap-daemon-secrets.yaml
@@ -2,8 +2,14 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "nginx.fullname" . }}-ldap-daemon
-  labels: {{- include "nginx.labels" . | nindent 4 }}
+  name: {{ template "common.names.fullname" . }}-ldap-daemon
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   ldap-daemon-ldap-bind-password: {{ .Values.ldapDaemon.ldapConfig.bindPassword | b64enc | quote}}

--- a/bitnami/nginx/templates/server-block-configmap.yaml
+++ b/bitnami/nginx/templates/server-block-configmap.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "nginx.fullname" . }}-server-block
-  labels: {{- include "nginx.labels" . | nindent 4 }}
+  name: {{ template "common.names.fullname" . }}-server-block
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
 data:
   server-blocks-paths.conf: |-
     include  "/opt/bitnami/nginx/conf/server_blocks/ldap/*.conf";

--- a/bitnami/nginx/templates/servicemonitor.yaml
+++ b/bitnami/nginx/templates/servicemonitor.yaml
@@ -2,17 +2,17 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "nginx.fullname" . }}
+  name: {{ template "common.names.fullname" . }}
   {{- if .Values.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.metrics.serviceMonitor.namespace }}
   {{- end }}
-  labels: {{- include "nginx.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- range $key, $value := .Values.metrics.serviceMonitor.selector }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
   selector:
-    matchLabels: {{ include "nginx.matchLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
   endpoints:
     - port: metrics
       path: /metrics

--- a/bitnami/nginx/templates/svc.yaml
+++ b/bitnami/nginx/templates/svc.yaml
@@ -1,15 +1,21 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "nginx.fullname" . }}
-  labels: {{- include "nginx.labels" . | nindent 4 }}
-  {{- if or .Values.service.annotations (and .Values.metrics.enabled .Values.metrics.service.annotations) }}
+  name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.service.annotations .Values.commonAnnotations (and .Values.metrics.enabled .Values.metrics.service.annotations) }}
   annotations:
     {{- if .Values.service.annotations }}
-    {{- include "nginx.tplValue" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
     {{- if and .Values.metrics.enabled .Values.metrics.service.annotations }}
-    {{- include "nginx.tplValue" ( dict "value" .Values.metrics.service.annotations "context" $) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.service.annotations "context" $) | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:
@@ -27,15 +33,17 @@ spec:
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.http)) }}
       nodePort: {{ .Values.service.nodePorts.http }}
       {{- end }}
+    {{- if .Values.containerPorts.https }}
     - name: https
       port: {{ .Values.service.httpsPort }}
       targetPort: {{ .Values.service.targetPort.https }}
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.https)) }}
       nodePort: {{ .Values.service.nodePorts.https }}
       {{- end }}
+    {{- end }}
     {{- if .Values.metrics.enabled }}
     - name: metrics
       port: {{ .Values.metrics.service.port }}
       targetPort: metrics
     {{- end }}
-  selector: {{- include "nginx.matchLabels" . | nindent 4 }}
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/nginx/templates/tls-secrets.yaml
+++ b/bitnami/nginx/templates/tls-secrets.yaml
@@ -1,14 +1,41 @@
 {{- if .Values.ingress.enabled }}
+{{- if .Values.ingress.secrets }}
 {{- range .Values.ingress.secrets }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "nginx.fullname" . }}
-  labels: {{- include "nginx.labels" . | nindent 4 }}
+  name: {{ .name }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .certificate | b64enc }}
   tls.key: {{ .key | b64enc }}
 ---
+{{- end }}
+{{- else if and .Values.ingress.tls (not .Values.ingress.certManager) }}
+{{- $ca := genCA "nginx-ca" 365 }}
+{{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-tls" .Values.ingress.hostname }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $cert.Cert | b64enc | quote }}
+  tls.key: {{ $cert.Key | b64enc | quote }}
+  ca.crt: {{ $ca.Cert | b64enc | quote }}
 {{- end }}
 {{- end }}

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -494,7 +494,7 @@ ingress:
   ## secrets:
   ##   - name: example.local-tls
   ##     key:
-  ##     certificate: 
+  ##     certificate:
   ##
   secrets: []
 
@@ -559,7 +559,7 @@ healthIngress:
   ## secrets:
   ##   - name: example.local-tls
   ##     key:
-  ##     certificate: 
+  ##     certificate:
   ##
   secrets: []
 
@@ -586,9 +586,7 @@ metrics:
   ## Prometheus exporter pods' annotation and labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##
-  podAnnotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9113"
+  podAnnotations: {}
 
   ## Prometheus exporter service parameters
   ##
@@ -599,7 +597,7 @@ metrics:
     ## Annotations for the Prometheus exporter service
     ##
     annotations:
-      prometheus.io/scrape: "true"
+      prometheus.io/scrape: true
       prometheus.io/port: "{{ .Values.metrics.service.port }}"
 
   ## NGINX Prometheus exporter resource requests and limits

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -22,9 +22,14 @@ image:
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## E.g.:
+  ## pullSecrets:
+  ##   - myRegistryKeySecretName
   ##
-  # pullSecrets:
-  #   - myRegistryKeySecretName
+  pullSecrets: []
+  ## Set to true if you would like to see extra information on logs
+  ##
+  debug: false
 
 ## String to partially override nginx.fullname template (will maintain the release name)
 ##
@@ -34,14 +39,42 @@ image:
 ##
 # fullnameOverride:
 
-## Name of existing ConfigMap with the server static site content
+## Kubernetes Cluster Domain
 ##
-# staticSiteConfigmap
+clusterDomain: cluster.local
 
-## Name of existing PVC with the server static site content
-## NOTE: This will override staticSiteConfigmap
+## Extra objects to deploy (value evaluated as a template)
 ##
-# staticSitePVC
+extraDeploy: []
+
+## Add labels to all the deployed resources
+##
+commonLabels: {}
+
+## Add annotations to all the deployed resources
+##
+commonAnnotations: {}
+
+## Command and args for running the container (set to default if not set). Use array form
+##
+# command:
+# args:
+
+## Additional environment variables to set
+## E.g:
+## extraEnvVars:
+##   - name: FOO
+##     value: BAR
+##
+extraEnvVars: []
+
+## ConfigMap with extra environment variables
+##
+# extraEnvVarsCM:
+
+## Secret with extra environment variables
+##
+# extraEnvVarsSecret:
 
 ## Get the server static content from a git repository
 ## NOTE: This will override staticSiteConfigmap and staticSitePVC
@@ -99,18 +132,23 @@ cloneStaticSiteFromGit:
 ##
 # existingServerBlockConfigmap:
 
+## Name of existing ConfigMap with the server static site content
+##
+# staticSiteConfigmap
+
+## Name of existing PVC with the server static site content
+## NOTE: This will override staticSiteConfigmap
+##
+# staticSitePVC
+
 ## Number of replicas to deploy
 ##
 replicaCount: 1
 
-## Deployment Container Port
+## Pod extra labels
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ##
-containerPort: 8080
-
-## If you would like to serve tls in the cluster set containerTlsPort
-##   This is required for extra serverBlocks that serve https.
-##
-## containerTlsPort: 8443
+podLabels: {}
 
 ## Pod annotations
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
@@ -132,6 +170,34 @@ nodeSelector: {}
 ##
 tolerations: {}
 
+## NGINX pods' Security Context.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+##
+podSecurityContext:
+  enabled: false
+  runAsUser: 1001
+  runAsNonRoot: true
+  ## sysctl settings
+  ## Example:
+  ## sysctls:
+  ## - name: net.core.somaxconn
+  ##   value: "10000"
+  ##
+  sysctls: {}
+
+## NGINX Core containers' Security Context (only main container).
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+##
+containerSecurityContext:
+  enabled: false
+  fsGroup: 1001
+
+## Configures the ports NGINX listens on
+##
+containerPorts:
+  http: 8080
+  # https: 8443
+
 ## NGINX containers' resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##
@@ -147,21 +213,48 @@ resources:
   #   cpu: 100m
   #   memory: 128Mi
 
-## NGINX containers' liveness and readiness probes
+## NGINX containers' liveness and readiness probes.
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 ##
 livenessProbe:
-  tcpSocket:
-    port: http
+  enabled: true
   initialDelaySeconds: 30
   timeoutSeconds: 5
+  periodSeconds: 10
   failureThreshold: 6
+  successThreshold: 1
 readinessProbe:
-  tcpSocket:
-    port: http
+  enabled: true
   initialDelaySeconds: 5
   timeoutSeconds: 3
   periodSeconds: 5
+  failureThreshold: 3
+  successThreshold: 1
+
+## Custom Liveness probe
+##
+customLivenessProbe: {}
+
+## Custom Rediness probe
+##
+customReadinessProbe: {}
+
+## Autoscaling parameters
+##
+autoscaling:
+  enabled: false
+  # minReplicas: 1
+  # maxReplicas: 10
+  # targetCPU: 50
+  # targetMemory: 50
+
+## Array to add extra volumes (evaluated as a template)
+##
+extraVolumes: []
+
+## Array to add extra mounts (normally used with extraVolumes, evaluated as a template)
+##
+extraVolumeMounts: []
 
 ## NGINX Service properties
 ##
@@ -207,7 +300,6 @@ service:
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   ##
   externalTrafficPolicy: Cluster
-
 
 ## LDAP Auth Daemon Properties
 ##
@@ -278,7 +370,7 @@ ldapDaemon:
 
   nginxServerBlock: |-
     server {
-    listen 0.0.0.0:{{ .Values.containerPort }};
+    listen 0.0.0.0:{{ .Values.containerPorts.http }};
 
     # You can provide a special subPath or the root
     location = / {
@@ -315,22 +407,31 @@ ldapDaemon:
   ##
   existingNginxServerBlockSecret:
 
-  ## LDAP Auth Daemon's liveness and readiness probes
+  ## LDAP Auth Daemon containers' liveness and readiness probes.
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   ##
   livenessProbe:
-    tcpSocket:
-      port: ldap-daemon
+    enabled: true
     initialDelaySeconds: 30
     timeoutSeconds: 5
+    periodSeconds: 10
     failureThreshold: 6
-
+    successThreshold: 1
   readinessProbe:
-    tcpSocket:
-      port: ldap-daemon
+    enabled: true
     initialDelaySeconds: 5
     timeoutSeconds: 3
     periodSeconds: 5
+    failureThreshold: 3
+    successThreshold: 1
+
+  ## Custom Liveness probe
+  ##
+  customLivenessProbe: {}
+
+  ## Custom Rediness probe
+  ##
+  customReadinessProbe: {}
 
 ## Ingress paramaters
 ##
@@ -345,41 +446,60 @@ ingress:
 
   ## When the ingress is enabled, a host pointing to this will be created
   ##
-  # hostname: example.local
-
-  ## The list of hosts and paths to be covered into ingress rules if more than one hosts
-  ## or only a host with a path is needed, this is an array
-  ## hosts:
-  ## - name: example.local
-  ##   path: /
+  hostname: example.local
 
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
   ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   ##
-  ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
-  annotations: {}
-  #  kubernetes.io/ingress.class: nginx
-
-  ## The tls configuration for the ingress
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
   ##
-  tls:
-    - hosts:
-        - example.local
-      secretName: example.local-tls
+  annotations: {}
 
-  hosts:
+  ## Enable TLS configuration for the hostname defined at ingress.hostname parameter
+  ## TLS certificates will be retrieved from a TLS secret with name: {{- printf "%s-tls" .Values.ingress.hostname }}
+  ## You can use the ingress.secrets parameter to create this TLS secret, relay on cert-manager to create it, or
+  ## let the chart create self-signed certificates for you
+  ##
+  tls: false
 
-    ## Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
-    extraPaths: []
-      # - path: /*
-      #   backend:
-      #     serviceName: ssl-redirect
-      #     servicePort: use-annotation
+  ## The list of additional hostnames to be covered with this ingress record.
+  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+  ## E.g.
+  ## extraHosts:
+  ##   - name: example.local
+  ##     path: /
+  ##
+  extraHosts: []
 
+  ## The tls configuration for additional hostnames to be covered with this ingress record.
+  ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## E.g.
+  ## extraTls:
+  ##   - hosts:
+  ##       - example.local
+  ##     secretName: example.local-tls
+  ##
+  extraTls: []
 
+  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or -----BEGIN RSA PRIVATE KEY-----
+  ## name should line up with a secretName set further up
+  ## If it is not set and you're using cert-manager, this is unneeded, as it will create the secret for you
+  ## If it is not set and you're NOT using cert-manager either, self-signed certificates will be created
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  ##
+  ## E.g.
+  ## secrets:
+  ##   - name: example.local-tls
+  ##     key:
+  ##     certificate: 
+  ##
+  secrets: []
+
+## Health Ingress parameters
+##
 healthIngress:
   ## Set to true to enable health ingress record generation
   ##
@@ -397,38 +517,51 @@ healthIngress:
   ## For a full list of possible ingress annotations, please see
   ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   ##
-  ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+  ##
   annotations: {}
-  #  kubernetes.io/ingress.class: nginx
+
+  ## Enable TLS configuration for the hostname defined at healthIngress.hostname parameter
+  ## TLS certificates will be retrieved from a TLS secret with name: {{- printf "%s-tls" .Values.healthIngress.hostname }}
+  ## You can use the healthIngress.secrets parameter to create this TLS secret, relay on cert-manager to create it, or
+  ## let the chart create self-signed certificates for you
+  ##
+  tls: false
 
   ## The list of additional hostnames to be covered with this health ingress record.
   ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
-  ## hosts:
-  ## - name: example.local
-  ##   path: /
-
-  ## The tls configuration for the health ingress
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## E.g.
+  ## extraHosts:
+  ##   - name: example.local
+  ##     path: /
   ##
-  tls:
-    - hosts:
-        - example.local
-      secretName: example.local-tls
+  extraHosts: []
 
-  secrets:
+  ## The tls configuration for additional hostnames to be covered with this health ingress record.
+  ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## E.g.
+  ## extraTls:
+  ##   - hosts:
+  ##       - example.local
+  ##     secretName: example.local-tls
+  ##
+  extraTls: []
+
   ## If you're providing your own certificates, please use this to add the certificates as secrets
-  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
-  ## -----BEGIN RSA PRIVATE KEY-----
-  ##
-  ## name should line up with a tlsSecret set further up
-  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
-  ##
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or -----BEGIN RSA PRIVATE KEY-----
+  ## name should line up with a secretName set further up
+  ## If it is not set and you're using cert-manager, this is unneeded, as it will create the secret for you
+  ## If it is not set and you're NOT using cert-manager either, self-signed certificates will be created
   ## It is also possible to create and manage the certificates outside of this helm chart
   ## Please see README.md for more information
-  # - name: example.local-tls
-  #   key:
-  #   certificate:
+  ##
+  ## E.g.
+  ## secrets:
+  ##   - name: example.local-tls
+  ##     key:
+  ##     certificate: 
+  ##
+  secrets: []
 
 ## Prometheus Exporter / Metrics
 ##
@@ -507,20 +640,3 @@ metrics:
     ##
     # selector:
     #   prometheus: my-prometheus
-
-## Autoscaling parameters
-##
-autoscaling:
-  enabled: false
-  # minReplicas: 1
-  # maxReplicas: 10
-  # targetCPU: 50
-  # targetMemory: 50
-
-## Array to add extra volumes (evaluated as a template)
-##
-extraVolumes: []
-
-## Array to add extra mounts (normally used with extraVolumes, evaluated as a template)
-##
-extraVolumeMounts: []


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

- This version also introduces `bitnami/common`, a [library chart](https://helm.sh/docs/topics/library_charts/#helm) as a dependency. More documentation about this new utility could be found [here](https://github.com/bitnami/charts/tree/master/bitnami/common#bitnami-common-library-chart).
- The PR includes several common parameters that were missing in the chart.
- Ingress configuration was also adapted to follow the Helm charts best practices.

**Benefits**

The chart includes the latest best practices.

**Possible drawbacks**

There is no backwards compatibility due to the above mentioned changes. It's necessary to install a new release of the chart, and migrate your existing application to the new NGINX instances.

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/3668

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files