### PR TITLE
[bitnami/spring-cloud-dataflow] NEW MAJOR: bumb mariadb dependency

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: spring-cloud-dataflow
-version: 0.7.4
+version: 1.0.0
 appVersion: 2.6.3
 description: Spring Cloud Data Flow is a microservices-based toolkit for building streaming and batch data processing pipelines in Cloud Foundry and Kubernetes.
 keywords:

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -487,9 +487,7 @@ helm upgrade my-release bitnami/spring-cloud-dataflow --set mariadb.auth.rootPas
 
 MariaDB dependency version was bumped to a new major version that introduces several incompatilibites. Therefore, backwards compatibility is not guaranteed unless an external database is used. Check [MariaDB Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/mariadb#to-800) for more information.
 
-To upgrade to `1.0.0`, you have an alternatives:
-
-- Reuse the PVC used to hold the MariaDB data on your previous release. To do so, follow the instructions below (the following example assumes that the release name is `dataflow`):
+To upgrade to `1.0.0`, you will need to reuse the PVC used to hold the MariaDB data on your previous release. To do so, follow the instructions below (the following example assumes that the release name is `dataflow`):
 
 > NOTE: Please, create a backup of your database before running any of those actions.
 

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -237,18 +237,19 @@ The following tables lists the configurable parameters of the Spring Cloud Data 
 | Parameter                                    | Description                                                                                            | Default                                                 |
 |----------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
 | `mariadb.enabled`                            | Enable/disable MariaDB chart installation                                                              | `true`                                                  |
-| `mariadb.replication.enabled`                | MariaDB replication enabled                                                                            | `false`                                                 |
-| `mariadb.db.name`                            | Name for new database to create                                                                        | `dataflow`                                              |
-| `mariadb.db.user`                            | Username of new user to create                                                                         | `dataflow`                                              |
-| `mariadb.db.password`                        | Password for the new user                                                                              | `change-me`_                                            |
+| `mariadb.architecture`                       | MariaDB architecture (`standalone` or `replication`)                                                   | `standalone`                                            |
+| `mariadb.auth.database`                      | Database name to create                                                                                | `dataflow`                                              |
+| `mariadb.auth.username`                      | Username of new user to create                                                                         | `dataflow`                                              |
+| `mariadb.auth.password`                      | Password for the new user                                                                              | `change-me`                                             |
+| `mariadb.auth.rootPassword`                  | Password for the MariaDB `root` user                                                                   | _random 10 character alphanumeric string_               |
 | `mariadb.initdbScripts`                      | Dictionary of initdb scripts                                                                           | Check `values.yaml` file                                |
 | `externalDatabase.host`                      | Host of the external database                                                                          | `localhost`                                             |
 | `externalDatabase.port`                      | External database port number                                                                          | `3306`                                                  |
 | `externalDatabase.password`                  | Password for the above username                                                                        | `""`                                                    |
 | `externalDatabase.existingPasswordSecret`    | Existing secret with database password                                                                 | `""`                                                    |
-| `externalDatabase.dataflow.user`             | Existing username in the external db to be used by Dataflow server                                     | `dataflow`                                              |
+| `externalDatabase.dataflow.username`         | Existing username in the external db to be used by Dataflow server                                     | `dataflow`                                              |
 | `externalDatabase.dataflow.database`         | Name of the existing database to be used by Dataflow server                                            | `dataflow`                                              |
-| `externalDatabase.skipper.user`              | Existing username in the external db to be used by Skipper server                                      | `skipper`                                               |
+| `externalDatabase.skipper.username`          | Existing username in the external db to be used by Skipper server                                      | `skipper`                                               |
 | `externalDatabase.skipper.database`          | Name of the existing database to be used by Skipper server                                             | `skipper`                                               |
 | `externalDatabase.hibernateDialect`          | Hibernate Dialect used by Dataflow/Skipper servers                                                     | `""`                                                    |
 
@@ -324,14 +325,10 @@ This chart includes a `values-production.yaml` file where you can find some para
 - Force users to specify a password and mount secrets as volumes instead of using environment variables on MariaDB:
 
 ```diff
-- mariadb.rootUser.forcePassword: false
-- mariadb.rootUser.injectSecretsAsVolume: false
-+ mariadb.rootUser.forcePassword: true
-+ mariadb.rootUser.injectSecretsAsVolume: true
-- mariadb.db.forcePassword: false
-- mariadb.db.injectSecretsAsVolume: false
-+ mariadb.db.forcePassword: true
-+ mariadb.db.injectSecretsAsVolume: true
+- mariadb.auth.forcePassword: false
++ mariadb.auth.forcePassword: true
+- mariadb.auth.usePasswordFiles: false
++ mariadb.auth.usePasswordFiles: true
 ```
 
 ### Features
@@ -456,14 +453,84 @@ For annotations, please see [this document](https://github.com/kubernetes/ingres
 
 ## Upgrading
 
-It's necessary to set the `mariadb.rootUser.password` parameter when upgrading for readiness/liveness probes to work properly. When you install this chart for the first time, unless you indicate set this parameter, a random value will be generated. Inspect the MariaDB secret to obtain the root password, then you can upgrade your chart using the command below:
+It's necessary to set the root user parameter when upgrading for readiness/liveness probes to work properly. When you install this chart for the first time, unless you indicate set this parameter, a random value will be generated. Inspect the MariaDB secret to obtain the root password, then you can upgrade your chart using the command below:
+
+#### v0.x.x
 
 ```bash
 helm upgrade my-release bitnami/spring-cloud-dataflow --set mariadb.rootUser.password=[MARIADB_ROOT_PASSWORD]
 ```
 
+#### v1.x.x
+
+```bash
+helm upgrade my-release bitnami/spring-cloud-dataflow --set mariadb.auth.rootPassword=[MARIADB_ROOT_PASSWORD]
+```
+
 If you enabled RabbitMQ chart to be used as the messaging solution for Skipper to manage streaming content, then it's necessary to set the `rabbitmq.auth.password` and `rabbitmq.auth.erlangCookie` parameters when upgrading for readiness/liveness probes to work properly. Inspect the RabbitMQ secret to obtain the password and the Erlang cookie, then you can upgrade your chart using the command below:
+
+#### v0.x.x
 
 ```bash
 helm upgrade my-release bitnami/spring-cloud-dataflow --set mariadb.rootUser.password=[MARIADB_ROOT_PASSWORD] --set rabbitmq.auth.password=[RABBITMQ_PASSWORD] --set rabbitmq.auth.erlangCookie=[RABBITMQ_ERLANG_COOKIE]
+```
+
+#### v1.x.x
+
+```bash
+helm upgrade my-release bitnami/spring-cloud-dataflow --set mariadb.auth.rootPassword=[MARIADB_ROOT_PASSWORD] --set rabbitmq.auth.password=[RABBITMQ_PASSWORD] --set rabbitmq.auth.erlangCookie=[RABBITMQ_ERLANG_COOKIE]
+```
+
+## Notable changes
+
+### v1.0.0
+
+MariaDB dependency version was bumped to a new major version that introduces several incompatilibites. Therefore, backwards compatibility is not guaranteed unless an external database is used. Check [MariaDB Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/mariadb#to-800) for more information.
+
+To upgrade to `1.0.0`, you have an alternatives:
+
+- Reuse the PVC used to hold the MariaDB data on your previous release. To do so, follow the instructions below (the following example assumes that the release name is `dataflow`):
+
+> NOTE: Please, create a backup of your database before running any of those actions.
+
+Obtain the credentials and the name of the PVC used to hold the MariaDB data on your current release:
+
+```console
+export MARIADB_ROOT_PASSWORD=$(kubectl get secret --namespace default dataflow-mariadb -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)
+export MARIADB_PASSWORD=$(kubectl get secret --namespace default dataflow-mariadb -o jsonpath="{.data.mariadb-password}" | base64 --decode)
+export MARIADB_PVC=$(kubectl get pvc -l app=mariadb,component=master,release=dataflow -o jsonpath="{.items[0].metadata.name}")
+export RABBITMQ_PASSWORD=$(kubectl get secret --namespace default dataflow-rabbitmq -o jsonpath="{.data.rabbitmq-password}" | base64 --decode)
+export RABBITMQ_ERLANG_COOKIE=$(kubectl get secret --namespace default dataflow-rabbitmq -o jsonpath="{.data.rabbitmq-erlang-cookie}" | base64 --decode)
+```
+
+Upgrade your release (maintaining the version) disabling MariaDB and scaling Data Flow replicas to 0:
+
+```console
+$ helm upgrade dataflow bitnami/spring-cloud-dataflow --version 0.7.4 \
+  --set server.replicaCount=0 \
+  --set skipper.replicaCount=0 \
+  --set mariadb.enabled=false \
+  --set rabbitmq.auth.password=$RABBITMQ_PASSWORD \
+  --set rabbitmq.auth.erlangCookie=$RABBITMQ_ERLANG_COOKIE
+```
+
+Finally, upgrade you release to 1.0.0 reusing the existing PVC, and enabling back MariaDB:
+
+```console
+$ helm upgrade dataflow bitnami/spring-cloud-dataflow \
+  --set mariadb.primary.persistence.existingClaim=$MARIADB_PVC \
+  --set mariadb.auth.rootPassword=$MARIADB_ROOT_PASSWORD \
+  --set mariadb.auth.password=$MARIADB_PASSWORD \
+  --set rabbitmq.auth.password=$RABBITMQ_PASSWORD \
+  --set rabbitmq.auth.erlangCookie=$RABBITMQ_ERLANG_COOKIE
+```
+
+You should see the lines below in MariaDB container logs:
+
+```console
+$ kubectl logs $(kubectl get pods -l app.kubernetes.io/instance=dataflow,app.kubernetes.io/name=mariadb,app.kubernetes.io/component=primary -o jsonpath="{.items[0].metadata.name}")
+...
+mariadb 12:13:24.98 INFO  ==> Using persisted data
+mariadb 12:13:25.01 INFO  ==> Running mysql_upgrade
+...
 ```

--- a/bitnami/spring-cloud-dataflow/requirements.lock
+++ b/bitnami/spring-cloud-dataflow/requirements.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 0.7.1
+  version: 0.8.1
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 7.10.2
+  version: 8.0.2
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
   version: 7.6.8
 - name: kafka
   repository: https://charts.bitnami.com/bitnami
   version: 11.8.6
-digest: sha256:0a09b6616a3992345fec1af5310c0f4b2852b4b31f6abadd1408512f2caee6b9
-generated: "2020-09-29T21:41:24.903245215Z"
+digest: sha256:7eb1d15f14e609e387f915768011d6350bc0402dc5309372a0d7c288f62ae567
+generated: "2020-10-07T13:41:51.66602805Z"

--- a/bitnami/spring-cloud-dataflow/requirements.yaml
+++ b/bitnami/spring-cloud-dataflow/requirements.yaml
@@ -5,7 +5,7 @@ dependencies:
     tags:
       - bitnami-common
   - name: mariadb
-    version: 7.x.x
+    version: 8.x.x
     repository: https://charts.bitnami.com/bitnami
     condition: mariadb.enabled
     tags:

--- a/bitnami/spring-cloud-dataflow/templates/NOTES.txt
+++ b/bitnami/spring-cloud-dataflow/templates/NOTES.txt
@@ -76,7 +76,7 @@ To access Spring Cloud Data Flow dashboard from outside the cluster execute the 
 {{- $secretNameExternalRabbitmq := printf "%s-%s" (include "scdf.fullname" .) "externalrabbitmq" -}}
 
 {{/* Mysql required password */}}
-{{- $passwordMysqlErrors := include "common.validations.values.mariadb.passwords" (dict "secretName" $secretNameMariadb "context" $) -}}
+{{- $passwordMysqlErrors := include "common.validations.values.mariadb.passwords" (dict "secret" $secretNameMariadb "subchart" true "context" $) -}}
 {{- $passwordErrors = append $passwordErrors $passwordMysqlErrors -}}
 
 {{/* Rabbitmq required password */}}

--- a/bitnami/spring-cloud-dataflow/templates/_helpers.tpl
+++ b/bitnami/spring-cloud-dataflow/templates/_helpers.tpl
@@ -209,7 +209,7 @@ Return the Data Flow Database Name
 */}}
 {{- define "scdf.database.server.name" -}}
 {{- if .Values.mariadb.enabled }}
-    {{- printf "dataflow" -}}
+    {{- printf "%s" .Values.mariadb.auth.database -}}
 {{- else -}}
     {{- printf "%s" .Values.externalDatabase.dataflow.database -}}
 {{- end -}}
@@ -220,9 +220,9 @@ Return the Data Flow Database User
 */}}
 {{- define "scdf.database.server.user" -}}
 {{- if .Values.mariadb.enabled }}
