### PR TITLE
[bitnami/ejbca] MAJOR change - bump MariaDB subchart

### DIFF
--- a/bitnami/ejbca/Chart.yaml
+++ b/bitnami/ejbca/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ejbca
-version: 0.4.0
+version: 1.0.0
 appVersion: 6.15.2-6
 description: Enterprise class PKI Certificate Authority built on JEE technology.
 icon: https://bitnami.com/assets/stacks/ejbca/img/ejbca-stack-220x234.png

--- a/bitnami/ejbca/README.md
+++ b/bitnami/ejbca/README.md
@@ -49,127 +49,129 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the EJBCA chart and their default values.
 
- Parameter                                  | Description                                                                           | Default                                                      |
-|-------------------------------------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `global.imageRegistry`                    | Global Docker image registry                                                          | `nil`                                                        |
-| `global.imagePullSecrets`                 | Global Docker registry secret names as an array                                       | `[]` (does not add image pull secrets to deployed pods)      |
-| `global.storageClass`                     | Global storage class for dynamic provisioning                                         | `nil`                                                        |
+| Parameter                 | Description                                     | Default                                                 |
+|---------------------------|-------------------------------------------------|---------------------------------------------------------|
+| `global.imageRegistry`    | Global Docker image registry                    | `nil`                                                   |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
+| `global.storageClass`     | Global storage class for dynamic provisioning   | `nil`                                                   |
 
 ### Common & Pod-specific parameters
 
-| Parameter                             | Description                                                                               | Default                                                      |
-|---------------------------------------|-------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `image.registry`                      | EJBCA image registry                                                                      | `docker.io`                                                  |
-| `image.repository`                    | EJBCA image name                                                                          | `bitnami/ejbca`                                              |
-| `image.tag`                           | EJBCA image tag                                                                           | `{TAG_NAME}`                                                 |
-| `image.pullPolicy`                    | EJBCA image pull policy                                                                   | `IfNotPresent`                                               |
-| `image.pullSecrets`                   | Specify docker-registry secret names as an array                                          | `[]` (does not add image pull secrets to deployed pods)      |
-| `nameOverride`                        | String to partially override discourse.fullname                                           | `nil`                                                        |
-| `fullnameOverride`                    | String to fully override discourse.fullname                                               | `nil`                                                        |
-| `replicaCount`                        | Number of EJBCA replicas                                                                  | `1`                                                          |
-| `extraVolumes`                        | Array of extra volumes to be added deployment. Requires setting `extraVolumeMounts`       | `[]` (evaluated as a template)                               |
-| `podAnnotations`                      | Additional pod annotations                                                                | `{}`                                                         |
-| `podLabels`                           | Additional pod labels                                                                     | `{}` (evaluated as a template)                               |
-| `commonAnnotations`                   | Annotations to be added to all deployed resources                                         | `{}` (evaluated as a template)                               |
-| `podSecurityContext.enabled`          | Enable security context for EJBCA pods                                                    | `true`                                                       |
-| `podSecurityContext.fsGroup`          | Group ID for the volumes of the pod                                                       | `1001`                                                       |
-| `podAffinityPreset`                   | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                                                         |
-| `podAntiAffinityPreset`               | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                                       |
-| `nodeAffinityPreset.type`             | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                                                         |
-| `nodeAffinityPreset.key`              | Node label key to match Ignored if `affinity` is set.                                     | `""`                                                         |
-| `nodeAffinityPreset.values`           | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                                                         |
-| `affinity`                            | Affinity for pod assignment                                                               | `{}` (evaluated as a template)                               |
-| `nodeSelector`                        | Node labels for pod assignment                                                            | `{}` (evaluated as a template)                               |
-| `tolerations`                         | Tolerations for pod assignment                                                            | `[]` (evaluated as a template)                               |
-| `sidecars`                            | Attach additional sidecar containers to the pod                                           | `[]` (evaluated as a template)                               |
-| `initContainers`                      | Additional init containers to add to the pods                                             | `[]` (evaluated as a template)                               |
-| `persistence.enabled`                 | Whether to enable persistence based on Persistent Volume Claims                           | `true`                                                       |
-| `persistence.storageClass`            | PVC Storage Class                                                                         | `nil`                                                        |
-| `persistence.existingClaim`           | Name of an existing PVC to reuse                                                          | `nil`                                                        |
-| `persistence.accessMode`              | PVC Access Mode (RWO, ROX, RWX)                                                           | `ReadWriteOnce`                                              |
-| `persistence.size`                    | Size of the PVC to request                                                                | `2Gi`                                                        |
+| Parameter                    | Description                                                                               | Default                                                 |
+|------------------------------|-------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `image.registry`             | EJBCA image registry                                                                      | `docker.io`                                             |
+| `image.repository`           | EJBCA image name                                                                          | `bitnami/ejbca`                                         |
+| `image.tag`                  | EJBCA image tag                                                                           | `{TAG_NAME}`                                            |
+| `image.pullPolicy`           | EJBCA image pull policy                                                                   | `IfNotPresent`                                          |
+| `image.pullSecrets`          | Specify docker-registry secret names as an array                                          | `[]` (does not add image pull secrets to deployed pods) |
+| `nameOverride`               | String to partially override discourse.fullname                                           | `nil`                                                   |
+| `fullnameOverride`           | String to fully override discourse.fullname                                               | `nil`                                                   |
+| `replicaCount`               | Number of EJBCA replicas                                                                  | `1`                                                     |
+| `extraVolumes`               | Array of extra volumes to be added deployment. Requires setting `extraVolumeMounts`       | `[]` (evaluated as a template)                          |
+| `podAnnotations`             | Additional pod annotations                                                                | `{}`                                                    |
+| `podLabels`                  | Additional pod labels                                                                     | `{}` (evaluated as a template)                          |
+| `commonAnnotations`          | Annotations to be added to all deployed resources                                         | `{}` (evaluated as a template)                          |
+| `podSecurityContext.enabled` | Enable security context for EJBCA pods                                                    | `true`                                                  |
+| `podSecurityContext.fsGroup` | Group ID for the volumes of the pod                                                       | `1001`                                                  |
+| `podAffinityPreset`          | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                                                    |
+| `podAntiAffinityPreset`      | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                                  |
+| `nodeAffinityPreset.type`    | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                                                    |
+| `nodeAffinityPreset.key`     | Node label key to match Ignored if `affinity` is set.                                     | `""`                                                    |
+| `nodeAffinityPreset.values`  | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                                                    |
+| `affinity`                   | Affinity for pod assignment                                                               | `{}` (evaluated as a template)                          |
+| `nodeSelector`               | Node labels for pod assignment                                                            | `{}` (evaluated as a template)                          |
+| `tolerations`                | Tolerations for pod assignment                                                            | `[]` (evaluated as a template)                          |
+| `sidecars`                   | Attach additional sidecar containers to the pod                                           | `[]` (evaluated as a template)                          |
+| `initContainers`             | Additional init containers to add to the pods                                             | `[]` (evaluated as a template)                          |
+| `persistence.enabled`        | Whether to enable persistence based on Persistent Volume Claims                           | `true`                                                  |
+| `persistence.storageClass`   | PVC Storage Class                                                                         | `nil`                                                   |
+| `persistence.existingClaim`  | Name of an existing PVC to reuse                                                          | `nil`                                                   |
+| `persistence.accessMode`     | PVC Access Mode (RWO, ROX, RWX)                                                           | `ReadWriteOnce`                                         |
+| `persistence.size`           | Size of the PVC to request                                                                | `2Gi`                                                   |
 
 ### Service parameters
 
