### PR TITLE
[bitnami/consul] fix wrong host on consul metrics exporter

### DIFF
--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: consul
-version: 8.0.0
+version: 8.0.1
 appVersion: 1.8.4
 description: Highly available and distributed service discovery and key-value store designed with support for the modern data center to make distributed systems and configuration easy.
 home: https://github.com/bitnami/charts/tree/master/bitnami/consul

--- a/bitnami/consul/templates/statefulset.yaml
+++ b/bitnami/consul/templates/statefulset.yaml
@@ -235,7 +235,7 @@ spec:
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
           command:
             - /bin/consul_exporter
-            - --consul.server=127.0.0.1:{{ .Values.containerPorts.http }}
+            - --consul.server={{ printf "%s-headless" (include "common.names.fullname" .) }}:{{ .Values.containerPorts.http }}
           ports:
             - name: metrics
               containerPort: 9107

--- a/bitnami/consul/templates/statefulset.yaml
+++ b/bitnami/consul/templates/statefulset.yaml
@@ -235,7 +235,7 @@ spec:
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
           command:
             - /bin/consul_exporter
-            - --consul.server={{ include "common.names.fullname" . }}:{{ .Values.service.port }}
+            - --consul.server=127.0.0.1:{{ .Values.containerPorts.http }}
           ports:
             - name: metrics
               containerPort: 9107


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Consul metrics exporter stopped working after upgrading the Consul Helm chart to 8.0.0. After quick look in the log I saw the following error:

```
2020-10-16 11:35:13 | level=error ts=2020-10-16T09:35:13.087Z caller=consul_exporter.go:250 msg="Can't query consul" err="Get \"http://consul:80/v1/status/leader\": dial tcp: lookup consul on 172.20.0.10:53: no such host"
  |   | 2020-10-16 11:35:13 | level=error ts=2020-10-16T09:35:13.084Z caller=consul_exporter.go:238 msg="Can't query consul" err="Get \"http://consul:80/v1/status/peers\": dial tcp: lookup consul on 172.20.0.10:53: no such host"
  |   | 2020-10-16 11:35:11 | level=error ts=2020-10-16T09:35:11.763Z caller=consul_exporter.go:311 msg="Failed to query service health" err="Get \"http://consul:80/v1/health/state/any?stale=\": dial tcp: lookup consul on 172.20.0.10:53: no such host"
  |   | 2020-10-16 11:35:11 | level=error ts=2020-10-16T09:35:11.758Z caller=consul_exporter.go:294 msg="Failed to query for services" err="Get \"http://consul:80/v1/catalog/services?stale=\": dial tcp: lookup consul on 172.20.0.10:53: no such host"
  |   | 2020-10-16 11:35:11 | level=error ts=2020-10-16T09:35:11.754Z caller=consul_exporter.go:280 msg="Failed to query member status" err="Get \"http://consul:80/v1/agent/members\": dial tcp: lookup consul on 172.20.0.10:53: no such host"
  |   | 2020-10-16 11:35:11 | level=error ts=2020-10-16T09:35:11.749Z caller=consul_exporter.go:268 msg="Failed to query catalog for nodes" err="Get \"http://consul:80/v1/catalog/nodes?stale=\": dial tcp: lookup consul on 172.20.0.10:53: no such host"
```

Which means that consul_exporter cannot resolve the consul host. The 8.0.0 Helm Chart upgrade removed the "consul" service and replaced it with a "consul-ui" and "consul-headless" service.

Since both containers are in the same pod we can just use localhost to resolve the connection to the consul container.



**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

The consul_exporter now points directly to the consul in the same pod. So traffic doesn't go anymore "over" the service resource. I'm not sure why this was here in the first place since from my understanding the service resource does kind of loadbalancing and we cannot guarantee that we have the metrics from all consul servers.

Old chain
svc/consul-metrics -> consul_exporter container -> **svc/consul** -> any other consul container

New chain
svc/consul-metrics -> consul_exporter container -> same consul container


I'm not even sure if we really need the metrics service resource since prometheus can just look at each pod annotation and resolve that?

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
