### PR TITLE
[bitnami/wordpress] New major version

### DIFF
--- a/bitnami/mediawiki/requirements.yaml
+++ b/bitnami/mediawiki/requirements.yaml
@@ -1,4 +1,9 @@
 dependencies:
+  - name: common
+    version: 0.x.x
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
   - name: mariadb
     version: 7.x.x
     repository: https://charts.bitnami.com/bitnami

--- a/bitnami/mediawiki/requirements.yaml
+++ b/bitnami/mediawiki/requirements.yaml
@@ -1,9 +1,4 @@
 dependencies:
-  - name: common
-    version: 0.x.x
-    repository: https://charts.bitnami.com/bitnami
-    tags:
-      - bitnami-common
   - name: mariadb
     version: 7.x.x
     repository: https://charts.bitnami.com/bitnami

--- a/bitnami/wordpress/Chart.lock
+++ b/bitnami/wordpress/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: mariadb
+  repository: https://charts.bitnami.com/bitnami
+  version: 9.0.1
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.0.0
+digest: sha256:5da0c5d657ce8c316759a44f887b640ffb807d430036b83ab7f3e416fdf09a19
+generated: "2020-11-18T13:54:28.134546+01:00"

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -1,24 +1,34 @@
-apiVersion: v1
-name: wordpress
-version: 9.10.0
+annotations:
+  category: CMS
+apiVersion: v2
 appVersion: 5.5.3
+dependencies:
+  - condition: mariadb.enabled
+    name: mariadb
+    repository: https://charts.bitnami.com/bitnami
+    version: 9.x.x
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
 description: Web publishing platform for building blogs and websites.
+engine: gotpl
+home: https://github.com/bitnami/charts/tree/master/bitnami/wordpress
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png
 keywords:
-  - wordpress
-  - cms
-  - blog
-  - http
-  - web
   - application
+  - blog
+  - cms
+  - http
   - php
-home: https://github.com/bitnami/charts/tree/master/bitnami/wordpress
+  - web
+  - wordpress
+maintainers:
+  - email: containers@bitnami.com
+    name: Bitnami
+name: wordpress
 sources:
   - https://github.com/bitnami/bitnami-docker-wordpress
   - http://www.wordpress.com/
-maintainers:
-  - name: Bitnami
-    email: containers@bitnami.com
-engine: gotpl
-annotations:
-  category: CMS
+version: 10.0.0

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -20,7 +20,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 ## Prerequisites
 
 - Kubernetes 1.12+
-- Helm 2.12+ or Helm 3.0-beta3+
+- Helm 3.0-beta3+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 
@@ -62,11 +62,12 @@ The following table lists the configurable parameters of the WordPress chart and
 
 | Parameter                                 | Description                                                                           | Default                                                      |
 |-------------------------------------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `nameOverride`                            | String to partially override wordpress.fullname                                       | `nil`                                                        |
-| `fullnameOverride`                        | String to fully override wordpress.fullname                                           | `nil`                                                        |
+| `nameOverride`                            | String to partially override common.names.fullname                                    | `nil`                                                        |
+| `fullnameOverride`                        | String to fully override common.names.fullname                                        | `nil`                                                        |
 | `clusterDomain`                           | Default Kubernetes cluster domain                                                     | `cluster.local`                                              |
 | `commonLabels`                            | Labels to add to all deployed objects                                                 | `{}`                                                         |
 | `commonAnnotations`                       | Annotations to add to all deployed objects                                            | `{}`                                                         |
+| `extraDeploy`                             | Array of extra objects to deploy with the release                                     | `[]` (evaluated as a template)                               |
 
 ### WordPress parameters
 
