### PR TITLE
[bitnami/redis] Add recommended labels to all resources

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 11.2.1
+version: 11.3.1
 appVersion: 6.0.8
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/bitnami/redis/templates/_helpers.tpl
+++ b/bitnami/redis/templates/_helpers.tpl
@@ -419,3 +419,16 @@ Usage:
         {{- tpl (.value | toYaml) .context }}
     {{- end }}
 {{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "redis.labels" -}}
+app.kubernetes.io/name: {{ include "redis.name" . }}
+helm.sh/chart: {{ include "redis.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/bitnami/redis/templates/configmap-scripts.yaml
+++ b/bitnami/redis/templates/configmap-scripts.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ template "redis.fullname" . }}-scripts
   namespace: {{ .Release.Namespace }}
   labels:
+    {{- include "redis.labels" . | nindent 4 }}
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     heritage: {{ .Release.Service }}

--- a/bitnami/redis/templates/configmap.yaml
+++ b/bitnami/redis/templates/configmap.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ template "redis.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
+    {{- include "redis.labels" . | nindent 4 }}
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     heritage: {{ .Release.Service }}

--- a/bitnami/redis/templates/headless-svc.yaml
+++ b/bitnami/redis/templates/headless-svc.yaml
@@ -4,8 +4,7 @@ metadata:
   name: {{ template "redis.fullname" . }}-headless
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ include "redis.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "redis.labels" . | nindent 4 }}
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     release: {{ .Release.Name }}

--- a/bitnami/redis/templates/headless-svc.yaml
+++ b/bitnami/redis/templates/headless-svc.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ template "redis.fullname" . }}-headless
   namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/name: {{ include "redis.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     release: {{ .Release.Name }}

--- a/bitnami/redis/templates/health-configmap.yaml
+++ b/bitnami/redis/templates/health-configmap.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ template "redis.fullname" . }}-health
   namespace: {{ .Release.Namespace }}
   labels:
+    {{- include "redis.labels" . | nindent 4 }}
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     heritage: {{ .Release.Service }}

--- a/bitnami/redis/templates/metrics-prometheus.yaml
+++ b/bitnami/redis/templates/metrics-prometheus.yaml
@@ -9,6 +9,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   {{- end }}
   labels:
+    {{- include "redis.labels" . | nindent 4 }}
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     release: {{ .Release.Name }}

