### PR TITLE
[bitnami/zookeeper] allow for overriding namespace in zookeeper helm chart

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zookeeper
-version: 5.22.9
+version: 5.22.0
 appVersion: 3.6.2
 description: A centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services for distributed applications.
 keywords:

--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: zookeeper
-version: 5.21.9
+version: 5.22.9
 appVersion: 3.6.2
 description: A centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services for distributed applications.
 keywords:

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -96,7 +96,7 @@ The following tables lists the configurable parameters of the ZooKeeper chart an
 | `jvmFlags`                                        | Default JVMFLAGS for the ZooKeeper process                                                                                        | `nil`                                                   |
 | `config`                                          | Configure ZooKeeper with a custom zoo.conf file                                                                                   | `nil`                                                   |
 | `dataLogDir`                                      | Data log directory                                                                                                                | `""`                                                   |
-| `namespace`                                       | Namespace for Zookeper resources                                                                                                  | The Release Namespace                                  |
+| `namespace`                                       | Namespace for ZooKeeper resources                                                                                                 | The Release Namespace                                  |
 
 ### Statefulset parameters
 

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -96,6 +96,7 @@ The following tables lists the configurable parameters of the ZooKeeper chart an
 | `jvmFlags`                                        | Default JVMFLAGS for the ZooKeeper process                                                                                        | `nil`                                                   |
 | `config`                                          | Configure ZooKeeper with a custom zoo.conf file                                                                                   | `nil`                                                   |
 | `dataLogDir`                                      | Data log directory                                                                                                                | `""`                                                   |
+| `namespace`                                       | Namespace for Zookeper resources                                                                                                  | The Release Namespace                                  |
 
 ### Statefulset parameters
 

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -96,7 +96,7 @@ The following tables lists the configurable parameters of the ZooKeeper chart an
 | `jvmFlags`                                        | Default JVMFLAGS for the ZooKeeper process                                                                                        | `nil`                                                   |
 | `config`                                          | Configure ZooKeeper with a custom zoo.conf file                                                                                   | `nil`                                                   |
 | `dataLogDir`                                      | Data log directory                                                                                                                | `""`                                                   |
-| `namespace`                                       | Namespace for ZooKeeper resources                                                                                                 | The Release Namespace                                  |
+| `namespaceOverride`                       | Namespace for ZooKeeper resources. Overrides the release namespace.                                                                       | The Release Namespace                                  |
 
 ### Statefulset parameters
 

--- a/bitnami/zookeeper/templates/NOTES.txt
+++ b/bitnami/zookeeper/templates/NOTES.txt
@@ -19,32 +19,32 @@
 
 ZooKeeper can be accessed via port 2181 on the following DNS name from within your cluster:
 
-    {{ template "zookeeper.fullname" . }}.{{ template "zookeeper.namespaceOverride" . }}.svc.{{ .Values.clusterDomain }}
+    {{ template "zookeeper.fullname" . }}.{{ template "zookeeper.namespace" . }}.svc.{{ .Values.clusterDomain }}
 
 To connect to your ZooKeeper server run the following commands:
 
-    export POD_NAME=$(kubectl get pods --namespace {{ template "zookeeper.namespaceOverride" . }} -l "app.kubernetes.io/name={{ template "zookeeper.name" . }},app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=zookeeper" -o jsonpath="{.items[0].metadata.name}")
+    export POD_NAME=$(kubectl get pods --namespace {{ template "zookeeper.namespace" . }} -l "app.kubernetes.io/name={{ template "zookeeper.name" . }},app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=zookeeper" -o jsonpath="{.items[0].metadata.name}")
     kubectl exec -it $POD_NAME -- zkCli.sh
 
 To connect to your ZooKeeper server from outside the cluster execute the following commands:
 
 {{- if contains "NodePort" .Values.service.type }}
 
