### PR TITLE
[bitnami/opencart] fix: init container parsing error

### DIFF
--- a/bitnami/opencart/Chart.yaml
+++ b/bitnami/opencart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: opencart
-version: 8.0.0
+version: 8.0.1
 appVersion: 3.0.3-6
 description: A free and open source e-commerce platform for online merchants. It provides a professional and reliable foundation for a successful online store.
 keywords:

--- a/bitnami/opencart/templates/deployment.yaml
+++ b/bitnami/opencart/templates/deployment.yaml
@@ -56,7 +56,10 @@ spec:
         - ip: "127.0.0.1"
           hostnames:
             - "status.localhost"
-      initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+      initContainers:
+        {{- if .Values.initContainers }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+        {{- end }}
         {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
         - name: volume-permissions
           image: {{ include "opencart.volumePermissions.image" . }}


### PR DESCRIPTION
Signed-off-by: darteaga <darteaga@vmware.com>

**Description of the change**

To add an `if` statement to avoid errors when using `volumePermissions.enabled=true` in combination with `initContainer: []` which is the default value.

**Benefits**

We will be able to use `volumePermissions.enabled=true`

**Possible drawbacks**

N/A

**Applicable issues**

  - rel https://github.com/bitnami/bitnami-docker-opencart/issues/84

**Additional information**

Testing it

```console
$ helm template opencart bitnami/opencart --set volumePermissions.enabled=true --set opencartHost=myhost -s templates/deployment.yaml --debug
```

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files