### PR TITLE
[bitnami/kafka] Sync README.md with values

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 11.8.5
+version: 11.8.6
 appVersion: 2.6.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -109,8 +109,8 @@ The following tables lists the configurable parameters of the Kafka chart and th
 | `extraVolumeMounts`                               | Extra volumeMount(s) to add to Kafka containers                                                                                   | `[]`                                                    |
 | `auth.clientProtocol`                             | Authentication protocol for communications with clients. Allowed protocols: `plaintext`, `tls`, `mtls`, `sasl` and `sasl_tls`     | `plaintext`                                             |
 | `auth.interBrokerProtocol`                        | Authentication protocol for inter-broker communications. Allowed protocols: `plaintext`, `tls`, `mtls`, `sasl` and `sasl_tls`     | `plaintext`                                             |
-| `auth.saslMechanisms`                             | SASL mechanisms when either `auth.interBrokerProtocol` or `auth.clientProtocol` are `sasl`. Allowed types: `plain`, `scram-sha-256`, `scram-sha-512` | `plain,scram-sha-256,scram-sha-512`                                |
-| `auth.saslInterBrokerMechanism`                   | SASL mechanism to use as inter broker protocol, it must be included at `auth.saslMechanisms`                                      | `plain`                                                   |
+| `auth.saslMechanisms`                             | SASL mechanisms when either `auth.interBrokerProtocol` or `auth.clientProtocol` are `sasl`. Allowed types: `plain`, `scram-sha-256`, `scram-sha-512` | `plain,scram-sha-256,scram-sha-512`  |
+| `auth.saslInterBrokerMechanism`                   | SASL mechanism to use as inter broker protocol, it must be included at `auth.saslMechanisms`                                      | `plain`                                                 |
 | `auth.jksSecret`                                  | Name of the existing secret containing the truststore and one keystore per Kafka broker you have in the cluster                   | `nil`                                                   |
 | `auth.jksPassword`                                | Password to access the JKS files when they are password-protected                                                                 | `nil`                                                   |
 | `auth.tlsEndpointIdentificationAlgorithm`         | The endpoint identification algorithm to validate server hostname using server certificate                                        | `https`                                                 |
@@ -146,13 +146,13 @@ The following tables lists the configurable parameters of the Kafka chart and th
 | `resources.requests`                              | The requested resources for Kafka containers                                                                                      | `{}`                                                    |
 | `livenessProbe`                                   | Liveness probe configuration for Kafka                                                                                            | `Check values.yaml file`                                |
 | `readinessProbe`                                  | Readiness probe configuration for Kafka                                                                                           | `Check values.yaml file`                                |
-| `customLivenessProbe`                             | Custom Liveness probe configuration for Kafka                                                                                            | `{}`                                |
-| `customReadinessProbe`                            | Custom Readiness probe configuration for Kafka                                                                                           | `{}`                                |
+| `customLivenessProbe`                             | Custom Liveness probe configuration for Kafka                                                                                     | `{}`                                                    |
+| `customReadinessProbe`                            | Custom Readiness probe configuration for Kafka                                                                                    | `{}`                                                    |
 | `pdb.create`                                      | Enable/disable a Pod Disruption Budget creation                                                                                   | `false`                                                 |
 | `pdb.minAvailable`                                | Minimum number/percentage of pods that should remain scheduled                                                                    | `nil`                                                   |
 | `pdb.maxUnavailable`                              | Maximum number/percentage of pods that may be made unavailable                                                                    | `1`                                                     |
-| `command`                                        | Override kafka container command                                                                         | `['/scripts/setup.sh']`  (evaluated as a template) |
-| `args`                                        | Override kafka container arguments                                                                             | `[]` (evaluated as a template) |
+| `command`                                         | Override kafka container command                                                                                                  | `['/scripts/setup.sh']`  (evaluated as a template)      |
+| `args`                                            | Override kafka container arguments                                                                                                | `[]` (evaluated as a template)                          |
 | `sidecars`                                        | Attach additional sidecar containers to the Kafka pod                                                                             | `{}`                                                    |
 
 ### Exposure parameters
@@ -366,6 +366,13 @@ This chart includes a `values-production.yaml` file where you can find some para
 + zookeeper.auth.clientPassword: zookeeperPassword
 + zookeeper.auth.serverUsers: zookeeperUser
 + zookeeper.auth.serverPasswords: zookeeperPassword
+```
+
+- Enable Pod Disruption Budget:
+
+```diff
+- pdb.create: false
++ pdb.create: true
 ```
 
 - Create a separate Kafka metrics exporter:

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -447,7 +447,7 @@ customReadinessProbe: {}
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions
 ##
 pdb:
-  create: true
+  create: false
   ## Min number of pods that must still be available after the eviction
   ##
   # minAvailable: 1


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

PDB shouldn't be created by default. It's a value to be enabled by default in the **values-production.yaml** exclusively.

**Benefits**

README.md is synced with the values.yaml

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/3791

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

