### PR TITLE
[bitnami/mongodb] Add 'auth.replicaSetKey' to schema json

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb
-version: 9.2.1
+version: 9.2.2
 appVersion: 4.4.1
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/bitnami/mongodb/values-production.yaml
+++ b/bitnami/mongodb/values-production.yaml
@@ -82,7 +82,7 @@ auth:
   ## Key used for replica set authentication
   ## Ignored when mongodb.architecture=standalone
   ##
-  # replicaSetKey: key
+  replicaSetKey: ""
 
   ## Existing secret with MongoDB credentials
   ## NOTE: When it's set the previous parameters are ignored.

--- a/bitnami/mongodb/values.schema.json
+++ b/bitnami/mongodb/values.schema.json
@@ -49,6 +49,16 @@
             "value": false,
             "path": "auth/enabled"
           }
+        },
+        "replicaSetKey": {
+          "type": "string",
+          "title": "Key used for replica set authentication",
+          "form": true,
+          "description": "Defaults to a random 10-character alphanumeric string if not set",
+          "hidden": {
+            "value": "standalone",
+            "path": "architecture"
+          }
         }
       }
     },

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -82,7 +82,7 @@ auth:
   ## Key used for replica set authentication
   ## Ignored when mongodb.architecture=standalone
   ##
-  # replicaSetKey: key
+  replicaSetKey: ""
 
   ## Existing secret with MongoDB credentials
   ## NOTE: When it's set the previous parameters are ignored.


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Updates the `values.schema.json` to include the `auth.replicaSetKey` parameter.

**Benefits**

Values validation

**Possible drawbacks**

None

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files