### PR TITLE
[bitnami/postgresql-ha] Fix secrets-mounted path

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql-ha
-version: 4.0.0
+version: 4.0.1
 appVersion: 11.9.1
 description: Chart for PostgreSQL with HA architecture (using Replication Manager (repmgr) and Pgpool).
 keywords:

--- a/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
@@ -176,7 +176,7 @@ spec:
               value: {{ (include "postgresql-ha.postgresqlRepmgrUsername" .) | quote }}
             {{- if .Values.postgresql.usePasswordFile }}
             - name: REPMGR_PASSWORD_FILE
-              value: "/opt/bitnami/repmgr/secrets/repmgr-password"
+              value: "/opt/bitnami/postgresql/secrets/repmgr-password"
             {{- else }}
             - name: REPMGR_PASSWORD
               valueFrom:


### PR DESCRIPTION
…for environment variable `REPMGR_PASSWORD_FILE` - fixes #3981

**Description of the change**

Fix file path of the repmgr password file.

**Benefits**

Container is finally starting up when providing passwords via secret.

**Possible drawbacks**

None.

**Applicable issues**

  - fixes #3981

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