@@ -80,7 +81,7 @@ The following table lists the configurable parameters of the WordPress chart and
 | `image.debug`                             | Specify if debug logs should be enabled                                               | `false`                                                      |
 | `wordpressSkipInstall`                    | Skip wizard installation when the external db already contains data from a previous WordPress installation [see](https://github.com/bitnami/bitnami-docker-wordpress#connect-wordpress-docker-container-to-an-existing-database) | `false`                                                      |
 | `wordpressUsername`                       | User of the application                                                               | `user`                                                       |
-| `existingSecret`   | Name of the existing Wordpress Secret (it must contain a key named `wordpress-password`). When it's set, `wordpressPassword` is ignored   | `nil`               |
+| `existingSecret`                          | Name of the existing Wordpress Secret (it must contain a key named `wordpress-password`). When it's set, `wordpressPassword` is ignored   | `nil`    |
 | `wordpressPassword`                       | Application password                                                                  | _random 10 character long alphanumeric string_               |
 | `wordpressEmail`                          | Admin email                                                                           | `user@example.com`                                           |
 | `wordpressFirstName`                      | First name                                                                            | `FirstName`                                                  |
@@ -88,7 +89,7 @@ The following table lists the configurable parameters of the WordPress chart and
 | `wordpressBlogName`                       | Blog name                                                                             | `User's Blog!`                                               |
 | `wordpressTablePrefix`                    | Table prefix                                                                          | `wp_`                                                        |
 | `wordpressScheme`                         | Scheme to generate application URLs [`http`, `https`]                                 | `http`                                                       |
-| `wordpressExtraConfigContent`             | Add extra content to the configuration file                                           | `""`                                                           |
+| `wordpressExtraConfigContent`             | Add extra content to the configuration file                                           | `""`                                                         |
 | `allowEmptyPassword`                      | Allow DB blank passwords                                                              | `true`                                                       |
 | `allowOverrideNone`                       | Set Apache AllowOverride directive to None                                            | `false`                                                      |
 | `htaccessPersistenceEnabled`              | Make `.htaccess` persistence so that it can be customized. [See](#disabling-htaccess) | `false`                                                      |
@@ -99,65 +100,60 @@ The following table lists the configurable parameters of the WordPress chart and
 | `smtpPassword`                            | SMTP password                                                                         | `nil`                                                        |
 | `smtpUsername`                            | User name for SMTP emails                                                             | `nil`                                                        |
 | `smtpProtocol`                            | SMTP protocol [`tls`, `ssl`, `none`]                                                  | `nil`                                                        |
-| `smtpExistingPassword`                    | Existing secret containing SMTP password in key `smtp-password`                        | `nil`                                                        |
+| `smtpExistingPassword`                    | Existing secret containing SMTP password in key `smtp-password`                       | `nil`                                                        |
 | `command`                                 | Override default container command (useful when using custom images)                  | `nil`                                                        |
 | `args`                                    | Override default container args (useful when using custom images)                     | `nil`                                                        |
-| `extraEnv`                                | Additional container environment variables                                            | `[]`                                                         |
-| `extraVolumeMounts`                       | Additional volume mounts                                                              | `[]`                                                         |
-| `extraVolumes`                            | Additional volumes                                                                    | `[]`                                                         |
-| `sidecars`                                | Attach additional sidecar containers to the pod                                       | `nil`                                                        |
+| `extraEnvVars`                            | Extra environment variables to be set on WordPress container                          | `{}`                                                         |
+| `extraEnvVarsCM`                          | Name of existing ConfigMap containing extra env vars                                  | `nil`                                                        |
+| `extraEnvVarsSecret`                      | Name of existing Secret containing extra env vars                                     | `nil`                                                        |
+
+### WordPress deployment parameters
+
+| Parameter                                 | Description                                                                           | Default                                                      |
+|-------------------------------------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------|
 | `replicaCount`                            | Number of WordPress Pods to run                                                       | `1`                                                          |
-| `updateStrategy`                          | Set up update strategy                                                                | `RollingUpdate`                                              |
-| `schedulerName`                           | Name of the alternate scheduler                                                       | `nil`                                                        |
-| `securityContext.enabled`                 | Enable security context for WordPress pods                                            | `true`                                                       |
-| `securityContext.fsGroup`                 | Group ID for the WordPress filesystem                                                 | `1001`                                                       |
-| `securityContext.runAsUser`               | User ID for the WordPress container                                                   | `1001`                                                       |
+| `containerPorts.http`                     | HTTP port to expose at container level                                                | `8080`                                                       |
+| `containerPorts.https`                    | HTTPS port to expose at container level                                               | `8443`                                                       |
+| `podSecurityContext`                      | WordPress pods' Security Context                                                      | Check `values.yaml` file                                     |
+| `containerSecurityContext`                | WordPress containers' Security Context                                                | Check `values.yaml` file                                     |
 | `resources.limits`                        | The resources limits for the WordPress container                                      | `{}`                                                         |
 | `resources.requests`                      | The requested resources for the WordPress container                                   | `{"memory": "512Mi", "cpu": "300m"}`                         |
+| `livenessProbe`                           | Liveness probe configuration for WordPress                                            | Check `values.yaml` file                                     |
+| `readinessProbe`                          | Readiness probe configuration for WordPress                                           | Check `values.yaml` file                                     |
+| `customLivenessProbe`                     | Override default liveness probe                                                       | `nil`                                                        |
+| `customReadinessProbe`                    | Override default readiness probe                                                      | `nil`                                                        |
+| `updateStrategy`                          | Set up update strategy                                                                | `RollingUpdate`                                              |
+| `schedulerName`                           | Name of the alternate scheduler                                                       | `nil`                                                        |
+| `podAntiAffinityPreset`                   | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`   | `soft`                                                  |
+| `nodeAffinityPreset.type`                 | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `""`                                                    |
+| `nodeAffinityPreset.key`                  | Node label key to match. Ignored if `affinity` is set.                                     | `""`                                                    |
+| `nodeAffinityPreset.values`               | Node label values to match. Ignored if `affinity` is set.                             | `[]`                                                         |
+| `affinity`                                | Affinity for pod assignment                                                           | `{}` (evaluated as a template)                               |
 | `nodeSelector`                            | Node labels for pod assignment                                                        | `{}` (evaluated as a template)                               |
 | `tolerations`                             | Tolerations for pod assignment                                                        | `[]` (evaluated as a template)                               |
-| `affinity`                                | Affinity for pod assignment                                                           | `{}` (evaluated as a template)                               |
-| `podLabels`                               | Pod labels                                                                            | `{}` (evaluated as a template)                               |
-| `podAnnotations`                          | Pod annotations                                                                       | `{}` (evaluated as a template)                               |
-| `healthcheckHttps`                        | Use https for liveliness and readiness                                                | `false`                                                      |
-| `livenessProbe.enabled`                   | Enable/disable livenessProbe                                                          | `true`                                                       |
-| `livenessProbe.initialDelaySeconds`       | Delay before liveness probe is initiated                                              | `120`                                                        |
-| `livenessProbe.periodSeconds`             | How often to perform the probe                                                        | `10`                                                         |
-| `livenessProbe.timeoutSeconds`            | When the probe times out                                                              | `5`                                                          |
-| `livenessProbe.failureThreshold`          | Minimum consecutive failures for the probe                                            | `6`                                                          |
-| `livenessProbe.successThreshold`          | Minimum consecutive successes for the probe                                           | `1`                                                          |
-| `livenessProbeHeaders`                    | Headers to use for livenessProbe                                                      | `{}`                                                         |
-| `customLivenessProbe`                     | Override default liveness probe (evaluated as a template)                             | `{}`                                                         |
-| `readinessProbe.enabled`                  | Enable/disable readinessProbe                                                         | `true`                                                       |
-| `readinessProbe.initialDelaySeconds`      | Delay before readiness probe is initiated                                             | `30`                                                         |
-| `readinessProbe.periodSeconds`            | How often to perform the probe                                                        | `10`                                                         |
-| `readinessProbe.timeoutSeconds`           | When the probe times out                                                              | `5`                                                          |
-| `readinessProbe.failureThreshold`         | Minimum consecutive failures for the probe                                            | `6`                                                          |
-| `readinessProbe.successThreshold`         | Minimum consecutive successes for the probe                                           | `1`                                                          |
-| `readinessProbeHeaders`                   | Headers to use for readinessProbe                                                     | `{}`                                                         |
-| `customReadinessProbe`                    | Override default readiness probe (evaluated as a template)                            | `{}`                                                         |
-| `service.annotations`                     | Service annotations                                                                   | `{}` (evaluated as a template)                               |
+| `podLabels`                               | Extra labels for WordPress pods                                                       | `{}`                                                         |
+| `podAnnotations`                          | Annotations for WordPress pods                                                        | `{}`                                                         |
+| `extraVolumeMounts`                       | Additional volume mounts                                                              | `[]`                                                         |
+| `extraVolumes`                            | Additional volumes                                                                    | `[]`                                                         |
+| `initContainers`                          | Add additional init containers to the WordPress pods                                  | `{}` (evaluated as a template)                               |
+| `sidecars`                                | Attach additional sidecar containers to the pod                                       | `{}` (evaluated as a template)                               |
+
+### Exposure parameters
+
+| Parameter                                 | Description                                                                           | Default                                                      |
+|-------------------------------------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------|
 | `service.type`                            | Kubernetes Service type                                                               | `LoadBalancer`                                               |
 | `service.port`                            | Service HTTP port                                                                     | `80`                                                         |
 | `service.httpsPort`                       | Service HTTPS port                                                                    | `443`                                                        |
 | `service.httpsTargetPort`                 | Service Target HTTPS port                                                             | `https`                                                      |
-| `service.loadBalancerSourceRanges`        | Restricts access for LoadBalancer (only with `service.type: LoadBalancer`)            | `[]`                                                         |
-| `service.metricsPort`                     | Service Metrics port                                                                  | `9117`                                                       |
-| `service.externalTrafficPolicy`           | Enable client source IP preservation                                                  | `Cluster`                                                    |
 | `service.nodePorts.http`                  | Kubernetes http node port                                                             | `""`                                                         |
 | `service.nodePorts.https`                 | Kubernetes https node port                                                            | `""`                                                         |
-| `service.nodePorts.metrics`               | Kubernetes metrics node port                                                          | `""`                                                         |
 | `service.extraPorts`                      | Extra ports to expose in the service (normally used with the `sidecar` value)         | `nil`                                                        |
-| `persistence.enabled`                     | Enable persistence using PVC                                                          | `true`                                                       |
-| `persistence.existingClaim`               | Enable persistence using an existing PVC                                              | `nil`                                                        |
-| `persistence.storageClass`                | PVC Storage Class                                                                     | `nil` (uses alpha storage class annotation)                  |
-| `persistence.accessMode`                  | PVC Access Mode                                                                       | `ReadWriteOnce`                                              |
-| `persistence.size`                        | PVC Storage Request                                                                   | `10Gi`                                                       |
-
-### Ingress parameters
-
-| Parameter                                 | Description                                                                           | Default                                                      |
-|-------------------------------------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `service.clusterIP`                       | WordPress service clusterIP IP                                                        | `None`                                                       |
+| `service.loadBalancerSourceRanges`        | Restricts access for LoadBalancer (only with `service.type: LoadBalancer`)            | `[]`                                                         |
+| `service.loadBalancerIP`                  | loadBalancerIP if service type is `LoadBalancer`                                      | `nil`                                                        |
+| `service.externalTrafficPolicy`           | Enable client source IP preservation                                                  | `Cluster`                                                    |
+| `service.annotations`                     | Service annotations                                                                   | `{}` (evaluated as a template)                               |
 | `ingress.enabled`                         | Enable ingress controller resource                                                    | `false`                                                      |
 | `ingress.certManager`                     | Add annotations for cert-manager                                                      | `false`                                                      |
 | `ingress.hostname`                        | Default host for the ingress resource                                                 | `wordpress.local`                                            |
@@ -172,6 +168,16 @@ The following table lists the configurable parameters of the WordPress chart and
 | `ingress.secrets[0].name`                 | TLS Secret Name                                                                       | `nil`                                                        |
 | `ingress.secrets[0].certificate`          | TLS Secret Certificate                                                                | `nil`                                                        |
 | `ingress.secrets[0].key`                  | TLS Secret Key                                                                        | `nil`                                                        |
+
+### Persistence parameters
+
+| Parameter                                 | Description                                                                           | Default                                                      |
+|-------------------------------------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `persistence.enabled`                     | Enable persistence using PVC                                                          | `true`                                                       |
+| `persistence.existingClaim`               | Enable persistence using an existing PVC                                              | `nil`                                                        |
+| `persistence.storageClass`                | PVC Storage Class                                                                     | `nil` (uses alpha storage class annotation)                  |
+| `persistence.accessMode`                  | PVC Access Mode                                                                       | `ReadWriteOnce`                                              |
+| `persistence.size`                        | PVC Storage Request                                                                   | `10Gi`                                                       |
 
 ### Database parameters
 
@@ -188,10 +194,10 @@ The following table lists the configurable parameters of the WordPress chart and
 | `mariadb.primary.persistence.size`        | Database Persistent Volume Size                                                       | `8Gi`                                                        |
 | `externalDatabase.host`                   | Host of the external database                                                         | `localhost`                                                  |
 | `externalDatabase.user`                   | Existing username in the external db                                                  | `bn_wordpress`                                               |
-| `externalDatabase.existingSecret`         | Name of the database existing Secret Object                                           | `nil`                                                        |
 | `externalDatabase.password`               | Password for the above username                                                       | `nil`                                                        |
 | `externalDatabase.database`               | Name of the existing database                                                         | `bitnami_wordpress`                                          |
 | `externalDatabase.port`                   | Database port number                                                                  | `3306`                                                       |
+| `externalDatabase.existingSecret`         | Name of the database existing Secret Object                                           | `nil`                                                        |
 
 ### Metrics parameters
 
@@ -203,7 +209,8 @@ The following table lists the configurable parameters of the WordPress chart and
 | `metrics.image.tag`                       | Apache exporter image tag                                                             | `{TAG_NAME}`                                                 |
 | `metrics.image.pullPolicy`                | Image pull policy                                                                     | `IfNotPresent`                                               |
 | `metrics.image.pullSecrets`               | Specify docker-registry secret names as an array                                      | `[]` (does not add image pull secrets to deployed pods)      |
-| `metrics.podAnnotations`                  | Additional annotations for Metrics exporter pod                                       | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
+| `metrics.service.port`                    | Service Metrics port                                                                  | `9117`                                                       |
+| `metrics.service.annotations`             | Annotations for enabling prometheus to access the metrics endpoints                   | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
 | `metrics.resources.limits`                | The resources limits for the metrics exporter container                               | `{}`                                                         |
 | `metrics.resources.requests`              | The requested resources for the metrics exporter container                            | `{}`                                                         |
 | `metrics.serviceMonitor.enabled`          | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator          | `false`                                                      |
@@ -213,6 +220,19 @@ The following table lists the configurable parameters of the WordPress chart and
 | `metrics.serviceMonitor.relabellings`     | Specify Metric Relabellings to add to the scrape endpoint                             | `nil`                                                        |
 | `metrics.serviceMonitor.honorLabels`      | honorLabels chooses the metric's labels on collisions with target labels.             | `false`                                                      |
 | `metrics.serviceMonitor.additionalLabels` | Used to pass Labels that are required by the Installed Prometheus Operator            | `{}`                                                         |
+
+### Other parameters
+
+| Parameter                                 | Description                                                                           | Default                                                      |
+|-------------------------------------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `pdb.create`                              | Enable/disable a Pod Disruption Budget creation                                       | `false`                                                      |
+| `pdb.minAvailable`                        | Minimum number/percentage of pods that should remain scheduled                        | `1`                                                          |
+| `pdb.maxUnavailable`                      | Maximum number/percentage of pods that may be made unavailable                        | `nil`                                                        |
+| `autoscaling.enabled`                     | Enable autoscaling for WordPress                                                      | `false`                                                      |
+| `autoscaling.minReplicas`                 | Minimum number of WordPress replicas                                                  | `1`                                                          |
+| `autoscaling.maxReplicas`                 | Maximum number of WordPress replicas                                                  | `11`                                                         |
+| `autoscaling.targetCPU`                   | Target CPU utilization percentage                                                     | `nil`                                                        |
+| `autoscaling.targetMemory`                | Target Memory utilization percentage                                                  | `nil`                                                        |
 
 The above parameters map to the env variables defined in [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress). For more information please refer to the [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress) image documentation.
 
@@ -309,6 +329,19 @@ kubectl exec $(kubectl get pods -l app.kubernetes.io/name=wordpress -o jsonpath=
 kubectl exec $(kubectl get pods -l app.kubernetes.io/name=wordpress -o jsonpath='{.items[2].metadata.name}') -c wordpress -- wp maintenance-mode activate
 ```
 
+### Adding extra environment variables
+
+In case you want to add extra environment variables (useful for advanced operations like custom init scripts), you can use the `extraEnvVars` property.
+
+```yaml
+kong:
+  extraEnvVars:
+    - name: LOG_LEVEL
+      value: error
+```
+
+Alternatively, you can use a ConfigMap or a Secret with the environment variables. To do so, use the `extraEnvVarsCM` or the `extraEnvVarsSecret` values.
+
 ### Sidecars
 
 If you have a need for additional containers to run within the same pod as WordPress (e.g. an additional metrics or logging exporter), you can do so via the `sidecars` config parameter. Simply define your container according to the Kubernetes container spec.
@@ -350,6 +383,12 @@ externalDatabase.port=3306
 Note also if you disable MariaDB per above you MUST supply values for the `externalDatabase` connection.
 
 In case the database already contains data from a previous WordPress installation, you need to set the `wordpressSkipInstall` parameter to _true_. Otherwise, the container would execute the installation wizard and could modify the existing data in the database. This parameter force the container to not execute the WordPress installation wizard. This is necessary in case you use a database that already has WordPress data [+info](https://github.com/bitnami/bitnami-docker-wordpress#connect-wordpress-docker-container-to-an-existing-database).
+
+### Setting Pod's affinity
+
+This chart allows you to set your custom affinity using the `affinity` paremeter. Find more infomation about Pod's affinity in the [kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity).
+
+As an alternative, you can use of the preset configurations for pod affinity, pod anti-affinity, and node affinity available at the [bitnami/common](https://github.com/bitnami/charts/tree/master/bitnami/common#affinities) chart. To do so, set the `podAffinityPreset`, `podAntiAffinityPreset`, or `nodeAffinityPreset` parameters.
 
 ### Ingress
 
@@ -451,14 +490,25 @@ Find more information about how to deal with common errors related to Bitnami’
 
 ### To 10.0.0
 
-MariaDB dependency version was bumped to a new major version that introduces several incompatilibites. Therefore, backwards compatibility is not guaranteed unless an external database is used. Check [MariaDB Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/mariadb#to-800) for more information.
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
 
-To upgrade to `10.0.0`, there are two alternatives:
+#### What changes were introduced in this major version?
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- Move dependency information from the *requirements.yaml* to the *Chart.yaml*.
+- After running `helm dependency update`, a *Chart.lock* file is generated containing the same structure used in the previous *requirements.lock*.
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts.
+- MariaDB dependency version was bumped to a new major version that introduces several incompatilibites. Therefore, backwards compatibility is not guaranteed unless an external database is used. Check [MariaDB Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/mariadb#to-800) for more information.
+
+#### Considerations when upgrading to this version
+
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore.
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3.
+- If you want to upgrade to this version from a previous one installed with Helm v3, there are two alternatives:
+  - Install a new WordPress chart, and migrate your WordPress site using backup/restore tools such as [VaultPress](https://vaultpress.com/) or [All-in-One WP Migration](https://wordpress.org/plugins/all-in-one-wp-migration/).
+  - Reuse the PVC used to hold the MariaDB data on your previous release. To do so, follow the instructions below (the following example assumes that the release name is `wordpress`).
 
 > Warning: please create a backup of your database before running any of these actions. The steps below would be only valid if your application (e.g. any plugins or custom code) is compatible with MariaDB 10.5.
-
-- Install a new WordPress chart, and migrate your WordPress site using backup/restore tools such as [VaultPress](https://vaultpress.com/) or [All-in-One WP Migration](https://wordpress.org/plugins/all-in-one-wp-migration/).
-- Reuse the PVC used to hold the MariaDB data on your previous release. To do so, follow the instructions below (the following example assumes that the release name is `wordpress`):
 
 Obtain the credentials and the name of the PVC used to hold the MariaDB data on your current release:
 
@@ -475,7 +525,7 @@ Upgrade your release (maintaining the version) disabling MariaDB and scaling Wor
 $ helm upgrade wordpress bitnami/wordpress --set wordpressPassword=$WORDPRESS_PASSWORD --set replicaCount=0 --set mariadb.enabled=false --version 9.6.4
 ```
 
-Finally, upgrade you release to 10.0.0 reusing the existing PVC, and enabling back MariaDB:
+Finally, upgrade you release to `10.0.0` reusing the existing PVC, and enabling back MariaDB:
 
 ```console
 $ helm upgrade wordpress bitnami/wordpress --set mariadb.primary.persistence.existingClaim=$MARIADB_PVC --set mariadb.auth.rootPassword=$MARIADB_ROOT_PASSWORD --set mariadb.auth.password=$MARIADB_PASSWORD --set wordpressPassword=$WORDPRESS_PASSWORD 
@@ -490,6 +540,12 @@ mariadb 12:13:24.98 INFO  ==> Using persisted data
 mariadb 12:13:25.01 INFO  ==> Running mysql_upgrade
 ...
 ```
+
+#### Useful links
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
 
 ### To 9.0.0
 

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -178,14 +178,14 @@ The following table lists the configurable parameters of the WordPress chart and
 | Parameter                                 | Description                                                                           | Default                                                      |
 |-------------------------------------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------|
 | `mariadb.enabled`                         | Deploy MariaDB container(s)                                                           | `true`                                                       |
-| `mariadb.rootUser.password`               | MariaDB admin password                                                                | `nil`                                                        |
-| `mariadb.db.name`                         | Database name to create                                                               | `bitnami_wordpress`                                          |
-| `mariadb.db.user`                         | Database user to create                                                               | `bn_wordpress`                                               |
-| `mariadb.db.password`                     | Password for the database                                                             | _random 10 character long alphanumeric string_               |
-| `mariadb.replication.enabled`             | MariaDB replication enabled                                                           | `false`                                                      |
-| `mariadb.master.persistence.enabled`      | Enable database persistence using PVC                                                 | `true`                                                       |
-| `mariadb.master.persistence.accessModes`  | Database Persistent Volume Access Modes                                               | `[ReadWriteOnce]`                                            |
-| `mariadb.master.persistence.size`         | Database Persistent Volume Size                                                       | `8Gi`                                                        |
+| `mariadb.architecture`                    | MariaDB architecture (`standalone` or `replication`)                                  | `standalone`                                                 |
+| `mariadb.auth.rootPassword`               | Password for the MariaDB `root` user                                                  | _random 10 character alphanumeric string_                    |
+| `mariadb.auth.database`                   | Database name to create                                                               | `bitnami_wordpress`                                          |
+| `mariadb.auth.username`                   | Database user to create                                                               | `bn_wordpress`                                               |
+| `mariadb.auth.password`                   | Password for the database                                                             | _random 10 character long alphanumeric string_               |
+| `mariadb.primary.persistence.enabled`     | Enable database persistence using PVC                                                 | `true`                                                       |
+| `mariadb.primary.persistence.accessModes` | Database Persistent Volume Access Modes                                               | `[ReadWriteOnce]`                                            |
+| `mariadb.primary.persistence.size`        | Database Persistent Volume Size                                                       | `8Gi`                                                        |
 | `externalDatabase.host`                   | Host of the external database                                                         | `localhost`                                                  |
 | `externalDatabase.user`                   | Existing username in the external db                                                  | `bn_wordpress`                                               |
 | `externalDatabase.existingSecret`         | Name of the database existing Secret Object                                           | `nil`                                                        |
@@ -222,7 +222,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 helm install my-release \
   --set wordpressUsername=admin \
   --set wordpressPassword=password \
-  --set mariadb.mariadbRootPassword=secretpassword \
+  --set mariadb.auth.rootPassword=secretpassword \
     bitnami/wordpress
 ```
 
@@ -294,7 +294,7 @@ Then, you can deploy WordPress chart using the proper parameters:
 
 ```console
 persistence.storageClass=nfs
-mariadb.master.persistence.storageClass=nfs
+mariadb.primary.persistence.storageClass=nfs
 ```
 
 #### Known limitations
@@ -449,6 +449,12 @@ Find more information about how to deal with common errors related to Bitnami’
 
 ## Upgrading
 
+### To 10.0.0
+
+MariaDB dependency version was bumped to a new major version that introduces several incompatilibites. Therefore, backwards compatibility is not guaranteed unless an external database is used. Check [MariaDB Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/mariadb#to-800) for more information.
+
+To upgrade to `10.0.0`, it's recommended to install a new WordPress chart, and migrate your WordPress site using backup/restore tools such as [VaultPress](https://vaultpress.com/) or [All-in-One WP Migration](https://wordpress.org/plugins/all-in-one-wp-migration/).
+
 ### To 9.0.0
 
 The [Bitnami WordPress](https://github.com/bitnami/bitnami-docker-wordpress) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Apache daemon was started as the `daemon` user. From now on, both the container and the Apache daemon run as user `1001`. You can revert this behavior by setting the parameters `securityContext.runAsUser`, and `securityContext.fsGroup` to `0`.
@@ -460,7 +466,7 @@ Consequences:
 - No writing permissions will be granted on `wp-config.php` by default.
 - Backwards compatibility is not guaranteed.
 
-To upgrade to `9.0.0`, install a new WordPress chart, and migrate your WordPress site using backup/restore tools such as [VaultPress](https://vaultpress.com/) or [All-in-One WP Migration](https://wordpress.org/plugins/all-in-one-wp-migration/).
+To upgrade to `9.0.0`, it's recommended to install a new WordPress chart, and migrate your WordPress site using backup/restore tools such as [VaultPress](https://vaultpress.com/) or [All-in-One WP Migration](https://wordpress.org/plugins/all-in-one-wp-migration/).
 
 ### To 8.0.0
 

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -453,7 +453,9 @@ Find more information about how to deal with common errors related to Bitnami’
 
 MariaDB dependency version was bumped to a new major version that introduces several incompatilibites. Therefore, backwards compatibility is not guaranteed unless an external database is used. Check [MariaDB Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/mariadb#to-800) for more information.
 
-To upgrade to `10.0.0`, you have two alternatives:
+To upgrade to `10.0.0`, there are two alternatives:
+
+> Warning: please create a backup of your database before running any of these actions. The steps below would be only valid if your application (e.g. any plugins or custom code) is compatible with MariaDB 10.5.
 
 - Install a new WordPress chart, and migrate your WordPress site using backup/restore tools such as [VaultPress](https://vaultpress.com/) or [All-in-One WP Migration](https://wordpress.org/plugins/all-in-one-wp-migration/).
 - Reuse the PVC used to hold the MariaDB data on your previous release. To do so, follow the instructions below (the following example assumes that the release name is `wordpress`):
@@ -461,10 +463,10 @@ To upgrade to `10.0.0`, you have two alternatives:
 Obtain the credentials and the name of the PVC used to hold the MariaDB data on your current release:
 
 ```console
-export WORDPRESS_PASSWORD=$(kubectl get secret --namespace default wordpress -o jsonpath="{.data.wordpress-password}" | base64 --decode)
-export MARIADB_ROOT_PASSWORD=$(kubectl get secret --namespace default wordpress-mariadb -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)
-export MARIADB_PASSWORD=$(kubectl get secret --namespace default wordpress-mariadb -o jsonpath="{.data.mariadb-password}" | base64 --decode)
-export MARIADB_PVC=$(kubectl get pvc -l app.kubernetes.io/instance=wordpress,app.kubernetes.io/name=mariadb,app.kubernetes.io/component=primary -o jsonpath="{.items[0].metadata.name}")
+$ export WORDPRESS_PASSWORD=$(kubectl get secret --namespace default wordpress -o jsonpath="{.data.wordpress-password}" | base64 --decode)
+$ export MARIADB_ROOT_PASSWORD=$(kubectl get secret --namespace default wordpress-mariadb -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)
+$ export MARIADB_PASSWORD=$(kubectl get secret --namespace default wordpress-mariadb -o jsonpath="{.data.mariadb-password}" | base64 --decode)
+$ export MARIADB_PVC=$(kubectl get pvc -l app.kubernetes.io/instance=wordpress,app.kubernetes.io/name=mariadb,app.kubernetes.io/component=primary -o jsonpath="{.items[0].metadata.name}")
 ```
 
 Upgrade your release (maintaining the version) disabling MariaDB and scaling WordPress replicas to 0:

--- a/bitnami/wordpress/ci/ct-values.yaml
+++ b/bitnami/wordpress/ci/ct-values.yaml
@@ -1,2 +1,0 @@
-service:
-  type: ClusterIP

--- a/bitnami/wordpress/ci/values-hpa-pdb.yaml
+++ b/bitnami/wordpress/ci/values-hpa-pdb.yaml
@@ -1,0 +1,4 @@
+autoscaling:
+  enabled: true
+pdb:
+  create: true

--- a/bitnami/wordpress/ci/values-metrics-and-ingress.yaml
+++ b/bitnami/wordpress/ci/values-metrics-and-ingress.yaml
@@ -1,0 +1,9 @@
+ingress:
+  enabled: true
+  tls: true
+
+service:
+  type: ClusterIP
+
+metrics:
+  enabled: true

--- a/bitnami/wordpress/requirements.lock
+++ b/bitnami/wordpress/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: mariadb
-  repository: https://charts.bitnami.com/bitnami
-  version: 7.10.4
-digest: sha256:e5bbedb6c4063d76c30b975b1130cba7e4791bfbdc6cbd3b85fd3174d76155d2
-generated: "2020-10-08T08:27:11.411680729Z"

--- a/bitnami/wordpress/requirements.yaml
+++ b/bitnami/wordpress/requirements.yaml
@@ -1,7 +1,0 @@
-dependencies:
-  - name: mariadb
-    version: 7.x.x
-    repository: https://charts.bitnami.com/bitnami
-    condition: mariadb.enabled
-    tags:
-      - wordpress-database

--- a/bitnami/wordpress/templates/NOTES.txt
+++ b/bitnami/wordpress/templates/NOTES.txt
@@ -1,8 +1,9 @@
+
 ** Please be patient while the chart is being deployed **
 
 Your WordPress site can be accessed through the following DNS name from within your cluster:
 
-    {{ include "wordpress.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} (port {{ .Values.service.port }})
+    {{ include "common.names.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} (port {{ .Values.service.port }})
 
 To access your WordPress site from outside the cluster follow the steps below:
 
@@ -21,7 +22,7 @@ To access your WordPress site from outside the cluster follow the steps below:
 
 {{- if contains "NodePort" .Values.service.type }}
 
-   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "wordpress.fullname" . }})
+   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "common.names.fullname" . }})
    export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
    echo "WordPress URL: http://$NODE_IP:$NODE_PORT/"
    echo "WordPress Admin URL: http://$NODE_IP:$NODE_PORT/admin"
@@ -29,15 +30,15 @@ To access your WordPress site from outside the cluster follow the steps below:
 {{- else if contains "LoadBalancer" .Values.service.type }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "wordpress.fullname" . }}'
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "common.names.fullname" . }}'
 
-   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "wordpress.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
    echo "WordPress URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}/"
    echo "WordPress Admin URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}/admin"
 
 {{- else if contains "ClusterIP"  .Values.service.type }}
 
-   kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "wordpress.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }} &
+   kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "common.names.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }} &
    echo "WordPress URL: http://127.0.0.1{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}//"
    echo "WordPress Admin URL: http://127.0.0.1{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}//admin"
 
@@ -49,7 +50,7 @@ To access your WordPress site from outside the cluster follow the steps below:
 3. Login with the following credentials below to see your blog:
 
   echo Username: {{ .Values.wordpressUsername }}
-  echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "wordpress.fullname" . }} -o jsonpath="{.data.wordpress-password}" | base64 --decode)
+  echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} -o jsonpath="{.data.wordpress-password}" | base64 --decode)
 
 {{- if .Values.metrics.enabled }}
 
@@ -57,8 +58,8 @@ You can access Apache Prometheus metrics following the steps below:
 
 1. Get the Apache Prometheus metrics URL by running:
 
-    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "wordpress.fullname" . }} {{ .Values.service.metricsPort }}:{{ .Values.service.metricsPort }} &
-    echo "Apache Prometheus metrics URL: http://127.0.0.1:{{ .Values.service.metricsPort }}/metrics"
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ printf "%s-metrics" (include "common.names.fullname" .) }} {{ .Values.metrics.service.port }}:{{ .Values.metrics.service.port }} &
+    echo "Apache Prometheus metrics URL: http://127.0.0.1:{{ .Values.metrics.service.port }}/metrics"
 
 2. Open a browser and access Apache Prometheus metrics using the obtained URL.
 