-    {{- printf "dataflow" -}}
+    {{- printf "%s" .Values.mariadb.auth.username -}}
 {{- else -}}
-    {{- printf "%s" .Values.externalDatabase.dataflow.user -}}
+    {{- printf "%s" .Values.externalDatabase.dataflow.username -}}
 {{- end -}}
 {{- end -}}
 
@@ -244,7 +244,7 @@ Return the Skipper Database User
 {{- if .Values.mariadb.enabled }}
     {{- printf "skipper" -}}
 {{- else -}}
-    {{- printf "%s" .Values.externalDatabase.skipper.user -}}
+    {{- printf "%s" .Values.externalDatabase.skipper.username -}}
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/spring-cloud-dataflow/values-production.yaml
+++ b/bitnami/spring-cloud-dataflow/values-production.yaml
@@ -725,40 +725,28 @@ metrics:
 ##
 mariadb:
   enabled: true
-  ## Enable replication. This enables the creation of replicas of MariaDB. If false, only a
-  ## master statefulset would be created
+  ## MariaDB architecture. Allowed values: standalone or replication
   ##
-  replication:
-    enabled: false
-  ## MariaDB admin credentials
-  ##
-  rootUser:
-    ## Option to force users to specify a password. That is required for 'helm upgrade' to work properly.
-    ## If it is not force, a random password will be generated.
-    ##
-    forcePassword: true
-    ## Mount admin password as a file instead of using an environment variable
-    ##
-    injectSecretsAsVolume: true
+  architecture: standalone
   ## Custom user/db credentials
   ##
