### PR TITLE
[bitnami/prestashop] fix: wrong database password key

### DIFF
--- a/bitnami/prestashop/Chart.yaml
+++ b/bitnami/prestashop/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prestashop
-version: 11.0.0
+version: 11.0.1
 appVersion: 1.7.6-8
 description: A popular open source ecommerce solution. Professional tools are easily accessible to increase online sales including instant guest checkout, abandoned cart reminders and automated Email marketing.
 keywords:

--- a/bitnami/prestashop/templates/NOTES.txt
+++ b/bitnami/prestashop/templates/NOTES.txt
@@ -24,7 +24,7 @@ host. To configure PrestaShop with the URL of your service:
   export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "prestashop.secretName" . }} -o jsonpath="{.data.prestashop-password}" | base64 --decode)
   export DATABASE_ROOT_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "prestashop.databaseSecretName" . }} -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)
   {{- end }}
-  export APP_DATABASE_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "prestashop.databaseSecretName" . }} -o jsonpath="{.data.mariadb-password}" | base64 --decode)
+  export APP_DATABASE_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "prestashop.databaseSecretName" . }} -o jsonpath="{.data.{{- include "prestashop.databasePasswordKey" . -}}}" | base64 --decode)
 
 2. Complete your PrestaShop deployment by running:
 

--- a/bitnami/prestashop/templates/_helpers.tpl
+++ b/bitnami/prestashop/templates/_helpers.tpl
@@ -142,3 +142,14 @@ Return the MariaDB Secret Name
     {{- printf "%s-%s" .Release.Name "externaldb" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the database password key
+*/}}
+{{- define "prestashop.databasePasswordKey" -}}
+{{- if .Values.mariadb.enabled -}}
+mariadb-password
+{{- else -}}
+db-password
+{{- end -}}
+{{- end -}}

--- a/bitnami/prestashop/templates/deployment.yaml
+++ b/bitnami/prestashop/templates/deployment.yaml
@@ -173,7 +173,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "prestashop.databaseSecretName" . }}
-                  key: mariadb-password
+                  key: {{ include "prestashop.databasePasswordKey" . }}
             - name: PRESTASHOP_SKIP_BOOTSTRAP
               value: {{ ternary "yes" "no" .Values.prestashopSkipInstall | quote }}
             {{- $port:=.Values.service.port | toString }}


### PR DESCRIPTION
Signed-off-by: darteaga <darteaga@vmware.com>

**Description of the change**

Add a helper to decide between different keys when an externalDatabase is set

**Benefits**

We can use external databases

**Possible drawbacks**

N/A

**Applicable issues**

rel #3949

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files