### PR TITLE
[bitnami/phpbb] fix: version mismatch between mariadb and common

### DIFF
--- a/bitnami/phpbb/Chart.yaml
+++ b/bitnami/phpbb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: phpbb
-version: 8.0.0
+version: 8.0.1
 appVersion: 3.3.1
 description: Community forum that supports the notion of users and groups, file attachments, full-text search, notifications and more.
 keywords:

--- a/bitnami/phpbb/ci/ct-values.yaml
+++ b/bitnami/phpbb/ci/ct-values.yaml
@@ -1,2 +1,6 @@
 service:
   type: ClusterIP
+
+containerPorts:
+  http: 8080
+  https: 8443

--- a/bitnami/phpbb/ci/ct-values.yaml
+++ b/bitnami/phpbb/ci/ct-values.yaml
@@ -1,6 +1,2 @@
 service:
   type: ClusterIP
-
-containerPorts:
-  http: 8080
-  https: 8443

--- a/bitnami/phpbb/requirements.lock
+++ b/bitnami/phpbb/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 7.10.3
+  version: 7.10.4
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 0.7.1
-digest: sha256:977b92abaea3671f29fce3b20475eb2670326e3f1c2313875a98f55a7cd306be
-generated: "2020-10-01T11:07:39.611637+02:00"
+digest: sha256:5f22fe7cbd6975ac37e970b3d200a18ed6f1eafe5ab80ca22d2aba0eb4472e80
+generated: "2020-10-13T15:21:57.913161567Z"

--- a/bitnami/phpbb/requirements.yaml
+++ b/bitnami/phpbb/requirements.yaml
@@ -4,5 +4,5 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: mariadb.enabled
   - name: common
-    version: 0.x.x
+    version: 0.7.x
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
Signed-off-by: darteaga <darteaga@vmware.com>

**Description of the change**

Change the version for common dependency.

**Benefits**

We fix a version mismatch issue.

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
