### PR TITLE
[bitnami/postgresql-ha] Adds parallel deployment to postgresql statefulset

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql-ha
-version: 4.0.2
+version: 5.0.0
 appVersion: 11.9.1
 description: Chart for PostgreSQL with HA architecture (using Replication Manager (repmgr) and Pgpool).
 keywords:

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -483,6 +483,13 @@ $ helm upgrade my-release bitnami/postgresql-ha \
 
 > Note: you need to substitute the placeholders _[POSTGRESQL_PASSWORD]_, and _[REPMGR_PASSWORD]_ with the values obtained from instructions in the installation notes.
 
+## 5.0.0
+This release uses parallel deployment for the postgresql statefullset. This should fix the issues related to not being able to restart the cluster under some contions where the master node is not longer node `-0`.
+This version is next major version to v3.x.y
+
+## 4.0.x
+Due to an error handling the version numbers these versions are actually part of the 3.x versions and not a new major version.
+
 ## 3.0.0
 
 A new major version of repmgr (5.1.0) was included. To upgrade to this major version, it's necessary to upgrade the repmgr extension installed on the database. To do so, follow the steps below:

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -483,9 +483,31 @@ $ helm upgrade my-release bitnami/postgresql-ha \
 
 > Note: you need to substitute the placeholders _[POSTGRESQL_PASSWORD]_, and _[REPMGR_PASSWORD]_ with the values obtained from instructions in the installation notes.
 
+> Note: As general rule, it is always wise to do a backup before the upgrading procedures.
+
 ## 5.0.0
 This release uses parallel deployment for the postgresql statefullset. This should fix the issues related to not being able to restart the cluster under some contions where the master node is not longer node `-0`.
 This version is next major version to v3.x.y
+
+- To upgrade to this version you will need to delete the deployment, keep the PVCs and launch a new deployment keeping the deployment name.
+
+```bash
+$ # e.g. Previous deployment v3.9.1
+$ helm install my-release \
+    --set postgresql.password=[POSTGRESQL_PASSWORD] \
+    --set postgresql.repmgrPassword=[REPMGR_PASSWORD] \
+    bitnami/postgresql-ha --version 3.9.1
+
+$ # Update repository information
+$ helm repo update
+
+$ # upgrade to v5.0.0
+$ helm delete my-release
+$ helm install my-release \
+    --set postgresql.password=[POSTGRESQL_PASSWORD] \
+    --set postgresql.repmgrPassword=[REPMGR_PASSWORD] \
+    bitnami/postgresql-ha --version 5.0.0
+```
 
 ## 4.0.x
 Due to an error handling the version numbers these versions are actually part of the 3.x versions and not a new major version.

--- a/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
@@ -21,6 +21,7 @@ spec:
     {{- if (eq "Recreate" .Values.postgresql.updateStrategyType) }}
     rollingUpdate: null
     {{- end }}
+  podManagementPolicy: Parallel
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: postgresql


### PR DESCRIPTION
**Description of the change**

Adding the Pod Management Policy to Parallel we are able to recover the cluster when the primary is not the node 0

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

-  fixes #3603

**Additional information**
Add reverted change in https://github.com/bitnami/charts/pull/3681

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