--- a/bitnami/wordpress/templates/NOTES.txt
+++ b/bitnami/wordpress/templates/NOTES.txt
@@ -65,3 +65,10 @@ You can access Apache Prometheus metrics following the steps below:
 {{- end }}
 
 {{- include "wordpress.checkRollingTags" . }}
+{{- $passwordValidationErrors := list -}}
+{{- if .Values.mariadb.enabled }}
+    {{- $mariadbSecretName := include "wordpress.databaseSecretName" . -}}
+    {{- $mariadbPasswordValidationErrors := include "common.validations.values.mariadb.passwords" (dict "secret" $mariadbSecretName "subchart" true "context" $) -}}
+    {{- $passwordValidationErrors = append $passwordValidationErrors $mariadbPasswordValidationErrors -}}
+{{- end }}
+{{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordValidationErrors "context" $) -}}

--- a/bitnami/wordpress/templates/NOTES.txt
+++ b/bitnami/wordpress/templates/NOTES.txt
@@ -64,8 +64,15 @@ You can access Apache Prometheus metrics following the steps below:
 
 {{- end }}
 
-{{- include "wordpress.checkRollingTags" . }}
+{{- include "common.warnings.rollingTag" .Values.image }}
+{{- include "common.warnings.rollingTag" .Values.metrics.image }}
 {{- $passwordValidationErrors := list -}}
