### PR TITLE
[bitnami/wordpress] Add podLabels option to WordPress chart

### DIFF
--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wordpress
-version: 9.7.0
+version: 9.8.0
 appVersion: 5.5.1
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -117,6 +117,7 @@ The following table lists the configurable parameters of the WordPress chart and
 | `nodeSelector`                            | Node labels for pod assignment                                                        | `{}` (evaluated as a template)                               |
 | `tolerations`                             | Tolerations for pod assignment                                                        | `[]` (evaluated as a template)                               |
 | `affinity`                                | Affinity for pod assignment                                                           | `{}` (evaluated as a template)                               |
+| `podLabels`                               | Pod labels                                                                            | `{}` (evaluated as a template)                               |
 | `podAnnotations`                          | Pod annotations                                                                       | `{}` (evaluated as a template)                               |
 | `healthcheckHttps`                        | Use https for liveliness and readiness                                                | `false`                                                      |
 | `livenessProbe.enabled`                   | Enable/disable livenessProbe                                                          | `true`                                                       |

--- a/bitnami/wordpress/templates/deployment.yaml
+++ b/bitnami/wordpress/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
   template:
     metadata:
       labels: {{- include "wordpress.labels" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- include "wordpress.tplValue" ( dict "value" .Values.podLabels "context" $ ) | nindent 8 }}
+        {{- end }}
       {{- if or .Values.podAnnotations .Values.metrics.enabled }}
       annotations:
         {{- if .Values.podAnnotations }}

--- a/bitnami/wordpress/values-production.yaml
+++ b/bitnami/wordpress/values-production.yaml
@@ -221,6 +221,11 @@ nodeSelector: {}
 ##
 tolerations: {}
 
+## Pod Labels
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+##
+podLabels: {}
+
 ## Pod annotations
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 ##

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -221,7 +221,7 @@ nodeSelector: {}
 ##
 tolerations: {}
 
-## Pod Lables
+## Pod Labels
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ##
 podLabels: {}

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -221,6 +221,11 @@ nodeSelector: {}
 ##
 tolerations: {}
 
+## Pod Lables
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+##
+podLabels: {}
+
 ## Pod annotations
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Add `podLabels` value option to WordPress chart. It sets additional values on the pod created by the WordPress deployment.

**Benefits**

Being able to set podLabels which enables selectors to target the pod for example a NetworkPolicy.

**Possible drawbacks**

Increased maintenance?

**Applicable issues**

/fixes #4047 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
