### PR TITLE
[bitnami/spring-cloud-dataflow] Fixes external database config

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: spring-cloud-dataflow
-version: 1.1.0
+version: 1.2.0
 appVersion: 2.6.3
 description: Spring Cloud Data Flow is a microservices-based toolkit for building streaming and batch data processing pipelines in Cloud Foundry and Kubernetes.
 keywords:

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -244,12 +244,16 @@ The following tables lists the configurable parameters of the Spring Cloud Data 
 | `mariadb.auth.password`                      | Password for the new user                                                                              | `change-me`                                             |
 | `mariadb.auth.rootPassword`                  | Password for the MariaDB `root` user                                                                   | _random 10 character alphanumeric string_               |
 | `mariadb.initdbScripts`                      | Dictionary of initdb scripts                                                                           | Check `values.yaml` file                                |
+| `externalDatabase.driver`                    | The fully qualified name of the JDBC Driver class                                                      | `""`                                                    |
+| `externalDatabase.scheme`                    | The scheme is a vendor-specific or shared protocol string that follows the "jdbc:" of the URL          | `""`                                                    |
 | `externalDatabase.host`                      | Host of the external database                                                                          | `localhost`                                             |
 | `externalDatabase.port`                      | External database port number                                                                          | `3306`                                                  |
 | `externalDatabase.password`                  | Password for the above username                                                                        | `""`                                                    |
 | `externalDatabase.existingPasswordSecret`    | Existing secret with database password                                                                 | `""`                                                    |
+| `externalDatabase.dataflow.url`              | JDBC URL for dataflow server. Overrides external scheme, host, port, database, and jdbc parameters.    | `""`                                                    |
 | `externalDatabase.dataflow.username`         | Existing username in the external db to be used by Dataflow server                                     | `dataflow`                                              |
 | `externalDatabase.dataflow.database`         | Name of the existing database to be used by Dataflow server                                            | `dataflow`                                              |
+| `externalDatabase.skipper.url`               | JDBC URL for skipper. Overrides external scheme, host, port, database, and jdbc parameters.            | `""`                                                    |
 | `externalDatabase.skipper.username`          | Existing username in the external db to be used by Skipper server                                      | `skipper`                                               |
 | `externalDatabase.skipper.database`          | Name of the existing database to be used by Skipper server                                             | `skipper`                                               |
 | `externalDatabase.hibernateDialect`          | Hibernate Dialect used by Dataflow/Skipper servers                                                     | `""`                                                    |
@@ -376,6 +380,7 @@ Sometimes you may want to have Spring Cloud components connect to an external da
 
 ```console
 mariadb.enabled=false
+externalDatabase.scheme=mariadb
 externalDatabase.host=myexternalhost
 externalDatabase.port=3306
 externalDatabase.password=mypassword
@@ -385,7 +390,21 @@ externalDatabase.dataflow.user=myskipperuser
 externalDatabase.dataflow.database=myskipperdatabase
 ```
 
-Note also if you disable MariaDB per above you MUST supply values for the `externalDatabase` connection.
+NOTE: When using the indidual propertes (scheme, host, port, database, an optional jdbcParameters) this chart will format the JDBC URL as `jdbc:{scheme}://{host}:{port}/{database}{jdbcParameters}`. The URL format follows that of the MariaDB database drive but may not work for other database vendors.
+
+To use an alternate database vendor (other than MariaDB) you can use the `externalDatabase.dataflow.url` and `externalDatabase.skipper.url` properties to provide the JDBC URLs for the dataflow server and skipper respectively. If these properties are defined, they will take precendence over the individual attributes. As an example of configuring an external MS SQL Server database:
+
+```console
+mariadb.enabled=false
+externalDatabase.password=mypassword
+externalDatabase.dataflow.url=jdbc:sqlserver://mssql-server:1433
+externalDatabase.dataflow.user=mydataflowuser
+externalDatabase.skipper.url=jdbc:sqlserver://mssql-server:1433
+externalDatabase.skipper.user=myskipperuser
+externalDatabase.hibernateDialect=org.hibernate.dialect.SQLServer2012Dialect
+```
+
+NOTE: If you disable MariaDB per above you MUST supply values for the `externalDatabase` connection.
 
 ### Adding extra flags
 

