### PR TITLE
[bitnami/mediawiki] Fix service selector greediness

### DIFF
--- a/bitnami/mediawiki/Chart.yaml
+++ b/bitnami/mediawiki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mediawiki
-version: 10.0.8
+version: 10.0.9
 appVersion: 1.35.0
 description: Extremely powerful, scalable software and a feature-rich wiki implementation that uses PHP to process and display data stored in a database.
 home: https://github.com/bitnami/charts/tree/master/bitnami/mediawiki

--- a/bitnami/mediawiki/templates/svc.yaml
+++ b/bitnami/mediawiki/templates/svc.yaml
@@ -32,3 +32,4 @@ spec:
   {{- end }}
   selector:
     app: {{ template "mediawiki.name" . }}
+    release: "{{ .Release.Name }}"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This PR makes pod selection in the MediaWiki service less greedy. Instead of just looking at `app` label, `release` label is also taken into the account now.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

The change allows deploying two instances of MediaWiki into a single namespace (in my case these are `main` and `sandbox`). Without the addition label selector, the services are selecting pods across apps, thus randomly showing users different instances of the wiki.

Before:

```txt
service A      service B
    ↓     ↘  ↙     ↓ 
  pod A          pod B
```

After:

```txt
service A      service B
    ↓              ↓ 
  pod A          pod B
```

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

Unknown
<!-- Describe any known limitations with your change -->

<!-- **Applicable issues** -->

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
<!--  - fixes # -->

**Additional information**

Source of inspiration:

https://github.com/bitnami/charts/blob/f5033e893646592e1ec6b063f229eff030e90f7a/bitnami/mariadb/templates/master-svc.yaml#L44-L47

After manually tweaking the selectors in the deployed services via the k8s dashboard, I can conclude that the suggested patch is working.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- ~~Variables are documented in the README.md~~ (N/A)
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- ~~If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files~~ (N/A)

<!-- :warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror. -->