-  db:
-    ## MariaDB username and password
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#creating-a-database-user-on-first-run
+  auth:
+    ## MariaDB root password
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
     ##
-    user: dataflow
+    rootPassword: ''
+    ## MariaDB custom user and database
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+    ##
+    username: dataflow
     password: change-me
     ## Database to create
     ## ref: https://github.com/bitnami/bitnami-docker-mariadb#creating-a-database-on-first-run
     ##
-    name: dataflow
-    ## Option to force users to specify a password. That is required for 'helm upgrade' to work properly.
-    ## If it is not force, a random password will be generated.
-    ##
+    database: dataflow
     forcePassword: true
-    ## Mount user password as a file instead of using an environment variable
-    ##
-    injectSecretsAsVolume: true
+    usePasswordFiles: true
   ## initdb scripts: specify dictionary of scripts to be run at first boot
   ## We can only create one database on MariaDB using parameters. However, when streaming
   ## is enabled we need a second database for Skipper.

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -726,23 +726,28 @@ metrics:
 ##
 mariadb:
   enabled: true
-  ## Enable replication. This enables the creation of replicas of MariaDB. If false, only a
-  ## master statefulset would be created
+  ## MariaDB architecture. Allowed values: standalone or replication
   ##
-  replication:
-    enabled: false
+  architecture: standalone
   ## Custom user/db credentials
   ##
