### PR TITLE
[bitnami/external-dns] Add ability to monitor contour entries added in 0.7.4

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 3.4.5
+version: 3.4.6
 appVersion: 0.7.4
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/bitnami/external-dns/templates/role.yaml
+++ b/bitnami/external-dns/templates/role.yaml
@@ -49,6 +49,14 @@ rules:
     verbs:
       - patch
       - update
+  - apiGroups: 
+      - projectcontour.io
+    resources:
+      - httpproxies
+    verbs: 
+      - get
+      - watch
+      - list
   {{- if or .Values.crd.create .Values.crd.apiversion }}
   - apiGroups:
       {{- if .Values.crd.create }}

--- a/bitnami/external-dns/values.yaml
+++ b/bitnami/external-dns/values.yaml
@@ -38,6 +38,7 @@ sources:
   # - crd
   - service
   - ingress
+  # - contour-httpproxy
 
 ## DNS provider where the DNS records will be created. Available providers are:
 ## - alibabacloud, aws, azure, azure-private-dns, cloudflare, coredns, designate, digitalocean, google, infoblox, rfc2136, transip


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.

 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Adds in necessary RBAC permissions to watch contour httpproxy CRD, functionality added in External DNS 0.7.4

**Benefits**

<!-- What benefits will be realized by the code change? -->

Allows bitnami chart to work out of the box with Contour's HTTPProxy CRD.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
Defaults to always giving the permissions, which appears how other CRDs are handled as well.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