-| Parameter                                 | Description                                                                           | Default                                                      |
-|-------------------------------------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `service.type`                            | Kubernetes Service type                                                               | `LoadBalancer`                                               |
-| `service.port`                            | Service HTTP port                                                                     | `8080`                                                       |
-| `service.httpsPort`                       | Service HTTPS port                                                                    | `8443`                                                       |
-| `service.advertisedHttpsPort`             | Port used for the administration's urls                                               | `443`                                                        |
-| `service.httpsTargetPort`                 | Service Target HTTPS port                                                             | `https`                                                      |
-| `service.nodePorts.http`                  | Kubernetes http node port                                                             | `""`                                                         |
-| `service.nodePorts.https`                 | Kubernetes https node port                                                            | `""`                                                         |
-| `service.externalTrafficPolicy`           | Enable client source IP preservation                                                  | `Cluster`                                                    |
-| `service.annotations`                     | Service annotations                                                                   | `{}` (evaluated as a template)                               |
-| `service.loadBalancerSourceRanges`        | Restricts access for LoadBalancer (only with `service.type: LoadBalancer`)            | `[]`                                                         |
-| `service.extraPorts`                      | Extra ports to expose in the service (normally used with the `sidecar` value)         | `nil`                                                        |
+| Parameter                          | Description                                                                   | Default                        |
+|------------------------------------|-------------------------------------------------------------------------------|--------------------------------|
+| `service.type`                     | Kubernetes Service type                                                       | `LoadBalancer`                 |
+| `service.port`                     | Service HTTP port                                                             | `8080`                         |
+| `service.httpsPort`                | Service HTTPS port                                                            | `8443`                         |
+| `service.advertisedHttpsPort`      | Port used for the administration's urls                                       | `443`                          |
+| `service.httpsTargetPort`          | Service Target HTTPS port                                                     | `https`                        |
+| `service.nodePorts.http`           | Kubernetes http node port                                                     | `""`                           |
+| `service.nodePorts.https`          | Kubernetes https node port                                                    | `""`                           |
+| `service.externalTrafficPolicy`    | Enable client source IP preservation                                          | `Cluster`                      |
+| `service.annotations`              | Service annotations                                                           | `{}` (evaluated as a template) |
+| `service.loadBalancerSourceRanges` | Restricts access for LoadBalancer (only with `service.type: LoadBalancer`)    | `[]`                           |
+| `service.extraPorts`               | Extra ports to expose in the service (normally used with the `sidecar` value) | `nil`                          |
 
 ### EJBCA parameters
 
