### PR TITLE
[bitnami/wordpress] Fix template issue when using certs

### DIFF
--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 9.6.6
+version: 9.6.7
 appVersion: 5.5.1
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/bitnami/wordpress/templates/tls-secrets.yaml
+++ b/bitnami/wordpress/templates/tls-secrets.yaml
@@ -5,11 +5,11 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .name }}
-  labels: {{- include "wordpress.labels" . | nindent 4 }}
-    {{- if .Values.commonLabels }}
+  labels: {{- include "wordpress.labels" $ | nindent 4 }}
+    {{- if $.Values.commonLabels }}
     {{- include "wordpress.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if .Values.commonAnnotations }}
+  {{- if $.Values.commonAnnotations }}
   annotations: {{- include "wordpress.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 type: kubernetes.io/tls


### PR DESCRIPTION
**Description of the change**

Currently, this is the result of `helm template my-release .`:
```
Error: template: wordpress/templates/tls-secrets.yaml:8:14: executing "wordpress/templates/tls-secrets.yaml" at <include "wordpress.labels" .>: error calling include: template: wordpress/templates/_helpers.tpl:37:27: executing "wordpress.labels" at <include "wordpress.name" .>: error calling include: template: wordpress/templates/_helpers.tpl:6:18: executing "wordpress.name" at <.Chart.Name>: nil pointer evaluating interface {}.Name
```

The conditional logic is being evaluated inside a `range` loop. This means `.` we're using to access `Values` or find the chart name, is not the expected one, as it's overridden for each range iteration evaluation. Using `$`, which references the global scope, the issue should be solved. The template is properly render after running `helm template my-release .`:

```yaml
# Source: wordpress/templates/tls-secrets.yaml
apiVersion: v1
kind: Secret
metadata:
  name: wordpress.local-tls
  labels:
    app.kubernetes.io/name: wordpress
    helm.sh/chart: wordpress-9.6.6
    app.kubernetes.io/instance: my-release
    app.kubernetes.io/managed-by: Helm
type: kubernetes.io/tls
data:
  tls.crt: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tcGV0ZXRlLS0tLS1FTkQgUFJJVkFURSBLRVktLS0tLQ==
  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tcGV0ZXRlLS0tLS1FTkQgUFJJVkFURSBLRVktLS0tLQ==
```

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #3885

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files