### PR TITLE
[bitnami/nats] Check if it's available ingress api 'networking.k8s.io/v1beta1'

### DIFF
--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: nats
-version: 4.5.5
-appVersion: 2.1.8
+version: 4.5.6
+appVersion: 2.1.9
 description: An open-source, cloud-native messaging system
 keywords:
   - nats

--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: nats
 version: 4.5.6
-appVersion: 2.1.9
+appVersion: 2.1.8
 description: An open-source, cloud-native messaging system
 keywords:
   - nats

--- a/bitnami/nats/templates/_helpers.tpl
+++ b/bitnami/nats/templates/_helpers.tpl
@@ -71,6 +71,17 @@ Return the appropriate apiVersion for networkpolicy.
 {{- end -}}
 
 {{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "ingress.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "extensions/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the proper image name (for the metrics image)
 */}}
 {{- define "nats.metrics.image" -}}

--- a/bitnami/nats/templates/ingress.yaml
+++ b/bitnami/nats/templates/ingress.yaml
@@ -1,6 +1,11 @@
 {{- if .Values.ingress.enabled -}}
+{{- $apiVersions := .Capabilities.APIVersions -}}
 {{- range .Values.ingress.hosts }}
+{{- if $apiVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ template "nats.fullname" $ }}-monitoring

--- a/bitnami/nats/templates/ingress.yaml
+++ b/bitnami/nats/templates/ingress.yaml
@@ -1,11 +1,6 @@
 {{- if .Values.ingress.enabled -}}
-{{- $apiVersions := .Capabilities.APIVersions -}}
 {{- range .Values.ingress.hosts }}
-{{- if $apiVersions.Has "networking.k8s.io/v1beta1" }}
-apiVersion: networking.k8s.io/v1beta1
-{{- else }}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: {{ include "ingress.apiVersion" $ }}
 kind: Ingress
 metadata:
   name: {{ template "nats.fullname" $ }}-monitoring


### PR DESCRIPTION


<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Check and use if it's available ingress apiVersion `networking.k8s.io/v1beta1`.

**Benefits**

`extensions/v1beta1` is deprecated in k8s v1.22, so avoid becoming unavailable this chart.

ref: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

```
The v1.22 release will stop serving the following deprecated API versions in favor of newer and more stable API versions:

Ingress in the extensions/v1beta1 API version will no longer be served
Migrate to use the networking.k8s.io/v1beta1 API version, available since v1.14. Existing persisted data can be retrieved/updated via the new version.
```

**Possible drawbacks**

- none

<!-- Describe any known limitations with your change -->

**Applicable issues**

- none

**Additional information**

- none

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
