### PR TITLE
[bitnami/common] Allow backward compatibility for existingSecret

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -2,8 +2,8 @@ annotations:
   category: Infrastructure
 apiVersion: v1
 # Please make sure that version and appVersion are always the same.
-version: 0.8.1
-appVersion: 0.8.1
+version: 0.8.2
+appVersion: 0.8.2
 description: A Library Helm Chart for grouping common logic between bitnami charts.
   This chart is not deployable by itself.
 home: https://github.com/bitnami/charts/tree/master/bitnami/common

--- a/bitnami/common/templates/_secrets.tpl
+++ b/bitnami/common/templates/_secrets.tpl
@@ -6,8 +6,9 @@ Usage:
 {{ include "common.secrets.name" (dict "existingSecret" .Values.path.to.the.existingSecret "defaultNameSuffix" "mySuffix" "context" $) }}
 
 Params:
-  - existingSecret - ExistingSecret - Optional. The path to the existing secrets in the values.yaml given by the user
-    to be used istead of the default one. +info: https://github.com/bitnami/charts/tree/master/bitnami/common#existingsecret
+  - existingSecret - ExistingSecret/String - Optional. The path to the existing secrets in the values.yaml given by the user
+    to be used instead of the default one. Allows for it to be of type String (just the secret name) for backwards compatibility.
+    +info: https://github.com/bitnami/charts/tree/master/bitnami/common#existingsecret
   - defaultNameSuffix - String - Optional. It is used only if we have several secrets in the same deployment.
   - context - Dict - Required. The context for the template evaluation.
 */}}
@@ -36,8 +37,9 @@ Usage:
 {{ include "common.secrets.key" (dict "existingSecret" .Values.path.to.the.existingSecret "key" "keyName") }}
 
 Params:
-  - existingSecret - ExistingSecret - Optional. The path to the existing secrets in the values.yaml given by the user
-    to be used istead of the default one. +info: https://github.com/bitnami/charts/tree/master/bitnami/common#existingsecret
+  - existingSecret - ExistingSecret/String - Optional. The path to the existing secrets in the values.yaml given by the user
+    to be used instead of the default one. Allows for it to be of type String (just the secret name) for backwards compatibility.
+    +info: https://github.com/bitnami/charts/tree/master/bitnami/common#existingsecret
   - key - String - Required. Name of the key in the secret.
 */}}
 {{- define "common.secrets.key" -}}

--- a/bitnami/common/templates/_secrets.tpl
+++ b/bitnami/common/templates/_secrets.tpl
@@ -19,7 +19,11 @@ Params:
 {{- end -}}
 
 {{- with .existingSecret -}}
+{{- if not (typeIs "string" .) -}}
 {{- $name = .name -}}
+{{- else -}}
+{{- $name = . -}}
+{{- end -}}
 {{- end -}}
 
 {{- printf "%s" $name -}}
@@ -40,9 +44,11 @@ Params:
 {{- $key := .key -}}
 
 {{- if .existingSecret -}}
-  {{- if .existingSecret.keyMapping -}}
-    {{- $key = index .existingSecret.keyMapping $.key -}}
-  {{- end -}}
+  {{- if not (typeIs "string" .existingSecret) -}}
+    {{- if .existingSecret.keyMapping -}}
+      {{- $key = index .existingSecret.keyMapping $.key -}}
+    {{- end -}}
+  {{- end }}
 {{- end -}}
 
 {{- printf "%s" $key -}}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

As described in #3979, there is an error with `existingSecrets` using the previous implementation (only providing the secret name). It has been decided to allow backward compatibility in `common` to avoid having to release a new major of said chart.

**Benefits**

It would allow the use of `common.secrets.name` and `common.secrets.key` with the previous implementation of `existingSecret`.

**Possible drawbacks**

None

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
