### PR TITLE
[bitnami/thanos] Enable thanos TLS client in a modular way #3988

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 2.4.5
+version: 2.4.6
 appVersion: 0.15.0
 description: Thanos is a highly available metrics system that can be added on top of existing Prometheus deployments, providing a global query view across all Prometheus installations.
 engine: gotpl

--- a/bitnami/thanos/templates/querier/deployment.yaml
+++ b/bitnami/thanos/templates/querier/deployment.yaml
@@ -86,9 +86,15 @@ spec:
             {{- end }}
             {{- if .Values.querier.grpcTLS.client.secure }}
             - --grpc-client-tls-secure
+            {{- if .Values.querier.grpcTLS.client.cert }}
             - --grpc-client-tls-cert=/tls/client/cert.pem
+            {{- end }}
+            {{- if .Values.querier.grpcTLS.client.key }}
             - --grpc-client-tls-key=/tls/client/key.pem
+            {{- end }}
+            {{- if .Values.querier.grpcTLS.client.ca }}
             - --grpc-client-tls-ca=/tls/client/ca.pem
+            {{- end }}
             {{- if .Values.querier.grpcTLS.client.servername }}
             - --grpc-client-server-name={{.Values.querier.grpcTLS.client.servername}}
             {{- end }}

--- a/bitnami/thanos/templates/querier/tls-client-secret.yaml
+++ b/bitnami/thanos/templates/querier/tls-client-secret.yaml
@@ -7,7 +7,13 @@ metadata:
     app.kubernetes.io/component: querier
 type: Opaque
 data:
+{{- if .Values.querier.grpcTLS.client.cert }}
   cert.pem: {{ .Values.querier.grpcTLS.client.cert | b64enc | quote }}
+{{- end }}
+{{- if .Values.querier.grpcTLS.client.key }}
   key.pem: {{ .Values.querier.grpcTLS.client.key | b64enc | quote }}
+{{- end }}
+{{- if .Values.querier.grpcTLS.client.ca }}
   ca.pem : {{ .Values.querier.grpcTLS.client.ca | b64enc | quote }}
+{{- end }}
 {{ end }}


### PR DESCRIPTION
**Description of the change**

This change enables the users to specify only the CA when choosing TLS secure client, in order to enable the communication across multiple ingresses that use the same CA, as Thanos Query only supports a global TLS configuration for its stores.

While previously it was required for the user to specify the client TLS CA, Cert and Key with this change it is possible to only pass CA if the user decides to do so.

**Benefits**

As explained on #3988 this would enable the usage of multiple ingresses as target stores if they are all under the same CA.

**Possible drawbacks**

It does not break compatibility as the user is still able to specify all CA, Cert and Key for its TLS client. This only makes it so it is modular enough for the user to only pass the information needed to its use-case.

**Applicable issues**

  - fixes #3988 

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

cc/ @carrodher, @juan131  