--- a/bitnami/spring-cloud-dataflow/templates/_helpers.tpl
+++ b/bitnami/spring-cloud-dataflow/templates/_helpers.tpl
@@ -150,6 +150,28 @@ Return true if a configmap object should be created for Spring Cloud Skipper
 {{- end -}}
 
 {{/*
+Return the database URL used by the dataflow server
+*/}}
+{{- define "scdf.database.dataflow.url" -}}
+  {{- if .Values.externalDatabase.dataflow.url }}
+    {{- printf "%s" .Values.externalDatabase.dataflow.url -}}
+  {{- else -}}
+    {{- printf "jdbc:%s://%s:%s/%s%s" (include "scdf.database.scheme" .) (include "scdf.database.host" .) (include "scdf.database.port" .) (include "scdf.database.server.name" .) (include "scdf.database.jdbc.parameters" .) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Return the database URL used by skipper
+*/}}
+{{- define "scdf.database.skipper.url" -}}
+  {{- if .Values.externalDatabase.skipper.url }}
+    {{- printf "%s" .Values.externalDatabase.skipper.url -}}
+  {{- else -}}
+    {{- printf "jdbc:%s://%s:%s/%s%s" (include "scdf.database.scheme" .) (include "scdf.database.host" .) (include "scdf.database.port" .) (include "scdf.database.skipper.name" .) (include "scdf.database.jdbc.parameters" .) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Return the database Hostname
 */}}
 {{- define "scdf.database.host" -}}

--- a/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
@@ -92,12 +92,7 @@ data:
             dialect: {{ $hibernateDialect }}
       {{- end }}
       datasource:
-        {{- $databaseScheme := include "scdf.database.scheme" .  }}
-        {{- $databaseHost := include "scdf.database.host" .  }}
-        {{- $databasePort := include "scdf.database.port" .  }}
-        {{- $databaseName := include "scdf.database.server.name" .  }}
-        {{- $jdbcParameters := include "scdf.database.jdbc.parameters" .  }}
-        url: 'jdbc:{{ $databaseScheme }}://{{ $databaseHost }}:{{ $databasePort }}/{{ $databaseName }}{{ $jdbcParameters }}'
+        url: '{{ include "scdf.database.dataflow.url" . }}'
         driverClassName: {{ include "scdf.database.driver" . }}
         username: {{ include "scdf.database.server.user" . }}
         {{ if .Values.externalDatabase.existingPasswordSecret }}

--- a/bitnami/spring-cloud-dataflow/templates/server/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/deployment.yaml
@@ -129,8 +129,8 @@ spec:
             - name: SPRING_CLOUD_DATAFLOW_TASK_COMPOSED_TASK_RUNNER_URI
               value: 'docker://{{ include "common.images.image" (dict "imageRoot" .Values.server.composedTaskRunner.image) }}'
             {{- range $key, $value := .Values.server.extraEnvVars }}
-            - name: {{ $key }}
-              value: "{{ $value }}"
+            - name: {{ $value.name }}
+              value: "{{ $value.value }}"
             {{- end }}
           {{- if or .Values.server.extraEnvVarsCM .Values.server.extraEnvVarsSecret }}
           envFrom:

--- a/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
@@ -64,12 +64,7 @@ data:
             dialect: {{ $hibernateDialect }}
       {{- end }}
       datasource:
-        {{- $databaseScheme := include "scdf.database.scheme" .  }}
-        {{- $databaseHost := include "scdf.database.host" .  }}
-        {{- $databasePort := include "scdf.database.port" .  }}
-        {{- $databaseName := include "scdf.database.skipper.name" .  }}
-        {{- $jdbcParameters := include "scdf.database.jdbc.parameters" .  }}
-        url: 'jdbc:{{ $databaseScheme }}://{{ $databaseHost }}:{{ $databasePort }}/{{ $databaseName }}{{ $jdbcParameters }}'
+        url: '{{ include "scdf.database.skipper.url" . }}'
         driverClassName: {{ include "scdf.database.driver" . }}
         username: {{ include "scdf.database.skipper.user" . }}
         {{ if .Values.externalDatabase.existingPasswordSecret }}

