### PR TITLE
[bitnami/kafka] Add docs clarity on interaction of config, existingConfigmap and environment variables

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka
-version: 11.8.6
+version: 11.8.7
 appVersion: 2.6.0
 description: Apache Kafka is a distributed streaming platform.
 keywords:

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -77,8 +77,8 @@ The following tables lists the configurable parameters of the Kafka chart and th
 | `image.pullPolicy`                                | Kafka image pull policy                                                                                                           | `IfNotPresent`                                          |
 | `image.pullSecrets`                               | Specify docker-registry secret names as an array                                                                                  | `[]` (does not add image pull secrets to deployed pods) |
 | `image.debug`                                     | Set to true if you would like to see extra information on logs                                                                    | `false`                                                 |
-| `config`                                          | Configuration file for Kafka. Auto-generated based on other parameters when not specified                                         | `nil`                                                   |
-| `existingConfigmap`                               | Name of existing ConfigMap with Kafka configuration                                                                               | `nil`                                                   |
+| `config`                                          | Configuration file for Kafka. Auto-generated based on other parameters when not specified (see [below](#setting-custom-parameters)) | `nil`                                                   |
+| `existingConfigmap`                               | Name of existing ConfigMap with Kafka configuration (see [below](#setting-custom-parameters))                                     | `nil`                                                   |
 | `log4j`                                           | An optional log4j.properties file to overwrite the default of the Kafka brokers.                                                  | `nil`                                                   |
 | `existingLog4jConfigMap`                          | The name of an existing ConfigMap containing a log4j.properties file.                                                             | `nil`                                                   |
 | `heapOpts`                                        | Kafka's Java Heap size                                                                                                            | `-Xmx1024m -Xms1024m`                                   |
@@ -104,7 +104,7 @@ The following tables lists the configurable parameters of the Kafka chart and th
 | `socketRequestMaxBytes`                           | The maximum size of a request that the socket server will accept (protection against OOM)                                         | `_104857600`                                            |
 | `socketSendBufferBytes`                           | The send buffer (SO_SNDBUF) used by the socket server                                                                             | `102400`                                                |
 | `zookeeperConnectionTimeoutMs`                    | Timeout in ms for connecting to Zookeeper                                                                                         | `6000`                                                  |
-| `extraEnvVars`                                    | Extra environment variables to add to kafka pods                                                                                  | `[]`                                                    |
+| `extraEnvVars`                                    | Extra environment variables to add to kafka pods (see [below](#setting-custom-parameters))                                        | `[]`                                                    |
 | `extraVolumes`                                    | Extra volume(s) to add to Kafka statefulset                                                                                       | `[]`                                                    |
 | `extraVolumeMounts`                               | Extra volumeMount(s) to add to Kafka containers                                                                                   | `[]`                                                    |
 | `auth.clientProtocol`                             | Authentication protocol for communications with clients. Allowed protocols: `plaintext`, `tls`, `mtls`, `sasl` and `sasl_tls`     | `plaintext`                                             |
@@ -400,6 +400,9 @@ To horizontally scale this chart once it has been deployed, you can upgrade the 
 ### Setting custom parameters
 
 Any environment variable beginning with `KAFKA_CFG_` will be mapped to its corresponding Kafka key. For example, use `KAFKA_CFG_BACKGROUND_THREADS` in order to set `background.threads`. In order to pass custom environment variables use the `extraEnvVars` property.
+
+Using `extraEnvVars` with `KAFKA_CFG_` is the preferred and simplest way to add custom Kafka parameters not otherwise specified in this chart. Alternatively, you can provide a *full* Kafka configuration using `config` or `existingConfigmap`.
+Setting either `config` or `existingConfigmap` will cause the chart to disregard `KAFKA_CFG_` settings, which are used by many other Kafka-related chart values described above, as well as dynamically generated parameters such as `zookeeper.connect`. This can cause unexpected behavior.
 
 ### Listeners configuration
 

--- a/bitnami/kafka/values-production.yaml
+++ b/bitnami/kafka/values-production.yaml
@@ -54,6 +54,7 @@ commonAnnotations: {}
 
 ## Kafka Configuration
 ## Specify content for server.properties
+## NOTE: This will override any KAFKA_CFG_ environment variables (including those set by the chart)
 ## The server.properties is auto-generated based on other parameters when this paremeter is not specified
 ##
 ## Example:
@@ -85,7 +86,7 @@ commonAnnotations: {}
 # config:
 
 ## ConfigMap with Kafka Configuration
-## NOTE: This will override config
+## NOTE: This will override config AND any KAFKA_CFG_ environment variables.
 ##
 # existingConfigmap:
 

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -54,6 +54,7 @@ commonAnnotations: {}
 
 ## Kafka Configuration
 ## Specify content for server.properties
+## NOTE: This will override any KAFKA_CFG_ environment variables (including those set by the chart)
 ## The server.properties is auto-generated based on other parameters when this paremeter is not specified
 ##
 ## Example:
@@ -85,7 +86,7 @@ commonAnnotations: {}
 # config:
 
 ## ConfigMap with Kafka Configuration
-## NOTE: This will override config
+## NOTE: This will override config AND any KAFKA_CFG_ environment variables.
 ##
 # existingConfigmap:
 


### PR DESCRIPTION
**Description of the change**

Update the README and in-line comments to provide more clarity about how setting `config` and `existingConfigmap` interacts with other values and Kafka config, and encouraging users to use `extraEnvVars` with `KAFKA_CFG_` to set custom Kafka config not otherwise available in the chart.

**Benefits**

Users of the chart are more likely to use the preferred path to configure their Kafka cluster, and less likely to have confusion about the impacts of setting `config` or `existingConfigmap`.

**Possible drawbacks**

Slightly longer docs.

**Applicable issues**

  - fixes #3958

**Additional information**

See issue for example of simple repro with chart exhibiting unexpected behavior that would be much more avoidable with this documentation change.

**Checklist**
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