-    export NODE_IP=$(kubectl get nodes --namespace {{ template "zookeeper.namespaceOverride" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
-    export NODE_PORT=$(kubectl get --namespace {{ template "zookeeper.namespaceOverride" . }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "zookeeper.fullname" . }})
+    export NODE_IP=$(kubectl get nodes --namespace {{ template "zookeeper.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    export NODE_PORT=$(kubectl get --namespace {{ template "zookeeper.namespace" . }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "zookeeper.fullname" . }})
     zkCli.sh $NODE_IP:$NODE_PORT
 
 {{- else if contains "LoadBalancer" .Values.service.type }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace {{ template "zookeeper.namespaceOverride" . }} -w {{ template "zookeeper.fullname" . }}'
+        Watch the status with: 'kubectl get svc --namespace {{ template "zookeeper.namespace" . }} -w {{ template "zookeeper.fullname" . }}'
 
-    export SERVICE_IP=$(kubectl get svc --namespace {{ template "zookeeper.namespaceOverride" . }} {{ template "zookeeper.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+    export SERVICE_IP=$(kubectl get svc --namespace {{ template "zookeeper.namespace" . }} {{ template "zookeeper.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
     zkCli.sh $SERVICE_IP:2181
 
 {{- else if contains "ClusterIP" .Values.service.type }}
 
-    kubectl port-forward --namespace {{ template "zookeeper.namespaceOverride" . }} svc/{{ template "zookeeper.fullname" . }} 2181:2181 &
+    kubectl port-forward --namespace {{ template "zookeeper.namespace" . }} svc/{{ template "zookeeper.fullname" . }} 2181:2181 &
     zkCli.sh 127.0.0.1:2181
 
 {{- end }}

--- a/bitnami/zookeeper/templates/NOTES.txt
+++ b/bitnami/zookeeper/templates/NOTES.txt
@@ -19,32 +19,32 @@
 
 ZooKeeper can be accessed via port 2181 on the following DNS name from within your cluster:
 
-    {{ template "zookeeper.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
+    {{ template "zookeeper.fullname" . }}.{{ template "zookeeper.namespaceOverride" . }}.svc.{{ .Values.clusterDomain }}
 
 To connect to your ZooKeeper server run the following commands:
 
-    export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "zookeeper.name" . }},app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=zookeeper" -o jsonpath="{.items[0].metadata.name}")
+    export POD_NAME=$(kubectl get pods --namespace {{ template "zookeeper.namespaceOverride" . }} -l "app.kubernetes.io/name={{ template "zookeeper.name" . }},app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=zookeeper" -o jsonpath="{.items[0].metadata.name}")
     kubectl exec -it $POD_NAME -- zkCli.sh
 
 To connect to your ZooKeeper server from outside the cluster execute the following commands:
 
 {{- if contains "NodePort" .Values.service.type }}
 
-    export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-    export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "zookeeper.fullname" . }})
+    export NODE_IP=$(kubectl get nodes --namespace {{ template "zookeeper.namespaceOverride" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    export NODE_PORT=$(kubectl get --namespace {{ template "zookeeper.namespaceOverride" . }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "zookeeper.fullname" . }})
     zkCli.sh $NODE_IP:$NODE_PORT
 
 {{- else if contains "LoadBalancer" .Values.service.type }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "zookeeper.fullname" . }}'
+        Watch the status with: 'kubectl get svc --namespace {{ template "zookeeper.namespaceOverride" . }} -w {{ template "zookeeper.fullname" . }}'
 
-    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "zookeeper.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+    export SERVICE_IP=$(kubectl get svc --namespace {{ template "zookeeper.namespaceOverride" . }} {{ template "zookeeper.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
     zkCli.sh $SERVICE_IP:2181
 
 {{- else if contains "ClusterIP" .Values.service.type }}
 
-    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "zookeeper.fullname" . }} 2181:2181 &
+    kubectl port-forward --namespace {{ template "zookeeper.namespaceOverride" . }} svc/{{ template "zookeeper.fullname" . }} 2181:2181 &
     zkCli.sh 127.0.0.1:2181
 
 {{- end }}

--- a/bitnami/zookeeper/templates/_helpers.tpl
+++ b/bitnami/zookeeper/templates/_helpers.tpl
@@ -210,3 +210,14 @@ but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else 
     {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return ZooKeeper Namespace to use
+*/}}
+{{- define "zookeeper.namespaceOverride" -}}
+    {{- if .Values.namespaceOverride }}
+        {{- .Values.namespaceOverride -}}
+    {{- else }}
+        {{- .Release.Namespace -}}
+    {{- end }}
+{{- end -}}

--- a/bitnami/zookeeper/templates/_helpers.tpl
+++ b/bitnami/zookeeper/templates/_helpers.tpl
@@ -214,7 +214,7 @@ but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else 
 {{/*
 Return ZooKeeper Namespace to use
 */}}
-{{- define "zookeeper.namespaceOverride" -}}
+{{- define "zookeeper.namespace" -}}
     {{- if .Values.namespaceOverride }}
         {{- .Values.namespaceOverride -}}
     {{- else }}

--- a/bitnami/zookeeper/templates/configmap.yaml
+++ b/bitnami/zookeeper/templates/configmap.yaml
@@ -3,7 +3,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "zookeeper.fullname" . }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace }}
+  {{- else }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "zookeeper.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/zookeeper/templates/configmap.yaml
+++ b/bitnami/zookeeper/templates/configmap.yaml
@@ -3,11 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "zookeeper.fullname" . }}
-  {{- if .Values.namespace }}
-  namespace: {{ .Values.namespace }}
-  {{- else }}
-  namespace: {{ .Release.Namespace }}
-  {{- end }}
+  namespace: {{ template "zookeeper.namespaceOverride" . }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "zookeeper.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/zookeeper/templates/configmap.yaml
+++ b/bitnami/zookeeper/templates/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "zookeeper.fullname" . }}
-  namespace: {{ template "zookeeper.namespaceOverride" . }}
+  namespace: {{ template "zookeeper.namespace" . }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "zookeeper.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/zookeeper/templates/metrics-svc.yaml
+++ b/bitnami/zookeeper/templates/metrics-svc.yaml
@@ -3,11 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "zookeeper.fullname" . }}-metrics
-  {{- if .Values.namespace }}
-  namespace: {{ .Values.namespace }}
-  {{- else }}
-  namespace: {{ .Release.Namespace }}
-  {{- end }}
+  namespace: {{ template "zookeeper.namespaceOverride" . }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     app.kubernetes.io/component: zookeeper
     {{- if .Values.commonLabels }}

--- a/bitnami/zookeeper/templates/metrics-svc.yaml
+++ b/bitnami/zookeeper/templates/metrics-svc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "zookeeper.fullname" . }}-metrics
-  namespace: {{ template "zookeeper.namespaceOverride" . }}
+  namespace: {{ template "zookeeper.namespace" . }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     app.kubernetes.io/component: zookeeper
     {{- if .Values.commonLabels }}

--- a/bitnami/zookeeper/templates/metrics-svc.yaml
+++ b/bitnami/zookeeper/templates/metrics-svc.yaml
@@ -3,7 +3,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "zookeeper.fullname" . }}-metrics
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace }}
+  {{- else }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     app.kubernetes.io/component: zookeeper
     {{- if .Values.commonLabels }}

--- a/bitnami/zookeeper/templates/networkpolicy.yaml
+++ b/bitnami/zookeeper/templates/networkpolicy.yaml
@@ -3,11 +3,7 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: {{ include "zookeeper.fullname" . }}
-  {{- if .Values.namespace }}
-  namespace: {{ .Values.namespace }}
-  {{- else }}
-  namespace: {{ .Release.Namespace }}
-  {{- end }}
+  namespace: {{ template "zookeeper.namespaceOverride" . }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "zookeeper.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/zookeeper/templates/networkpolicy.yaml
+++ b/bitnami/zookeeper/templates/networkpolicy.yaml
@@ -3,7 +3,11 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: {{ include "zookeeper.fullname" . }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace }}
+  {{- else }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "zookeeper.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/zookeeper/templates/networkpolicy.yaml
+++ b/bitnami/zookeeper/templates/networkpolicy.yaml
@@ -3,7 +3,7 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: {{ include "zookeeper.fullname" . }}
-  namespace: {{ template "zookeeper.namespaceOverride" . }}
+  namespace: {{ template "zookeeper.namespace" . }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "zookeeper.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/zookeeper/templates/poddisruptionbudget.yaml
+++ b/bitnami/zookeeper/templates/poddisruptionbudget.yaml
@@ -4,7 +4,11 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "zookeeper.fullname" . }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace }}
+  {{- else }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     app.kubernetes.io/component: zookeeper
     {{- if .Values.commonLabels }}

--- a/bitnami/zookeeper/templates/poddisruptionbudget.yaml
+++ b/bitnami/zookeeper/templates/poddisruptionbudget.yaml
@@ -4,7 +4,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "zookeeper.fullname" . }}
-  namespace: {{ template "zookeeper.namespaceOverride" . }}
+  namespace: {{ template "zookeeper.namespace" . }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     app.kubernetes.io/component: zookeeper
     {{- if .Values.commonLabels }}

--- a/bitnami/zookeeper/templates/poddisruptionbudget.yaml
+++ b/bitnami/zookeeper/templates/poddisruptionbudget.yaml
@@ -4,11 +4,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "zookeeper.fullname" . }}
-  {{- if .Values.namespace }}
-  namespace: {{ .Values.namespace }}
-  {{- else }}
-  namespace: {{ .Release.Namespace }}
-  {{- end }}
+  namespace: {{ template "zookeeper.namespaceOverride" . }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     app.kubernetes.io/component: zookeeper
     {{- if .Values.commonLabels }}

--- a/bitnami/zookeeper/templates/secrets.yaml
+++ b/bitnami/zookeeper/templates/secrets.yaml
@@ -3,11 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "zookeeper.fullname" . }}
-  {{- if .Values.namespace }}
-  namespace: {{ .Values.namespace }}
-  {{- else }}
-  namespace: {{ .Release.Namespace }}
-  {{- end }}
+  namespace: {{ template "zookeeper.namespaceOverride" . }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "zookeeper.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/zookeeper/templates/secrets.yaml
+++ b/bitnami/zookeeper/templates/secrets.yaml
@@ -3,7 +3,11 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "zookeeper.fullname" . }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace }}
+  {{- else }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "zookeeper.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/zookeeper/templates/secrets.yaml
+++ b/bitnami/zookeeper/templates/secrets.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "zookeeper.fullname" . }}
-  namespace: {{ template "zookeeper.namespaceOverride" . }}
+  namespace: {{ template "zookeeper.namespace" . }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "zookeeper.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/zookeeper/templates/serviceaccount.yaml
+++ b/bitnami/zookeeper/templates/serviceaccount.yaml
@@ -3,7 +3,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "zookeeper.serviceAccountName" . }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace }}
+  {{- else }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     role: zookeeper
     {{- if .Values.commonLabels }}

--- a/bitnami/zookeeper/templates/serviceaccount.yaml
+++ b/bitnami/zookeeper/templates/serviceaccount.yaml
@@ -3,11 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "zookeeper.serviceAccountName" . }}
-  {{- if .Values.namespace }}
-  namespace: {{ .Values.namespace }}
-  {{- else }}
-  namespace: {{ .Release.Namespace }}
-  {{- end }}
+  namespace: {{ template "zookeeper.namespaceOverride" . }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     role: zookeeper
     {{- if .Values.commonLabels }}

--- a/bitnami/zookeeper/templates/serviceaccount.yaml
+++ b/bitnami/zookeeper/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "zookeeper.serviceAccountName" . }}
-  namespace: {{ template "zookeeper.namespaceOverride" . }}
+  namespace: {{ template "zookeeper.namespace" . }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     role: zookeeper
     {{- if .Values.commonLabels }}

--- a/bitnami/zookeeper/templates/servicemonitor.yaml
+++ b/bitnami/zookeeper/templates/servicemonitor.yaml
@@ -34,5 +34,5 @@ spec:
       {{- end }}
   namespaceSelector:
     matchNames:
-      - {{ template "zookeeper.namespaceOverride" . }}
+      - {{ template "zookeeper.namespace" . }}
 {{- end }}

--- a/bitnami/zookeeper/templates/servicemonitor.yaml
+++ b/bitnami/zookeeper/templates/servicemonitor.yaml
@@ -34,5 +34,5 @@ spec:
       {{- end }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ template "zookeeper.namespaceOverride" . }}
 {{- end }}

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -2,7 +2,11 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "zookeeper.fullname" . }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace }}
+  {{- else }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     app.kubernetes.io/component: zookeeper
     role: zookeeper

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "zookeeper.fullname" . }}
-  namespace: {{ template "zookeeper.namespaceOverride" . }}
+  namespace: {{ template "zookeeper.namespace" . }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     app.kubernetes.io/component: zookeeper
     role: zookeeper
@@ -139,7 +139,7 @@ spec:
               {{- $replicaCount := int .Values.replicaCount }}
               {{- $followerPort := int .Values.service.followerPort }}
               {{- $electionPort := int .Values.service.electionPort }}
-              {{- $releaseNamespace := include "zookeeper.namespaceOverride" . }}
+              {{- $releaseNamespace := include "zookeeper.namespace" . }}
               {{- $zookeeperFullname := include "zookeeper.fullname" . }}
               {{- $zookeeperHeadlessServiceName := printf "%s-%s" $zookeeperFullname "headless" | trunc 63  }}
               {{- $clusterDomain := .Values.clusterDomain }}

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -2,11 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "zookeeper.fullname" . }}
-  {{- if .Values.namespace }}
-  namespace: {{ .Values.namespace }}
-  {{- else }}
-  namespace: {{ .Release.Namespace }}
-  {{- end }}
+  namespace: {{ template "zookeeper.namespaceOverride" . }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     app.kubernetes.io/component: zookeeper
     role: zookeeper
@@ -143,7 +139,7 @@ spec:
               {{- $replicaCount := int .Values.replicaCount }}
               {{- $followerPort := int .Values.service.followerPort }}
               {{- $electionPort := int .Values.service.electionPort }}
-              {{- $releaseNamespace := .Release.Namespace }}
+              {{- $releaseNamespace := include "zookeeper.namespaceOverride" . }}
               {{- $zookeeperFullname := include "zookeeper.fullname" . }}
               {{- $zookeeperHeadlessServiceName := printf "%s-%s" $zookeeperFullname "headless" | trunc 63  }}
               {{- $clusterDomain := .Values.clusterDomain }}

--- a/bitnami/zookeeper/templates/svc-headless.yaml
+++ b/bitnami/zookeeper/templates/svc-headless.yaml
@@ -2,11 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "zookeeper.fullname" . }}-headless
-  {{- if .Values.namespace }}
-  namespace: {{ .Values.namespace }}
-  {{- else }}
-  namespace: {{ .Release.Namespace }}
-  {{- end }}
+  namespace: {{ template "zookeeper.namespaceOverride" . }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     app.kubernetes.io/component: zookeeper
     {{- if .Values.commonLabels }}

--- a/bitnami/zookeeper/templates/svc-headless.yaml
+++ b/bitnami/zookeeper/templates/svc-headless.yaml
@@ -2,7 +2,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "zookeeper.fullname" . }}-headless
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace }}
+  {{- else }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     app.kubernetes.io/component: zookeeper
     {{- if .Values.commonLabels }}

--- a/bitnami/zookeeper/templates/svc-headless.yaml
+++ b/bitnami/zookeeper/templates/svc-headless.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "zookeeper.fullname" . }}-headless
-  namespace: {{ template "zookeeper.namespaceOverride" . }}
+  namespace: {{ template "zookeeper.namespace" . }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     app.kubernetes.io/component: zookeeper
     {{- if .Values.commonLabels }}

--- a/bitnami/zookeeper/templates/svc.yaml
+++ b/bitnami/zookeeper/templates/svc.yaml
@@ -2,11 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "zookeeper.fullname" . }}
-  {{- if .Values.namespace }}
-  namespace: {{ .Values.namespace }}
-  {{- else }}
-  namespace: {{ .Release.Namespace }}
-  {{- end }}
+  namespace: {{ template "zookeeper.namespaceOverride" . }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     app.kubernetes.io/component: zookeeper
     {{- if .Values.commonLabels }}

--- a/bitnami/zookeeper/templates/svc.yaml
+++ b/bitnami/zookeeper/templates/svc.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "zookeeper.fullname" . }}
-  namespace: {{ template "zookeeper.namespaceOverride" . }}
+  namespace: {{ template "zookeeper.namespace" . }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     app.kubernetes.io/component: zookeeper
     {{- if .Values.commonLabels }}

--- a/bitnami/zookeeper/templates/svc.yaml
+++ b/bitnami/zookeeper/templates/svc.yaml
@@ -2,7 +2,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "zookeeper.fullname" . }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace }}
+  {{- else }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels: {{- include "zookeeper.labels" . | nindent 4 }}
     app.kubernetes.io/component: zookeeper
     {{- if .Values.commonLabels }}

--- a/bitnami/zookeeper/values-production.yaml
+++ b/bitnami/zookeeper/values-production.yaml
@@ -200,7 +200,7 @@ dataLogDir: ""
 # config:
 
 ## Namespace for ZooKeeper resources
-# namespace:
+# namespaceOverride:
 
 ## Kubernetes configuration
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer

--- a/bitnami/zookeeper/values-production.yaml
+++ b/bitnami/zookeeper/values-production.yaml
@@ -199,6 +199,9 @@ dataLogDir: ""
 ##
 # config:
 
+## Namespace for ZooKeeper resources
+# namespace:
+
 ## Kubernetes configuration
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer
 ##

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -198,6 +198,9 @@ dataLogDir: ""
 ##
 # config:
 
+## Namespace for ZooKeeper resources
+# namespace:
+
 ## Kubernetes configuration
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer
 ##

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -199,7 +199,7 @@ dataLogDir: ""
 # config:
 
 ## Namespace for ZooKeeper resources
-# namespace:
+# namespaceOverride:
 
 ## Kubernetes configuration
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer


### PR DESCRIPTION
**Description of the change**

Allow for overriding the namespace that the ZooKeeper helm chart resources use.

**Benefits**

When ZooKeeper is included as a dependency of another helm chart, the preferred behaviour may be for it to be released into a different namespace than the parent. This change will allow for the parent chart values to override the namespace.

**Possible drawbacks**

Unknown

**Applicable issues**

  - addresses #3864

**Additional information**

By default behaviour will not change from taking the Release.Namespace value for the namespace.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
