### PR TITLE
[bitnami/redis] Allow use without cluster/sentinel

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 11.0.2
+version: 11.0.3
 appVersion: 6.0.8
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/bitnami/redis/templates/NOTES.txt
+++ b/bitnami/redis/templates/NOTES.txt
@@ -20,6 +20,20 @@
 {{- end }}
 {{- end }}
 
+{{- if and .Values.sentinel.enabled (not .Values.cluster.enabled)}}
+
+-------------------------------------------------------------------------------
+ WARNING
+
+    Using redis sentinel without a cluster is not supported. A single pod with
+    standalone redis has been deployed.
+
+    To deploy redis sentinel, please use the values "cluster.enabled=true" and
+    "sentinel.enabled=true".
+
+-------------------------------------------------------------------------------
+{{- end }}
+
 {{- if .Values.cluster.enabled }}
 {{- if .Values.sentinel.enabled }}
 Redis can be accessed via port {{ .Values.sentinel.service.redisPort }} on the following DNS name from within your cluster:

--- a/bitnami/redis/templates/configmap-scripts.yaml
+++ b/bitnami/redis/templates/configmap-scripts.yaml
@@ -284,7 +284,7 @@ data:
     {{- else }}
     exec redis-server "${ARGS[@]}"
     {{- end }}
-
+  {{- if .Values.cluster.enabled }}
   start-slave.sh: |
     #!/bin/bash
     {{- if (eq (.Values.securityContext.runAsUser | int) 0) }}
@@ -338,5 +338,6 @@ data:
     {{- else }}
     exec redis-server "${ARGS[@]}"
     {{- end }}
+  {{- end }}
 
 {{- end -}}

--- a/bitnami/redis/templates/redis-master-statefulset.yaml
+++ b/bitnami/redis/templates/redis-master-statefulset.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.cluster.enabled (not .Values.sentinel.enabled) }}
+{{- if (not .Values.sentinel.enabled) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/bitnami/redis/templates/redis-master-statefulset.yaml
+++ b/bitnami/redis/templates/redis-master-statefulset.yaml
@@ -1,4 +1,4 @@
-{{- if (not .Values.sentinel.enabled) }}
+{{- if or (not .Values.cluster.enabled) (not .Values.sentinel.enabled) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:


### PR DESCRIPTION

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

With the new version 11.0.0, the option to use redis as a standalone DDBB was axed unintentionally.

**Benefits**

As it was before v.11, using `cluster.enabled = false` and `sentinel.enabled = false` deploys only one pod with only the redis container.

**Possible drawbacks**

None

**Applicable issues**

  - fixes #3707 
  - fixes #3737

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