-| Parameter                                 | Description                                                                           | Default                                                      |
-|-------------------------------------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `ejbcaAdminUsername`                      | EJBCA administrator username                                                          | `bitnami`                                                    |
-| `ejbcaAdminPassword`                      | EJBCA administrator password                                                          | _random 10 character long alphanumeric string_               |
-| `existingSecret`                          | Name of an existing secret containing EJBCA admin password ('ejbca-admin-password' key) | `nil`                                                      |
-| `ejbcaJavaOpts`                           | Options used to launch the WildFly server                                             | `nil`                                                        |
-| `ejbcaCA.name`                            | Name of the CA EJBCA will instantiate by default                                      | `ManagementCA`                                               |
-| `ejbcaCA.baseDN`                          | Base DomainName of the CA EJBCA will instantiate by default                           | `nil`                                                        |
-| `ejbcaKeystoreExistingSecret`             | Existing Secret containing a Keystore to be imported by EBJCA                         | `nil`                                                        |
-| `extraEnvVars`                            | An array to add extra env vars                                                        | `[]` (evaluated as a template)                               |
-| `command`                                 | Custom command to override image cmd                                                  | `nil` (evaluated as a template)                              |
-| `args`                                    | Custom args for the custom commad                                                     | `nil` (evaluated as a template)                              |
-| `extraVolumeMounts`                       | Additional volume mounts (used along with `extraVolumes`)                             | `[]` (evaluated as a template)                               |
-| `resources`                               | EJBCA container's resource requests and limits                                        | `{}`                                                         |
-| `podSecurityContext.enabled`              | Enable security context for EJBCA container                                           | `true`                                                       |
-| `podSecurityContext.runAsUser`            | User ID for the EJBCA container                                                       | `1001`                                                       |
-| `livenessProbe.enabled`                   | Enable/disable livenessProbe                                                          | `true`                                                       |
-| `livenessProbe.initialDelaySeconds`       | Delay before liveness probe is initiated                                              | `500`                                                        |
-| `livenessProbe.periodSeconds`             | How often to perform the probe                                                        | `10`                                                         |
-| `livenessProbe.timeoutSeconds`            | When the probe times out                                                              | `5`                                                          |
-| `livenessProbe.failureThreshold`          | Minimum consecutive failures for the probe                                            | `6`                                                          |
-| `livenessProbe.successThreshold`          | Minimum consecutive successes for the probe                                           | `1`                                                          |
-| `readinessProbe.enabled`                  | Enable/disable readinessProbe                                                         | `true`                                                       |
-| `readinessProbe.initialDelaySeconds`      | Delay before readiness probe is initiated                                             | `500`                                                        |
-| `readinessProbe.periodSeconds`            | How often to perform the probe                                                        | `10`                                                         |
-| `readinessProbe.timeoutSeconds`           | When the probe times out                                                              | `5`                                                          |
-| `readinessProbe.failureThreshold`         | Minimum consecutive failures for the probe                                            | `6`                                                          |
-| `readinessProbe.successThreshold`         | Minimum consecutive successes for the probe                                           | `1`                                                          |
-| `customLivenessProbe`                     | Custom liveness probe to execute (when the main one is disabled)                      | `{}` (evaluated as a template)                               |
-| `customReadinessProbe`                    | Custom readiness probe to execute (when the main one is disabled)                     | `{}` (evaluated as a template)                               |
-| `containerPorts.http`                     | Port to open for HTTP traffic in EJBCA                                                | `8080`                                                       |
-| `containerPorts.https`                    | Port to open for HTTPS traffic in EJBCA                                               | `8443`                                                       |
-| `extraEnvVarsCM`                          | Array to add extra configmaps                                                         | `[]`                                                         |
-| `extraEnvVarsSecret`                      | Array to add extra environment from a Secret                                          | `nil`                                                        |
+| Parameter                            | Description                                                                             | Default                                        |
+|--------------------------------------|-----------------------------------------------------------------------------------------|------------------------------------------------|
+| `ejbcaAdminUsername`                 | EJBCA administrator username                                                            | `bitnami`                                      |
+| `ejbcaAdminPassword`                 | EJBCA administrator password                                                            | _random 10 character long alphanumeric string_ |
+| `existingSecret`                     | Name of an existing secret containing EJBCA admin password ('ejbca-admin-password' key) | `nil`                                          |
+| `ejbcaJavaOpts`                      | Options used to launch the WildFly server                                               | `nil`                                          |
+| `ejbcaCA.name`                       | Name of the CA EJBCA will instantiate by default                                        | `ManagementCA`                                 |
+| `ejbcaCA.baseDN`                     | Base DomainName of the CA EJBCA will instantiate by default                             | `nil`                                          |
+| `ejbcaKeystoreExistingSecret`        | Existing Secret containing a Keystore to be imported by EBJCA                           | `nil`                                          |
+| `extraEnvVars`                       | An array to add extra env vars                                                          | `[]` (evaluated as a template)                 |
+| `command`                            | Custom command to override image cmd                                                    | `nil` (evaluated as a template)                |
+| `args`                               | Custom args for the custom commad                                                       | `nil` (evaluated as a template)                |
+| `extraVolumeMounts`                  | Additional volume mounts (used along with `extraVolumes`)                               | `[]` (evaluated as a template)                 |
+| `resources`                          | EJBCA container's resource requests and limits                                          | `{}`                                           |
+| `podSecurityContext.enabled`         | Enable security context for EJBCA container                                             | `true`                                         |
+| `podSecurityContext.runAsUser`       | User ID for the EJBCA container                                                         | `1001`                                         |
+| `livenessProbe.enabled`              | Enable/disable livenessProbe                                                            | `true`                                         |
+| `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                                                | `500`                                          |
+| `livenessProbe.periodSeconds`        | How often to perform the probe                                                          | `10`                                           |
+| `livenessProbe.timeoutSeconds`       | When the probe times out                                                                | `5`                                            |
+| `livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe                                              | `6`                                            |
+| `livenessProbe.successThreshold`     | Minimum consecutive successes for the probe                                             | `1`                                            |
+| `readinessProbe.enabled`             | Enable/disable readinessProbe                                                           | `true`                                         |
+| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                                               | `500`                                          |
+| `readinessProbe.periodSeconds`       | How often to perform the probe                                                          | `10`                                           |
+| `readinessProbe.timeoutSeconds`      | When the probe times out                                                                | `5`                                            |
+| `readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe                                              | `6`                                            |
+| `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe                                             | `1`                                            |
+| `customLivenessProbe`                | Custom liveness probe to execute (when the main one is disabled)                        | `{}` (evaluated as a template)                 |
+| `customReadinessProbe`               | Custom readiness probe to execute (when the main one is disabled)                       | `{}` (evaluated as a template)                 |
+| `containerPorts.http`                | Port to open for HTTP traffic in EJBCA                                                  | `8080`                                         |
+| `containerPorts.https`               | Port to open for HTTPS traffic in EJBCA                                                 | `8443`                                         |
+| `extraEnvVarsCM`                     | Array to add extra configmaps                                                           | `[]`                                           |
+| `extraEnvVarsSecret`                 | Array to add extra environment from a Secret                                            | `nil`                                          |
 
 ### Ingress parameters
 