-  db:
-    ## MariaDB username and password
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#creating-a-database-user-on-first-run
+  auth:
+    ## MariaDB root password
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
     ##
-    user: dataflow
+    rootPassword: ""
+    ## MariaDB custom user and database
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+    ##
+    username: dataflow
     password: change-me
     ## Database to create
     ## ref: https://github.com/bitnami/bitnami-docker-mariadb#creating-a-database-on-first-run
     ##
-    name: dataflow
+    database: dataflow
+    forcePassword: false
+    usePasswordFiles: false
   ## initdb scripts: specify dictionary of scripts to be run at first boot
   ## We can only create one database on MariaDB using parameters. However, when streaming
   ## is enabled we need a second database for Skipper.
@@ -775,12 +780,12 @@ externalDatabase:
   ##
   dataflow:
     database: dataflow
-    user: dataflow
+    username: dataflow
   ## Skipper and database
   ##
   skipper:
     database: skipper
-    user: skipper
+    username: skipper
   ## Hibernate Dialect
   ## e.g: org.hibernate.dialect.MariaDB102Dialect
   ##


### PR DESCRIPTION
Signed-off-by: darteaga <darteaga@vmware.com>

**Description of the change**

This PR bumps Spring Cloud Dataflow major version since its dependency (MariaDB) bumped the major version including breaking changes. More info at #3849

**Benefits**

Use the latest MariaDB chart a take the advantage of its standardization such as upgrade validations for passwords

**Possible drawbacks**

It breaks backward compatibility.

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
