### PR TITLE
[bitnami/ghost] Fix ingress when tls is enabled

### DIFF
--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ghost
-version: 10.1.19
+version: 10.1.20
 appVersion: 3.35.5
 description: A simple, powerful publishing platform that allows you to share your stories with the world
 keywords:

--- a/bitnami/ghost/templates/ingress.yaml
+++ b/bitnami/ghost/templates/ingress.yaml
@@ -26,14 +26,14 @@ spec:
   {{- range .Values.ingress.hosts }}
     {{- if .tls }}
     - hosts:
-    {{- if .tlsHosts }}
-    {{- range $host := .tlsHosts }}
-      - {{ $host }}
-    {{- end }}
-    {{- else }}
-      - {{ .name }}
-    {{- end }}
-      secretName: {{ .tlsSecret }}
+      {{- if .tlsHosts }}
+      {{- range $host := .tlsHosts }}
+        - {{ $host }}
+      {{- end }}
+      {{- else }}
+        - {{ .name }}
+      {{- end }}
+      secretName: {{ default (printf "%s-tls" .name) .tlsSecret }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/bitnami/ghost/templates/tls-secrets.yaml
+++ b/bitnami/ghost/templates/tls-secrets.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
+    {{- if $.Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" $.Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if $.Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .certificate | b64enc }}
+  tls.key: {{ .key | b64enc }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Creates the `tls-secret.yaml` object, so the tls secret is generated when the `ingress.secrets` array is set. It also ensure the secretName is set in the Ingress object when it's not indicated in the `ingress.hosts` array.

**Benefits**

Users can set their own certificates fo TLS

**Possible drawbacks**

None

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

