### PR TITLE
[bitnami/apache] Add extra volume support

### DIFF
--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: apache
-version: 7.4.0
+version: 7.5.0
 appVersion: 2.4.46
 description: Chart for Apache HTTP Server
 keywords:

--- a/bitnami/apache/README.md
+++ b/bitnami/apache/README.md
@@ -114,6 +114,8 @@ The following tables lists the configurable parameters of the Apache chart and t
 | `service.nodePorts.https`        | Kubernetes https node port                                                                  | `""`                                                         |
 | `service.externalTrafficPolicy`  | Enable client source IP preservation                                                        | `Cluster`                                                    |
 | `service.loadBalancerIP`         | LoadBalancer service IP address                                                             | `""`                                                         |
+| `extraVolumes`                   | Array to add extra volumes                                                                  | `[]` (evaluated as a template)                               |
+| `extraVolumeMounts`              | Array to add extra mount                                                                    | `[]` (evaluated as a template)                               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/apache/templates/_helpers.tpl
+++ b/bitnami/apache/templates/_helpers.tpl
@@ -192,6 +192,17 @@ apache: htdocs-git-branch
 {{- end -}}
 
 {{/*
+Validate values of Apache - Incorrect extra volume settings
+*/}}
+{{- define "apache.validateValues.extraVolumes" -}}
+{{- if and (.Values.extraVolumes) (not .Values.extraVolumeMounts) -}}
+apache: missing-extra-volume-mounts
+    You specified extra volumes but not mount points for them. Please set
+    the extraVolumeMounts value
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the proper git image name
 */}}
 {{- define "git.image" -}}
@@ -248,3 +259,5 @@ Usage:
         {{- tpl (.value | toYaml) .context }}
     {{- end }}
 {{- end -}}
+
+

--- a/bitnami/apache/templates/deployment.yaml
+++ b/bitnami/apache/templates/deployment.yaml
@@ -122,6 +122,9 @@ spec:
               mountPath: /opt/bitnami/apache/conf/httpd.conf
               subPath: httpd.conf
             {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" ( dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
           image: {{ template "apache.metrics.image" . }}
@@ -161,3 +164,7 @@ spec:
           configMap:
             name: {{ include "apache.httpdConfConfigMap" . }}
         {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}
+

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -264,6 +264,14 @@ metrics:
     #   cpu: 100m
     #   memory: 128Mi
 
+## Array to add extra volumes (evaluated as a template)
+##
+extraVolumes: []
+
+## Array to add extra mounts (normally used with extraVolumes, evaluated as a template)
+##
+extraVolumeMounts: []
+
 ## Service paramaters
 ##
 service:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Add support for mounting volumes into the bitnami/apache chart.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
Allows apache to have local access to additional data. My case is a very simple web server with access to a very large datastore that is exposed as a posix file system with a PVC. This feature exists in the nginx chart, but apache has better built in directory listing formatting without additional modules and customizing docker images.

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
None

<!-- Describe any known limitations with your change -->

**Additional information**
Mostly copied the feature from the bitnami/nginx chart. Tested helm template,lint,install on my cluster and it worked.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