+{{- if not .Values.existingSecret -}}
+    {{- $secretName := include "wordpress.secretName" . -}}
+    {{- $requiredWordPressPassword := dict "valueKey" "wordpressPassword" "secret" $secretName "field" "wordpress-password" "context" $ -}}
+    {{- $requiredWordPressPasswordError := include "common.validations.values.single.empty" $requiredWordPressPassword -}}
+    {{- $passwordValidationErrors = append $passwordValidationErrors $requiredWordPressPasswordError -}}
+{{- end }}
 {{- if .Values.mariadb.enabled }}
     {{- $mariadbSecretName := include "wordpress.databaseSecretName" . -}}
     {{- $mariadbPasswordValidationErrors := include "common.validations.values.mariadb.passwords" (dict "secret" $mariadbSecretName "subchart" true "context" $) -}}

--- a/bitnami/wordpress/templates/_helpers.tpl
+++ b/bitnami/wordpress/templates/_helpers.tpl
@@ -296,13 +296,3 @@ Return the SMTP Secret Name
     {{- printf "%s" (include "wordpress.fullname" .) -}}
 {{- end -}}
 {{- end -}}
-
-{{/*
-Check if there are rolling tags in the images
-*/}}
-{{- define "wordpress.checkRollingTags" -}}
-{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
-WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
-+info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
-{{- end }}
-{{- end -}}

--- a/bitnami/wordpress/templates/_helpers.tpl
+++ b/bitnami/wordpress/templates/_helpers.tpl
@@ -219,7 +219,11 @@ Return the MariaDB Hostname
 */}}
 {{- define "wordpress.databaseHost" -}}
 {{- if .Values.mariadb.enabled }}
-    {{- printf "%s" (include "mariadb.fullname" .) -}}
+    {{- if eq .Values.mariadb.architecture "replication" }}
+        {{- printf "%s-%s" (include "mariadb.fullname" .) "primary" | trunc 63 | trimSuffix "-" -}}
+    {{- else -}}
+        {{- printf "%s" (include "mariadb.fullname" .) -}}
+    {{- end -}}
 {{- else -}}
     {{- printf "%s" .Values.externalDatabase.host -}}
 {{- end -}}
@@ -241,7 +245,7 @@ Return the MariaDB Database Name
 */}}
 {{- define "wordpress.databaseName" -}}
 {{- if .Values.mariadb.enabled }}
-    {{- printf "%s" .Values.mariadb.db.name -}}
+    {{- printf "%s" .Values.mariadb.auth.database -}}
 {{- else -}}
     {{- printf "%s" .Values.externalDatabase.database -}}
 {{- end -}}
@@ -252,7 +256,7 @@ Return the MariaDB User
 */}}
 {{- define "wordpress.databaseUser" -}}
 {{- if .Values.mariadb.enabled }}
-    {{- printf "%s" .Values.mariadb.db.user -}}
+    {{- printf "%s" .Values.mariadb.auth.username -}}
 {{- else -}}
     {{- printf "%s" .Values.externalDatabase.user -}}
 {{- end -}}

--- a/bitnami/wordpress/templates/_helpers.tpl
+++ b/bitnami/wordpress/templates/_helpers.tpl
@@ -1,58 +1,10 @@
 {{/* vim: set filetype=mustache: */}}
