### PR TITLE
[bitnami/nginx-ingress-controller] fix: annotation parssing errors

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx-ingress-controller
-version: 5.6.12
+version: 5.6.13
 appVersion: 0.40.2
 description: Chart for the nginx Ingress controller
 keywords:

--- a/bitnami/nginx-ingress-controller/templates/_helpers.tpl
+++ b/bitnami/nginx-ingress-controller/templates/_helpers.tpl
@@ -202,3 +202,14 @@ Usage:
         {{- tpl (.value | toYaml) .context }}
     {{- end }}
 {{- end -}}
+
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "nginx-ingress.annotations" ( dict "annotations" .Values.path.to.the.annotations "context" $) }}
+*/}}
+{{- define "nginx-ingress.annotations" -}}
+{{- range $key, $value := .annotations }}
+{{ $key }}: {{ include "nginx-ingress.tplValue" (dict "value" $value "context" $.context) | quote }}
+{{- end }}
+{{- end -}}

--- a/bitnami/nginx-ingress-controller/templates/addheaders-configmap.yaml
+++ b/bitnami/nginx-ingress-controller/templates/addheaders-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  annotations: {{- include "nginx-ingress.annotations" (dict "annotations" .Values.commonAnnotations "context" $) | trim | nindent 4 }}
   {{- end }}
 data: {{- toYaml .Values.addHeaders | nindent 2 }}
 {{- end }}

--- a/bitnami/nginx-ingress-controller/templates/clusterrole.yaml
+++ b/bitnami/nginx-ingress-controller/templates/clusterrole.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  annotations: {{- include "nginx-ingress.annotations" (dict "annotations" .Values.commonAnnotations "context" $) | trim | nindent 4 }}
   {{- end }}
 rules:
   - apiGroups:

