### PR TITLE
[bitnami/postgresql] Allow exporter port in network-policy if metrics enabled

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 9.8.2
+version: 9.8.3
 appVersion: 11.9.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/bitnami/postgresql/templates/networkpolicy.yaml
+++ b/bitnami/postgresql/templates/networkpolicy.yaml
@@ -30,7 +30,9 @@ spec:
             {{- include "common.labels.matchLabels" . | nindent 14 }}
               role: slave
       {{- end }}
+    {{- if .Values.metrics.enabled }}
     # Allow prometheus scrapes
     - ports:
         - port: 9187
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
**Description of the change**
If metrics.enabled set to false, then exporter port should not be declared in networkpolicy

**Benefits**

**Possible drawbacks**

**Additional information**

**Checklist**
- [x] Chart version bumped in Chart.yaml according to semver.
- [x]     Variables are documented in the README.md
- [x]     Title of the PR starts with chart name (e.g. [bitnami/chart])
- [x]     If the chart contains a values-production.yaml apart from values.yaml, ensure that you implement the changes in both files

Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the kubeapps repository. This is only a synchronized mirror.