### PR TITLE
[bitnami/node] Allow using Node application that do not require any database

### DIFF
--- a/bitnami/node/Chart.yaml
+++ b/bitnami/node/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node
-version: 13.0.5
+version: 13.1.0
 appVersion: 10.22.1
 description: Event-driven I/O server-side JavaScript environment based on V8
 keywords:

--- a/bitnami/node/README.md
+++ b/bitnami/node/README.md
@@ -108,6 +108,7 @@ The following table lists the configurable parameters of the Node chart and thei
 | `ingress.secrets[0].certificate`        | TLS Secret Certificate                                                      | `nil`                                                   |
 | `ingress.secrets[0].key`                | TLS Secret Key                                                              | `nil`                                                   |
 | `mongodb.install`                       | Wheter to install or not the MongoDB chart                                  | `true`                                                  |
+| `externaldb.enabled`                    | Enables or disables external database (ignored if `mongodb.install=true`)   | `false`                                                 |
 | `externaldb.secretName`                 | Secret containing existing database credentials                             | `nil`                                                   |
 | `externaldb.type`                       | Type of database that defines the database secret mapping                   | `osba`                                                  |
 | `externaldb.broker.serviceInstanceName` | The existing ServiceInstance to be used                                     | `nil`                                                   |
@@ -188,6 +189,7 @@ ingress:
 
   ```console
   mongodb.install=false
+  externaldb.enabled=true
   externaldb.secretName=my-database-secret
   ```
 
@@ -230,6 +232,7 @@ ingress:
 
     ```command
     mongodb.install=false
+    externaldb.enabled=true
     externaldb.broker.serviceInstanceName=azure-mongodb-instance
     externaldb.ssl=true
     ```

--- a/bitnami/node/templates/NOTES.txt
+++ b/bitnami/node/templates/NOTES.txt
@@ -22,4 +22,5 @@
 
 {{- end }}
 
-{{ include "node.checkRollingTags" . }}
+{{- include "node.checkRollingTags" . }}
+{{- include "node.validateValues" . }}

--- a/bitnami/node/templates/_helpers.tpl
+++ b/bitnami/node/templates/_helpers.tpl
@@ -248,3 +248,28 @@ Usage:
         {{- tpl (.value | toYaml) .context }}
     {{- end }}
 {{- end -}}
+
+
+{{/*
+Compile all warnings into a single message, and call fail.
+*/}}
+{{- define "node.validateValues" -}}
+{{- $messages := list -}}
+{{- $messages := append $messages (include "node.validateValues.database" .) -}}
+{{- $messages := without $messages "" -}}
+{{- $message := join "\n" $messages -}}
+
+{{- if $message -}}
+{{-   printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Validate values of Node - Database */}}
+{{- define "node.validateValues.database" -}}
+{{- if and .Values.mongodb.install .Values.externaldb.enabled -}}
+node: Database
+    You can only use one database.
+    Please choose installing a MongoDB chart (--set mongodb.install=true) or
+    using an external database (--set externaldb.enabled=true)
+{{- end -}}
+{{- end -}}

--- a/bitnami/node/templates/deployment.yaml
+++ b/bitnami/node/templates/deployment.yaml
@@ -94,22 +94,21 @@ spec:
               value: {{ .Values.mongodb.auth.database | quote }}
             - name: DATABASE_CONNECTION_OPTIONS
               value: ""
-            {{- else }}
+            {{- else if .Values.externaldb.enabled }}
             - name: DATABASE_HOST
               valueFrom:
                 secretKeyRef:
                   name: {{ template "node.secretName" . }}
                   key: host
-            {{- if not .Values.externaldb.broker.serviceInstanceName }}
             - name: DATABASE_NAME
+              {{- if not .Values.externaldb.broker.serviceInstanceName }}
               valueFrom:
                 secretKeyRef:
                   name: {{ template "node.secretName" . }}
                   key: database
-            {{- else }}
-            - name: DATABASE_NAME
+              {{- else }}
               value: ""
-            {{- end }}
+              {{- end }}
             - name: DATABASE_PORT
               valueFrom:
                 secretKeyRef:
@@ -125,13 +124,12 @@ spec:
                 secretKeyRef:
                   name: {{ template "node.secretName" . }}
                   key: password
-            {{- if .Values.externaldb.ssl }}
             - name: DATABASE_CONNECTION_OPTIONS
+              {{- if .Values.externaldb.ssl }}
               value: "ssl=true"
-            {{- else }}
-            - name: DATABASE_CONNECTION_OPTIONS
+              {{- else }}
               value: ""
-            {{- end }}
+              {{- end }}
             {{- end }}
             - name: DATA_FOLDER
               value: "/app"

--- a/bitnami/node/templates/mongodb-binding.yaml
+++ b/bitnami/node/templates/mongodb-binding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.externaldb.broker.serviceInstanceName }}
+{{- if and .Values.externaldb.enabled .Values.externaldb.broker.serviceInstanceName }}
 apiVersion: servicecatalog.k8s.io/v1beta1
 kind: ServiceBinding
 metadata:

--- a/bitnami/node/values.yaml
+++ b/bitnami/node/values.yaml
@@ -229,12 +229,14 @@ ingress:
   #   key:
   #   certificate:
 
+##
 ## MongoDB chart configuration
 ## ref: https://github.com/bitnami/charts/blob/master/bitnami/mongodb/values.yaml
 ##
 mongodb:
-  ## Whether to deploy a mongodb server to satisfy the applications database requirements.
+  ## Whether to deploy a MongoDB server to satisfy the applications database requirements.
   ## To use an external database set this to false and configure the externaldb parameters
+  ##
   install: true
   ## MongoDB custom user and database
   ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#creating-a-user-and-database-on-first-run
@@ -244,12 +246,18 @@ mongodb:
     database: test_db
     password: secret_password
 
-## Provision an external database (Only if mongodb.install is false)
-## You can:
+##
+## External Database Configuration
+##
+## Provision an external database
+## You have two alternatives:
 ##    1) Pass an already existing Secret with your database credentials
 ##    2) Pass an already existing ServiceInstance name and specify the service catalog broker to automatically create a ServiceBinding for your application.
 ##
 externaldb:
+  ## Enables or disables external database
+  ##
+  enabled: false
   ## Set to true if your external database has ssl enabled
   ##
   ssl: false


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Our current Node chart assumes the Node app to deploy uses a database, but that should be optional. This PR allows disabling the database.

**Benefits**

Covering more use cases.

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/4013

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