--- a/bitnami/spring-cloud-dataflow/templates/skipper/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/deployment.yaml
@@ -97,8 +97,8 @@ spec:
               value: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address={{ .Values.skipper.jdwp.port }}"
             {{- end }}
             {{- range $key, $value := .Values.skipper.extraEnvVars }}
-            - name: {{ $key }}
-              value: "{{ $value }}"
+            - name: {{ $value.name }}
+              value: "{{ $value.value }}"
             {{- end }}
           {{- if or .Values.skipper.extraEnvVarsCM .Values.skipper.extraEnvVarsSecret }}
           envFrom:

--- a/bitnami/spring-cloud-dataflow/values-production.yaml
+++ b/bitnami/spring-cloud-dataflow/values-production.yaml
@@ -770,6 +770,7 @@ mariadb:
 ## All of these values are ignored when mariadb.enabled is set to true
 ##
 externalDatabase:
+
   ## Database server host and port
   ##
   host: localhost
@@ -783,11 +784,21 @@ externalDatabase:
   ## Data Flow user and database
   ##
   dataflow:
+    ## Database JDBC URL
+    ## This provides a mechanism to define a fully customized JDBC URL for the data flow server rather than having it
+    ## derived from the common, individual attributes. This property, when defined, has precedence over the
+    ## individual attributes (scheme, host, port, database)
+    url: ""
     database: dataflow
     user: dataflow
   ## Skipper and database
   ##
   skipper:
+    ## Database JDBC URL
+    ## This provides a mechanism to define a fully customized JDBC URL for skipper rather than having it
+    ## derived from the common, individual attributes. This property, when defined, has precedence over the
+    ## individual attributes (scheme, host, port, database)
+    url: ""
     database: skipper
     user: skipper
   ## Hibernate Dialect

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -771,6 +771,7 @@ mariadb:
 ## All of these values are ignored when mariadb.enabled is set to true
 ##
 externalDatabase:
+
   ## Database server host and port
   ##
   host: localhost
@@ -784,11 +785,21 @@ externalDatabase:
   ## Data Flow user and database
   ##
   dataflow:
+    ## Database JDBC URL
+    ## This provides a mechanism to define a fully customized JDBC URL for the data flow server rather than having it
+    ## derived from the common, individual attributes. This property, when defined, has precedence over the
+    ## individual attributes (scheme, host, port, database)
+    url: ""
     database: dataflow
     username: dataflow
   ## Skipper and database
   ##
   skipper:
+    ## Database JDBC URL
+    ## This provides a mechanism to define a fully customized JDBC URL for skipper rather than having it
+    ## derived from the common, individual attributes. This property, when defined, has precedence over the
+    ## individual attributes (scheme, host, port, database)
+    url: ""
     database: skipper
     username: skipper
   ## Hibernate Dialect


### PR DESCRIPTION
This adds an "externalDatabase.url" property that gives the user better control when using an external/managed database. Prior to this fix, the combination of schema, host, port, database, and jdbc.parameters were used to derive the JDBC url and the resulting URL was not formatted correctly when using an alternate database such as MS SQL Server.

If a user defines the "url" property, this value will be used instead of composing the "url" from the other properties. I left the existing properties because I didn't want to break backwards compatibility, but I think it would make more sense to just allow a user to always use the "url" property. 

The second fix is to address an issue when adding environment variables via server.extraEnvVars. Prior to this fix, the extra environment variables were resulting in a malformed configuration file when the template was applied.

**Benefits**

This makes it much easier to use an external/managed database.

**Possible drawbacks**

It is a bit confusing having both a "url" property and also having separate properties (scheme, host, port, database, and properties) that essentially can also be used to derive a URL. I would recommend removing the individual properties because the resulting URL does not work for all vendor implementations.

**Applicable issues**

https://github.com/bitnami/charts/issues/3939


**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
