### PR TITLE
[bitnami/mxnet] Replace MXNet with Apache MXNet (Incubating) in docs and comments

### DIFF
--- a/bitnami/mxnet/Chart.yaml
+++ b/bitnami/mxnet/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mxnet
-version: 1.4.26
+version: 1.4.27
 appVersion: 1.7.0
 description: A flexible and efficient library for deep learning
 keywords:

--- a/bitnami/mxnet/README.md
+++ b/bitnami/mxnet/README.md
@@ -1,6 +1,6 @@
-# MXNet
+# Apache MXNet (Incubating)
 
-[MXNet](https://mxnet.apache.org/) is a deep learning platform that accelerates the transition from research prototyping to production deployment. It is built for full integration into Python that enables you to use it with its libraries and main packages.
+[Apache MXNet (Incubating)](https://mxnet.apache.org/) is a deep learning platform that accelerates the transition from research prototyping to production deployment. It is built for full integration into Python that enables you to use it with its libraries and main packages.
 
 ## TL;DR
 
@@ -11,7 +11,7 @@ $ helm install my-release bitnami/mxnet
 
 ## Introduction
 
-This chart bootstraps a [MXNet](https://github.com/bitnami/bitnami-docker-mxnet) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps an [Apache MXNet (Incubating)](https://github.com/bitnami/bitnami-docker-mxnet) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters. This Helm chart has been tested on top of [Bitnami Kubernetes Production Runtime](https://kubeprod.io/) (BKPR). Deploy BKPR to get automated TLS certificates, logging and monitoring for your applications.
 
@@ -31,7 +31,7 @@ $ helm repo add bitnami https://charts.bitnami.com/bitnami
 $ helm install my-release bitnami/mxnet
 ```
 
-These commands deploy MXNet on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured.
+These commands deploy Apache MXNet (Incubating) on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured.
 
 > **Tip**: List all releases using `helm list`
 
@@ -54,9 +54,9 @@ The following table lists the configurable parameters of the MinIO chart and the
 | `global.imageRegistry`               | Global Docker image registry                                                                                                                              | `nil`                                                   |
 | `global.imagePullSecrets`            | Global Docker registry secret names as an array                                                                                                           | `[]` (does not add image pull secrets to deployed pods) |
 | `global.storageClass`                | Global storage class for dynamic provisioning                                                                                                             | `nil`                                                   |
-| `image.registry`                     | MXNet image registry                                                                                                                                      | `docker.io`                                             |
-| `image.repository`                   | MXNet image name                                                                                                                                          | `bitnami/MXNet`                                         |
-| `image.tag`                          | MXNet image tag                                                                                                                                           | `{TAG_NAME}`                                            |
+| `image.registry`                     | Apache MXNet (Incubating) image registry                                                                                                                  | `docker.io`                                             |
+| `image.repository`                   | Apache MXNet (Incubating) image name                                                                                                                      | `bitnami/mxnet`                                         |
+| `image.tag`                          | Apache MXNet (Incubating) image tag                                                                                                                       | `{TAG_NAME}`                                            |
 | `image.pullPolicy`                   | Image pull policy                                                                                                                                         | `IfNotPresent`                                          |
 | `image.pullSecrets`                  | Specify docker-registry secret names as an array                                                                                                          | `[]` (does not add image pull secrets to deployed pods) |
 | `image.debug`                        | Specify if debug logs should be enabled                                                                                                                   | `false`                                                 |
@@ -78,11 +78,11 @@ The following table lists the configurable parameters of the MinIO chart and the
 | `entrypoint.args`                    | Args required by your entrypoint                                                                                                                          | `nil`                                                   |
 | `entrypoint.workDir`                 | Working directory for launching the entrypoint                                                                                                            | `'/app'`                                                |
 | `podManagementPolicy`                | StatefulSet (worker and server nodes) pod management policy                                                                                               | `Parallel`                                              |
-| `mode`                               | Run MXNet in standalone or distributed mode (possible values: `standalone`, `distributed`)                                                                | `standalone`                                            |
+| `mode`                               | Run Apache MXNet (Incubating) in standalone or distributed mode (possible values: `standalone`, `distributed`)                                            | `standalone`                                            |
 | `serverCount`                        | Number of server nodes that will execute your code                                                                                                        | `1`                                                     |
 | `workerCount`                        | Number of worker nodes that will execute your code                                                                                                        | `1`                                                     |
-| `schedulerPort`                      | MXNet scheduler port (only for distributed mode)                                                                                                          | `49875`                                                 |
-| `configMap`                          | Config map that contains the files you want to load in MXNet                                                                                              | `nil`                                                   |
+| `schedulerPort`                      | Apache MXNet (Incubating) scheduler port (only for distributed mode)                                                                                      | `49875`                                                 |
+| `configMap`                          | Config map that contains the files you want to load in Apache MXNet (Incubating)                                                                          | `nil`                                                   |
 | `cloneFilesFromGit.enabled`          | Enable in order to download files from git repository                                                                                                     | `false`                                                 |
 | `cloneFilesFromGit.repository`       | Repository that holds the files                                                                                                                           | `nil`                                                   |
 | `cloneFilesFromGit.revision`         | Revision from the repository to checkout                                                                                                                  | `master`                                                |
@@ -129,7 +129,7 @@ $ helm install my-release \
     bitnami/mxnet
 ```
 
-The above command creates 6 pods for MXNet: one scheduler, two servers, and three workers.
+The above command creates 6 pods for Apache MXNet (Incubating): one scheduler, two servers, and three workers.
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
@@ -151,7 +151,7 @@ Bitnami will release a new chart updating its containers if a new version of the
 
 This chart includes a `values-production.yaml` file where you can find some parameters oriented to production configuration in comparison to the regular `values.yaml`. You can use this file instead of the default one.
 
-- Run MXNet in distributed mode:
+- Run Apache MXNet (Incubating) in distributed mode:
 ```diff
 - mode: standalone
 + mode: distributed
@@ -171,7 +171,7 @@ This chart includes a `values-production.yaml` file where you can find some para
 
 ### Loading your files
 
-The MXNet chart supports three different ways to load your files. In order of priority, they are:
+The Apache MXNet (Incubating) chart supports three different ways to load your files. In order of priority, they are:
 
   1. Existing config map
   2. Files under the `files` directory
@@ -195,7 +195,7 @@ In case you want to add a file that includes sensitive information, pass a secre
 
 ### Distributed training example
 
-We will use the gluon example from the [MXNet official repository](https://github.com/apache/incubator-mxnet/tree/master/example/gluon). Launch it with the following values:
+We will use the gluon example from the [Apache MXNet (Incubating) official repository](https://github.com/apache/incubator-mxnet/tree/master/example/gluon). Launch it with the following values:
 
 ```console
 mode=distributed
@@ -250,7 +250,7 @@ You will now see log entries in the scheduler and server nodes.
 
 ### Sidecars and Init Containers
 
-If you have a need for additional containers to run within the same pod as MXNet (e.g. an additional metrics or logging exporter), you can do so via the `sidecars` config parameter. Simply define your container according to the Kubernetes container spec.
+If you have a need for additional containers to run within the same pod as Apache MXNet (Incubating) (e.g. an additional metrics or logging exporter), you can do so via the `sidecars` config parameter. Simply define your container according to the Kubernetes container spec.
 
 ```yaml
 sidecars:
@@ -276,7 +276,7 @@ initContainers:
 
 ## Persistence
 
-The [Bitnami MXNet](https://github.com/bitnami/bitnami-docker-mxnet) image can persist data. If enabled, the persisted path is `/bitnami/mxnet` by default.
+The [Bitnami Apache MXNet (Incubating)](https://github.com/bitnami/bitnami-docker-mxnet) image can persist data. If enabled, the persisted path is `/bitnami/mxnet` by default.
 
 The chart mounts a [Persistent Volume](http://kubernetes.io/docs/user-guide/persistent-volumes/) at this location. The volume is created using dynamic volume provisioning.
 

--- a/bitnami/mxnet/templates/_helpers.tpl
+++ b/bitnami/mxnet/templates/_helpers.tpl
@@ -50,7 +50,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{/*
-Return the proper MXNet image name
+Return the proper Apache MXNet (Incubating) image name
 */}}
 {{- define "mxnet.image" -}}
 {{- $registryName := .Values.image.registry -}}
@@ -72,7 +72,7 @@ Also, we can't use a single if because lazy evaluation is not an option
 {{- end -}}
 {{- end -}}
 
-{{/* Validate values of MXNet - number of workers must be greater than 0 */}}
+{{/* Validate values of Apache MXNet (Incubating) - number of workers must be greater than 0 */}}
 {{- define "mxnet.entrypoint" -}}
 {{- if .Values.entrypoint.file }}
   {{- if (.Values.entrypoint.file | regexFind "[.]py$") }}
@@ -165,7 +165,7 @@ Compile all warnings into a single message, and call fail.
 {{- end -}}
 {{- end -}}
 
-{{/* Validate values of MXNet - must provide a valid mode ("distributed" or "standalone") */}}
+{{/* Validate values of Apache MXNet (Incubating) - must provide a valid mode ("distributed" or "standalone") */}}
 {{- define "mxnet.validateValues.mode" -}}
 {{- if and (ne .Values.mode "distributed") (ne .Values.mode "standalone") -}}
 mxnet: mode
@@ -174,7 +174,7 @@ mxnet: mode
 {{- end -}}
 {{- end -}}
 
-{{/* Validate values of MXNet - number of workers must be greater than 0 */}}
+{{/* Validate values of Apache MXNet (Incubating) - number of workers must be greater than 0 */}}
 {{- define "mxnet.validateValues.workerCount" -}}
 {{- $replicaCount := int .Values.workerCount }}
 {{- if and (eq .Values.mode "distributed") (lt $replicaCount 1) -}}
@@ -200,7 +200,7 @@ mxnet: workerCount
 {{- end }}
 {{- end }}
 
-{{/* Validate values of MXNet - number of workers must be greater than 0 */}}
+{{/* Validate values of Apache MXNet (Incubating) - number of workers must be greater than 0 */}}
 {{- define "mxnet.validateValues.serverCount" -}}
 {{- $replicaCount := int .Values.serverCount }}
 {{- if and (eq .Values.mode "distributed") (lt $replicaCount 1) -}}

--- a/bitnami/mxnet/values-production.yaml
+++ b/bitnami/mxnet/values-production.yaml
@@ -8,7 +8,7 @@
 #     - myRegistryKeySecretName
 #   storageClass: myStorageClass
 
-## Bitnami MXNet image version
+## Bitnami Apache MXNet (Incubating) image version
 ## ref: https://hub.docker.com/r/bitnami/mxnet/tags/
 ##
 image:
@@ -113,7 +113,7 @@ entrypoint:
   workDir: /app
   # args:
 
-## MXNet deployment mode. Can be `standalone` or `distributed`
+## Apache MXNet (Incubating) deployment mode. Can be `standalone` or `distributed`
 ##
 mode: distributed
 
@@ -129,7 +129,7 @@ workerCount: 4
 ##
 # existingSecret:
 
-## Name of an existing config map containing all the files you want to load in MXNet
+## Name of an existing config map containing all the files you want to load in Apache MXNet (Incubating)
 ##
 # configMap:
 

--- a/bitnami/mxnet/values.yaml
+++ b/bitnami/mxnet/values.yaml
@@ -8,7 +8,7 @@
 #     - myRegistryKeySecretName
 #   storageClass: myStorageClass
 
-## Bitnami MXNet image version
+## Bitnami Apache MXNet (Incubating) image version
 ## ref: https://hub.docker.com/r/bitnami/mxnet/tags/
 ##
 image:
@@ -113,7 +113,7 @@ entrypoint:
   workDir: /app
   # args:
 
-## MXNet deployment mode. Can be `standalone` or `distributed`
+## Apache MXNet (Incubating) deployment mode. Can be `standalone` or `distributed`
 ##
 mode: standalone
 
@@ -129,7 +129,7 @@ workerCount: 1
 ##
 # existingSecret:
 
-## Name of an existing config map containing all the files you want to load in MXNet
+## Name of an existing config map containing all the files you want to load in Apache MXNet (Incubating)
 ##
 # configMap:
 


### PR DESCRIPTION
**Description of the change**

Replace "MXNet" with "Apache MXNet (Incubating)" in docs and comments

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files