### PR TITLE
bitnami/influxdb not starting chown: missing operand after #3863

### DIFF
--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.6.8
+version: 0.6.9
 appVersion: 1.8.3
 description: InfluxDB is an open source time-series database designed to handle large write and read loads in real-time.
 engine: gotpl

--- a/bitnami/influxdb/templates/influxdb/deployment-standalone.yaml
+++ b/bitnami/influxdb/templates/influxdb/deployment-standalone.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "influxdb.fullname" . }}
-  labels: 
+  labels:
     {{- include "influxdb.labels" . | nindent 4 }}
     app.kubernetes.io/component: influxdb
 spec:
@@ -14,12 +14,12 @@ spec:
     rollingUpdate: null
     {{- end }}
   selector:
-    matchLabels: 
+    matchLabels:
       {{- include "influxdb.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: influxdb
   template:
     metadata:
-      labels: 
+      labels:
         {{- include "influxdb.labels" . | nindent 8 }}
         app.kubernetes.io/component: influxdb
     spec:
@@ -30,7 +30,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             - topologyKey: "kubernetes.io/hostname"
               labelSelector:
-                matchLabels: 
+                matchLabels:
                   {{- include "influxdb.matchLabels" . | nindent 18 }}
                   app.kubernetes.io/component: influxdb
         {{- else if eq .Values.influxdb.antiAffinity "soft" }}
@@ -40,7 +40,7 @@ spec:
               podAffinityTerm:
                 topologyKey: kubernetes.io/hostname
                 labelSelector:
-                  matchLabels: 
+                  matchLabels:
                     {{- include "influxdb.matchLabels" . | nindent 20 }}
                     app.kubernetes.io/component: influxdb
         {{- end }}
@@ -68,7 +68,7 @@ spec:
             - |
               mkdir -p /bitnami/influxdb/{data,meta,wal}
               chmod 700 /bitnami/influxdb/{data,meta,wal}
-              find /bitnami/influxdb/{data,meta,wal} -mindepth 1 -maxdepth 1 | \
+              find /bitnami/influxdb/{data,meta,wal} -mindepth 0 -maxdepth 1 | \
               {{- if eq ( toString ( .Values.volumePermissions.securityContext.runAsUser )) "auto" }}
                 xargs chown -R `id -u`:`id -G | cut -d " " -f2`
               {{- else }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

InfluxDb could not start when having `volumePermissions` enabled

**Benefits**

InfluxDb can start

**Possible drawbacks**

N/A

**Applicable issues**

  - fixes #3863

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x ] Variables are documented in the README.md
- [x ] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
