### PR TITLE
[bitnami/postgresql-ha] Fix volumnMounts path collision for pgpool secrets

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql-ha
-version: 3.9.0
+version: 3.9.1
 appVersion: 11.9.0
 description: Chart for PostgreSQL with HA architecture (using Replication Manager (repmgr) and Pgpool).
 keywords:

--- a/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
@@ -243,11 +243,16 @@ spec:
             {{- end }}
             {{- if .Values.postgresql.usePasswordFile }}
             - name: postgresql-password
-              mountPath: /opt/bitnami/pgpool/secrets/
+              subPath: pgpool-password
+              mountPath: /opt/bitnami/pgpool/secrets/pgpool-password
+            - name: postgresql-password
+              subPath: pgpool-sr-check-password
+              mountPath: /opt/bitnami/pgpool/secrets/pgpool-sr-check-password
             {{- end }}
             {{- if .Values.pgpool.usePasswordFile }}
             - name: pgpool-password
-              mountPath: /opt/bitnami/pgpool/secrets/
+              subPath: admin-password
+              mountPath: /opt/bitnami/pgpool/secrets/admin-password
             {{- end }}
             {{- if .Values.pgpool.tls.enabled }}
             - name: pgpool-certificates


### PR DESCRIPTION
**Description of the change**

Fixes a filesystem path collision when mounting secrets for password of both, PostgreSQL and Pgpool-II.

**Benefits**

Allows to use secrets for all passwords.

**Possible drawbacks**

Available password files are limited to the explicitly mounted names and need extension as soon as more files need to be picked up.

**Applicable issues**

  - fixes #3922 


**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
