### PR TITLE
[bitnami/sealed-secrets] add sealed secrets chart

### DIFF
--- a/bitnami/sealed-secrets/.helmignore
+++ b/bitnami/sealed-secrets/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/bitnami/sealed-secrets/Chart.yaml
+++ b/bitnami/sealed-secrets/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+name: sealed-secrets
+description: A Helm chart for Sealed Secrets
+version: 1.10.3
+appVersion: 0.12.4
+keywords:
+  - "secrets"
+home: https://github.com/bitnami/charts/tree/master/bitnami/sealed-secrets
+sources:
+  - https://github.com/bitnami-labs/sealed-secrets
+home: https://github.com/bitnami-labs/sealed-secrets
+maintainers:
+  - name: stefanprodan
+    email: stefan.prodan@gmail.com
+  - name: olib963
+    email: olib963@gmail.com
+  - name: onedr0p
+    email: devin.kray@gmail.com
+  - name: Bitnami
+    email: containers@bitnami.com
+annotations:
+  category: Infrastructure

--- a/bitnami/sealed-secrets/Chart.yaml
+++ b/bitnami/sealed-secrets/Chart.yaml
@@ -8,7 +8,6 @@ keywords:
 home: https://github.com/bitnami/charts/tree/master/bitnami/sealed-secrets
 sources:
   - https://github.com/bitnami-labs/sealed-secrets
-home: https://github.com/bitnami-labs/sealed-secrets
 maintainers:
   - name: stefanprodan
     email: stefan.prodan@gmail.com