-{{/*
-Expand the name of the chart.
-*/}}
-{{- define "wordpress.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "wordpress.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
-{{- define "wordpress.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Common labels
-*/}}
-{{- define "wordpress.labels" -}}
-app.kubernetes.io/name: {{ include "wordpress.name" . }}
-helm.sh/chart: {{ include "wordpress.chart" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end -}}
-
-{{/*
-Labels to use on {deploy|sts}.spec.selector.matchLabels and svc.spec.selector
-*/}}
-{{- define "wordpress.matchLabels" -}}
-app.kubernetes.io/name: {{ include "wordpress.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end -}}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-*/}}
-{{- define "mariadb.fullname" -}}
+{{- define "wordpress.mariadb.fullname" -}}
 {{- printf "%s-%s" .Release.Name "mariadb" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -60,23 +12,28 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Return the proper WordPress image name
 */}}
 {{- define "wordpress.image" -}}
-{{- $registryName := .Values.image.registry -}}
-{{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
-{{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) -}}
 {{- end -}}
+
+{{/*
+Return the proper image name (for the metrics image)
+*/}}
+{{- define "wordpress.metrics.image" -}}
+{{- include "common.images.image" (dict "imageRoot" .Values.metrics.image "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "wordpress.imagePullSecrets" -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.metrics.image) "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
+Return  the proper Storage Class
+*/}}
+{{- define "wordpress.storageClass" -}}
+{{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) -}}
 {{- end -}}
 
 {{/*
@@ -87,142 +44,14 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
-Return the proper image name (for the metrics image)
-*/}}
-{{- define "wordpress.metrics.image" -}}
-{{- $registryName := .Values.metrics.image.registry -}}
-{{- $repositoryName := .Values.metrics.image.repository -}}
-{{- $tag := .Values.metrics.image.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
-{{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return the proper Docker Image Registry Secret Names
-*/}}
-{{- define "wordpress.imagePullSecrets" -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
-Also, we can not use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets:
-{{- range .Values.global.imagePullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- else if or .Values.image.pullSecrets .Values.metrics.image.pullSecrets }}
-imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- range .Values.metrics.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end -}}
-{{- else if or .Values.image.pullSecrets .Values.metrics.image.pullSecrets }}
-imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- range .Values.metrics.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return  the proper Storage Class
-*/}}
-{{- define "wordpress.storageClass" -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
-*/}}
-{{- if .Values.global -}}
-    {{- if .Values.global.storageClass -}}
-        {{- if (eq "-" .Values.global.storageClass) -}}
-            {{- printf "storageClassName: \"\"" -}}
-        {{- else }}
-            {{- printf "storageClassName: %s" .Values.global.storageClass -}}
-        {{- end -}}
-    {{- else -}}
-        {{- if .Values.persistence.storageClass -}}
-              {{- if (eq "-" .Values.persistence.storageClass) -}}
-                  {{- printf "storageClassName: \"\"" -}}
-              {{- else }}
-                  {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
-              {{- end -}}
-        {{- end -}}
-    {{- end -}}
-{{- else -}}
-    {{- if .Values.persistence.storageClass -}}
-        {{- if (eq "-" .Values.persistence.storageClass) -}}
-            {{- printf "storageClassName: \"\"" -}}
-        {{- else }}
-            {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
-        {{- end -}}
-    {{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return the appropriate apiVersion for ingress.
-*/}}
-{{- define "wordpress.ingress.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
-{{- print "networking.k8s.io/v1beta1" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return the appropriate apiVersion for deployment.
-*/}}
-{{- define "wordpress.deployment.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
-{{- print "apps/v1" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Renders a value that contains template.
-Usage:
-{{ include "wordpress.tplValue" ( dict "value" .Values.path.to.the.Value "context" $) }}
-*/}}
-{{- define "wordpress.tplValue" -}}
-    {{- if typeIs "string" .value }}
-        {{- tpl .value .context }}
-    {{- else }}
-        {{- tpl (.value | toYaml) .context }}
-    {{- end }}
-{{- end -}}
-
-{{/*
 Return the MariaDB Hostname
 */}}
 {{- define "wordpress.databaseHost" -}}
 {{- if .Values.mariadb.enabled }}
     {{- if eq .Values.mariadb.architecture "replication" }}
-        {{- printf "%s-%s" (include "mariadb.fullname" .) "primary" | trunc 63 | trimSuffix "-" -}}
+        {{- printf "%s-%s" (include "wordpress.mariadb.fullname" .) "primary" | trunc 63 | trimSuffix "-" -}}
     {{- else -}}
-        {{- printf "%s" (include "mariadb.fullname" .) -}}
+        {{- printf "%s" (include "wordpress.mariadb.fullname" .) -}}
     {{- end -}}
 {{- else -}}
     {{- printf "%s" .Values.externalDatabase.host -}}
@@ -267,7 +96,7 @@ Return the MariaDB Secret Name
 */}}
 {{- define "wordpress.databaseSecretName" -}}
 {{- if .Values.mariadb.enabled }}
-    {{- printf "%s" (include "mariadb.fullname" .) -}}
+    {{- printf "%s" (include "wordpress.mariadb.fullname" .) -}}
 {{- else if .Values.externalDatabase.existingSecret -}}
     {{- printf "%s" .Values.externalDatabase.existingSecret -}}
 {{- else -}}
@@ -282,7 +111,7 @@ Return the WordPress Secret Name
 {{- if .Values.existingSecret }}
     {{- printf "%s" .Values.existingSecret -}}
 {{- else -}}
-    {{- printf "%s" (include "wordpress.fullname" .) -}}
+    {{- printf "%s" (include "common.names.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 
@@ -293,6 +122,6 @@ Return the SMTP Secret Name
 {{- if .Values.smtpExistingSecret }}
     {{- printf "%s" .Values.smtpExistingSecret -}}
 {{- else -}}
-    {{- printf "%s" (include "wordpress.fullname" .) -}}
+    {{- printf "%s" (include "common.names.fullname" .) -}}
 {{- end -}}
 {{- end -}}

--- a/bitnami/wordpress/templates/deployment.yaml
+++ b/bitnami/wordpress/templates/deployment.yaml
@@ -1,38 +1,38 @@
-apiVersion: {{ template "wordpress.deployment.apiVersion" . }}
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
-  name: {{ template "wordpress.fullname" . }}
-  labels: {{- include "wordpress.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
-    {{- include "wordpress.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "wordpress.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   selector:
-    matchLabels: {{- include "wordpress.matchLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
   {{- if .Values.updateStrategy }}
-  strategy: {{ toYaml .Values.updateStrategy | nindent 4 }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
-      labels: {{- include "wordpress.labels" . | nindent 8 }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
         {{- if .Values.podLabels }}
-        {{- include "wordpress.tplValue" ( dict "value" .Values.podLabels "context" $ ) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
       {{- if or .Values.podAnnotations .Values.metrics.enabled }}
       annotations:
         {{- if .Values.podAnnotations }}
-        {{- include "wordpress.tplValue" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
         {{- if .Values.metrics.podAnnotations }}
-        {{- include "wordpress.tplValue" (dict "value" .Values.metrics.podAnnotations "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.metrics.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
       {{- end }}
     spec:
-{{- include "wordpress.imagePullSecrets" . | indent 6 }}
+      {{- include "wordpress.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.schedulerName }}
       schedulerName: {{ .Values.schedulerName | quote }}
       {{- end }}
@@ -41,31 +41,37 @@ spec:
           hostnames:
             - "status.localhost"
       {{- if .Values.affinity }}
-      affinity: {{- include "wordpress.tplValue" (dict "value" .Values.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAffinityPreset "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAntiAffinityPreset "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
       {{- if .Values.nodeSelector }}
-      nodeSelector: {{- include "wordpress.tplValue" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.tolerations }}
-      tolerations: {{- include "wordpress.tplValue" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
       {{- end }}
-      {{- if .Values.securityContext.enabled }}
-      securityContext:
-        runAsUser: {{ .Values.securityContext.runAsUser }}
-        fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       {{- if .Values.initContainers }}
-      initContainers: {{- include "wordpress.tplValue" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+      initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
       {{- end }}
       containers:
         - name: wordpress
           image: {{ template "wordpress.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           {{- if .Values.command }}
-          command: {{- include "wordpress.tplValue" ( dict "value" .Values.command "context" $) | nindent 12 }}
+          command: {{- include "common.tplvalues.render" ( dict "value" .Values.command "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.args }}
-          args: {{- include "wordpress.tplValue" ( dict "value" .Values.args "context" $) | nindent 12 }}
+          args: {{- include "common.tplvalues.render" ( dict "value" .Values.args "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           env:
             {{- if .Values.image.debug }}
@@ -126,66 +132,46 @@ spec:
             - name: SMTP_USER
               value: {{ .Values.smtpUser | quote }}
             {{- end }}
-            {{- if (or .Values.smtpPassword .Values.smtpExistingSecret) }}
+            {{- if or .Values.smtpPassword .Values.smtpExistingSecret }}
             - name: SMTP_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "wordpress.smtpSecretName" . }}
                   key: smtp-password
             {{- end }}
-            {{- if .Values.smtpUsername }}
-            - name: SMTP_USERNAME
-              value: {{ .Values.smtpUsername | quote }}
-            {{- end }}
             {{- if .Values.smtpProtocol }}
             - name: SMTP_PROTOCOL
               value: {{ .Values.smtpProtocol | quote }}
             {{- end }}
-            {{- if .Values.extraEnv }}
-            {{- include "wordpress.tplValue" (dict "value" .Values.extraEnv "context" $) | nindent 12 }}
+            {{- if .Values.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- if .Values.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
             {{- end }}
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: {{ .Values.containerPorts.http }}
             - name: https
-              containerPort: 8443
+              containerPort: {{ .Values.containerPorts.https }}
           {{- if .Values.livenessProbe.enabled }}
-          livenessProbe:
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.livenessProbe.successThreshold }}
-            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
-            httpGet:
-              path: /wp-admin/install.php
-              port: {{ ternary "https" "http" .Values.healthcheckHttps }}
-              {{- if .Values.healthcheckHttps }}
-              scheme: HTTPS
-              {{- end }}
-              {{- if .Values.livenessProbeHeaders }}
-              httpHeaders: {{- toYaml .Values.livenessProbeHeaders | nindent 16 }}
-              {{- end }}
+          livenessProbe: {{- omit .Values.livenessProbe "enabled" | toYaml | nindent 12 }}
           {{- else if .Values.customLivenessProbe }}
-          livenessProbe: {{- include "wordpress.tplValue" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
-          readinessProbe:
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
-            httpGet:
-              path: /wp-login.php
-              port: {{ ternary "https" "http" .Values.healthcheckHttps }}
-              {{- if .Values.healthcheckHttps }}
-              scheme: HTTPS
-              {{- end }}
-              {{- if .Values.readinessProbeHeaders }}
-              httpHeaders: {{- toYaml .Values.readinessProbeHeaders | nindent 16 }}
-              {{- end }}
+          readinessProbe: {{- omit .Values.readinessProbe "enabled" | toYaml | nindent 12 }}
           {{- else if .Values.customReadinessProbe }}
-          readinessProbe: {{- include "wordpress.tplValue" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.resources }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
             - mountPath: /bitnami/wordpress
@@ -196,11 +182,8 @@ spec:
               name: custom-htaccess
             {{- end }}
             {{- if .Values.extraVolumeMounts }}
-            {{- include "wordpress.tplValue" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
-          {{- if .Values.resources }}
-          resources: {{- toYaml .Values.resources | nindent 12 }}
-          {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
           image: {{ template "wordpress.metrics.image" . }}
@@ -229,7 +212,7 @@ spec:
           {{- end }}
         {{- end }}
         {{- if .Values.sidecars }}
-        {{- include "wordpress.tplValue" (dict "value" .Values.sidecars "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | nindent 8 }}
         {{- end }}
       volumes:
         {{- if and .Values.allowOverrideNone .Values.customHTAccessCM }}
@@ -243,10 +226,10 @@ spec:
         - name: wordpress-data
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ .Values.persistence.existingClaim | default (include "wordpress.fullname" .) }}
+            claimName: {{ .Values.persistence.existingClaim | default (include "common.names.fullname" .) }}
           {{- else }}
           emptyDir: {}
           {{ end }}
         {{- if .Values.extraVolumes }}
-        {{- include "wordpress.tplValue" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}

--- a/bitnami/wordpress/templates/externaldb-secrets.yaml
+++ b/bitnami/wordpress/templates/externaldb-secrets.yaml
@@ -1,14 +1,14 @@
-{{- if (not (or .Values.mariadb.enabled .Values.externalDatabase.existingSecret)) }}
+{{- if not (or .Values.mariadb.enabled .Values.externalDatabase.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
-  labels: {{- include "wordpress.labels" . | nindent 4 }}
+  name: {{ printf "%s-externaldb" (include "common.names.fullname" .) }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
-    {{- include "wordpress.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "wordpress.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 type: Opaque
 data:

--- a/bitnami/wordpress/templates/extra-list.yaml
+++ b/bitnami/wordpress/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/bitnami/wordpress/templates/hpa.yaml
+++ b/bitnami/wordpress/templates/hpa.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+    kind: Deployment
+    name: {{ template "common.names.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPU }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPU }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemory }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemory  }}
+    {{- end }}
+{{- end }}

--- a/bitnami/wordpress/templates/ingress.yaml
+++ b/bitnami/wordpress/templates/ingress.yaml
@@ -1,21 +1,21 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: {{ template "wordpress.ingress.apiVersion" . }}
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: {{ template "wordpress.fullname" . }}
-  labels: {{- include "wordpress.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
-    {{- include "wordpress.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   annotations:
     {{- if .Values.ingress.certManager }}
     kubernetes.io/tls-acme: "true"
     {{- end }}
     {{- if .Values.ingress.annotations }}
-    {{- include "wordpress.tplValue" (dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
-    {{- include "wordpress.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
 spec:
   rules:
@@ -28,7 +28,7 @@ spec:
           {{- end }}
           - path: {{ .Values.ingress.path }}
             backend:
-              serviceName: {{ template "wordpress.fullname" . }}
+              serviceName: {{ include "common.names.fullname" . }}
               servicePort: http
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
@@ -37,7 +37,7 @@ spec:
         paths:
           - path: {{ default "/" .path }}
             backend:
-              serviceName: {{ template "wordpress.fullname" $ }}
+              serviceName: {{ include "common.names.fullname" $ }}
               servicePort: http
     {{- end }}
   {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
@@ -48,7 +48,7 @@ spec:
       secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
     {{- end }}
     {{- if .Values.ingress.extraTls }}
-    {{- toYaml .Values.ingress.extraTls | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.extraTls "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/bitnami/wordpress/templates/metrics-svc.yaml
+++ b/bitnami/wordpress/templates/metrics-svc.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-metrics" (include "common.names.fullname" .) }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.metrics.service.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.metrics.service.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.service.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: metrics
+      port: {{ .Values.metrics.service.port }}
+      protocol: TCP
+      targetPort: metrics
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
+{{- end }}

--- a/bitnami/wordpress/templates/pdb.yaml
+++ b/bitnami/wordpress/templates/pdb.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.pdb.create }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
+{{- end }}

--- a/bitnami/wordpress/templates/pvc.yaml
+++ b/bitnami/wordpress/templates/pvc.yaml
@@ -2,13 +2,13 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ template "wordpress.fullname" . }}
-  labels: {{- include "wordpress.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
-    {{- include "wordpress.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "wordpress.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   accessModes:
@@ -16,5 +16,5 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
-  {{ include "wordpress.storageClass" . }}
+  {{- include "wordpress.storageClass" . | nindent 2 }}
 {{- end }}

--- a/bitnami/wordpress/templates/secrets.yaml
+++ b/bitnami/wordpress/templates/secrets.yaml
@@ -1,14 +1,14 @@
-{{- if or (not .Values.existingSecret) (and (not .Values.smtpExistingSecret) .Values.smtpPassword) -}}
+{{- if or (not .Values.existingSecret) (and (not .Values.smtpExistingSecret) .Values.smtpPassword) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "wordpress.fullname" . }}
-  labels: {{- include "wordpress.labels" . | nindent 4 }}
+  name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
-    {{- include "wordpress.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "wordpress.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 type: Opaque
 data:
@@ -24,4 +24,4 @@ data:
   smtp-password: {{ .Values.smtpPassword | b64enc | quote }}
   {{- end }}
   {{- end }}
-{{- end -}}
+{{- end }}

--- a/bitnami/wordpress/templates/servicemonitor.yaml
+++ b/bitnami/wordpress/templates/servicemonitor.yaml
@@ -2,19 +2,20 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "wordpress.fullname" . }}
+  name: {{ include "common.names.fullname" . }}
   {{- if .Values.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.metrics.serviceMonitor.namespace }}
   {{- end }}
-  labels: {{- include "wordpress.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
     {{- if .Values.metrics.serviceMonitor.additionalLabels }}
-    {{- include "wordpress.tplValue" (dict "value" .Values.metrics.serviceMonitor.additionalLabels "context" $) | nindent 4 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.additionalLabels "context" $) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonLabels }}
-    {{- include "wordpress.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "wordpress.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   endpoints:
@@ -31,5 +32,6 @@ spec:
     matchNames:
       - {{ .Release.Namespace }}
   selector:
-    matchLabels: {{- include "wordpress.matchLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: metrics
 {{- end }}

--- a/bitnami/wordpress/templates/svc.yaml
+++ b/bitnami/wordpress/templates/svc.yaml
@@ -1,34 +1,38 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "wordpress.fullname" . }}
-  labels: {{- include "wordpress.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
-    {{- include "wordpress.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if or .Values.service.annotations .Values.commonAnnotations }}
   annotations:
     {{- if .Values.service.annotations }}
-    {{- include "wordpress.tplValue" (dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
-    {{- include "wordpress.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if and .Values.service.clusterIP (eq .Values.service.type "ClusterIP") }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
   {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
   {{- end }}
   {{- if (and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerSourceRanges) }}
-  loadBalancerSourceRanges:
-  {{- with .Values.service.loadBalancerSourceRanges }}
-{{ toYaml . | indent 4 }}
+  loadBalancerSourceRanges: {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if (and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP))) }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
   ports:
     - name: http
       port: {{ .Values.service.port }}
+      protocol: TCP
       targetPort: http
       {{- if (and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.http))) }}
       nodePort: {{ .Values.service.nodePorts.http }}
@@ -37,23 +41,14 @@ spec:
       {{- end }}
     - name: https
       port: {{ .Values.service.httpsPort }}
+      protocol: TCP
       targetPort: {{ .Values.service.httpsTargetPort }}
       {{- if (and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.https))) }}
       nodePort: {{ .Values.service.nodePorts.https }}
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
-      {{- if .Values.metrics.enabled }}
-    - name: metrics
-      port: {{ .Values.service.metricsPort }}
-      targetPort: metrics
-      {{- if (and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.metrics))) }}
-      nodePort: {{ .Values.service.nodePorts.metrics }}
-      {{- else if eq .Values.service.type "ClusterIP" }}
-      nodePort: null
-      {{- end }}
-      {{- end }}
     {{- if .Values.service.extraPorts }}
-    {{- include "wordpress.tplValue" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  selector: {{- include "wordpress.matchLabels" . | nindent 4 }}
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/wordpress/templates/tests/test-mariadb-connection.yaml
+++ b/bitnami/wordpress/templates/tests/test-mariadb-connection.yaml
@@ -6,13 +6,15 @@ metadata:
   annotations:
     "helm.sh/hook": test-success
 spec:
+  {{- if .Values.podSecurityContext.enabled }}
+  securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 4 }}
+  {{- end }}
   containers:
     - name: {{ .Release.Name }}-credentials-test
       image: {{ template "wordpress.image" . }}
       imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-      {{- if .Values.securityContext.enabled }}
-      securityContext:
-        runAsUser: {{ .Values.securityContext.runAsUser }}
+      {{- if .Values.containerSecurityContext.enabled }}
+      securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       env:
         - name: MARIADB_HOST

--- a/bitnami/wordpress/templates/tests/test-mariadb-connection.yaml
+++ b/bitnami/wordpress/templates/tests/test-mariadb-connection.yaml
@@ -16,17 +16,17 @@ spec:
       {{- end }}
       env:
         - name: MARIADB_HOST
-          value: {{ template "mariadb.fullname" . }}
+          value: {{ include "wordpress.databaseHost" . | quote }}
         - name: MARIADB_PORT
           value: "3306"
         - name: WORDPRESS_DATABASE_NAME
-          value: {{ default "" .Values.mariadb.db.name | quote }}
+          value: {{ default "" .Values.mariadb.auth.database | quote }}
         - name: WORDPRESS_DATABASE_USER
-          value: {{ default "" .Values.mariadb.db.user | quote }}
+          value: {{ default "" .Values.mariadb.auth.username | quote }}
         - name: WORDPRESS_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "mariadb.fullname" . }}
+              name: {{ include "wordpress.databaseSecretName" . }}
               key: mariadb-password
       command:
         - /bin/bash

--- a/bitnami/wordpress/templates/tls-secrets.yaml
+++ b/bitnami/wordpress/templates/tls-secrets.yaml
@@ -5,7 +5,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .name }}
-  labels: {{- include "wordpress.labels" $ | nindent 4 }}
+  namespace: {{ $.Release.Namespace }}
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
     {{- if $.Values.commonLabels }}
     {{- include "wordpress.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -25,7 +26,14 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-tls" .Values.ingress.hostname }}
-  labels: {{- include "wordpress.labels" . | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 type: kubernetes.io/tls
 data:
   tls.crt: {{ $cert.Cert | b64enc | quote }}

--- a/bitnami/wordpress/values-production.yaml
+++ b/bitnami/wordpress/values-production.yaml
@@ -30,17 +30,13 @@ image:
   ##
   debug: false
 
-## String to partially override wordpress.fullname template (will maintain the release name)
+## String to partially override aspnet-core.fullname template (will maintain the release name)
 ##
 # nameOverride:
 
-## String to fully override wordpress.fullname template
+## String to fully override aspnet-core.fullname template
 ##
 # fullnameOverride:
-
-## Kubernetes Cluster Domain
-##
-clusterDomain: cluster.local
 
 ## Add labels to all the deployed resources
 ##
@@ -50,10 +46,13 @@ commonLabels: {}
 ##
 commonAnnotations: {}
 
-## Use existing secret (does not create the WordPress Secret object)
-## Must contain key `wordpress-secret`
-## NOTE: When it's set, the `wordpressPassword` parameter is ignored
-# existingSecret:
+## Kubernetes Cluster Domain
+##
+clusterDomain: cluster.local
+
+## Extra objects to deploy (value evaluated as a template)
+##
+extraDeploy: []
 
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
@@ -65,6 +64,12 @@ wordpressUsername: user
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
 ##
 # wordpressPassword:
+
+## Use existing secret (does not create the WordPress Secret object)
+## Must contain key `wordpress-secret`
+## NOTE: When it's set, the `wordpressPassword` parameter is ignored
+##
+# existingSecret:
 
 ## Admin email
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
@@ -113,7 +118,7 @@ allowEmptyPassword: true
 ## Set Apache allowOverride to None
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
 ##
-allowOverrideNone: false
+allowOverrideNone: true
 
 ## Persist the custom changes of the htaccess. It depends on the value of
 ## `.Values.allowOverrideNone`, when `yes` it will persist `/opt/bitnami/wordpress/wordpress-htaccess.conf`
@@ -150,64 +155,117 @@ updateStrategy:
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress/#smtp-configuration
 ##
+# smtpHost:
+# smtpPort:
+# smtpUser:
+# smtpPassword:
+# smtpProtocol:
 
 ## Use an existing secret for the SMTP Password
 ## Can be the same secret as existingSecret
 ## Must contain key `smtp-password`
 ## NOTE: When it's set, the `smtpPassword` parameter is ignored
+##
 # smtpExistingSecret:
 
-# smtpHost:
-# smtpPort:
-# smtpUser:
-# smtpPassword:
-# smtpUsername:
-# smtpProtocol:
-
+## Number of replicas (requires ReadWriteMany PVC support)
+##
 replicaCount: 3
 
-## Additional container environment variables
-## Example: Configure SSL for database
-## extraEnv:
-##   - name: WORDPRESS_DATABASE_SSL_CA_FILE
-##     value: /path/to/ca_cert
+## An array to add extra env vars
+## Example:
+## extraEnvVars:
+##   - name: FOO
+##     value: "bar"
 ##
-extraEnv: []
+extraEnvVars: []
 
-## Additional volume mounts
-## Example: Mount CA file
-## extraVolumeMounts
-##   - name: ca-cert
-##     subPath: ca_cert
-##     mountPath: /path/to/ca_cert
+## ConfigMap with extra environment variables
 ##
-extraVolumeMounts: []
+extraEnvVarsCM:
 
-## Additional volumes
-## Example: Add secret volume
-## extraVolumes:
-##  - name: ca-cert
-##    secret:
-##      secretName: ca-cert
-##      items:
-##        - key: ca-cert
-##          path: ca_cert
+## Secret with extra environment variables
+##
+extraEnvVarsSecret:
+
+## Extra volumes to add to the deployment
 ##
 extraVolumes: []
 
-## WordPress containers' resource requests and limits
-## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+## Extra volume mounts to add to the container
 ##
-resources:
-  limits: {}
-  #   cpu: 500m
-  #   memory: 1Gi
-  requests:
-    memory: 512Mi
-    cpu: 300m
+extraVolumeMounts: []
+
+## Add sidecars to the pod.
+## Example:
+## sidecars:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+sidecars: {}
+
+## Add init containers to the pod.
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+## Example:
+## initContainers:
+##  - name: your-image-name
+##    image: your-image
+##    imagePullPolicy: Always
+##    command: ['sh', '-c', 'copy themes and plugins from git and push to /bitnami/wordpress/wp-content. Should work with extraVolumeMounts and extraVolumes']
+##
+initContainers: {}
+
+## Pod Labels
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+##
+podLabels: {}
+
+## Pod annotations
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+
+## Pod affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+## Allowed values: soft, hard
+##
+podAffinityPreset: ""
+
+## Pod anti-affinity preset
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+## Allowed values: soft, hard
+##
+podAntiAffinityPreset: soft
+
+## Node affinity preset
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+## Allowed values: soft, hard
+##
+nodeAffinityPreset:
+  ## Node affinity type
+  ## Allowed values: soft, hard
+  ##
+  type: ""
+  ## Node label key to match
+  ## E.g.
+  ## key: "kubernetes.io/e2e-az-name"
+  ##
+  key: ""
+  ## Node label values to match
+  ## E.g.
+  ## values:
+  ##   - e2e-az1
+  ##   - e2e-az2
+  ##
+  values: []
 
 ## Affinity for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## Note: podAffinityPreset, podAntiAffinityPreset, and  nodeAffinityPreset will be ignored when it's set
 ##
 affinity: {}
 
@@ -221,33 +279,48 @@ nodeSelector: {}
 ##
 tolerations: {}
 
-## Pod Labels
-## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+## WordPress containers' resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##
-podLabels: {}
+resources:
+  limits: {}
+  requests:
+    memory: 512Mi
+    cpu: 300m
 
-## Pod annotations
-## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+## Configure Pods Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ##
-podAnnotations: {}
-
-## K8s Security Context for WordPress pods
-## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-##
-securityContext:
+podSecurityContext:
   enabled: true
   fsGroup: 1001
+
+## Configure Container Security Context (only main container)
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+##
+containerSecurityContext:
+  enabled: true
   runAsUser: 1001
 
-## Allow health checks to be pointed at the https port
-##
-healthcheckHttps: false
-
-## WordPress pod extra options for liveness and readiness probes
-## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+## WordPress containers' liveness and readiness probes.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
 ##
 livenessProbe:
   enabled: true
+  httpGet:
+    path: /wp-admin/install.php
+    port: http
+    scheme: HTTP
+    ## If using an HTTPS-terminating load-balancer, the probes may need to behave
+    ## like the balancer to prevent HTTP 302 responses. According to the Kubernetes
+    ## docs, 302 should be considered "successful", but this issue on GitHub
+    ## (https://github.com/kubernetes/kubernetes/issues/47893) shows that it isn't.
+    ##
+    ## httpHeaders:
+    ## - name: X-Forwarded-Proto
+    ##   value: https
+    ##
+    httpHeaders: []
   initialDelaySeconds: 120
   periodSeconds: 10
   timeoutSeconds: 5
@@ -255,6 +328,20 @@ livenessProbe:
   successThreshold: 1
 readinessProbe:
   enabled: true
+  httpGet:
+    path: /wp-login.php
+    port: http
+    scheme: HTTP
+    ## If using an HTTPS-terminating load-balancer, the probes may need to behave
+    ## like the balancer to prevent HTTP 302 responses. According to the Kubernetes
+    ## docs, 302 should be considered "successful", but this issue on GitHub
+    ## (https://github.com/kubernetes/kubernetes/issues/47893) shows that it isn't.
+    ##
+    ## httpHeaders:
+    ## - name: X-Forwarded-Proto
+    ##   value: https
+    ##
+    httpHeaders: []
   initialDelaySeconds: 30
   periodSeconds: 10
   timeoutSeconds: 5
@@ -266,19 +353,11 @@ readinessProbe:
 customLivenessProbe: {}
 customReadinessProbe: {}
 
-## If using an HTTPS-terminating load-balancer, the probes may need to behave
-## like the balancer to prevent HTTP 302 responses. According to the Kubernetes
-## docs, 302 should be considered "successful", but this issue on GitHub
-## (https://github.com/kubernetes/kubernetes/issues/47893) shows that it isn't.
+## Container ports
 ##
-# livenessProbeHeaders:
-# - name: X-Forwarded-Proto
-#   value: https
-# readinessProbeHeaders:
-# - name: X-Forwarded-Proto
-#   value: https
-livenessProbeHeaders: {}
-readinessProbeHeaders: {}
+containerPorts:
+  http: 8080
+  https: 8443
 
 ## Kubernetes configuration
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer or ClusterIP
@@ -296,29 +375,37 @@ service:
   ## if you want the target port to be "http" or "80" you can specify that here.
   ##
   httpsTargetPort: https
-  ## Metrics Port
-  ##
-  metricsPort: 9117
   ## Node Ports to expose
   ## nodePorts:
   ##   http: <to set explicitly, choose port between 30000-32767>
   ##   https: <to set explicitly, choose port between 30000-32767>
-  ##   metrics: <to set explicitly, choose port between 30000-32767>
   ##
   nodePorts:
     http: ""
     https: ""
-    metrics: ""
+  ## Service clusterIP.
+  ##
+  # clusterIP: None
+  ## loadBalancerIP for the SuiteCRM Service (optional, cloud specific)
+  ## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
+  ##
+  # loadBalancerIP:
+  ## Load Balancer sources
+  ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  ## Example:
+  ## loadBalancerSourceRanges:
+  ##   - 10.10.10.0/24
+  ##
+  loadBalancerSourceRanges: []
   ## Enable client source IP preservation
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   ##
   externalTrafficPolicy: Local
-  annotations: {}
-  ## Limits which cidr blocks can connect to service's load balancer
-  ## Only valid if service.type: LoadBalancer
+  ## Provide any additional annotations which may be required (evaluated as a template).
   ##
-  loadBalancerSourceRanges: []
+  annotations: {}
   ## Extra ports to expose (normally used with the `sidecar` value)
+  ##
   # extraPorts:
 
 ## Configure the ingress resource that allows you to access the
@@ -413,92 +500,29 @@ persistence:
   ## If you want to reuse an existing claim, you can pass the name of the PVC using
   ## the existingClaim variable
   # existingClaim: your-claim
-  ##
-  ## To use the /admin portal and to ensure you can scale wordpress you need to provide a
-  ## ReadWriteMany PVC, if you dont have a provisioner for this type of storage
-  ## We recommend that you install the nfs provisioner and map it to a RWO volume
-  ## helm install nfs-server stable/nfs-server-provisioner --set persistence.enabled=true,persistence.size=10Gi
-  ##
   accessMode: ReadWriteMany
   size: 10Gi
 
+## Wordpress Pod Disruption Budget configuration
+## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
 ##
-## MariaDB chart configuration
+pdb:
+  create: false
+  ## Min number of pods that must still be available after the eviction
+  ##
+  minAvailable: 1
+  ## Max number of pods that can be unavailable after the eviction
+  ##
+  # maxUnavailable: 1
+
+## Wordpress Autoscaling configuration
 ##
-## https://github.com/bitnami/charts/blob/master/bitnami/mariadb/values.yaml
-##
-mariadb:
-  ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
-  ##
-  enabled: true
-
-  ## MariaDB architecture. Allowed values: standalone or replication
-  ##
-  architecture: standalone
-
-  ## MariaDB Authentication parameters
-  ##
-  auth:
-    ## MariaDB root password
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
-    ##
-    rootPassword: ""
-    ## MariaDB custom user and database
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
-    ##
-    database: bitnami_wordpress
-    username: bn_wordpress
-    password: ""
-
-  primary:
-    ## Enable persistence using Persistent Volume Claims
-    ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-    ##
-    persistence:
-      enabled: true
-      ## mariadb data Persistent Volume Storage Class
-      ## If defined, storageClassName: <storageClass>
-      ## If set to "-", storageClassName: "", which disables dynamic provisioning
-      ## If undefined (the default) or set to null, no storageClassName spec is
-      ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-      ##   GKE, AWS & OpenStack)
-      ##
-      # storageClass: "-"
-      accessModes:
-        - ReadWriteOnce
-      size: 8Gi
-
-##
-## External Database Configuration
-##
-## All of these values are only used when mariadb.enabled is set to false
-##
-externalDatabase:
-  ## Use existing secret (ignores previous password)
-  ## must contain key `mariadb-password`
-  ## NOTE: When it's set, the `externalDatabase.password` parameter is ignored
-  # existingSecret:
-
-  ## Database host
-  ##
-  host: localhost
-
-  ## non-root Username for Wordpress Database
-  ##
-  user: bn_wordpress
-
-  ## Database password
-  ##
-  password: ""
-
-  ## Database name
-  ##
-  database: bitnami_wordpress
-
-  ## Database port number
-  ##
-  port: 3306
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 11
+  # targetCPU: 50
+  # targetMemory: 50
 
 ## Prometheus Exporter / Metrics
 ##
@@ -515,11 +539,18 @@ metrics:
     ##
     # pullSecrets:
     #   - myRegistryKeySecretName
-  ## Metrics exporter pod Annotation and Labels
+
+  ## Prometheus expoter service parameters
   ##
-  podAnnotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9117"
+  service:
+    ## Metrics port
+    ##
+    port: 9117
+    ## Annotations for the Prometheus exporter service
+    ##
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "{{ .Values.metrics.service.port }}"
 
   ## Metrics exporter containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -553,28 +584,76 @@ metrics:
     ##
     additionalLabels: {}
 
-## Add sidecars to the pod.
-## Example:
-## sidecars:
-##   - name: your-image-name
-##     image: your-image
-##     imagePullPolicy: Always
-##     ports:
-##       - name: portname
-##         containerPort: 1234
 ##
-sidecars: {}
+## MariaDB chart configuration
+##
+## https://github.com/bitnami/charts/blob/master/bitnami/mariadb/values.yaml
+##
+mariadb:
+  ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+  ##
+  enabled: true
+  ## MariaDB architecture. Allowed values: standalone or replication
+  ##
+  architecture: standalone
+  ## MariaDB Authentication parameters
+  ##
+  auth:
+    ## MariaDB root password
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
+    ##
+    rootPassword: ""
+    ## MariaDB custom user and database
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+    ##
+    database: bitnami_wordpress
+    username: bn_wordpress
+    password: ""
+  primary:
+    ## Enable persistence using Persistent Volume Claims
+    ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+    ##
+    persistence:
+      enabled: true
+      ## mariadb data Persistent Volume Storage Class
+      ## If defined, storageClassName: <storageClass>
+      ## If set to "-", storageClassName: "", which disables dynamic provisioning
+      ## If undefined (the default) or set to null, no storageClassName spec is
+      ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+      ##   GKE, AWS & OpenStack)
+      ##
+      # storageClass: "-"
+      accessModes:
+        - ReadWriteOnce
+      size: 8Gi
 
-## Add init containers to the pod.
-## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
-## Example:
-## initContainers:
-##  - name: your-image-name
-##    image: your-image
-##    imagePullPolicy: Always
-##    command: ['sh', '-c', 'copy themes and plugins from git and push to /bitnami/wordpress/wp-content. Should work with extraVolumeMounts and extraVolumes']
 ##
-initContainers: {}
+## External Database Configuration
+##
+## All of these values are only used when mariadb.enabled is set to false
+##
+externalDatabase:
+  ## Database host
+  ##
+  host: localhost
+  ## non-root Username for Wordpress Database
+  ##
+  user: bn_wordpress
+  ## Database password
+  ##
+  password: ""
+  ## Database name
+  ##
+  database: bitnami_wordpress
+  ## Database port number
+  ##
+  port: 3306
+  ## Use existing secret (ignores previous password)
+  ## must contain key `mariadb-password`
+  ## NOTE: When it's set, the `externalDatabase.password` parameter is ignored
+  ##
+  # existingSecret:
 
 ## Make use of custom post-init.d user scripts functionality inside the bitnami/wordpress image
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress/tree/master/5/debian-10/rootfs/post-init.d

--- a/bitnami/wordpress/values-production.yaml
+++ b/bitnami/wordpress/values-production.yaml
@@ -431,31 +431,30 @@ mariadb:
   ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
   ##
   enabled: true
-  ## Disable MariaDB replication
-  ##
-  replication:
-    enabled: false
 
-  ## Create a database and a database user
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ## MariaDB architecture. Allowed values: standalone or replication
   ##
-  db:
-    name: bitnami_wordpress
-    user: bn_wordpress
-    ## If the password is not specified, mariadb will generates a random password
+  architecture: standalone
+
+  ## MariaDB Authentication parameters
+  ##
+  auth:
+    ## MariaDB root password
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
     ##
-    # password:
+    rootPassword: ""
+    ## MariaDB custom user and database
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+    ##
+    database: bitnami_wordpress
+    username: bn_wordpress
+    password: ""
 
-  ## MariaDB admin password
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
-  ##
-  # rootUser:
-  #   password:
-
-  ## Enable persistence using Persistent Volume Claims
-  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-  ##
-  master:
+  primary:
+    ## Enable persistence using Persistent Volume Claims
+    ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+    ##
     persistence:
       enabled: true
       ## mariadb data Persistent Volume Storage Class

--- a/bitnami/wordpress/values.schema.json
+++ b/bitnami/wordpress/values.schema.json
@@ -48,7 +48,7 @@
           "form": true,
           "description": "Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database switch this off and configure the external database details"
         },
-        "master": {
+        "primary": {
           "type": "object",
           "properties": {
             "persistence": {

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -425,31 +425,30 @@ mariadb:
   ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
   ##
   enabled: true
-  ## Disable MariaDB replication
-  ##
-  replication:
-    enabled: false
 
-  ## Create a database and a database user
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ## MariaDB architecture. Allowed values: standalone or replication
   ##
-  db:
-    name: bitnami_wordpress
-    user: bn_wordpress
-    ## If the password is not specified, mariadb will generates a random password
+  architecture: standalone
+
+  ## MariaDB Authentication parameters
+  ##
+  auth:
+    ## MariaDB root password
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
     ##
-    # password:
+    rootPassword: ""
+    ## MariaDB custom user and database
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+    ##
+    database: bitnami_wordpress
+    username: bn_wordpress
+    password: ""
 
-  ## MariaDB admin password
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
-  ##
-  # rootUser:
-  #   password:
-
-  ## Enable persistence using Persistent Volume Claims
-  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-  ##
-  master:
+  primary:
+    ## Enable persistence using Persistent Volume Claims
+    ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+    ##
     persistence:
       enabled: true
       ## mariadb data Persistent Volume Storage Class

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -30,17 +30,13 @@ image:
   ##
   debug: false
 
-## String to partially override wordpress.fullname template (will maintain the release name)
+## String to partially override aspnet-core.fullname template (will maintain the release name)
 ##
 # nameOverride:
 
-## String to fully override wordpress.fullname template
+## String to fully override aspnet-core.fullname template
 ##
 # fullnameOverride:
-
-## Kubernetes Cluster Domain
-##
-clusterDomain: cluster.local
 
 ## Add labels to all the deployed resources
 ##
@@ -50,10 +46,13 @@ commonLabels: {}
 ##
 commonAnnotations: {}
 
-## Use existing secret (does not create the WordPress Secret object)
-## Must contain key `wordpress-secret`
-## NOTE: When it's set, the `wordpressPassword` parameter is ignored
-# existingSecret:
+## Kubernetes Cluster Domain
+##
+clusterDomain: cluster.local
+
+## Extra objects to deploy (value evaluated as a template)
+##
+extraDeploy: []
 
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
@@ -65,6 +64,12 @@ wordpressUsername: user
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
 ##
 # wordpressPassword:
+
+## Use existing secret (does not create the WordPress Secret object)
+## Must contain key `wordpress-secret`
+## NOTE: When it's set, the `wordpressPassword` parameter is ignored
+##
+# existingSecret:
 
 ## Admin email
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
@@ -150,64 +155,117 @@ updateStrategy:
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress/#smtp-configuration
 ##
+# smtpHost:
+# smtpPort:
+# smtpUser:
+# smtpPassword:
+# smtpProtocol:
 
 ## Use an existing secret for the SMTP Password
 ## Can be the same secret as existingSecret
 ## Must contain key `smtp-password`
 ## NOTE: When it's set, the `smtpPassword` parameter is ignored
+##
 # smtpExistingSecret:
 
-# smtpHost:
-# smtpPort:
-# smtpUser:
-# smtpPassword:
-# smtpUsername:
-# smtpProtocol:
-
+## Number of replicas (requires ReadWriteMany PVC support)
+##
 replicaCount: 1
 
-## Additional container environment variables
-## Example: Configure SSL for database
-## extraEnv:
-##   - name: WORDPRESS_DATABASE_SSL_CA_FILE
-##     value: /path/to/ca_cert
+## An array to add extra env vars
+## Example:
+## extraEnvVars:
+##   - name: FOO
+##     value: "bar"
 ##
-extraEnv: []
+extraEnvVars: []
 
-## Additional volume mounts
-## Example: Mount CA file
-## extraVolumeMounts
-##   - name: ca-cert
-##     subPath: ca_cert
-##     mountPath: /path/to/ca_cert
+## ConfigMap with extra environment variables
 ##
-extraVolumeMounts: []
+extraEnvVarsCM:
 
-## Additional volumes
-## Example: Add secret volume
-## extraVolumes:
-##  - name: ca-cert
-##    secret:
-##      secretName: ca-cert
-##      items:
-##        - key: ca-cert
-##          path: ca_cert
+## Secret with extra environment variables
+##
+extraEnvVarsSecret:
+
+## Extra volumes to add to the deployment
 ##
 extraVolumes: []
 
-## WordPress containers' resource requests and limits
-## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+## Extra volume mounts to add to the container
 ##
-resources:
-  limits: {}
-  #   cpu: 500m
-  #   memory: 1Gi
-  requests:
-    memory: 512Mi
-    cpu: 300m
+extraVolumeMounts: []
+
+## Add sidecars to the pod.
+## Example:
+## sidecars:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+sidecars: {}
+
+## Add init containers to the pod.
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+## Example:
+## initContainers:
+##  - name: your-image-name
+##    image: your-image
+##    imagePullPolicy: Always
+##    command: ['sh', '-c', 'copy themes and plugins from git and push to /bitnami/wordpress/wp-content. Should work with extraVolumeMounts and extraVolumes']
+##
+initContainers: {}
+
+## Pod Labels
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+##
+podLabels: {}
+
+## Pod annotations
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+
+## Pod affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+## Allowed values: soft, hard
+##
+podAffinityPreset: ""
+
+## Pod anti-affinity preset
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+## Allowed values: soft, hard
+##
+podAntiAffinityPreset: soft
+
+## Node affinity preset
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+## Allowed values: soft, hard
+##
+nodeAffinityPreset:
+  ## Node affinity type
+  ## Allowed values: soft, hard
+  ##
+  type: ""
+  ## Node label key to match
+  ## E.g.
+  ## key: "kubernetes.io/e2e-az-name"
+  ##
+  key: ""
+  ## Node label values to match
+  ## E.g.
+  ## values:
+  ##   - e2e-az1
+  ##   - e2e-az2
+  ##
+  values: []
 
 ## Affinity for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## Note: podAffinityPreset, podAntiAffinityPreset, and  nodeAffinityPreset will be ignored when it's set
 ##
 affinity: {}
 
@@ -221,29 +279,48 @@ nodeSelector: {}
 ##
 tolerations: {}
 
-## Pod Labels
-## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+## WordPress containers' resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##
-podLabels: {}
+resources:
+  limits: {}
+  requests:
+    memory: 512Mi
+    cpu: 300m
 
-## Pod annotations
-## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+## Configure Pods Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ##
-podAnnotations: {}
-
-## K8s Security Context for WordPress pods
-## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-##
-securityContext:
+podSecurityContext:
   enabled: true
   fsGroup: 1001
+
+## Configure Container Security Context (only main container)
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+##
+containerSecurityContext:
+  enabled: true
   runAsUser: 1001
 
-## WordPress pod extra options for liveness and readiness probes
-## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+## WordPress containers' liveness and readiness probes.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
 ##
 livenessProbe:
   enabled: true
+  httpGet:
+    path: /wp-admin/install.php
+    port: http
+    scheme: HTTP
+    ## If using an HTTPS-terminating load-balancer, the probes may need to behave
+    ## like the balancer to prevent HTTP 302 responses. According to the Kubernetes
+    ## docs, 302 should be considered "successful", but this issue on GitHub
+    ## (https://github.com/kubernetes/kubernetes/issues/47893) shows that it isn't.
+    ##
+    ## httpHeaders:
+    ## - name: X-Forwarded-Proto
+    ##   value: https
+    ##
+    httpHeaders: []
   initialDelaySeconds: 120
   periodSeconds: 10
   timeoutSeconds: 5
@@ -251,34 +328,36 @@ livenessProbe:
   successThreshold: 1
 readinessProbe:
   enabled: true
+  httpGet:
+    path: /wp-login.php
+    port: http
+    scheme: HTTP
+    ## If using an HTTPS-terminating load-balancer, the probes may need to behave
+    ## like the balancer to prevent HTTP 302 responses. According to the Kubernetes
+    ## docs, 302 should be considered "successful", but this issue on GitHub
+    ## (https://github.com/kubernetes/kubernetes/issues/47893) shows that it isn't.
+    ##
+    ## httpHeaders:
+    ## - name: X-Forwarded-Proto
+    ##   value: https
+    ##
+    httpHeaders: []
   initialDelaySeconds: 30
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 6
   successThreshold: 1
 
-## Allow health checks to be pointed at the https port
-##
-healthcheckHttps: false
-
 ## Custom liveness and readiness probes, it overrides the default one (evaluated as a template)
 ##
 customLivenessProbe: {}
 customReadinessProbe: {}
 
-## If using an HTTPS-terminating load-balancer, the probes may need to behave
-## like the balancer to prevent HTTP 302 responses. According to the Kubernetes
-## docs, 302 should be considered "successful", but this issue on GitHub
-## (https://github.com/kubernetes/kubernetes/issues/47893) shows that it isn't.
+## Container ports
 ##
-# livenessProbeHeaders:
-# - name: X-Forwarded-Proto
-#   value: https
-# readinessProbeHeaders:
-# - name: X-Forwarded-Proto
-#   value: https
-livenessProbeHeaders: {}
-readinessProbeHeaders: {}
+containerPorts:
+  http: 8080
+  https: 8443
 
 ## Kubernetes configuration
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer or ClusterIP
@@ -296,29 +375,37 @@ service:
   ## if you want the target port to be "http" or "80" you can specify that here.
   ##
   httpsTargetPort: https
-  ## Metrics Port
-  ##
-  metricsPort: 9117
   ## Node Ports to expose
   ## nodePorts:
   ##   http: <to set explicitly, choose port between 30000-32767>
   ##   https: <to set explicitly, choose port between 30000-32767>
-  ##   metrics: <to set explicitly, choose port between 30000-32767>
   ##
   nodePorts:
     http: ""
     https: ""
-    metrics: ""
+  ## Service clusterIP.
+  ##
+  # clusterIP: None
+  ## loadBalancerIP for the SuiteCRM Service (optional, cloud specific)
+  ## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
+  ##
+  # loadBalancerIP:
+  ## Load Balancer sources
+  ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  ## Example:
+  ## loadBalancerSourceRanges:
+  ##   - 10.10.10.0/24
+  ##
+  loadBalancerSourceRanges: []
   ## Enable client source IP preservation
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   ##
   externalTrafficPolicy: Cluster
-  annotations: {}
-  ## Limits which cidr blocks can connect to service's load balancer
-  ## Only valid if service.type: LoadBalancer
+  ## Provide any additional annotations which may be required (evaluated as a template).
   ##
-  loadBalancerSourceRanges: []
+  annotations: {}
   ## Extra ports to expose (normally used with the `sidecar` value)
+  ##
   # extraPorts:
 
 ## Configure the ingress resource that allows you to access the
@@ -416,83 +503,26 @@ persistence:
   accessMode: ReadWriteOnce
   size: 10Gi
 
+## Wordpress Pod Disruption Budget configuration
+## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
 ##
-## MariaDB chart configuration
+pdb:
+  create: false
+  ## Min number of pods that must still be available after the eviction
+  ##
+  minAvailable: 1
+  ## Max number of pods that can be unavailable after the eviction
+  ##
+  # maxUnavailable: 1
+
+## Wordpress Autoscaling configuration
 ##
-## https://github.com/bitnami/charts/blob/master/bitnami/mariadb/values.yaml
-##
-mariadb:
-  ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
-  ##
-  enabled: true
-
-  ## MariaDB architecture. Allowed values: standalone or replication
-  ##
-  architecture: standalone
-
-  ## MariaDB Authentication parameters
-  ##
-  auth:
-    ## MariaDB root password
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
-    ##
-    rootPassword: ""
-    ## MariaDB custom user and database
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
-    ##
-    database: bitnami_wordpress
-    username: bn_wordpress
-    password: ""
-
-  primary:
-    ## Enable persistence using Persistent Volume Claims
-    ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-    ##
-    persistence:
-      enabled: true
-      ## mariadb data Persistent Volume Storage Class
-      ## If defined, storageClassName: <storageClass>
-      ## If set to "-", storageClassName: "", which disables dynamic provisioning
-      ## If undefined (the default) or set to null, no storageClassName spec is
-      ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-      ##   GKE, AWS & OpenStack)
-      ##
-      # storageClass: "-"
-      accessModes:
-        - ReadWriteOnce
-      size: 8Gi
-
-##
-## External Database Configuration
-##
-## All of these values are only used when mariadb.enabled is set to false
-##
-externalDatabase:
-  ## Use existing secret (ignores previous password)
-  ## must contain key `mariadb-password`
-  ## NOTE: When it's set, the `externalDatabase.password` parameter is ignored
-  # existingSecret:
-
-  ## Database host
-  ##
-  host: localhost
-
-  ## non-root Username for Wordpress Database
-  ##
-  user: bn_wordpress
-
-  ## Database password
-  ##
-  password: ""
-
-  ## Database name
-  ##
-  database: bitnami_wordpress
-
-  ## Database port number
-  ##
-  port: 3306
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 11
+  # targetCPU: 50
+  # targetMemory: 50
 
 ## Prometheus Exporter / Metrics
 ##
@@ -509,11 +539,18 @@ metrics:
     ##
     # pullSecrets:
     #   - myRegistryKeySecretName
-  ## Metrics exporter pod Annotation and Labels
+
+  ## Prometheus expoter service parameters
   ##
-  podAnnotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9117"
+  service:
+    ## Metrics port
+    ##
+    port: 9117
+    ## Annotations for the Prometheus exporter service
+    ##
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "{{ .Values.metrics.service.port }}"
 
   ## Metrics exporter containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -547,28 +584,76 @@ metrics:
     ##
     additionalLabels: {}
 
-## Add sidecars to the pod.
-## Example:
-## sidecars:
-##   - name: your-image-name
-##     image: your-image
-##     imagePullPolicy: Always
-##     ports:
-##       - name: portname
-##         containerPort: 1234
 ##
-sidecars: {}
+## MariaDB chart configuration
+##
+## https://github.com/bitnami/charts/blob/master/bitnami/mariadb/values.yaml
+##
+mariadb:
+  ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+  ##
+  enabled: true
+  ## MariaDB architecture. Allowed values: standalone or replication
+  ##
+  architecture: standalone
+  ## MariaDB Authentication parameters
+  ##
+  auth:
+    ## MariaDB root password
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
+    ##
+    rootPassword: ""
+    ## MariaDB custom user and database
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+    ##
+    database: bitnami_wordpress
+    username: bn_wordpress
+    password: ""
+  primary:
+    ## Enable persistence using Persistent Volume Claims
+    ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+    ##
+    persistence:
+      enabled: true
+      ## mariadb data Persistent Volume Storage Class
+      ## If defined, storageClassName: <storageClass>
+      ## If set to "-", storageClassName: "", which disables dynamic provisioning
+      ## If undefined (the default) or set to null, no storageClassName spec is
+      ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+      ##   GKE, AWS & OpenStack)
+      ##
+      # storageClass: "-"
+      accessModes:
+        - ReadWriteOnce
+      size: 8Gi
 
-## Add init containers to the pod.
-## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
-## Example:
-## initContainers:
-##  - name: your-image-name
-##    image: your-image
-##    imagePullPolicy: Always
-##    command: ['sh', '-c', 'copy themes and plugins from git and push to /bitnami/wordpress/wp-content. Should work with extraVolumeMounts and extraVolumes']
 ##
-initContainers: {}
+## External Database Configuration
+##
+## All of these values are only used when mariadb.enabled is set to false
+##
+externalDatabase:
+  ## Database host
+  ##
+  host: localhost
+  ## non-root Username for Wordpress Database
+  ##
+  user: bn_wordpress
+  ## Database password
+  ##
+  password: ""
+  ## Database name
+  ##
+  database: bitnami_wordpress
+  ## Database port number
+  ##
+  port: 3306
+  ## Use existing secret (ignores previous password)
+  ## must contain key `mariadb-password`
+  ## NOTE: When it's set, the `externalDatabase.password` parameter is ignored
+  ##
+  # existingSecret:
 
 ## Make use of custom post-init.d user scripts functionality inside the bitnami/wordpress image
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress/tree/master/5/debian-10/rootfs/post-init.d


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR bumps WP major version since its dependency (MariaDB) bumped the major version including breaking changes. More info at https://github.com/bitnami/charts/pull/3849

It also:

- Bump apiVersion from `v1` to `v2` in **Chart.yaml**
- Fields in **Chart.yaml** file has been ordered alphabetically
- Move dependency information from the **requirements.yaml** to the **Chart.yaml**

**Benefits**

- Standardization.
- Reduces technical debt.

**Possible drawbacks**

- It breaks backwards compatibility.
- Helm v2 is no longer supported


**Applicable issues**

None

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
