### PR TITLE
[bitnami/cassandra] align existingSecret attribute to documentation

### DIFF
--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cassandra
-version: 6.0.1
+version: 6.0.2
 appVersion: 3.11.8
 description: Apache Cassandra is a free and open-source distributed database management system designed to handle large amounts of data across many commodity servers, providing high availability with no single point of failure. Cassandra offers robust support for clusters spanning multiple datacenters, with asynchronous masterless replication allowing low latency operations for all clients.
 keywords:

--- a/bitnami/cassandra/templates/NOTES.txt
+++ b/bitnami/cassandra/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{- $cassandraPasswordKey := ( include "common.secrets.key" (dict "existingSecret" .Values.dbUser.existingSecret "key" "cassandra-password") ) -}}
-{{- $cassandraSecretName := (include "common.names.fullname" .) -}}
+{{- $cassandraSecretName := ( include "common.secrets.name" (dict "existingSecret" .Values.dbUser.existingSecret "context" $) ) -}}
 
 ** Please be patient while the chart is being deployed **
 

--- a/bitnami/cassandra/templates/statefulset.yaml
+++ b/bitnami/cassandra/templates/statefulset.yaml
@@ -122,7 +122,7 @@ spec:
             - name: CASSANDRA_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.dbUser.existingSecret }}{{ .Values.dbUser.existingSecret }}{{- else }}{{ include "common.names.fullname" . }}{{- end }}
+                  name: {{ include "common.secrets.name" (dict "existingSecret" .Values.dbUser.existingSecret "context" $) }}
                   key: {{ include "common.secrets.key" (dict "existingSecret" .Values.dbUser.existingSecret "key" "cassandra-password") }}
             - name: POD_IP
               valueFrom:

--- a/bitnami/cassandra/templates/statefulset.yaml
+++ b/bitnami/cassandra/templates/statefulset.yaml
@@ -123,7 +123,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ if .Values.dbUser.existingSecret }}{{ .Values.dbUser.existingSecret }}{{- else }}{{ include "common.names.fullname" . }}{{- end }}
-                  key: cassandra-password
+                  key: {{ include "common.secrets.key" (dict "existingSecret" .Values.dbUser.existingSecret "key" "cassandra-password") }}
             - name: POD_IP
               valueFrom:
                 fieldRef:

--- a/bitnami/cassandra/values-production.yaml
+++ b/bitnami/cassandra/values-production.yaml
@@ -193,7 +193,19 @@ dbUser:
   user: cassandra
   forcePassword: true
   # password:
+
+  ## Use an existing secrets which already stores your password data.
+  ## for backwards compatibility, existingSecret can be a simple string,
+  ## referencing the secret by name.
   # existingSecret:
+  #   ## Name of the existing secret
+  #   ##
+  #   name: mySecret
+  #   ## Key mapping where <key> is the value which the deployment is expecting and
+  #   ## <value> is the name of the key in the existing secret.
+  #   ##
+  #   keyMapping:
+  #     cassandra-password: myCassandraPasswordKey
 
 ## ConfigMap with cql scripts. Useful for creating a keyspace
 ## and pre-populating data

--- a/bitnami/cassandra/values.yaml
+++ b/bitnami/cassandra/values.yaml
@@ -194,6 +194,9 @@ dbUser:
   forcePassword: false
   # password:
   # existingSecret:
+  #  name: mySecret
+  #  keyMapping:
+  #    cassandra-password: myKey
 
 ## ConfigMap with cql scripts. Useful for creating a keyspace
 ## and pre-populating data

--- a/bitnami/cassandra/values.yaml
+++ b/bitnami/cassandra/values.yaml
@@ -193,10 +193,19 @@ dbUser:
   user: cassandra
   forcePassword: false
   # password:
+
+  ## Use an existing secrets which already stores your password data.
+  ## for backwards compatibility, existingSecret can be a simple string,
+  ## referencing the secret by name.
   # existingSecret:
-  #  name: mySecret
-  #  keyMapping:
-  #    cassandra-password: myKey
+  #   ## Name of the existing secret
+  #   ##
+  #   name: mySecret
+  #   ## Key mapping where <key> is the value which the deployment is expecting and
+  #   ## <value> is the name of the key in the existing secret.
+  #   ##
+  #   keyMapping:
+  #     cassandra-password: myCassandraPasswordKey
 
 ## ConfigMap with cql scripts. Useful for creating a keyspace
 ## and pre-populating data


### PR DESCRIPTION
**Description of the change**

The current layout of existingSecret does not match https://github.com/bitnami/charts/tree/master/bitnami/common#existingsecret, so either the instruction in NOTES.txt or in statefulset.yaml will fail, as they both expect a different layout.

To reproduce the current error:
- Set any `existingSecret` value as simple string
- apply the helm chart
- get error

example error
```
[...] "cassandra/templates/NOTES.txt" at <include "common.secrets.key" (dict "existingSecret" .Values.dbUser.existingSecret "key" "cassandra-password")>: error calling include: template: cassandra/charts/common/templates/_secrets.tpl:43:24: executing "common.secrets.key" at <.existingSecret.keyMapping>: can't evaluate field keyMapping in type interface {}
```

**Benefits**

As an accidental benefit, the user is now able to configure the key inside the secret used for storing the existing Secret, so it no longer has to be 'cassandra-password'

**Possible drawbacks**

It is no longer sufficient to specify a simple String for `existingSecret`, the user now has to adhere to the format laid out in https://github.com/bitnami/charts/tree/master/bitnami/common#existingsecret .

This will break compatibility. On the other hand, this functionality is **broken right now anyways**, so I don't think a major version bump is justified, but I want to leave that decision up to you, the maintainer.

**Applicable issues**

  - fixes #3979

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml`
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] linter is happy

I am currently stuck with getting the linter to pass, since the original 'existingSecret' key, 'cassandra-password' contains a dash.