--- a/bitnami/sealed-secrets/README.md
+++ b/bitnami/sealed-secrets/README.md
@@ -1,0 +1,99 @@
+# Sealed Secrets
+
+[sealed-secrets](https://github.com/bitnami-labs/sealed-secrets) is an open source, Kubernetes controller and tool for one-way encrypted Secrets.
+
+## TL;DR
+
+```console
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm install my-release bitnami/sealed-secrets
+```
+
+## Introduction
+Bitnami charts for Helm are carefully engineered, actively maintained and are the quickest and easiest way to deploy containers on a Kubernetes cluster that are ready to handle production workloads.
+
+This chart bootstraps a [sealed-secrets](https://github.com/bitnami-labs/sealed-secrets) controller and [CRD](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/) on a Kubernetes cluster in the default configuration. The [Parameters](#Parameters) section lists the parameters that can be configured during installation.
+
+Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters. This Helm chart has been tested on top of [Bitnami Kubernetes Production Runtime](https://kubeprod.io/) (BKPR). Deploy BKPR to get automated TLS certificates, logging and monitoring for your applications.
+
+## Prerequisites
+
+- Kubernetes 1.9+
+- Helm 2.12+ or Helm 3.0-beta3+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm install my-release bitnami/sealed-secrets
+```
+
+The command deploys a controller and [CRD](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/) for sealed secrets on the Kubernetes cluster in the default configuration. The [Parameters](#Parameters) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete [--purge] my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Using kubeseal
+
+Install the kubeseal CLI by downloading the binary from [sealed-secrets/releases](https://github.com/bitnami-labs/sealed-secrets/releases).
+
+Fetch the public key by passing the release name and namespace:
+
+```bash
+kubeseal --fetch-cert \
+--controller-name=my-release \
+--controller-namespace=my-release-namespace \
+> pub-cert.pem
+```
+
+Read about kubeseal usage on [sealed-secrets docs](https://github.com/bitnami-labs/sealed-secrets#usage).
+
+## Parameters
+
+|                     Parameter | Description                                                                | Default                                     |
+|------------------------------:|:---------------------------------------------------------------------------|:--------------------------------------------|
+|         **controller.create** | `true` if Sealed Secrets controller resources should be created            | `true`                                      |
+|                 **namespace** | The name of the Namespace to deploy the controller                         | `.Release.namespace`                        |
+|               **rbac.create** | `true` if rbac resources should be created                                 | `true`                                      |
+|           **rbac.pspEnabled** | `true` if psp resources should be created                                  | `false`                                     |
+|     **serviceAccount.create** | Whether to create a service account or not                                 | `true`                                      |
+|       **serviceAccount.name** | The name of the service account to create or use                           | `"sealed-secrets-controller"`               |
+|                **secretName** | The name of the TLS secret containing the key used to encrypt secrets      | `"sealed-secrets-key"`                      |
+|                 **image.tag** | The `Sealed Secrets` image tag                                             | `v0.12.4`                                   |
+|          **image.pullPolicy** | The image pull policy for the deployment                                   | `IfNotPresent`                              |
+|          **image.repository** | The repository to get the controller image from                            | `quay.io/bitnami/sealed-secrets-controller` |
+|                 **resources** | CPU/Memory resource requests/limits                                        | `{}`                                        |
+|                **crd.create** | `true` if crd resources should be created                                  | `true`                                      |
+|                  **crd.keep** | `true` if the sealed secret CRD should be kept when the chart is deleted   | `true`                                      |
+|             **networkPolicy** | Whether to create a network policy that allows access to the service       | `false`                                     |
+| **securityContext.runAsUser** | Defines under which user the operator Pod and its containers/processes run | `1001`                                      |
+|   **securityContext.fsGroup** | Defines fsGroup for the operator Pod and its containers/processes run      | `65534`                                     |
+|               **commandArgs** | Set optional command line arguments passed to the controller process       | `[]`                                        |
+|           **ingress.enabled** | Enables Ingress                                                            | `false`                                     |
+|       **ingress.annotations** | Ingress annotations                                                        | `{}`                                        |
+|              **ingress.path** | Ingress path                                                               | `/v1/cert.pem`                              |
+|             **ingress.hosts** | Ingress accepted hostnames                                                 | `["chart-example.local"]`                   |
+|               **ingress.tls** | Ingress TLS configuration                                                  | `[]`                                        |
+|            **podAnnotations** | Annotations to annotate pods with.                                         | `{}`                                        |
+|                 **podLabels** | Labels to be added to pods                                                 | `{}`                                        |
+|         **priorityClassName** | Optional class to specify priority for pods                                | `""`                                        |
+
+
+- In the case that **serviceAccount.create** is `false` and **rbac.create** is `true` it is expected for a service account with the name **serviceAccount.name** to exist _in the same namespace as this chart_ before installation.
+- If **serviceAccount.create** is `true` there cannot be an existing service account with the name **serviceAccount.name**.
+- If a secret with name **secretName** does not exist _in the same namespace as this chart_, then on install one will be created. If a secret already exists with this name the keys inside will be used.
+- OpenShift: unset the runAsUser and fsGroup like this:
+```
+  securityContext:
+    runAsUser:
+    fsGroup:
+```

--- a/bitnami/sealed-secrets/templates/NOTES.txt
+++ b/bitnami/sealed-secrets/templates/NOTES.txt
@@ -1,0 +1,47 @@
+{{ if .Values.controller.create -}}
+You should now be able to create sealed secrets.
+
+1. Install client-side tool into /usr/local/bin/
+
+GOOS=$(go env GOOS)
+GOARCH=$(go env GOARCH)
+wget https://github.com/bitnami-labs/sealed-secrets/releases/download/{{ .Values.image.tag }}/kubeseal-$GOOS-$GOARCH
+sudo install -m 755 kubeseal-$GOOS-$GOARCH /usr/local/bin/kubeseal
+
+2. Create a sealed secret file
+
+# note the use of `--dry-run` - this does not create a secret in your cluster
+kubectl create secret generic secret-name --dry-run --from-literal=foo=bar -o [json|yaml] | \
+ kubeseal \
+ --controller-name={{ template "sealed-secrets.fullname" . }} \
+ --controller-namespace={{ .Release.Namespace }} \
+ --format [json|yaml] > mysealedsecret.[json|yaml]
+
+The file mysealedsecret.[json|yaml] is a commitable file.
+
+If you would rather not need access to the cluster to generate the sealed secret you can run
+
+kubeseal \
+ --controller-name={{ template "sealed-secrets.fullname" . }} \
+ --controller-namespace={{ .Release.Namespace }} \
+ --fetch-cert > mycert.pem
+
+to retrieve the public cert used for encryption and store it locally. You can then run 'kubeseal --cert mycert.pem' instead to use the local cert e.g.
+
+kubectl create secret generic secret-name --dry-run --from-literal=foo=bar -o [json|yaml] | \
+kubeseal \
+ --controller-name={{ template "sealed-secrets.fullname" . }} \
+ --controller-namespace={{ .Release.Namespace }} \
+ --format [json|yaml] --cert mycert.pem > mysealedsecret.[json|yaml]
+
+3. Apply the sealed secret
+
+kubectl create -f mysealedsecret.[json|yaml]
+
+Running 'kubectl get secret secret-name -o [json|yaml]' will show the decrypted secret that was generated from the sealed secret.
+
+Both the SealedSecret and generated Secret must have the same name and namespace.
+{{- else }}
+Sealed Secrets controller not installed, You need to install controller before
+sealed secrets can be created.
+{{- end }}

--- a/bitnami/sealed-secrets/templates/_helpers.tpl
+++ b/bitnami/sealed-secrets/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/*
+Expand to the namespace sealed-secrets installs into.
+*/}}
+{{- define "sealed-secrets.namespace" -}}
+{{- default .Release.Namespace .Values.namespace -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "sealed-secrets.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sealed-secrets.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "sealed-secrets.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "sealed-secrets.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "sealed-secrets.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/bitnami/sealed-secrets/templates/cluster-role-binding.yaml
+++ b/bitnami/sealed-secrets/templates/cluster-role-binding.yaml
@@ -1,0 +1,21 @@
+{{ if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "sealed-secrets.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: secrets-unsealer
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ template "sealed-secrets.serviceAccountName" . }}
+    namespace: {{ template "sealed-secrets.namespace" . }}
+{{ end }}

--- a/bitnami/sealed-secrets/templates/cluster-role.yaml
+++ b/bitnami/sealed-secrets/templates/cluster-role.yaml
@@ -1,0 +1,43 @@
+{{ if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: secrets-unsealer
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+rules:
+  - apiGroups:
+      - bitnami.com
+    resources:
+      - sealedsecrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - bitnami.com
+    resources:
+      - sealedsecrets/status
+    verbs:
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+{{ end }}

--- a/bitnami/sealed-secrets/templates/deployment.yaml
+++ b/bitnami/sealed-secrets/templates/deployment.yaml
@@ -1,0 +1,88 @@
+{{- if .Values.controller.create -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "sealed-secrets.fullname" . }}
+  namespace: {{ template "sealed-secrets.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      annotations:
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ template "sealed-secrets.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
+      containers:
+        - name: {{ template "sealed-secrets.fullname" . }}
+          command:
+            - controller
+          args:
+            - "--key-prefix"
+            - "{{ .Values.secretName }}"
+            {{- range $value := .Values.commandArgs }}
+            - {{ $value | quote }}
+            {{- end }}
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 8080
+              name: http
+          volumeMounts:
+          - mountPath: /tmp
+            name: tmp
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          securityContext:
+            readOnlyRootFilesystem: true
+            {{- if .Values.securityContext.runAsUser }}
+            runAsNonRoot: true
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+            {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+      {{- if .Values.securityContext.fsGroup }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- end }}
+      volumes:
+      - name: tmp
+        emptyDir: {}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- end }}

--- a/bitnami/sealed-secrets/templates/ingress.yaml
+++ b/bitnami/sealed-secrets/templates/ingress.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "sealed-secrets.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ template "sealed-secrets.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: 8080
+  {{- end }}
+{{- end }}

--- a/bitnami/sealed-secrets/templates/networkpolicy.yaml
+++ b/bitnami/sealed-secrets/templates/networkpolicy.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.networkPolicy -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "sealed-secrets.fullname" . }}
+  namespace: {{ template "sealed-secrets.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+  ingress:
+    - ports:
+      - port: 8080
+{{- end -}}

--- a/bitnami/sealed-secrets/templates/psp-clusterrole.yaml
+++ b/bitnami/sealed-secrets/templates/psp-clusterrole.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.pspEnabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "sealed-secrets.fullname" . }}-psp
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "sealed-secrets.fullname" . }}
+{{- end }}

--- a/bitnami/sealed-secrets/templates/psp-clusterrolebinding.yaml
+++ b/bitnami/sealed-secrets/templates/psp-clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "sealed-secrets.fullname" . }}-psp
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "sealed-secrets.fullname" . }}-psp
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "sealed-secrets.serviceAccountName" . }}
+    namespace: {{ template "sealed-secrets.namespace" . }}
+{{- end }}

--- a/bitnami/sealed-secrets/templates/psp.yaml
+++ b/bitnami/sealed-secrets/templates/psp.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "sealed-secrets.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  allowedCapabilities: []
+  volumes:
+  - 'configMap'
+  - 'emptyDir'
+  - 'projected'
+  - 'secret'
+  - 'downwardAPI'
+  - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+{{- end }}

--- a/bitnami/sealed-secrets/templates/role-binding.yaml
+++ b/bitnami/sealed-secrets/templates/role-binding.yaml
@@ -1,0 +1,42 @@
+{{ if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "sealed-secrets.fullname" . }}-key-admin
+  namespace: {{ template "sealed-secrets.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "sealed-secrets.fullname" . }}-key-admin
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ template "sealed-secrets.serviceAccountName" . }}
+    namespace: {{ template "sealed-secrets.namespace" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "sealed-secrets.fullname" . }}-service-proxier
+  namespace: {{ template "sealed-secrets.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "sealed-secrets.fullname" . }}-service-proxier
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+{{ end }}

--- a/bitnami/sealed-secrets/templates/role.yaml
+++ b/bitnami/sealed-secrets/templates/role.yaml
@@ -1,0 +1,52 @@
+{{ if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "sealed-secrets.fullname" . }}-key-admin
+  namespace: {{ template "sealed-secrets.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+rules:
+  - apiGroups:
+      - ""
+    resourceNames:
+      - {{ .Values.secretName }}
+    resources:
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "sealed-secrets.fullname" . }}-service-proxier
+  namespace: {{ template "sealed-secrets.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+rules:
+- apiGroups:
+  - ""
+  resourceNames:
+  - 'http:{{ template "sealed-secrets.fullname" . }}:'
+  - {{ template "sealed-secrets.fullname" . }}
+  resources:
+  - services/proxy
+  verbs:
+  - create
+  - get
+{{ end }}

--- a/bitnami/sealed-secrets/templates/sealedsecret-crd.yaml
+++ b/bitnami/sealed-secrets/templates/sealedsecret-crd.yaml
@@ -1,0 +1,27 @@
+{{ if .Values.crd.create }}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: sealedsecrets.bitnami.com
+  {{ if .Values.crd.keep }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{ end }}
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+spec:
+  group: bitnami.com
+  names:
+    kind: SealedSecret
+    listKind: SealedSecretList
+    plural: sealedsecrets
+    singular: sealedsecret
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+{{ end }}

--- a/bitnami/sealed-secrets/templates/service-account.yaml
+++ b/bitnami/sealed-secrets/templates/service-account.yaml
@@ -1,0 +1,13 @@
+{{ if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "sealed-secrets.serviceAccountName" . }}
+  namespace: {{ template "sealed-secrets.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+{{ end }}

--- a/bitnami/sealed-secrets/templates/service.yaml
+++ b/bitnami/sealed-secrets/templates/service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.controller.create -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "sealed-secrets.fullname" . }}
+  namespace: {{ template "sealed-secrets.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+spec:
+  ports:
+    - port: 8080
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+  type: ClusterIP
+{{- end }}

--- a/bitnami/sealed-secrets/values.yaml
+++ b/bitnami/sealed-secrets/values.yaml
@@ -1,0 +1,63 @@
+image:
+  repository: quay.io/bitnami/sealed-secrets-controller
+  tag: v0.12.4
+  pullPolicy: IfNotPresent
+
+resources: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+controller:
+  # controller.create: `true` if Sealed Secrets controller should be created
+  create: true
+
+# namespace: Namespace to deploy the controller.
+namespace: ""
+
+serviceAccount:
+  # serviceAccount.create: Whether to create a service account or not
+  create: true
+  # serviceAccount.name: The name of the service account to create or use
+  name: ""
+
+rbac:
+  # rbac.create: `true` if rbac resources should be created
+  create: true
+  pspEnabled: false
+
+# secretName: The name of the TLS secret containing the key used to encrypt secrets
+secretName: "sealed-secrets-key"
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /v1/cert.pem
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+crd:
+  # crd.create: `true` if the crd resources should be created
+  create: true
+  # crd.keep: `true` if the sealed secret CRD should be kept when the chart is deleted
+  keep: true
+
+networkPolicy: false
+
+securityContext:
+  # securityContext.runAsUser defines under which user the operator Pod and its containers/processes run.
+  runAsUser: 1001
+  # securityContext.fsGroup defines the filesystem group
+  fsGroup: 65534
+
+podAnnotations: {}
+
+podLabels: {}
+
+priorityClassName: ""


### PR DESCRIPTION
**Description of the change**

Adds sealed-secrets helm chart, copied from https://github.com/helm/charts/tree/master/stable/sealed-secrets

**Benefits**

Seeing as the official Helm chart repo will be deprecated on Nov 13th 2020 is makes sense to migrate here.

Closes https://github.com/bitnami/charts/issues/4016
Closes https://github.com/bitnami-labs/sealed-secrets/issues/389

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
