### PR TITLE
[bitnami/wavefront] Add imagePullSecret logic

### DIFF
--- a/bitnami/wavefront/Chart.yaml
+++ b/bitnami/wavefront/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: wavefront
 description: Chart for Wavefront Collector for Kubernetes
 appVersion: 1.2.4
-version: 0.1.1
+version: 0.1.2
 keywords:
   - metric
   - monitoring

--- a/bitnami/wavefront/templates/_helpers.tpl
+++ b/bitnami/wavefront/templates/_helpers.tpl
@@ -13,6 +13,13 @@ Return the proper proxy image name
 {{- end -}}
 
 {{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "wavefront.imagePullSecrets" -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.collector.image .Values.proxy.image) "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "wavefront.collector.serviceAccountName" -}}

--- a/bitnami/wavefront/templates/collector-daemonset.yaml
+++ b/bitnami/wavefront/templates/collector-daemonset.yaml
@@ -30,6 +30,7 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ template "wavefront.collector.serviceAccountName" . }}
+      {{- include "wavefront.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.collector.affinity }}
       affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.collector.affinity "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/wavefront/templates/collector-deployment.yaml
+++ b/bitnami/wavefront/templates/collector-deployment.yaml
@@ -30,6 +30,7 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ template "wavefront.collector.serviceAccountName" . }}
+      {{- include "wavefront.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.collector.affinity }}
       affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.collector.affinity "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/wavefront/templates/proxy-deployment.yaml
+++ b/bitnami/wavefront/templates/proxy-deployment.yaml
@@ -30,6 +30,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.proxy.podLabels "context" $) | nindent 8 }}
         {{- end }}
     spec:
+      {{- include "wavefront.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.proxy.affinity }}
       affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.proxy.affinity "context" $) | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
**Description of the change**

The value was set, but the logic was not implemented.


```
helm template --set clusterName=fake-wavefront --set wavefront.url=https://fake.wavefront.com --set wavefront.token=fake --set global.imagePullSecrets[0]=myPullSecret wavefront .
```
```yaml
# Source: wavefront/templates/proxy-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app.kubernetes.io/name: wavefront
    helm.sh/chart: wavefront-0.1.2
    app.kubernetes.io/instance: wavefront
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: proxy
  name: wavefront-proxy
spec:
  strategy:
    type: RollingUpdate
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: wavefront
      app.kubernetes.io/instance: wavefront
      app.kubernetes.io/component: proxy
  template:
    metadata:
      labels:
        app.kubernetes.io/name: wavefront
        helm.sh/chart: wavefront-0.1.2
        app.kubernetes.io/instance: wavefront
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/component: proxy
    spec:
      imagePullSecrets:
        - name: myPullSecret
```