### PR TITLE
[bitnami/contour] add podAnnotations to templates

### DIFF
--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: contour
 description: Contour Ingress controller for Kubernetes
-version: 2.3.0
+version: 2.3.1
 appVersion: 1.8.1
 keywords:
   - ingress

--- a/bitnami/contour/templates/contour/deployment.yaml
+++ b/bitnami/contour/templates/contour/deployment.yaml
@@ -19,14 +19,14 @@ spec:
       app.kubernetes.io/component: contour
   template:
     metadata:
-      {{- if .Values.configInline }}
+      {{- if or .Values.configInline .Values.contour.podAnnotations }}
       annotations:
         {{- if .Values.contour.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.contour.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
+        {{- if .Values.configInline }}
         checksum/config: {{ include (print $.Template.BasePath "/contour/configmap.yaml") . | sha256sum }}
-      {{- else if .Values.contour.podAnnotations }}
-      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.contour.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: contour

--- a/bitnami/contour/templates/contour/deployment.yaml
+++ b/bitnami/contour/templates/contour/deployment.yaml
@@ -21,7 +21,12 @@ spec:
     metadata:
       {{- if .Values.configInline }}
       annotations:
+        {{- if .Values.contour.podAnnotations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.contour.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/contour/configmap.yaml") . | sha256sum }}
+      {{- else if .Values.contour.podAnnotations }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.contour.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: contour

--- a/bitnami/contour/templates/envoy/daemonset.yaml
+++ b/bitnami/contour/templates/envoy/daemonset.yaml
@@ -16,6 +16,9 @@ spec:
       app.kubernetes.io/component: envoy
   template:
     metadata:
+      {{- if .Values.envoy.podAnnotations }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.envoy.podAnnotations "context" $) | nindent 8 }}
+      {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: envoy
     spec:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Uses the `podAnnotations` values referenced in the README in the template files for Contour and Envoy.

**Benefits**

Being able to specify pod annotations in line with what the README leads to believe

**Possible drawbacks**

N/A

**Applicable issues**

  - fixes #3809

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
