### PR TITLE
[bitnami/prestashop] fix: init container parsing error

### DIFF
--- a/bitnami/prestashop/Chart.yaml
+++ b/bitnami/prestashop/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prestashop
-version: 11.0.1
+version: 11.0.2
 appVersion: 1.7.6-8
 description: A popular open source ecommerce solution. Professional tools are easily accessible to increase online sales including instant guest checkout, abandoned cart reminders and automated Email marketing.
 keywords:

--- a/bitnami/prestashop/templates/deployment.yaml
+++ b/bitnami/prestashop/templates/deployment.yaml
@@ -56,7 +56,10 @@ spec:
         - ip: "127.0.0.1"
           hostnames:
             - "status.localhost"
-      initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+      initContainers:
+        {{- if .Values.initContainers }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+        {{- end }}
         {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
         - name: volume-permissions
           image: {{ include "prestashop.volumePermissions.image" . }}


### PR DESCRIPTION
Signed-off-by: darteaga <darteaga@vmware.com>

**Description of the change**

To add an `if` statement to avoid errors when using `volumePermissions.enabled=true` in combination with `initContainer: []` which is the default value.

**Benefits**

We will be able to use `volumePermissions.enabled=true`

**Possible drawbacks**

N/A

**Applicable issues**

  - fixes #4018

**Additional information**

Testing it

```console
$ helm template opencart bitnami/prestashop --set volumePermissions.enabled=true --set prestashopHost=myhost -s templates/deployment.yaml --debug
```

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files