### PR TITLE
[bitnami/contour]: Fix installation notes to display correct kubectl commands

### DIFF
--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: contour
 description: Contour Ingress controller for Kubernetes
-version: 2.1.0
+version: 2.1.1
 appVersion: 1.8.1
 keywords:
   - ingress

--- a/bitnami/contour/templates/NOTES.txt
+++ b/bitnami/contour/templates/NOTES.txt
@@ -9,7 +9,7 @@
 
      Once 'EXTERNAL-IP' is no longer '<pending>':
 
-         $ kubectl describe svc {{ include "common.names.fullname" . }} --namespace {{ .Release.Namespace }} | grep Ingress | awk '{print $3}'
+         $ kubectl describe svc {{ include "common.names.fullname" . }}-envoy --namespace {{ .Release.Namespace }} | grep Ingress | awk '{print $3}'
 
 2. Configure DNS records corresponding to Kubernetes ingress resources to point to the load balancer IP/hostname found in step 1
 {{- end }}

--- a/bitnami/contour/templates/NOTES.txt
+++ b/bitnami/contour/templates/NOTES.txt
@@ -5,7 +5,7 @@
 
      You can watch the status by running:
 
-         $ kubectl get svc {{ include "common.names.fullname" . }} --namespace {{ .Release.Namespace }} -w
+         $ kubectl get svc {{ include "common.names.fullname" . }}-envoy --namespace {{ .Release.Namespace }} -w
 
      Once 'EXTERNAL-IP' is no longer '<pending>':
 


### PR DESCRIPTION
**Description of the change**
This fix corrects the notes displayed by Helm after Contour is installed. The kubectl commands used the wrong service name, as the external ip gets assigned to the **contour-envoy** service and not the **contour** service. 

**Benefits**
The benefits are that the example kubectl commands will run as expected and output the correct values. 

**Possible drawbacks**
None?!

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.