### PR TITLE
[redis] add helm3-migration-compatibility flag

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 11.1.0
+version: 11.1.1
 appVersion: 6.0.8
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -284,6 +284,7 @@ The following table lists the configurable parameters of the Redis chart and the
 | `sysctlImage.mountHostSys`                    | Mount the host `/sys` folder to `/host-sys`                                                                                                         | `false`                                                 |
 | `sysctlImage.resources`                       | sysctlImage Init container CPU/Memory resource requests/limits                                                                                      | {}                                                      |
 | `podSecurityPolicy.create`                    | Specifies whether a PodSecurityPolicy should be created                                                                                             | `false`                                                 |
+| `helm3-migration-compatibility`               | Sets the "heritage" label on the StatefulSet's VolumeClaimTemplate to "Tiller", as this field is immutable and must be preserved in a helm2-to-helm3 upgrade. | `false`                                       |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/redis/templates/redis-master-statefulset.yaml
+++ b/bitnami/redis/templates/redis-master-statefulset.yaml
@@ -317,7 +317,7 @@ spec:
         labels:
           app: {{ template "redis.name" . }}
           release: {{ .Release.Name }}
-          heritage: {{ .Release.Service }}
+          heritage: {{ if index .Values "helm3-migration-compatibility" -}} Tiller {{- else }}{{ .Release.Service }}{{ end }}
           component: master
       spec:
         accessModes:

--- a/bitnami/redis/templates/redis-node-statefulset.yaml
+++ b/bitnami/redis/templates/redis-node-statefulset.yaml
@@ -421,7 +421,7 @@ spec:
         labels:
           app: {{ template "redis.name" . }}
           release: {{ .Release.Name }}
-          heritage: {{ .Release.Service }}
+          heritage: {{ if index .Values "helm3-migration-compatibility" -}} Tiller {{- else }}{{ .Release.Service }}{{ end }}
           component: slave
       spec:
         accessModes:

--- a/bitnami/redis/templates/redis-slave-statefulset.yaml
+++ b/bitnami/redis/templates/redis-slave-statefulset.yaml
@@ -326,7 +326,7 @@ spec:
         labels:
           app: {{ template "redis.name" . }}
           release: {{ .Release.Name }}
-          heritage: {{ .Release.Service }}
+          heritage: {{ if index .Values "helm3-migration-compatibility" -}} Tiller {{- else }}{{ .Release.Service }}{{ end }}
           component: slave
       spec:
         accessModes:

--- a/bitnami/redis/values-production.yaml
+++ b/bitnami/redis/values-production.yaml
@@ -800,3 +800,8 @@ podDisruptionBudget:
   enabled: false
   minAvailable: 1
   # maxUnavailable: 1
+
+# Sets the "heritage" label on the StatefulSet's VolumeClaimTemplate to
+# "Tiller", as this field is immutable and must be preserved in a
+# helm2-to-helm3 upgrade.
+helm3-migration-compatibility: false

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -800,3 +800,8 @@ podDisruptionBudget:
   enabled: false
   minAvailable: 1
   # maxUnavailable: 1
+
+# Sets the "heritage" label on the StatefulSet's VolumeClaimTemplate to
+# "Tiller", as this field is immutable and must be preserved in a
+# helm2-to-helm3 upgrade.
+helm3-migration-compatibility: false


### PR DESCRIPTION
Signed-off-by: Alice Sawatzky <alice.sawatzky@farmersedge.ca>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This adds a `helm3-migration-compatibility` flag that hard-codes the StatefulSets' VolumeClaimTemplate `heritage` label value to "Tiller", to prevent issues with helm3 trying to modify an immutable field when upgrading a release that was created under helm2.

**Benefits**

- Upgrade path for helm2 releases

**Possible drawbacks**

- It's conceptually ugly

**Applicable issues**

- The underlying issue is documented in https://github.com/helm/helm/issues/7211

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files