### PR TITLE
[bitnami/thanos] Use GRPC extra hosts for thanos querier

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 2.4.2
+version: 2.4.3
 appVersion: 0.15.0
 description: Thanos is a highly available metrics system that can be added on top of existing Prometheus deployments, providing a global query view across all Prometheus installations.
 engine: gotpl

--- a/bitnami/thanos/templates/querier/ingress.yaml
+++ b/bitnami/thanos/templates/querier/ingress.yaml
@@ -68,7 +68,7 @@ spec:
               serviceName: {{ template "thanos.fullname" . }}-querier
               servicePort: grpc
     {{- end }}
-    {{- range .Values.querier.ingress.extraHosts }}
+    {{- range .Values.querier.ingress.grpc.extraHosts }}
     - host: {{ .name }}
       http:
         paths:


### PR DESCRIPTION
Seems there was a typo in the thanos querier grpc ingress which means it's using the extraHosts for HTTP ingress rather than grpc

**Description of the change**

Fix a bug where the wrong extraHosts are being used for GRPC ingress for Thanos

**Benefits**

Ability to have different hosts for GRPC vs HTTP in Thanos Ingress

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
