### PR TITLE
[bitnami/mariadb] Add heritage label to pods in statefulset templates

### DIFF
--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb
-version: 7.10.1
+version: 7.10.2
 appVersion: 10.3.24
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/bitnami/mariadb/templates/master-statefulset.yaml
+++ b/bitnami/mariadb/templates/master-statefulset.yaml
@@ -32,6 +32,7 @@ spec:
         app: {{ template "mariadb.name" . }}
         chart: {{ template "mariadb.chart" . }}
         release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
         component: master
         {{- include "mariadb.podLabels" . | nindent 8 }}
     spec:

--- a/bitnami/mariadb/templates/slave-statefulset.yaml
+++ b/bitnami/mariadb/templates/slave-statefulset.yaml
@@ -33,6 +33,7 @@ spec:
         app: {{ template "mariadb.name" . }}
         chart: {{ template "mariadb.chart" . }}
         release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
         component: slave
         {{- include "mariadb.podLabels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
**Description of the change**

This change adds `heritage: Helm` label to the pods template for master and slave statefulset templates. The statefulesets have the heritage label, but the pods they create don't.

**Benefits**

This makes labeling consistent across the resources in the chart, which help with k8s label filters for mariadb users.

**Possible drawbacks**

None

**Applicable issues**

  - fixes #3719

**Additional information**

N/A

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

