### PR TITLE
[bitnami/harbor] MAJOR change - bump Redis subchart

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: harbor
-version: 7.4.3
+version: 8.0.0
 appVersion: 2.1.0
 description: Harbor is an an open source trusted cloud native registry project that stores, signs, and scans content
 keywords:

--- a/bitnami/harbor/README.md
+++ b/bitnami/harbor/README.md
@@ -835,6 +835,10 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 
 > NOTE: In you are upgrading an installation that contains a high amount of data, it is recommended to disable the liveness/readiness probes as the migration can take a substantial amount of time.
 
+## 8.0.0
+
+Redis dependency version was bumped to the new major version `11.x.x`, which introduced breaking changes regarding sentinel. By default, this Chart does not use of this feature and hence no issues are expected between upgrades. You may refer to [Redis Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/redis#to-1100) for further information.
+
 ## 7.0.0
 
 This major version include a major change in the PostgreSQL subchart labeling. Backwards compatibility from previous versions to this one is not guarantee during the upgrade.

--- a/bitnami/harbor/requirements.lock
+++ b/bitnami/harbor/requirements.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 9.8.4
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 10.9.0
+  version: 11.2.1
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 0.8.2
-digest: sha256:ea025651bbc059e95b057c5ab12a399f659bb9dde6bb05aa7efd82e1a2c2636d
-generated: "2020-10-17T15:49:10.745439517Z"
+digest: sha256:148d71e438deacf3c6b2790bb8a233afb44570fbc4fd576c52429ddc818c56f4
+generated: "2020-10-19T16:36:30.705922+02:00"

--- a/bitnami/harbor/requirements.yaml
+++ b/bitnami/harbor/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: redis
-    version: 10.x.x
+    version: 11.x.x
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: common

--- a/bitnami/harbor/templates/_helpers.tpl
+++ b/bitnami/harbor/templates/_helpers.tpl
@@ -790,17 +790,6 @@ Return the proper Storage Class for trivy
 {{- end -}}
 
 {{/*
-Return the appropriate apiVersion for deployment.
-*/}}
-{{- define "deployment.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
-{{- print "apps/v1" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Set the http prefix if the externalURl dont have it
 */}}
 {{- define "harbor.externalUrl" -}}

--- a/bitnami/harbor/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/bitnami/harbor/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.chartmuseum.enabled }}
-apiVersion: {{ template "deployment.apiVersion" . }}
+apiVersion: {{ template "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ include "harbor.chartmuseum" . }}

--- a/bitnami/harbor/templates/clair/clair-dpl.yaml
+++ b/bitnami/harbor/templates/clair/clair-dpl.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.clair.enabled }}
-apiVersion: {{ template "deployment.apiVersion" . }}
+apiVersion: {{ template "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ include "harbor.clair" . }}

--- a/bitnami/harbor/templates/core/core-dpl.yaml
+++ b/bitnami/harbor/templates/core/core-dpl.yaml
@@ -1,4 +1,4 @@
-apiVersion: {{ template "deployment.apiVersion" . }}
+apiVersion: {{ template "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ include "harbor.core" . }}

--- a/bitnami/harbor/templates/jobservice/jobservice-dpl.yaml
+++ b/bitnami/harbor/templates/jobservice/jobservice-dpl.yaml
@@ -1,4 +1,4 @@
-apiVersion: {{ template "deployment.apiVersion" . }}
+apiVersion: {{ template "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ include "harbor.jobservice" . }}

--- a/bitnami/harbor/templates/nginx/deployment.yaml
+++ b/bitnami/harbor/templates/nginx/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if not .Values.ingress.enabled }}
-apiVersion: {{ template "deployment.apiVersion" . }}
+apiVersion: {{ template "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ include "harbor.nginx" . }}

--- a/bitnami/harbor/templates/portal/portal-dpl.yaml
+++ b/bitnami/harbor/templates/portal/portal-dpl.yaml
@@ -1,4 +1,4 @@
-apiVersion: {{ template "deployment.apiVersion" . }}
+apiVersion: {{ template "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ include "harbor.portal" . }}

--- a/bitnami/harbor/templates/registry/registry-dpl.yaml
+++ b/bitnami/harbor/templates/registry/registry-dpl.yaml
@@ -1,4 +1,4 @@
-apiVersion: {{ template "deployment.apiVersion" . }}
+apiVersion: {{ template "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ include "harbor.registry" . }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
This PR bumps Harbor major version since its dependency (Redis) bumped the major version including breaking changes. More info at #3658

Additionally, `apiVersion` helper was changed to use the common library so as to match other charts.
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Up-to-date subcomponents, standardization.

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
None

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
NA

**Additional information**
This chart does not use sentinel so, no breaking changes should be expected.
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
