### PR TITLE
[bitnami/kube-prometheus] Fix _helpers.tpl to take into account global.labels option

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.42.1
 description: kube-prometheus collects Kubernetes manifests to provide easy to operate end-to-end Kubernetes cluster monitoring with Prometheus using the Prometheus Operator.
 name: kube-prometheus
-version: 2.1.0
+version: 2.1.1
 keywords:
   - prometheus
   - alertmanager

--- a/bitnami/kube-prometheus/templates/_helpers.tpl
+++ b/bitnami/kube-prometheus/templates/_helpers.tpl
@@ -60,10 +60,20 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Common Labels
+*/}}
+{{- define "kube-prometheus.labels" -}}
+{{ include "common.labels.standard" . }}
+{{- if .Values.global.labels }}
+{{ toYaml .Values.global.labels }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Labels for operator
 */}}
 {{- define "kube-prometheus.operator.labels" -}}
-{{ include "common.labels.standard" . }}
+{{ include "kube-prometheus.labels" . }}
 app.kubernetes.io/component: operator
 {{- end -}}
 
@@ -71,7 +81,7 @@ app.kubernetes.io/component: operator
 Labels for prometheus
 */}}
 {{- define "kube-prometheus.prometheus.labels" -}}
-{{ include "common.labels.standard" . }}
+{{ include "kube-prometheus.labels" . }}
 app.kubernetes.io/component: prometheus
 {{- end -}}
 
@@ -79,7 +89,7 @@ app.kubernetes.io/component: prometheus
 Labels for alertmanager
 */}}
 {{- define "kube-prometheus.alertmanager.labels" -}}
-{{ include "common.labels.standard" . }}
+{{ include "kube-prometheus.labels" . }}
 app.kubernetes.io/component: alertmanager
 {{- end -}}
 


### PR DESCRIPTION
**Description of the change**

Fix _helpers.tpl to take into account global.labels option.

**Benefits**

Global labels are used by k8s manifests.

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

Non

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
