### PR TITLE
[bitnami/kong] Fix init-scripts not found error

### DIFF
--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kong
-version: 1.3.7
+version: 1.3.8
 appVersion: 2.1.4
 description: Kong is a scalable, open source API layer (aka API gateway or API middleware) that runs in front of any RESTful API. Extra functionalities beyond the core platform are extended through plugins. Kong is built on top of reliable technologies like NGINX and provides an easy-to-use RESTful API to operate and configure the system.
 keywords:

--- a/bitnami/kong/templates/deployment.yaml
+++ b/bitnami/kong/templates/deployment.yaml
@@ -319,6 +319,18 @@ spec:
           configMap:
             name: {{ template "kong.fullname" . }}-metrics-exporter
         {{- end }}
+        {{- if .Values.kong.initScriptsCM }}
+        - name: custom-init-scripts-cm
+          configMap:
+            name: {{ .Values.kong.initScriptsCM }}
+            defaultMode: 0755
+        {{- end }}
+        {{- if .Values.kong.initScriptsSecret }}
+        - name: custom-init-scripts-secret
+          secret:
+            secretName: {{ .Values.kong.initScriptsSecret }}
+            defaultMode: 0755
+        {{- end }}
       {{- if .Values.extraVolumes }}
       {{- include "kong.tplValue" (dict "value" .Values.extraVolumes "context" $) | nindent 6 }}
       {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

When using `kong.initScriptsCM` or `kong.initScriptsSecret` the chart gives a `Not found: "custom-init-scripts-cm"`. The volumes using the scripts were been mounted but not created in `deployment.yaml`.

**Benefits**

**Possible drawbacks**

**Applicable issues**

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
