### PR TITLE
[bitnami/common] Fix secret name bug with defaulNameSuffix.

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -2,8 +2,8 @@ annotations:
   category: Infrastructure
 apiVersion: v1
 # Please make sure that version and appVersion are always the same.
-version: 0.8.0
-appVersion: 0.8.0
+version: 0.8.1
+appVersion: 0.8.1
 description: A Library Helm Chart for grouping common logic between bitnami charts.
   This chart is not deployable by itself.
 home: https://github.com/bitnami/charts/tree/master/bitnami/common

--- a/bitnami/common/templates/_secrets.tpl
+++ b/bitnami/common/templates/_secrets.tpl
@@ -15,7 +15,7 @@ Params:
 {{- $name := (include "common.names.fullname" .context) -}}
 
 {{- if .defaultNameSuffix -}}
-{{- $name = printf "%s-%s" $name .defaultNameSuffix -}}
+{{- $name = printf "%s-%s" $name .defaultNameSuffix | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- with .existingSecret -}}

--- a/bitnami/common/templates/_secrets.tpl
+++ b/bitnami/common/templates/_secrets.tpl
@@ -15,7 +15,7 @@ Params:
 {{- $name := (include "common.names.fullname" .context) -}}
 
 {{- if .defaultNameSuffix -}}
-{{- $name = cat $name .defaultNameSuffix -}}
+{{- $name = printf "%s-%s" $name .defaultNameSuffix -}}
 {{- end -}}
 
 {{- with .existingSecret -}}

--- a/bitnami/metallb/values.yaml
+++ b/bitnami/metallb/values.yaml
@@ -41,21 +41,23 @@ rbac:
   # create specifies whether to install and use RBAC rules.
   create: true
 
-psp:
-  # create specifies whether to install PodSecurityPolicies.
-  create: true
+prometheus:
+  enabled: false
 
-# Prometheus Operator alertmanager alerts
-prometheusRule:
-  enabled: true
+  # Prometheus Operator service monitors
+  serviceMonitor:
+    # enable support for Prometheus Operator
+    enabled: false
+    # Job label for scrape target
+    jobLabel: "app.kubernetes.io/name"
+    # Scrape interval. If not set, the Prometheus default scrape interval is used.
+    interval: ""
+    metricRelabelings: []
+    relabelings: []
 
-## Add labels to all the deployed resources 
-## 
-commonLabels: {} 
-
-## Add annotations to all the deployed resources 
-## 
-commonAnnotations: {}
+  # Prometheus Operator alertmanager alerts
+  prometheusRule:
+    enabled: true
 
 ## Metallb Controller deployment.
 ## ref: https://hub.docker.com/r/metallb/controller/tags
@@ -165,18 +167,6 @@ controller:
     successThreshold: 1
     timeoutSeconds: 1
 
-  prometheus:
-    # Prometheus Operator service monitors
-    serviceMonitor:
-      # enable support for Prometheus Operator
-      enabled: false
-      # Job label for scrape target
-      jobLabel: "app.kubernetes.io/name"
-      # Scrape interval. If not set, the Prometheus default scrape interval is used.
-      interval: ""
-      metricRelabelings: []
-      relabelings: []
-
 ## Metallb Speaker daemonset.
 ## ref: https://hub.docker.com/r/metallb/speaker/tags
 speaker:
@@ -250,7 +240,7 @@ speaker:
 
   ## Defines a secret to use outside of the auto generated
   ## Default: {{ randAlphaNum 256 | b64enc | quote }}
-  ## The auto generated has secretName: {{ "common.names.fullname" }}-memberlist
+  ## The auto generated has secretName: {{ "metallb.fullname" }}-memberlist
   ## and secretKey: secretkey
   ##
   # secretName:
@@ -297,15 +287,3 @@ speaker:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
-
-  prometheus:
-    # Prometheus Operator service monitors
-    serviceMonitor:
-      # enable support for Prometheus Operator
-      enabled: false
-      # Job label for scrape target
-      jobLabel: "app.kubernetes.io/name"
-      # Scrape interval. If not set, the Prometheus default scrape interval is used.
-      interval: ""
-      metricRelabelings: []
-      relabelings: []

--- a/bitnami/metallb/values.yaml
+++ b/bitnami/metallb/values.yaml
@@ -41,23 +41,21 @@ rbac:
   # create specifies whether to install and use RBAC rules.
   create: true
 
-prometheus:
-  enabled: false
+psp:
+  # create specifies whether to install PodSecurityPolicies.
+  create: true
 
-  # Prometheus Operator service monitors
-  serviceMonitor:
-    # enable support for Prometheus Operator
-    enabled: false
-    # Job label for scrape target
-    jobLabel: "app.kubernetes.io/name"
-    # Scrape interval. If not set, the Prometheus default scrape interval is used.
-    interval: ""
-    metricRelabelings: []
-    relabelings: []
+# Prometheus Operator alertmanager alerts
+prometheusRule:
+  enabled: true
 
-  # Prometheus Operator alertmanager alerts
-  prometheusRule:
-    enabled: true
+## Add labels to all the deployed resources 
+## 
+commonLabels: {} 
+
+## Add annotations to all the deployed resources 
+## 
+commonAnnotations: {}
 
 ## Metallb Controller deployment.
 ## ref: https://hub.docker.com/r/metallb/controller/tags
@@ -167,6 +165,18 @@ controller:
     successThreshold: 1
     timeoutSeconds: 1
 
+  prometheus:
+    # Prometheus Operator service monitors
+    serviceMonitor:
+      # enable support for Prometheus Operator
+      enabled: false
+      # Job label for scrape target
+      jobLabel: "app.kubernetes.io/name"
+      # Scrape interval. If not set, the Prometheus default scrape interval is used.
+      interval: ""
+      metricRelabelings: []
+      relabelings: []
+
 ## Metallb Speaker daemonset.
 ## ref: https://hub.docker.com/r/metallb/speaker/tags
 speaker:
@@ -240,7 +250,7 @@ speaker:
 
   ## Defines a secret to use outside of the auto generated
   ## Default: {{ randAlphaNum 256 | b64enc | quote }}
-  ## The auto generated has secretName: {{ "metallb.fullname" }}-memberlist
+  ## The auto generated has secretName: {{ "common.names.fullname" }}-memberlist
   ## and secretKey: secretkey
   ##
   # secretName:
@@ -287,3 +297,15 @@ speaker:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
+
+  prometheus:
+    # Prometheus Operator service monitors
+    serviceMonitor:
+      # enable support for Prometheus Operator
+      enabled: false
+      # Job label for scrape target
+      jobLabel: "app.kubernetes.io/name"
+      # Scrape interval. If not set, the Prometheus default scrape interval is used.
+      interval: ""
+      metricRelabelings: []
+      relabelings: []


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

It fixes the creation of non-complient names for secrets.
All names which are created need to be dns-compliant.

The `cat` function combines two strings by adding a whitespace character.
I replaced it by the `printf` function.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