-| Parameter                                 | Description                                                                           | Default                                                      |
-|-------------------------------------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `ingress.enabled`                         | Enable ingress controller resource                                                    | `false`                                                      |
-| `ingress.hostname`                        | Default host for the ingress resource                                                 | `ejbca.local`                                                |
-| `ingress.annotations`                     | Ingress annotations                                                                   | `[]` (evaluated as a template)                               |
+| Parameter             | Description                           | Default                        |
+|-----------------------|---------------------------------------|--------------------------------|
+| `ingress.enabled`     | Enable ingress controller resource    | `false`                        |
+| `ingress.hostname`    | Default host for the ingress resource | `ejbca.local`                  |
+| `ingress.annotations` | Ingress annotations                   | `[]` (evaluated as a template) |
 
 ### Database parameters
 
-| Parameter                                 | Description                                                                           | Default                                                      |
-|-------------------------------------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `mariadb.enabled`                         | Deploy MariaDB container(s)                                                           | `true`                                                       |
-| `mariadb.rootUser.password`               | MariaDB admin password                                                                | `nil`                                                        |
-| `mariadb.db.name`                         | Database name to create                                                               | `bitnami_ejbca`                                              |
-| `mariadb.db.user`                         | Database user to create                                                               | `bn_ejbca`                                                   |
-| `mariadb.db.password`                     | Password for the database                                                             | _random 10 character long alphanumeric string_               |
-| `mariadb.existingSecret`                  | Use existing secret for password details (`rootUser.password`, `db.password`, `replication.password` will be ignored and picked up from this secret) See [ref](https://github.com/bitnami/charts/tree/master/bitnami/mariadb)                                                                                         | `nil`                                                        |
-| `mariadb.replication.enabled`             | MariaDB replication enabled                                                           | `false`                                                      |
-| `mariadb.master.persistence.enabled`      | Enable database persistence using PVC                                                 | `true`                                                       |
-| `mariadb.master.persistence.accessModes`  | Database Persistent Volume Access Modes                                               | `[ReadWriteOnce]`                                            |
-| `mariadb.master.persistence.size`         | Database Persistent Volume Size                                                       | `8Gi`                                                        |
-| `externalDatabase.host`                   | Host of the external database                                                         | `localhost`                                                  |
-| `externalDatabase.user`                   | Existing username in the external db                                                  | `bn_ejbca`                                                   |
-| `externalDatabase.password`               | Password for the above username                                                       | `nil`                                                        |
-| `externalDatabase.existingSecret`         | Name of an existing secret resource containing the DB password in a 'mariadb-password' key | `nil`                                                   |
-| `externalDatabase.database`               | Name of the existing database                                                         | `bitnami_ejbca`                                              |
-| `externalDatabase.port`                   | Database port number                                                                  | `3306`                                                       |
+| Parameter                                   | Description                                                                                | Default                                        |
+|---------------------------------------------|--------------------------------------------------------------------------------------------|------------------------------------------------|
+| `mariadb.enabled`                           | Deploy MariaDB container(s)                                                                | `true`                                         |
+| `mariadb.architecture`                      | MariaDB architecture (`standalone` or `replication`)                                       | `standalone`                                   |
+| `mariadb.auth.rootPassword`                 | Password for the MariaDB `root` user                                                       | _random 10 character alphanumeric string_      |
+| `mariadb.auth.database`                     | Database name to create                                                                    | `bitnami_ejbca`                                |
+| `mariadb.auth.username`                     | Database user to create                                                                    | `bn_ejbca`                                     |
+| `mariadb.auth.password`                     | Password for the database                                                                  | _random 10 character long alphanumeric string_ |
+| `mariadb.primary.persistence.enabled`       | Enable database persistence using PVC                                                      | `true`                                         |
+| `mariadb.primary.persistence.existingClaim` | Name of an existing `PersistentVolumeClaim` for MariaDB primary replicas                   | `nil`                                          |
+| `mariadb.primary.persistence.accessModes`   | Database Persistent Volume Access Modes                                                    | `[ReadWriteOnce]`                              |
+| `mariadb.primary.persistence.size`          | Database Persistent Volume Size                                                            | `8Gi`                                          |
+| `mariadb.primary.persistence.hostPath`      | Set path in case you want to use local host path volumes (not recommended in production)   | `nil`                                          |
+| `mariadb.primary.persistence.storageClass`  | MariaDB primary persistent volume storage Class                                            | `nil`                                          |
+| `externalDatabase.host`                     | Host of the external database                                                              | `localhost`                                    |
+| `externalDatabase.username`                 | Existing username in the external db                                                       | `bn_ejbca`                                     |
+| `externalDatabase.password`                 | Password for the above username                                                            | `nil`                                          |
+| `externalDatabase.existingSecret`           | Name of an existing secret resource containing the DB password in a 'mariadb-password' key | `nil`                                          |
+| `externalDatabase.database`                 | Name of the existing database                                                              | `bitnami_ejbca`                                |
+| `externalDatabase.port`                     | Database port number                                                                       | `3306`                                         |
 
 The above parameters map to the env variables defined in [bitnami/ejbca](http://github.com/bitnami/bitnami-docker-ejbca). For more information please refer to the [bitnami/ejbca](http://github.com/bitnami/bitnami-docker-ejbca) image documentation.
 
@@ -177,7 +179,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 
 ```console
 $ helm install my-release \
-  --set ejbcaAdminUsername=admin,ejbcaAdminPassword=password,mariadb.db.password=secretpassword \
+  --set ejbcaAdminUsername=admin,ejbcaAdminPassword=password,mariadb.auth.password=secretpassword \
     bitnami/discourse
 ```
 
@@ -205,9 +207,9 @@ By default, this Chart only deploys a single pod running EJBCA. Should you want 
 
 1. Create a conventional release with only one replica, that will be scaled later.
 2. Wait for the release to complete and EJBCA to be running successfully. You may verify you have access to the main page in order to do this.
-3. Perform an upgrade specifying the number of replicas and the credentials that were previously used. Set the parameters `replicaCount`, `ejbcaAdminPassword` and `mariadb.db.password` accordingly.
+3. Perform an upgrade specifying the number of replicas and the credentials that were previously used. Set the parameters `replicaCount`, `ejbcaAdminPassword` and `mariadb.auth.password` accordingly.
 
-For example, for a release using `secretPassword` and `dbPassword` to scale up to a total of `2` replicas, the aforementioned parameters should hold these values `replicaCount=2`, `ejbcaAdminPassword=secretPassword`, `mariadb.db.password=dbPassword`.
+For example, for a release using `secretPassword` and `dbPassword` to scale up to a total of `2` replicas, the aforementioned parameters should hold these values `replicaCount=2`, `ejbcaAdminPassword=secretPassword`, `mariadb.auth.password=dbPassword`.
 
 > **Tip**: You can modify the file [values.yaml](values.yaml)
 
@@ -280,3 +282,47 @@ imagePullSecrets:
   - name: SECRET_NAME
 ```
 3. Install the chart
+
+## Upgrading
+
+### To 1.0.0
+
+MariaDB dependency version was bumped to a new major version that introduces several incompatilibites. Therefore, backwards compatibility is not guaranteed unless an external database is used. Check [MariaDB Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/mariadb#to-800) for more information.
+
+To upgrade to `1.0.0`, you have two alternatives:
+
+- Install a new EJBCA chart, and migrate your EJBCA following [the official documentation](https://doc.primekey.com/ejbca/ejbca-operations/ejbca-operations-guide/ca-operations-guide/ejbca-maintenance/backup-and-restore).
+- Reuse the PVC used to hold the MariaDB data on your previous release. To do so, follow the instructions below (the following example assumes that the release name is `ejbca`):
+
+> NOTE: Please, create a backup of your database before running any of those actions. The steps below would be only valid if your application (e.g. any plugins or custom code) is compatible with MariaDB 10.5.x
+
+Obtain the credentials and the name of the PVC used to hold the MariaDB data on your current release:
+
+```console
+export EJBCA_ADMIN_PASSWORD=$(kubectl get secret --namespace default ejbca -o jsonpath="{.data.ejbca-admin-password}" | base64 --decode)
+export MARIADB_ROOT_PASSWORD=$(kubectl get secret --namespace default ejbca-mariadb -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)
+export MARIADB_PASSWORD=$(kubectl get secret --namespace default ejbca-mariadb -o jsonpath="{.data.mariadb-password}" | base64 --decode)
+export MARIADB_PVC=$(kubectl get pvc -l app=mariadb,component=master,release=ejbca -o jsonpath="{.items[0].metadata.name}")
+```
+
+Upgrade your release (maintaining the version) disabling MariaDB and scaling EJBCA replicas to 0:
+
+```console
+$ helm upgrade ejbca bitnami/ejbca --set ejbcaAdminPassword=$EJBCA_ADMIN_PASSWORD --set replicaCount=0 --set mariadb.enabled=false --version 0.4.0
+```
+
+Finally, upgrade you release to 1.0.0 reusing the existing PVC, and enabling back MariaDB:
+
+```console
+$ helm upgrade ejbca bitnami/ejbca --set mariadb.primary.persistence.existingClaim=$MARIADB_PVC --set mariadb.auth.rootPassword=$MARIADB_ROOT_PASSWORD --set mariadb.auth.password=$MARIADB_PASSWORD --set ejbcaAdminPassword=$EJBCA_ADMIN_PASSWORD
+```
+
+You should see the lines below in MariaDB container logs:
+
+```console
+$ kubectl logs $(kubectl get pods -l app.kubernetes.io/instance=ejbca,app.kubernetes.io/name=mariadb,app.kubernetes.io/component=primary -o jsonpath="{.items[0].metadata.name}")
+...
+mariadb 12:13:24.98 INFO  ==> Using persisted data
+mariadb 12:13:25.01 INFO  ==> Running mysql_upgrade
+...
+```

--- a/bitnami/ejbca/requirements.lock
+++ b/bitnami/ejbca/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 0.7.1
+  version: 0.8.1
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 7.10.2
-digest: sha256:d0c560e5556b5298b43893431f7d94797ea637e6c11010a683df77e12c9205b6
-generated: "2020-09-23T16:38:27.664616+02:00"
+  version: 8.0.3
+digest: sha256:b62e4ae3422259ce4cda1f3dc0dacd6ea37b09ce7ad78d9e93e8cc0e5bfc847c
+generated: "2020-10-08T11:52:02.845375+02:00"

--- a/bitnami/ejbca/requirements.yaml
+++ b/bitnami/ejbca/requirements.yaml
@@ -5,7 +5,7 @@ dependencies:
     tags:
       - bitnami-common
   - name: mariadb
-    version: 7.x.x
+    version: 8.x.x
     repository: https://charts.bitnami.com/bitnami
     condition: mariadb.enabled
     tags:

--- a/bitnami/ejbca/templates/NOTES.txt
+++ b/bitnami/ejbca/templates/NOTES.txt
@@ -57,6 +57,6 @@ To access your EJBCA site from outside the cluster follow the steps below:
 
 {{- $mariadbSecretName := include "ejbca.databaseSecretName" . -}}
 {{- $mariadbPasswordValidationErrors := include "common.validations.values.mariadb.passwords" (dict "secret" $mariadbSecretName "subchart" true "context" $) -}}
-{{- $passwordValidationErrors = append $passwordValidationErrors $mariadbPasswordValidationErrors -}}
+{{- $passwordErrors = append $passwordErrors $mariadbPasswordValidationErrors -}}
 
-{{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordValidationErrors "context" $) -}}
+{{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordErrors "context" $) -}}

--- a/bitnami/ejbca/templates/NOTES.txt
+++ b/bitnami/ejbca/templates/NOTES.txt
@@ -17,7 +17,6 @@ To access your EJBCA site from outside the cluster follow the steps below:
    echo "EJBCA Admin URL: https://$NODE_IP:$NODE_PORT/ejbca/adminweb"
    echo "EJBCA Enrol URL: https://$NODE_IP:$NODE_PORT/ejbca/enrol/keystore.jsp"
 
-
 {{- else if contains "LoadBalancer" .Values.service.type }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
@@ -27,7 +26,6 @@ To access your EJBCA site from outside the cluster follow the steps below:
    echo "EJBCA Public URL: https://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.httpsPort }}{{ end }}/ejbca"
    echo "EJBCA Admin URL: https://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.httpsPort }}{{ end }}/ejbca/adminweb"
    echo "EJBCA Enrol URL: https://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.httpsPort }}{{ end }}/ejbca/enrol/keystore.jsp"
-
 
 {{- else if contains "ClusterIP"  .Values.service.type }}
 
@@ -57,14 +55,8 @@ To access your EJBCA site from outside the cluster follow the steps below:
   {{- $passwordErrors =  append $passwordErrors $requiredEJBCAPasswordError -}}
 {{- end -}}
 
-{{- $passwordMysqlErrors := include "common.validations.values.mariadb.passwords" (dict "secretName" $databaseSecretName "context" $) -}}
-{{- $passwordErrors = append $passwordErrors $passwordMysqlErrors -}}
+{{- $mariadbSecretName := include "ejbca.databaseSecretName" . -}}
+{{- $mariadbPasswordValidationErrors := include "common.validations.values.mariadb.passwords" (dict "secret" $mariadbSecretName "subchart" true "context" $) -}}
+{{- $passwordValidationErrors = append $passwordValidationErrors $mariadbPasswordValidationErrors -}}
 
-{{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordErrors "context" $) -}}
-
-{{- if and (not .Values.mariadb.enabled) .Release.IsUpgrade -}}
-  {{- $requiredExternalPassword := dict "valueKey" "externalDatabase.password" "secret" $databaseSecretName "field" "mariadb-password" -}}
-
-WARNING: Review values for the following password in the command, if they are correct please ignore this notice.
-  {{- include "common.validations.values.multiple.empty" (dict "required" (list $requiredExternalPassword) "context" $) -}}
-{{- end -}}
+{{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordValidationErrors "context" $) -}}

--- a/bitnami/ejbca/templates/_helpers.tpl
+++ b/bitnami/ejbca/templates/_helpers.tpl
@@ -100,14 +100,22 @@ Return the appropriate apiVersion for ingress.
 {{- end -}}
 
 {{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "ejbca.mariadb.fullname" -}}
+{{- printf "%s-%s" .Release.Name "mariadb" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Return the MariaDB Hostname
 */}}
 {{- define "ejbca.databaseHost" -}}
 {{- if .Values.mariadb.enabled }}
     {{- if eq .Values.mariadb.architecture "replication" }}
-        {{- printf "%s-%s" (include "drupal.mariadb.fullname" .) "primary" | trunc 63 | trimSuffix "-" -}}
+        {{- printf "%s-%s" (include "ejbca.mariadb.fullname" .) "primary" | trunc 63 | trimSuffix "-" -}}
     {{- else -}}
-        {{- printf "%s" (include "drupal.mariadb.fullname" .) -}}
+        {{- printf "%s" (include "ejbca.mariadb.fullname" .) -}}
     {{- end -}}
 {{- else -}}
     {{- printf "%s" .Values.externalDatabase.host -}}

--- a/bitnami/ejbca/templates/_helpers.tpl
+++ b/bitnami/ejbca/templates/_helpers.tpl
@@ -104,7 +104,11 @@ Return the MariaDB Hostname
 */}}
 {{- define "ejbca.databaseHost" -}}
 {{- if .Values.mariadb.enabled }}
-    {{- printf "%s" (include "mariadb.fullname" .) -}}
+    {{- if eq .Values.mariadb.architecture "replication" }}
+        {{- printf "%s-%s" (include "drupal.mariadb.fullname" .) "primary" | trunc 63 | trimSuffix "-" -}}
+    {{- else -}}
+        {{- printf "%s" (include "drupal.mariadb.fullname" .) -}}
+    {{- end -}}
 {{- else -}}
     {{- printf "%s" .Values.externalDatabase.host -}}
 {{- end -}}
@@ -115,9 +119,9 @@ Return the MariaDB Port
 */}}
 {{- define "ejbca.databasePort" -}}
 {{- if .Values.mariadb.enabled }}
-    {{- printf "3306" | quote -}}
+    {{- printf "3306" -}}
 {{- else -}}
-    {{- printf "%s" (.Values.externalDatabase.port | quote ) -}}
+    {{- printf "%d" (.Values.externalDatabase.port | int ) -}}
 {{- end -}}
 {{- end -}}
 
@@ -126,7 +130,7 @@ Return the MariaDB Database Name
 */}}
 {{- define "ejbca.databaseName" -}}
 {{- if .Values.mariadb.enabled }}
-    {{- printf "%s" .Values.mariadb.db.name -}}
+    {{- printf "%s" .Values.mariadb.auth.database -}}
 {{- else -}}
     {{- printf "%s" .Values.externalDatabase.database -}}
 {{- end -}}
@@ -137,7 +141,7 @@ Return the MariaDB User
 */}}
 {{- define "ejbca.databaseUsername" -}}
 {{- if .Values.mariadb.enabled }}
-    {{- printf "%s" .Values.mariadb.db.user -}}
+    {{- printf "%s" .Values.mariadb.auth.username -}}
 {{- else -}}
     {{- printf "%s" .Values.externalDatabase.user -}}
 {{- end -}}

--- a/bitnami/ejbca/values.yaml
+++ b/bitnami/ejbca/values.yaml
@@ -179,6 +179,7 @@ podAntiAffinityPreset: soft
 nodeAffinityPreset:
   ## Node affinity type
   ## Allowed values: soft, hard
+  ##
   type: ""
   ## Node label key to match
   ## E.g.
@@ -330,35 +331,30 @@ mariadb:
   ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
   ##
   enabled: true
-  ## Disable MariaDB replication
-  ##
-  replication:
-    enabled: false
 
-  ## Create a database and a database user
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ## MariaDB architecture. Allowed values: standalone or replication
   ##
-  db:
-    name: bitnami_ejbca
-    user: bn_ejbca
-    ## If the password is not specified, mariadb will generates a random password
+  architecture: standalone
+
+  ## MariaDB Authentication parameters
+  ##
+  auth:
+    ## MariaDB root password
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
     ##
-    # password:
+    rootPassword: ""
+    ## MariaDB custom user and database
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+    ##
+    database: bitnami_ejbca
+    username: bn_ejbca
+    password: ""
 
-  ## MariaDB admin password
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
-  ##
-  # rootUser:
-  #   password:
-
-  ## Use existing secret (ignores root, db and replication passwords)
-  ##
-  # existingSecret:
-
-  ## Enable persistence using Persistent Volume Claims
-  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-  ##
-  master:
+  primary:
+    ## Enable persistence using Persistent Volume Claims
+    ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+    ##
     persistence:
       enabled: true
       ## mariadb data Persistent Volume Storage Class
@@ -368,10 +364,15 @@ mariadb:
       ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
       ##   GKE, AWS & OpenStack)
       ##
-      # storageClass: "-"
-      accessModes:
-        - ReadWriteOnce
+      storageClass:
+      accessMode: ReadWriteOnce
       size: 8Gi
+      ## Set path in case you want to use local host path volumes (not recommended in production)
+      ##
+      hostPath:
+      ## Use an existing PVC
+      ##
+      existingClaim:
 
 ##
 ## External Database Configuration


### PR DESCRIPTION

**Description of the change**

This PR bumps EJBCA major version since its dependency (MariaDB) bumped the major version including breaking changes. More info at https://github.com/bitnami/charts/pull/3849

**Benefits**

- Standardization.

**Benefits**

**Possible drawbacks**

It breaks backwards compatibility.

**Applicable issues**

None

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
