### PR TITLE
[bitnami/redis] Add exec to forward signals to redis

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 11.0.0
+version: 11.0.1
 appVersion: 6.0.8
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/bitnami/redis/templates/configmap-scripts.yaml
+++ b/bitnami/redis/templates/configmap-scripts.yaml
@@ -121,9 +121,9 @@ data:
 
     touch /data/redisboot.lock
     {{- if .Values.slave.command }}
-    {{ .Values.slave.command }} "${ARGS[@]}"
+    exec {{ .Values.slave.command }} "${ARGS[@]}"
     {{- else }}
-    redis-server "${ARGS[@]}"
+    exec redis-server "${ARGS[@]}"
     {{- end }}
 
   start-sentinel.sh: |
@@ -235,7 +235,7 @@ data:
     {{- end }}
     {{- end }}
     touch /data/sentinelboot.lock
-    redis-server /opt/bitnami/redis-sentinel/etc/sentinel.conf --sentinel {{- if .Values.tls.enabled }} "${ARGS[@]}" {{- end }}
+    exec redis-server /opt/bitnami/redis-sentinel/etc/sentinel.conf --sentinel {{- if .Values.tls.enabled }} "${ARGS[@]}" {{- end }}
 {{- else }}
   start-master.sh: |
     #!/bin/bash
@@ -280,9 +280,9 @@ data:
     {{- end }}
     {{- end }}
     {{- if .Values.master.command }}
-    {{ .Values.master.command }} ${ARGS[@]}
+    exec {{ .Values.master.command }} "${ARGS[@]}"
     {{- else }}
-    redis-server "${ARGS[@]}"
+    exec redis-server "${ARGS[@]}"
     {{- end }}
 
   start-slave.sh: |
@@ -334,9 +334,9 @@ data:
     {{- end }}
     {{- end }}
     {{- if .Values.slave.command }}
-    {{ .Values.slave.command }} "${ARGS[@]}"
+    exec {{ .Values.slave.command }} "${ARGS[@]}"
     {{- else }}
-    redis-server "${ARGS[@]}"
+    exec redis-server "${ARGS[@]}"
     {{- end }}
 
 {{- end -}}


### PR DESCRIPTION
**Description of the change**

Calling the next script without exec is causing a fork, which means all
the signals that are being sent to the Pod are lost.

This is especially dangerous for databases such as Redis, because
handling the SIGTERM when Kubernetes needs to scale down the pod is
critical for ensuring a clean shutdown and data integrity.

Adding `exec` ensures that we're not forking, and the signals work as
intended.

More reading:
- https://hynek.me/articles/docker-signals/
- https://ss64.com/bash/exec.html

**Benefits**

Not losing data. Faster pod deletion.

**Possible drawbacks**

n/a

**Applicable issues**

  - fixes #3710

**Additional information**

Current workaround is to set the command directly, e.g. `--set master.command="exec /run.sh"`

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files