### PR TITLE
[bitnami/thanos] fixes thanos querier sdconfig mount as file, not as path

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 2.4.1
+version: 2.4.2
 appVersion: 0.15.0
 description: Thanos is a highly available metrics system that can be added on top of existing Prometheus deployments, providing a global query view across all Prometheus installations.
 engine: gotpl

--- a/bitnami/thanos/templates/querier/deployment.yaml
+++ b/bitnami/thanos/templates/querier/deployment.yaml
@@ -116,6 +116,7 @@ spec:
       {{- if or (include "thanos.querier.createSDConfigmap" .) .Values.querier.existingSDConfigmap }}
             - name: sd-config
               mountPath: /conf/servicediscovery.yml
+              subPath: servicediscovery.yml
       {{- end }}
       {{- if .Values.querier.grpcTLS.server.secure }}
             - name: tls-server


### PR DESCRIPTION
Signed-off-by: agrassi <agrassi@cuebiq.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
This is a simple addition that fixes https://github.com/bitnami/charts/issues/3781 by adding the subpath in the volumeMounts spec for the servicediscovery configuration file.
**Benefits**

<!-- What benefits will be realized by the code change? -->
The configmap will be correctly mounted as file

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
None
**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #3781

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