--- a/bitnami/redis/templates/metrics-svc.yaml
+++ b/bitnami/redis/templates/metrics-svc.yaml
@@ -9,6 +9,8 @@ metadata:
     chart: {{ template "redis.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "redis.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "metrics"
     {{- if .Values.metrics.service.labels -}}
     {{- toYaml .Values.metrics.service.labels | nindent 4 }}

--- a/bitnami/redis/templates/metrics-svc.yaml
+++ b/bitnami/redis/templates/metrics-svc.yaml
@@ -5,13 +5,12 @@ metadata:
   name: {{ template "redis.fullname" . }}-metrics
   namespace: {{ .Release.Namespace }}
   labels:
+    {{- include "redis.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "metrics"
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    app.kubernetes.io/name: {{ include "redis.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/component: "metrics"
     {{- if .Values.metrics.service.labels -}}
     {{- toYaml .Values.metrics.service.labels | nindent 4 }}
     {{- end -}}

--- a/bitnami/redis/templates/networkpolicy.yaml
+++ b/bitnami/redis/templates/networkpolicy.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ template "redis.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
+    {{- include "redis.labels" . | nindent 4 }}
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     release: {{ .Release.Name }}

--- a/bitnami/redis/templates/pdb.yaml
+++ b/bitnami/redis/templates/pdb.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ template "redis.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
+    {{- include "redis.labels" . | nindent 4 }}
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
 spec:

--- a/bitnami/redis/templates/prometheusrule.yaml
+++ b/bitnami/redis/templates/prometheusrule.yaml
@@ -9,6 +9,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   {{- end }}
   labels:
+    {{- include "redis.labels" . | nindent 4 }}
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     release: {{ .Release.Name | quote }}

--- a/bitnami/redis/templates/psp.yaml
+++ b/bitnami/redis/templates/psp.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ template "redis.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
+    {{- include "redis.labels" . | nindent 4 }}
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     heritage: {{ .Release.Service }}

--- a/bitnami/redis/templates/redis-master-statefulset.yaml
+++ b/bitnami/redis/templates/redis-master-statefulset.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ template "redis.fullname" . }}-master
   namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/name: {{ include "redis.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     release: {{ .Release.Name }}

--- a/bitnami/redis/templates/redis-master-statefulset.yaml
+++ b/bitnami/redis/templates/redis-master-statefulset.yaml
@@ -5,8 +5,7 @@ metadata:
   name: {{ template "redis.fullname" . }}-master
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ include "redis.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "redis.labels" . | nindent 4 }}
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     release: {{ .Release.Name }}

--- a/bitnami/redis/templates/redis-master-svc.yaml
+++ b/bitnami/redis/templates/redis-master-svc.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ template "redis.fullname" . }}-master
   namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/name: {{ include "redis.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     release: {{ .Release.Name }}

--- a/bitnami/redis/templates/redis-master-svc.yaml
+++ b/bitnami/redis/templates/redis-master-svc.yaml
@@ -5,8 +5,7 @@ metadata:
   name: {{ template "redis.fullname" . }}-master
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ include "redis.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "redis.labels" . | nindent 4 }}
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     release: {{ .Release.Name }}

--- a/bitnami/redis/templates/redis-node-statefulset.yaml
+++ b/bitnami/redis/templates/redis-node-statefulset.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ template "redis.fullname" . }}-node
   namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/name: {{ include "redis.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     release: {{ .Release.Name }}

--- a/bitnami/redis/templates/redis-node-statefulset.yaml
+++ b/bitnami/redis/templates/redis-node-statefulset.yaml
@@ -5,8 +5,7 @@ metadata:
   name: {{ template "redis.fullname" . }}-node
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ include "redis.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "redis.labels" . | nindent 4 }}
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     release: {{ .Release.Name }}

--- a/bitnami/redis/templates/redis-role.yaml
+++ b/bitnami/redis/templates/redis-role.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ template "redis.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
+    {{- include "redis.labels" . | nindent 4 }}
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     release: {{ .Release.Name }}

--- a/bitnami/redis/templates/redis-rolebinding.yaml
+++ b/bitnami/redis/templates/redis-rolebinding.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ template "redis.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
+    {{- include "redis.labels" . | nindent 4 }}
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     release: {{ .Release.Name }}

--- a/bitnami/redis/templates/redis-serviceaccount.yaml
+++ b/bitnami/redis/templates/redis-serviceaccount.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ template "redis.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
+    {{- include "redis.labels" . | nindent 4 }}
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     release: {{ .Release.Name }}

--- a/bitnami/redis/templates/redis-slave-statefulset.yaml
+++ b/bitnami/redis/templates/redis-slave-statefulset.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ template "redis.fullname" . }}-slave
   namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/name: {{ include "redis.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     release: {{ .Release.Name }}

--- a/bitnami/redis/templates/redis-slave-statefulset.yaml
+++ b/bitnami/redis/templates/redis-slave-statefulset.yaml
@@ -5,8 +5,7 @@ metadata:
   name: {{ template "redis.fullname" . }}-slave
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ include "redis.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "redis.labels" . | nindent 4 }}
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     release: {{ .Release.Name }}

--- a/bitnami/redis/templates/redis-slave-svc.yaml
+++ b/bitnami/redis/templates/redis-slave-svc.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ template "redis.fullname" . }}-slave
   namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/name: {{ include "redis.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     release: {{ .Release.Name }}

--- a/bitnami/redis/templates/redis-slave-svc.yaml
+++ b/bitnami/redis/templates/redis-slave-svc.yaml
@@ -5,8 +5,7 @@ metadata:
   name: {{ template "redis.fullname" . }}-slave
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ include "redis.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "redis.labels" . | nindent 4 }}
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     release: {{ .Release.Name }}

--- a/bitnami/redis/templates/redis-with-sentinel-svc.yaml
+++ b/bitnami/redis/templates/redis-with-sentinel-svc.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ template "redis.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/name: {{ include "redis.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     release: {{ .Release.Name }}

--- a/bitnami/redis/templates/redis-with-sentinel-svc.yaml
+++ b/bitnami/redis/templates/redis-with-sentinel-svc.yaml
@@ -5,8 +5,7 @@ metadata:
   name: {{ template "redis.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ include "redis.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "redis.labels" . | nindent 4 }}
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     release: {{ .Release.Name }}

--- a/bitnami/redis/templates/secret.yaml
+++ b/bitnami/redis/templates/secret.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ template "redis.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
+    {{- include "redis.labels" . | nindent 4 }}
     app: {{ template "redis.name" . }}
     chart: {{ template "redis.chart" . }}
     release: "{{ .Release.Name }}"


### PR DESCRIPTION
**Description of the change**

Adds a template helper with recommended labels (`app.kubernetes.io/name`, `app.kubernetes.io/instance`, `app.kubernetes.io/version`, `app.kubernetes.io/managed-by` and `helm.sh/chart`) to all Redis resources.

**Benefits**

- This is a best practice/recommended by Kubernetes (https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/)
- Related to the above, makes it easier to manage Redis resources with tooling (eg. kubectl) that relies on shared labels

**Possible drawbacks**

~None AFAIK~ **Edit**: As juan131 notes below, this change breaks backwards compatibility with `matchLabels`. 

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
