### PR TITLE
[bitnami/postgresql-ha] Fix script errors in pre-stop.sh

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql-ha
-version: 4.0.0
+version: 4.0.2
 appVersion: 11.9.1
 description: Chart for PostgreSQL with HA architecture (using Replication Manager (repmgr) and Pgpool).
 keywords:

--- a/bitnami/postgresql-ha/templates/postgresql/hooks-scripts-configmap.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/hooks-scripts-configmap.yaml
@@ -53,8 +53,7 @@ data:
     fi
 
     # Load PostgreSQL & repmgr environment variables
-    eval "$(repmgr_env)"
-    eval "$(postgresql_env)"
+    . /opt/bitnami/scripts/postgresql-env.sh
 
     postgresql_enable_nss_wrapper
 


### PR DESCRIPTION
**Description of the change**

Fix script errors in provided `pre-stop.sh` script.

**Benefits**

Working default lifecycle hooks.

**Possible drawbacks**

Using images older than the following will fail to stop the primary gracefully:
* [9.6.18-debian-10-r37](https://github.com/bitnami/bitnami-docker-postgresql-repmgr/commit/7723f5365ff00edea5f518738f325c0418c827fc)
* [10.13.0-debian-10-r36](https://github.com/bitnami/bitnami-docker-postgresql-repmgr/commit/f4212aa29811d96b18c9739e4e526e0776395d9c)
* [11.8.0-debian-10-r37](https://github.com/bitnami/bitnami-docker-postgresql-repmgr/commit/571d0fec9eba5f7df5fb7031afb89733a3574013)
* [12.3.0-debian-10-r36](https://github.com/bitnami/bitnami-docker-postgresql-repmgr/commit/429b997b5799cce8cf610513ff3899d8793f2034)

**Applicable issues**

  - fixes #3983 

**Additional information**

Created after PR #3982 (version bump).

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
