### PR TITLE
[bitnami/airflow] Fix ingress labels

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: airflow
-version: 6.5.0
+version: 6.5.1
 appVersion: 1.10.12
 description: Apache Airflow is a platform to programmatically author, schedule and monitor workflows.
 keywords:

--- a/bitnami/airflow/templates/ingress.yaml
+++ b/bitnami/airflow/templates/ingress.yaml
@@ -4,10 +4,10 @@ kind: Ingress
 metadata:
   name: {{ template "airflow.fullname" . }}
   labels:
-    app: "{{ template "airflow.fullname" . }}"
-    chart: "{{ template "airflow.chart" . }}"
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "airflow.name" . }}
+    helm.sh/chart: {{ include "airflow.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
     {{- if .Values.ingress.certManager }}
     kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

While the rest of manifests on this chart use the [K8s recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/), the Ingress uses the old labels. This PR amends this.

**Benefits**

Standardization

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

We don't need to bump major version since it only affects Ingress metadata.

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
