### PR TITLE
[bitnami/external-dns] fix: pods annotations wrong indentation

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: external-dns
-version: 3.4.8
+version: 3.4.9
 appVersion: 0.7.4
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 keywords:

--- a/bitnami/external-dns/templates/_helpers.tpl
+++ b/bitnami/external-dns/templates/_helpers.tpl
@@ -51,10 +51,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/* podAnnotations */}}
 {{- define "external-dns.podAnnotations" -}}
 {{- if .Values.podAnnotations }}
-{{- toYaml .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations }}
 {{- end }}
 {{- if .Values.metrics.podAnnotations }}
-{{- toYaml .Values.metrics.podAnnotations }}
+{{ toYaml .Values.metrics.podAnnotations }}
 {{- end }}
 {{- end -}}
 

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -12,7 +12,7 @@ spec:
       labels: {{ include "external-dns.labels" . | nindent 8 }}
       annotations:
         {{- if or .Values.podAnnotations .Values.metrics.enabled }}
-        {{ include "external-dns.podAnnotations" . | nindent 8 }}
+        {{- include "external-dns.podAnnotations" . | trim | nindent 8 }}
         {{- end }}
         {{- if (include "external-dns.createSecret" .) }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}


### PR DESCRIPTION
Signed-off-by: darteaga <darteaga@vmware.com>

**Description of the change**

Correct some indentation errors

**Benefits**

We will be able to use podAnnotations

**Possible drawbacks**

N/A

**Applicable issues**

  - fixes #4024

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files