### PR TITLE
[bitnami/wordpress] POC removing Helm 2 support

### DIFF
--- a/bitnami/wordpress/Chart.lock
+++ b/bitnami/wordpress/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: mariadb
+  repository: https://charts.bitnami.com/bitnami
+  version: 7.10.2
+digest: sha256:ecd83ec5e59f95e44d844efdfc45e7222f8f503f8e82124e1c24038c5d88cdd7
+generated: "2020-09-21T11:48:28.502861103Z"

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -1,8 +1,17 @@
+annotations:
+  category: CMS
 apiVersion: v2
-name: wordpress
-version: 10.0.0
 appVersion: 5.5.1
+dependencies:
+  - condition: mariadb.enabled
+    name: mariadb
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - wordpress-database
+    version: 7.x.x
 description: Web publishing platform for building blogs and websites.
+engine: gotpl
+home: https://github.com/bitnami/charts/tree/master/bitnami/wordpress
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png
 keywords:
   - wordpress
@@ -12,20 +21,11 @@ keywords:
   - web
   - application
   - php
-home: https://github.com/bitnami/charts/tree/master/bitnami/wordpress
+maintainers:
+  - email: containers@bitnami.com
+    name: Bitnami
+name: wordpress
 sources:
   - https://github.com/bitnami/bitnami-docker-wordpress
   - http://www.wordpress.com/
-maintainers:
-  - name: Bitnami
-    email: containers@bitnami.com
-engine: gotpl
-annotations:
-  category: CMS
-dependencies:
-  - name: mariadb
-    version: 7.x.x
-    repository: https://charts.bitnami.com/bitnami
-    condition: mariadb.enabled
-    tags:
-      - wordpress-database
+version: 10.0.0

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
-apiVersion: v1
+apiVersion: v2
 name: wordpress
-version: 9.5.6
+version: 10.0.0
 appVersion: 5.5.1
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png
@@ -22,3 +22,10 @@ maintainers:
 engine: gotpl
 annotations:
   category: CMS
+dependencies:
+  - name: mariadb
+    version: 7.x.x
+    repository: https://charts.bitnami.com/bitnami
+    condition: mariadb.enabled
+    tags:
+      - wordpress-database

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -441,7 +441,7 @@ See the [Parameters](#parameters) section to configure the PVC or to disable per
 
 ### To 10.0.0
 
-On November 13, 2020, Helm v2 support will formally end, this major version is the result of the required changes applied to the chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+[On November 13, 2020, Helm v2 support will formally end](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
 
 **What changes were introduced in this major version?**
 

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -20,7 +20,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 ## Prerequisites
 
 - Kubernetes 1.12+
-- Helm 2.12+ or Helm 3.0-beta3+
+- Helm 3.0-beta3+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -441,14 +441,14 @@ See the [Parameters](#parameters) section to configure the PVC or to disable per
 
 ### To 10.0.0
 
-[On November 13, 2020, Helm v2 support will formally end](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
 
 **What changes were introduced in this major version?**
 
-- Previous versions of this chart use `apiVersion: v1` (installable by both Helm 2 and 3), this chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
 - Move dependency information from the *requirements.yaml* to the *Chart.yaml*
 - After running `helm dependency update`, a *Chart.lock* file is generated containing the same structure used in the previous *requirements.lock*
-- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami charts
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
 
 **Considerations when upgrading to this version**
 

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -439,6 +439,29 @@ See the [Parameters](#parameters) section to configure the PVC or to disable per
 
 ## Upgrading
 
+### To 10.0.0
+
+On November 13, 2020, Helm v2 support will formally end, this major version is the result of the required changes applied to the chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+**What changes were introduced in this major version?**
+
+- Previous versions of this chart use `apiVersion: v1` (installable by both Helm 2 and 3), this chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- Move dependency information from the *requirements.yaml* to the *Chart.yaml*
+- After running `helm dependency update`, a *Chart.lock* file is generated containing the same structure used in the previous *requirements.lock*
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami charts
+
+**Considerations when upgrading to this version**
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+**Useful links**
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
+
 ### To 9.0.0
 
 The [Bitnami WordPress](https://github.com/bitnami/bitnami-docker-wordpress) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Apache daemon was started as the `daemon` user. From now on, both the container and the Apache daemon run as user `1001`. You can revert this behavior by setting the parameters `securityContext.runAsUser`, and `securityContext.fsGroup` to `0`.

--- a/bitnami/wordpress/requirements.lock
+++ b/bitnami/wordpress/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: mariadb
-  repository: https://charts.bitnami.com/bitnami
-  version: 7.10.1
-digest: sha256:a3d9836286bbd2c40252c7c02abb6eec9ced6ce33a74ee7d8c7c5b9ea0ca643a
-generated: "2020-09-17T13:25:24.303462417Z"

--- a/bitnami/wordpress/requirements.yaml
+++ b/bitnami/wordpress/requirements.yaml
@@ -1,7 +1,0 @@
-dependencies:
-  - name: mariadb
-    version: 7.x.x
-    repository: https://charts.bitnami.com/bitnami
-    condition: mariadb.enabled
-    tags:
-      - wordpress-database


### PR DESCRIPTION
- Bump `apiVersion` from `v1` to `v2` in _Chart.yaml_
- Move dependency information from the _requirements.yaml_ to the _Chart.yaml_
- After running `helm dependency update`, a new _Chart.lock_ file is generated containing the same structure used in the previous _requirements.lock_