### PR TITLE
[bitnami/mariadb] Adds release labels to all mariadb resources

### DIFF
--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mariadb
-version: 8.0.2
-appVersion: 10.5.6
+version: 8.0.3
+appVersion: 10.5.5
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:
   - mariadb

--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mariadb
 version: 8.0.2
-appVersion: 10.5.5
+appVersion: 10.5.6
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:
   - mariadb

--- a/bitnami/mariadb/templates/primary/configmap.yaml
+++ b/bitnami/mariadb/templates/primary/configmap.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: primary
+    release: {{ .Release.Name | quote }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/mariadb/templates/primary/initialization-configmap.yaml
+++ b/bitnami/mariadb/templates/primary/initialization-configmap.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: primary
+    release: {{ .Release.Name | quote }}
 data:
 {{- include "common.tplvalues.render" (dict "value" .Values.initdbScripts "context" .) | nindent 2 }}
 {{ end }}

--- a/bitnami/mariadb/templates/primary/pdb.yaml
+++ b/bitnami/mariadb/templates/primary/pdb.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: primary
+    release: {{ .Release.Name | quote }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/mariadb/templates/primary/statefulset.yaml
+++ b/bitnami/mariadb/templates/primary/statefulset.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "mariadb.primary.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    release: {{ .Release.Name }}
     app.kubernetes.io/component: primary
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
@@ -16,6 +17,7 @@ spec:
   selector:
     matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: primary
+      release: {{ .Release.Name }}
   serviceName: {{ include "mariadb.primary.fullname" . }}
   updateStrategy:
     type: {{ .Values.primary.updateStrategy }}
@@ -36,6 +38,7 @@ spec:
         {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: primary
+        release: {{ .Release.Name }}
     spec:
       {{- include "mariadb.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.schedulerName }}
@@ -307,6 +310,7 @@ spec:
         name: data
         labels: {{ include "common.labels.matchLabels" . | nindent 10 }}
           app.kubernetes.io/component: primary
+          release: {{ .Release.Name }}
       spec:
         accessModes:
           {{- range .Values.primary.persistence.accessModes }}

--- a/bitnami/mariadb/templates/primary/svc.yaml
+++ b/bitnami/mariadb/templates/primary/svc.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: primary
+    release: {{ .Release.Name | quote }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/mariadb/templates/role.yaml
+++ b/bitnami/mariadb/templates/role.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "common.names.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    release: {{ .Release.Name | quote }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/mariadb/templates/rolebinding.yaml
+++ b/bitnami/mariadb/templates/rolebinding.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "common.names.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    release: {{ .Release.Name | quote }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/mariadb/templates/secondary/configmap.yaml
+++ b/bitnami/mariadb/templates/secondary/configmap.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: secondary
+    release: {{ .Release.Name | quote }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/mariadb/templates/secondary/statefulset.yaml
+++ b/bitnami/mariadb/templates/secondary/statefulset.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "mariadb.secondary.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    release: {{ .Release.Name }}
     app.kubernetes.io/component: secondary
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
@@ -17,6 +18,7 @@ spec:
   selector:
     matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: secondary
+      release: {{ .Release.Name }}
   serviceName: {{ include "mariadb.secondary.fullname" . }}
   updateStrategy:
     type: {{ .Values.secondary.updateStrategy }}
@@ -37,6 +39,7 @@ spec:
         {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: secondary
+        release: {{ .Release.Name }}
     spec:
       {{- include "mariadb.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.schedulerName }}
@@ -281,6 +284,7 @@ spec:
         name: data
         labels: {{ include "common.labels.matchLabels" . | nindent 10 }}
           app.kubernetes.io/component: secondary
+          release: {{ .Release.Name }}
       spec:
         accessModes:
           {{- range .Values.secondary.persistence.accessModes }}

--- a/bitnami/mariadb/templates/secondary/svc.yaml
+++ b/bitnami/mariadb/templates/secondary/svc.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: secondary
+    release: {{ .Release.Name | quote }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/mariadb/templates/secrets.yaml
+++ b/bitnami/mariadb/templates/secrets.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "common.names.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    release: {{ .Release.Name | quote }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/mariadb/templates/serviceaccount.yaml
+++ b/bitnami/mariadb/templates/serviceaccount.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "mariadb.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    release: {{ .Release.Name | quote }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/mariadb/templates/servicemonitor.yaml
+++ b/bitnami/mariadb/templates/servicemonitor.yaml
@@ -9,6 +9,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   {{- end }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    release: {{ .Release.Name | quote }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Release labels are missing from all mariadb resources like configmaps, secrets, pods, deployments, etc

**Benefits**

This PR adds the release label to all the resources spun up by mariadb chart and allows the user to filter resources easily.
```
kubectl get pods -w --namespace {{ .Release.Namespace }} -l release={{ .Release.Name }}
kubectl get cm --namespace {{ .Release.Namespace }} -l release={{ .Release.Name }}
kubectl get secrets --namespace {{ .Release.Namespace }} -l release={{ .Release.Name }}
kubectl get deploy --namespace {{ .Release.Namespace }} -l release={{ .Release.Name }}
```

The below command lists all the resources of particular release
```
kubectl get all -l release={{ .Release.Name }}
```

![mariadb](https://user-images.githubusercontent.com/22347290/95289237-e295b000-0887-11eb-95dd-eba19e7938ae.PNG)


**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

None

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
