### PR TITLE
[bitnami/mariadb] #3975 fix missing key mariadb-replication-password

### DIFF
--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mariadb
-version: 8.0.3
+version: 8.0.4
 appVersion: 10.5.6
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/bitnami/mariadb/templates/primary/statefulset.yaml
+++ b/bitnami/mariadb/templates/primary/statefulset.yaml
@@ -288,8 +288,10 @@ spec:
                 path: mariadb-root-password
               - key: mariadb-password
                 path: mariadb-password
+              {{- if eq .Values.architecture "replication" }}
               - key: mariadb-replication-password
                 path: mariadb-replication-password
+              {{- end }}
         {{- end }}
         {{- if .Values.primary.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.primary.extraVolumes "context" $) | nindent 8 }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Conditionally use key mariadb-replication-password in primary statefulset.

**Benefits**

MariaDB container starts.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

  - fixes ##3975

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
