### PR TITLE
Allow ARNs from AWS Gov-Cloud in values.yaml

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 3.4.1
+version: 3.4.2
 appVersion: 0.7.3
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/bitnami/external-dns/templates/_helpers.tpl
+++ b/bitnami/external-dns/templates/_helpers.tpl
@@ -281,7 +281,7 @@ Validate values of External DNS:
 */}}
 {{- define "external-dns.validateValues.aws" -}}
 {{- if and (eq .Values.provider "aws") .Values.aws.assumeRoleArn -}}
-{{- if not (regexMatch "^arn:aws:iam::.*$" .Values.aws.assumeRoleArn) -}}
+{{- if not (regexMatch "^arn:(aws|aws-us-gov):iam::.*$" .Values.aws.assumeRoleArn) -}}
 external-dns: aws.assumeRoleArn
     The AWS Role to assume must follow ARN format: `arn:aws:iam::123455567:role/external-dns`
     Ref: https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html


### PR DESCRIPTION
AWS Gov-Cloud prefixes their arns differently.  This adds support for
gov cloud arns while providing an ARN of an IAM to assume.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Allows for assuming IAMs created in AWS US Gov Cloud

**Benefits**

Allows this project to be used in gov cloud instances.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