--- a/bitnami/nginx-ingress-controller/templates/clusterrolebinding.yaml
+++ b/bitnami/nginx-ingress-controller/templates/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  annotations: {{- include "nginx-ingress.annotations" (dict "annotations" .Values.commonAnnotations "context" $) | trim | nindent 4 }}
   {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bitnami/nginx-ingress-controller/templates/controller-configmap.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  annotations: {{- include "nginx-ingress.annotations" (dict "annotations" .Values.commonAnnotations "context" $) | trim | nindent 4 }}
   {{- end }}
 data:
   {{- if .Values.addHeaders }}

--- a/bitnami/nginx-ingress-controller/templates/controller-daemonset.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-daemonset.yaml
@@ -26,10 +26,7 @@ spec:
   template:
     metadata:
       {{- if .Values.podAnnotations }}
-      annotations:
-        {{- range $key, $value := .Values.podAnnotations }}
-        {{ $key }}: {{ include "nginx-ingress.tplValue" (dict "value" $value "context" $) | quote }}
-        {{- end }}
+      annotations: {{- include "nginx-ingress.annotations" (dict "annotations" .Values.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
       labels: {{- include "nginx-ingress.labels" . | nindent 8 }}
         component: {{ .Values.name }}

--- a/bitnami/nginx-ingress-controller/templates/controller-daemonset.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-daemonset.yaml
@@ -11,7 +11,10 @@ metadata:
     {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  annotations:
+    {{- range $key, $value := .Values.commonAnnotations }}
+    {{ $key }}: {{ include "nginx-ingress.tplValue" (dict "value" $value "context" $) | quote }}
+    {{- end }}
   {{- end }}
 spec:
   selector:
@@ -23,7 +26,10 @@ spec:
   template:
     metadata:
       {{- if .Values.podAnnotations }}
-      annotations: {{- include "nginx-ingress.tplValue" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+      annotations:
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ include "nginx-ingress.tplValue" (dict "value" $value "context" $) | quote }}
+        {{- end }}
       {{- end }}
       labels: {{- include "nginx-ingress.labels" . | nindent 8 }}
         component: {{ .Values.name }}

--- a/bitnami/nginx-ingress-controller/templates/controller-deployment.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-deployment.yaml
@@ -10,7 +10,10 @@ metadata:
     {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  annotations:
+    {{- range $key, $value := .Values.commonAnnotations }}
+    {{ $key }}: {{ include "nginx-ingress.tplValue" (dict "value" $value "context" $) | quote }}
+    {{- end }}
   {{- end }}
 spec:
   selector:
@@ -23,7 +26,10 @@ spec:
   template:
     metadata:
       {{- if .Values.podAnnotations }}
-      annotations: {{- include "nginx-ingress.tplValue" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+      annotations:
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ include "nginx-ingress.tplValue" (dict "value" $value "context" $) | quote }}
+        {{- end }}
       {{- end }}
       labels: {{- include "nginx-ingress.labels" . | nindent 8 }}
         component: {{ .Values.name }}

--- a/bitnami/nginx-ingress-controller/templates/controller-deployment.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-deployment.yaml
@@ -10,10 +10,7 @@ metadata:
     {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations:
-    {{- range $key, $value := .Values.commonAnnotations }}
-    {{ $key }}: {{ include "nginx-ingress.tplValue" (dict "value" $value "context" $) | quote }}
-    {{- end }}
+  annotations: {{- include "nginx-ingress.annotations" (dict "annotations" .Values.commonAnnotations "context" $) | trim | nindent 4 }}
   {{- end }}
 spec:
   selector:
@@ -26,10 +23,7 @@ spec:
   template:
     metadata:
       {{- if .Values.podAnnotations }}
-      annotations:
-        {{- range $key, $value := .Values.podAnnotations }}
-        {{ $key }}: {{ include "nginx-ingress.tplValue" (dict "value" $value "context" $) | quote }}
-        {{- end }}
+      annotations: {{- include "nginx-ingress.annotations" (dict "annotations" .Values.podAnnotations "context" $) | trim | nindent 8 }}
       {{- end }}
       labels: {{- include "nginx-ingress.labels" . | nindent 8 }}
         component: {{ .Values.name }}

--- a/bitnami/nginx-ingress-controller/templates/controller-hpa.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-hpa.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  annotations: {{- include "nginx-ingress.annotations" (dict "annotations" .Values.commonAnnotations "context" $) | trim | nindent 4 }}
   {{- end }}
 spec:
   scaleTargetRef:

--- a/bitnami/nginx-ingress-controller/templates/controller-metrics-service.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-metrics-service.yaml
@@ -15,10 +15,10 @@ metadata:
   {{- if or .Values.metrics.service.annotations .Values.commonAnnotations }}
   annotations:
     {{- if .Values.commonAnnotations }}
-    {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+    {{- include "nginx-ingress.annotations" (dict "annotations" .Values.commonAnnotations "context" $) | trim | nindent 4 }}
     {{- end }}
     {{- if .Values.metrics.service.annotations }}
-    {{- include "nginx-ingress.tplValue" (dict "value" .Values.metrics.service.annotations "context" $) | nindent 4 }}
+    {{- include "nginx-ingress.annotations" (dict "annotations" .Values.metrics.service.annotations "context" $) | trim | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:

--- a/bitnami/nginx-ingress-controller/templates/controller-poddisruptionbudget.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-poddisruptionbudget.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  annotations: {{- include "nginx-ingress.annotations" (dict "annotations" .Values.commonAnnotations "context" $) | trim | nindent 4 }}
   {{- end }}
 spec:
   selector:

--- a/bitnami/nginx-ingress-controller/templates/controller-prometheusrules.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-prometheusrules.yaml
@@ -17,7 +17,7 @@ metadata:
     {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  annotations: {{- include "nginx-ingress.annotations" (dict "annotations" .Values.commonAnnotations "context" $) | trim | nindent 4 }}
   {{- end }}
 spec:
   {{- with .Values.metrics.prometheusRule.rules }}

--- a/bitnami/nginx-ingress-controller/templates/controller-service.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-service.yaml
@@ -14,10 +14,10 @@ metadata:
   {{- if or .Values.service.annotations .Values.commonAnnotations }}
   annotations:
     {{- if .Values.commonAnnotations }}
-    {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+    {{- include "nginx-ingress.annotations" (dict "annotations" .Values.commonAnnotations "context" $) | trim | nindent 4 }}
     {{- end }}
     {{- if .Values.service.annotations }}
-    {{- include "nginx-ingress.tplValue" (dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+    {{- include "nginx-ingress.annotations" (dict "annotations" .Values.service.annotations "context" $) | trim | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:

--- a/bitnami/nginx-ingress-controller/templates/controller-servicemonitor.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-servicemonitor.yaml
@@ -17,7 +17,7 @@ metadata:
     {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  annotations: {{- include "nginx-ingress.annotations" (dict "annotations" .Values.commonAnnotations "context" $) | trim | nindent 4 }}
   {{- end }}
 spec:
   endpoints:

--- a/bitnami/nginx-ingress-controller/templates/default-backend-deployment.yaml
+++ b/bitnami/nginx-ingress-controller/templates/default-backend-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  annotations: {{- include "nginx-ingress.annotations" (dict "annotations" .Values.commonAnnotations "context" $) | trim | nindent 4 }}
   {{- end }}
 spec:
   selector:
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       {{- if .Values.defaultBackend.podAnnotations }}
-      annotations: {{- include "nginx-ingress.tplValue" (dict "value" .Values.defaultBackend.podAnnotations "context" $) | nindent 8 }}
+      annotations: {{- include "nginx-ingress.annotations" (dict "annotations" .Values.defaultBackend.podAnnotations "context" $) | trim | nindent 8 }}
       {{- end }}
       labels: {{- include "nginx-ingress.labels" . | nindent 8 }}
         component: {{ .Values.defaultBackend.name }}

--- a/bitnami/nginx-ingress-controller/templates/default-backend-poddisruptionbudget.yaml
+++ b/bitnami/nginx-ingress-controller/templates/default-backend-poddisruptionbudget.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  annotations: {{- include "nginx-ingress.annotations" (dict "annotations" .Values.commonAnnotations "context" $) | trim | nindent 4 }}
   {{- end }}
 spec:
   selector:

--- a/bitnami/nginx-ingress-controller/templates/default-backend-service.yaml
+++ b/bitnami/nginx-ingress-controller/templates/default-backend-service.yaml
@@ -12,10 +12,10 @@ metadata:
   {{- if or .Values.defaultBackend.service.annotations .Values.commonAnnotations }}
   annotations:
     {{- if .Values.commonAnnotations }}
-    {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+    {{- include "nginx-ingress.annotations" (dict "annotations" .Values.commonAnnotations "context" $) | trim | nindent 4 }}
     {{- end }}
     {{- if .Values.defaultBackend.service.annotations }}
-    {{- include "nginx-ingress.tplValue" (dict "value" .Values.defaultBackend.service.annotations "context" $) | nindent 4 }}
+    {{- include "nginx-ingress.annotations" (dict "annotations" .Values.defaultBackend.service.annotations "context" $) | trim | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:

--- a/bitnami/nginx-ingress-controller/templates/podsecuritypolicy.yaml
+++ b/bitnami/nginx-ingress-controller/templates/podsecuritypolicy.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  annotations: {{- include "nginx-ingress.annotations" (dict "annotations" .Values.commonAnnotations "context" $) | trim | nindent 4 }}
   {{- end }}
 spec:
   allowedCapabilities:

--- a/bitnami/nginx-ingress-controller/templates/proxyheaders-configmap.yaml
+++ b/bitnami/nginx-ingress-controller/templates/proxyheaders-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  annotations: {{- include "nginx-ingress.annotations" (dict "annotations" .Values.commonAnnotations "context" $) | trim | nindent 4 }}
   {{- end }}
 data:
 {{- if .Values.proxySetHeaders }}

--- a/bitnami/nginx-ingress-controller/templates/role.yaml
+++ b/bitnami/nginx-ingress-controller/templates/role.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  annotations: {{- include "nginx-ingress.annotations" (dict "annotations" .Values.commonAnnotations "context" $) | trim | nindent 4 }}
   {{- end }}
 rules:
   - apiGroups:

--- a/bitnami/nginx-ingress-controller/templates/rolebinding.yaml
+++ b/bitnami/nginx-ingress-controller/templates/rolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  annotations: {{- include "nginx-ingress.annotations" (dict "annotations" .Values.commonAnnotations "context" $) | trim | nindent 4 }}
   {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bitnami/nginx-ingress-controller/templates/serviceaccount.yaml
+++ b/bitnami/nginx-ingress-controller/templates/serviceaccount.yaml
@@ -11,10 +11,10 @@ metadata:
   {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
   annotations:
     {{- if .Values.commonAnnotations }}
-    {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+    {{- include "nginx-ingress.annotations" (dict "annotations" .Values.commonAnnotations "context" $) | trim | nindent 4 }}
     {{- end }}
     {{- if .Values.serviceAccount.annotations }}
-    {{- include "nginx-ingress.tplValue" (dict "value" .Values.serviceAccount.annotations "context" $) | nindent 4 }}
+    {{- include "nginx-ingress.annotations" (dict "annotations" .Values.serviceAccount.annotations "context" $) | trim | nindent 4 }}
     {{- end }}
   {{- end }}
 {{- end -}}

--- a/bitnami/nginx-ingress-controller/templates/tcp-configmap.yaml
+++ b/bitnami/nginx-ingress-controller/templates/tcp-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  annotations: {{- include "nginx-ingress.annotations" (dict "annotations" .Values.commonAnnotations "context" $) | trim | nindent 4 }}
   {{- end }}
 data: {{- include "nginx-ingress.tplValue" (dict "value" .Values.tcp "context" $) | nindent 2 }}
 {{- end }}

--- a/bitnami/nginx-ingress-controller/templates/udp-configmap.yaml
+++ b/bitnami/nginx-ingress-controller/templates/udp-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "nginx-ingress.tplValue" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  annotations: {{- include "nginx-ingress.annotations" (dict "annotations" .Values.commonAnnotations "context" $) | trim | nindent 4 }}
   {{- end }}
 data: {{- include "nginx-ingress.tplValue" (dict "value" .Values.udp "context" $) | nindent 2 }}
 {{- end }}

--- a/bitnami/nginx-ingress-controller/values-production.yaml
+++ b/bitnami/nginx-ingress-controller/values-production.yaml
@@ -73,7 +73,7 @@ dnsPolicy: ClusterFirst
 ## Required only if defaultBackend.enabled = false
 ## Must be <namespace>/<service_name>
 ##
-defaultBackendService: ""
+defaultBackendService: ''
 
 ## Election ID to use for status update
 ##
@@ -96,7 +96,7 @@ publishService:
   ## Allows overriding of the publish service to bind to
   ## Must be <namespace>/<service_name>
   ##
-  pathOverride: ""
+  pathOverride: ''
 
 ## Limit the scope of the controller
 ## Defaults to `.Release.Namespace`
@@ -107,21 +107,21 @@ scope:
 ## Allows customization of the configmap / nginx-configmap namespace
 ## Defaults to .Release.Namespace
 ##
-configMapNamespace: ""
+configMapNamespace: ''
 
 ## Allows customization of the tcp-services-configmap namespace
 ## Defaults to .Release.Namespace
 ##
-tcpConfigMapNamespace: ""
+tcpConfigMapNamespace: ''
 
 ## Allows customization of the udp-services-configmap namespace
 ## Defaults to .Release.Namespace
 ##
-udpConfigMapNamespace: ""
+udpConfigMapNamespace: ''
 
 ## License key used to download Geolite2 database
 ##
-maxmindLicenseKey: ""
+maxmindLicenseKey: ''
 
 ## Additional command line arguments to pass to nginx-ingress-controller
 ## E.g. to specify the default SSL certificate you can use
@@ -234,7 +234,7 @@ lifecycle: {}
 ## priorityClassName
 ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
 ##
-priorityClassName: ""
+priorityClassName: ''
 
 ## Rollback limit
 ##
@@ -305,12 +305,11 @@ extraVolumes: []
 ##     command: ['sh', '-c', 'install_packages dnsutils && until nslookup myservice; do echo waiting for myservice; sleep 2; done;']
 extraInitContainers: []
 
-
 ## Override NGINX template
 ##
 customTemplate:
-  configMapName: ""
-  configMapKey: ""
+  configMapName: ''
+  configMapKey: ''
 
 ## Service parameters
 ##
@@ -327,8 +326,8 @@ service:
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
   ##
   nodePorts:
-    http: ""
-    https: ""
+    http: ''
+    https: ''
     tcp: {}
     udp: {}
 
@@ -362,7 +361,7 @@ service:
   ## Set external traffic policy to: "Local" to preserve source IP on providers supporting it
   ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
   ##
-  externalTrafficPolicy: ""
+  externalTrafficPolicy: ''
   healthCheckNodePort: 0
 
 ## Default 404 backend
@@ -488,8 +487,8 @@ metrics:
     ## Annotations for the Prometheus exporter service
     ##
     annotations:
-      prometheus.io/scrape: "true"
-      prometheus.io/port: "{{ .Values.metrics.service.port }}"
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '{{ .Values.metrics.service.port }}'
 
   ## Prometheus Operator ServiceMonitor configuration
   ##
@@ -498,17 +497,14 @@ metrics:
     ## Namespace in which Prometheus is running
     ##
     # namespace: monitoring
-
     ## Interval at which metrics should be scraped.
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
     ##
     # interval: 10s
-
     ## Timeout after which the scrape is ended
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
     ##
     # scrapeTimeout: 10s
-
     ## ServiceMonitor selector labels
     ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
     ##
@@ -518,7 +514,7 @@ metrics:
   prometheusRule:
     enabled: false
     additionalLabels: {}
-    namespace: ""
+    namespace: ''
     rules: []
 
 ## Role Based Access
@@ -532,13 +528,15 @@ rbac:
 ## Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in.
 ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
 ##
+## topologySpreadConstraints:
+##   - maxSkew: 1
+##     topologyKey: failure-domain.beta.kubernetes.io/zone
+##     whenUnsatisfiable: DoNotSchedule
+##     labelSelector:
+##       matchLabels:
+##         app.kubernetes.io/instance: ingress-nginx-internal
+##
 topologySpreadConstraints: []
-  # - maxSkew: 1
-  #   topologyKey: failure-domain.beta.kubernetes.io/zone
-  #   whenUnsatisfiable: DoNotSchedule
-  #   labelSelector:
-  #     matchLabels:
-  #       app.kubernetes.io/instance: ingress-nginx-internal
 
 ## Pods Service Account
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/

--- a/bitnami/nginx-ingress-controller/values.yaml
+++ b/bitnami/nginx-ingress-controller/values.yaml
@@ -73,7 +73,7 @@ dnsPolicy: ClusterFirst
 ## Required only if defaultBackend.enabled = false
 ## Must be <namespace>/<service_name>
 ##
-defaultBackendService: ""
+defaultBackendService: ''
 
 ## Election ID to use for status update
 ##
@@ -96,7 +96,7 @@ publishService:
   ## Allows overriding of the publish service to bind to
   ## Must be <namespace>/<service_name>
   ##
-  pathOverride: ""
+  pathOverride: ''
 
 ## Limit the scope of the controller
 ## Defaults to `.Release.Namespace`
@@ -107,21 +107,21 @@ scope:
 ## Allows customization of the configmap / nginx-configmap namespace
 ## Defaults to .Release.Namespace
 ##
-configMapNamespace: ""
+configMapNamespace: ''
 
 ## Allows customization of the tcp-services-configmap namespace
 ## Defaults to .Release.Namespace
 ##
-tcpConfigMapNamespace: ""
+tcpConfigMapNamespace: ''
 
 ## Allows customization of the udp-services-configmap namespace
 ## Defaults to .Release.Namespace
 ##
-udpConfigMapNamespace: ""
+udpConfigMapNamespace: ''
 
 ## License key used to download Geolite2 database
 ##
-maxmindLicenseKey: ""
+maxmindLicenseKey: ''
 
 ## Additional command line arguments to pass to nginx-ingress-controller
 ## E.g. to specify the default SSL certificate you can use
@@ -234,7 +234,7 @@ lifecycle: {}
 ## priorityClassName
 ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
 ##
-priorityClassName: ""
+priorityClassName: ''
 
 ## Rollback limit
 ##
@@ -305,12 +305,11 @@ extraVolumes: []
 ##     command: ['sh', '-c', 'install_packages dnsutils && until nslookup myservice; do echo waiting for myservice; sleep 2; done;']
 extraInitContainers: []
 
-
 ## Override NGINX template
 ##
 customTemplate:
-  configMapName: ""
-  configMapKey: ""
+  configMapName: ''
+  configMapKey: ''
 
 ## Service parameters
 ##
@@ -327,8 +326,8 @@ service:
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
   ##
   nodePorts:
-    http: ""
-    https: ""
+    http: ''
+    https: ''
     tcp: {}
     udp: {}
 
@@ -362,7 +361,7 @@ service:
   ## Set external traffic policy to: "Local" to preserve source IP on providers supporting it
   ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
   ##
-  externalTrafficPolicy: ""
+  externalTrafficPolicy: ''
   healthCheckNodePort: 0
 
 ## Default 404 backend
@@ -488,8 +487,8 @@ metrics:
     ## Annotations for the Prometheus exporter service
     ##
     annotations:
-      prometheus.io/scrape: "true"
-      prometheus.io/port: "{{ .Values.metrics.service.port }}"
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '{{ .Values.metrics.service.port }}'
 
   ## Prometheus Operator ServiceMonitor configuration
   ##
@@ -498,17 +497,14 @@ metrics:
     ## Namespace in which Prometheus is running
     ##
     # namespace: monitoring
-
     ## Interval at which metrics should be scraped.
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
     ##
     # interval: 10s
-
     ## Timeout after which the scrape is ended
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
     ##
     # scrapeTimeout: 10s
-
     ## ServiceMonitor selector labels
     ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
     ##
@@ -518,7 +514,7 @@ metrics:
   prometheusRule:
     enabled: false
     additionalLabels: {}
-    namespace: ""
+    namespace: ''
     rules: []
 
 ## Role Based Access
@@ -532,13 +528,15 @@ rbac:
 ## Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in.
 ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
 ##
+## topologySpreadConstraints:
+##   - maxSkew: 1
+##     topologyKey: failure-domain.beta.kubernetes.io/zone
+##     whenUnsatisfiable: DoNotSchedule
+##     labelSelector:
+##       matchLabels:
+##         app.kubernetes.io/instance: ingress-nginx-internal
+##
 topologySpreadConstraints: []
-  # - maxSkew: 1
-  #   topologyKey: failure-domain.beta.kubernetes.io/zone
-  #   whenUnsatisfiable: DoNotSchedule
-  #   labelSelector:
-  #     matchLabels:
-  #       app.kubernetes.io/instance: ingress-nginx-internal
 
 ## Pods Service Account
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/


### PR DESCRIPTION
**Description of the change**

- When annotation contains a number and it is set from the command line then templates are wrong. We are adding a `quote` pipe to all the extra annotations. 
-  Add some yamllint error fixes.

**Benefits**

We can use numbers in annotations

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

You can test and reproduce the issue by executing this command

```console
$ helm template nginx-controller bitnami/nginx-ingress-controller \
  --set podAnnotations."prometheus\.io/scrape"=true \
  --set podAnnotations."prometheus\.io/port"="10254" \
  --set podAnnotations."prometheus\.io/path"="/metrics" \
  --set podAnnotations."prometheus\.io/scheme"="http" \
  -s templates/controller-deployment.yaml
```

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
