### PR TITLE
Add chart scaffolding to serve as a guide when creating new charts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,5 +39,5 @@ When submitting a PR make sure that it:
 
 There are only three major requirements to add a new chart in our catalog:
 - The chart should use Bitnami based container images. If they don't exist, you can [open a GitHub issue](https://github.com/bitnami/charts/issues/new/choose) and we will work together to create them.
-- Follow the same structure/patterns that the rest of the Bitnami charts and the [Best Practices for Creating Production-Ready Helm charts](https://docs.bitnami.com/tutorials/production-ready-charts/) guide.
+- Follow the same structure/patterns that the rest of the Bitnami charts (you can find a basic scaffolding in the [`templates` directory](https://github.com/bitnami/charts/tree/master/templates)) and the [Best Practices for Creating Production-Ready Helm charts](https://docs.bitnami.com/tutorials/production-ready-charts/) guide.
 - Use an [OSI approved license](https://opensource.org/licenses) for all the software.

--- a/template/CHART_NAME/.helmignore
+++ b/template/CHART_NAME/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/template/CHART_NAME/Chart.yaml
+++ b/template/CHART_NAME/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+name: %%CHART_NAME%%
+description: %%DESCRIPTION%%
+appVersion: %%UPSTREAM_PROJECT_VERSION%%
+version: 0.1.0
+keywords:
+  - %%UPSTREAM_PROJECT_KEYWORD%%
+  - %%UPSTREAM_PROJECT_KEYWORD%%
+  - ...
+home: %%UPSTREAM_PROJECT_URL%%
+sources:
+  - https://github.com/bitnami/bitnami-docker-%%IMAGE_NAME%%
+  - %%UPSTREAM_PROJECT_SOURCE_CODE_URL%%
+  - ...
+maintainers:
+  - name: Bitnami
+    email: containers@bitnami.com
+engine: gotpl
+icon: https://bitnami.com/assets/stacks/%%IMAGE_NAME%%/img/%%IMAGE_NAME%%-stack-110x117.png
+annotations:
+  category: %%CHOOSE_ONE_FROM_CHART_CATEGORIES_FILE%%

--- a/template/CHART_NAME/requirements.yaml
+++ b/template/CHART_NAME/requirements.yaml
@@ -1,0 +1,10 @@
+dependencies:
+  - name: common
+    version: 0.x.x
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+  - name: SUBCHART_NAME
+    repository: https://charts.bitnami.com/bitnami
+    version: %%MAJOR_SUBCHART_VERSION_(A.X.X)%%
+    condition: SUBCHART_NAME.enabled

--- a/template/CHART_NAME/templates/NOTES.txt
+++ b/template/CHART_NAME/templates/NOTES.txt
@@ -1,0 +1,5 @@
+%%Instructions to access the application depending on the serviceType and other considerations%%
+
+{{ include "common.warnings.rollingTag" .Values.%%MAIN_OBJECT_BLOCK%%.image }}
+{{ include "common.warnings.rollingTag" .Values.%%OTHER_OBJECT_BLOCK%%.image }}
+{{- include "%%TEMPLATE_NAME%%.validateValues" . }}

--- a/template/CHART_NAME/templates/NOTES.txt
+++ b/template/CHART_NAME/templates/NOTES.txt
@@ -1,5 +1,5 @@
 %%Instructions to access the application depending on the serviceType and other considerations%%
 
-{{ include "common.warnings.rollingTag" .Values.%%MAIN_OBJECT_BLOCK%%.image }}
-{{ include "common.warnings.rollingTag" .Values.%%OTHER_OBJECT_BLOCK%%.image }}
+{{- include "common.warnings.rollingTag" .Values.%%MAIN_OBJECT_BLOCK%%.image }}
+{{- include "common.warnings.rollingTag" .Values.%%OTHER_OBJECT_BLOCK%%.image }}
 {{- include "%%TEMPLATE_NAME%%.validateValues" . }}

--- a/template/CHART_NAME/templates/_helpers.tpl
+++ b/template/CHART_NAME/templates/_helpers.tpl
@@ -1,0 +1,40 @@
+{{/*
+Return the proper %%MAIN_OBJECT_BLOCK%% image name
+*/}}
+{{- define "%%TEMPLATE_NAME%%.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.%%MAIN_OBJECT_BLOCK%%.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "%%TEMPLATE_NAME%%.imagePullSecrets" -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.%%MAIN_OBJECT_BLOCK%%.image .Values.%%SECONDARY_OBJECT_BLOCK%%.image) "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "%%TEMPLATE_NAME%%.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (printf "%s-foo" (include "common.names.fullname" .)) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Compile all warnings into a single message.
+*/}}
+{{- define "%%TEMPLATE_NAME%%.validateValues" -}}
+{{- $messages := list -}}
+{{- $messages := append $messages (include "%%TEMPLATE_NAME%%.validateValues.foo" .) -}}
+{{- $messages := append $messages (include "%%TEMPLATE_NAME%%.validateValues.bar" .) -}}
+{{- $messages := without $messages "" -}}
+{{- $message := join "\n" $messages -}}
+
+{{- if $message -}}
+{{-   printf "\nVALUES VALIDATION:\n%s" $message -}}
+{{- end -}}
+{{- end -}}
+

--- a/template/CHART_NAME/templates/_helpers.tpl
+++ b/template/CHART_NAME/templates/_helpers.tpl
@@ -6,10 +6,17 @@ Return the proper %%MAIN_OBJECT_BLOCK%% image name
 {{- end -}}
 
 {{/*
+Return the proper image name (for the init container volume-permissions image)
+*/}}
+{{- define "%%TEMPLATE_NAME%%.volumePermissions.image" -}}
+{{- include "common.images.image" ( dict "imageRoot" .Values.volumePermissions.image "global" .Values.global ) -}}
+{{- end -}}
+
+{{/*
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "%%TEMPLATE_NAME%%.imagePullSecrets" -}}
-{{- include "common.images.pullSecrets" (dict "images" (list .Values.%%MAIN_OBJECT_BLOCK%%.image .Values.%%SECONDARY_OBJECT_BLOCK%%.image) "global" .Values.global) -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.%%MAIN_OBJECT_BLOCK%%.image .Values.%%SECONDARY_OBJECT_BLOCK%%.image .Values.volumePermissions.image) "global" .Values.global) -}}
 {{- end -}}
 
 {{/*

--- a/template/CHART_NAME/templates/clusterrolebinding.yaml
+++ b/template/CHART_NAME/templates/clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: %%COMPONENT_NAME%%
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  name: {{ template "common.names.fullname" . }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "common.names.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "%%TEMPLATE_NAME%%.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/template/CHART_NAME/templates/configmap.yaml
+++ b/template/CHART_NAME/templates/configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: %%COMPONENT_NAME%%
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  name: {{ template "common.names.fullname" . }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+data:
+  %%CONFIG_FILE_NAME%%: |
+  # Config file

--- a/template/CHART_NAME/templates/daemonset.yaml
+++ b/template/CHART_NAME/templates/daemonset.yaml
@@ -45,9 +45,25 @@ spec:
       {{- if .Values.%%MAIN_OBJECT_BLOCK%%.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.%%MAIN_OBJECT_BLOCK%%.podSecurityContext "enabled" | toYaml | nindent 12 }}
       {{- end }}
-      {{- if .Values.%%MAIN_OBJECT_BLOCK%%.initContainers }}
-      initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.initContainers "context" $) | nindent 8 }}
-      {{- end }}
+      initContainers:
+        {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
+        - name: volume-permissions
+          image: {{ include "%%TEMPLATE_NAME%%.volumePermissions.image" . }}
+          imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
+          command:
+            - %%commands%%
+          securityContext:
+            runAsUser: 0
+          {{- if .Values.volumePermissions.resources }}
+          resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: foo
+              mountPath: bar
+        {{- end }}
+        {{- if .Values.%%MAIN_OBJECT_BLOCK%%.initContainers }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.initContainers "context" $) | nindent 8 }}
+        {{- end }}
       containers:
         - name: %%CONTAINER_NAME%%
           image: {{ template "%%TEMPLATE_NAME%%.image" . }}

--- a/template/CHART_NAME/templates/daemonset.yaml
+++ b/template/CHART_NAME/templates/daemonset.yaml
@@ -32,6 +32,11 @@ spec:
       {{- include "%%TEMPLATE_NAME%%.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.%%MAIN_OBJECT_BLOCK%%.affinity }}
       affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.%%MAIN_OBJECT_BLOCK%%.podAffinityPreset "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.%%MAIN_OBJECT_BLOCK%%.podAntiAffinityPreset "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.%%MAIN_OBJECT_BLOCK%%.nodeAffinityPreset.type "key" .Values.%%MAIN_OBJECT_BLOCK%%.nodeAffinityPreset.key "values" .Values.%%MAIN_OBJECT_BLOCK%%.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
       {{- if .Values.%%MAIN_OBJECT_BLOCK%%.nodeSelector }}
       nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.nodeSelector "context" $) | nindent 8 }}

--- a/template/CHART_NAME/templates/daemonset.yaml
+++ b/template/CHART_NAME/templates/daemonset.yaml
@@ -58,11 +58,8 @@ spec:
           {{- if .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
-          command:
           {{- if .Values.%%MAIN_OBJECT_BLOCK%%.command }}
-          {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.command "context" $) | nindent 12 }}
-          {{- else }}
-            %%CONTAINER_COMMAND%%
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.command "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.%%MAIN_OBJECT_BLOCK%%.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.args "context" $) | nindent 12 }}

--- a/template/CHART_NAME/templates/daemonset.yaml
+++ b/template/CHART_NAME/templates/daemonset.yaml
@@ -86,18 +86,25 @@ spec:
           resources: {{- toYaml .Values.%%MAIN_OBJECT_BLOCK%%.resources | nindent 12 }}
           {{- end }}
           {{- if .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe.enabled }}
-          livenessProbe: {{- omit .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe "enabled" | toYaml | nindent 12 }}
-            exec:
-              command:
-                - commands
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            %%httpGet || command || etc%%
+            initialDelaySeconds: {{ .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe.failureThreshold }}
           {{- else if .Values.%%MAIN_OBJECT_BLOCK%%.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe.enabled }}
-          readinessProbe: {{- omit .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe "enabled" | toYaml | nindent 12 }}
-            exec:
-              command:
-                - commands
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            %%httpGet || command || etc%%
+            initialDelaySeconds: {{ .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe.failureThreshold }}
           {{- else if .Values.%%MAIN_OBJECT_BLOCK%%.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}

--- a/template/CHART_NAME/templates/daemonset.yaml
+++ b/template/CHART_NAME/templates/daemonset.yaml
@@ -1,0 +1,117 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: %%COMPONENT_NAME%%
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  name: {{ template "common.names.fullname" . }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.%%MAIN_OBJECT_BLOCK%%.updateStrategy }}
+  updateStrategy: {{- toYaml .Values.%%MAIN_OBJECT_BLOCK%%.updateStrategy | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: %%COMPONENT_NAME%%
+  template:
+    metadata:
+      {{- if .Values.%%MAIN_OBJECT_BLOCK%%.podAnnotations }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.podAnnotations "context" $) | nindent 8 }}
+      {{- end }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        app.kubernetes.io/component: %%COMPONENT_NAME%%
+        {{- if .Values.%%MAIN_OBJECT_BLOCK%%.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.podLabels "context" $) | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ template "%%TEMPLATE_NAME%%.serviceAccountName" . }}
+      {{- include "%%TEMPLATE_NAME%%.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.%%MAIN_OBJECT_BLOCK%%.affinity }}
+      affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.affinity "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.%%MAIN_OBJECT_BLOCK%%.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      tolerations:
+        {{- if .Values.%%MAIN_OBJECT_BLOCK%%.tolerations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.tolerations "context" .) | nindent 8 }}
+        {{- end }}
+      {{- if .Values.%%MAIN_OBJECT_BLOCK%%.priorityClassName }}
+      priorityClassName: {{ .Values.%%MAIN_OBJECT_BLOCK%%.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.%%MAIN_OBJECT_BLOCK%%.podSecurityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.%%MAIN_OBJECT_BLOCK%%.podSecurityContext.fsGroup }}
+      {{- end }}
+      {{- if .Values.%%MAIN_OBJECT_BLOCK%%.initContainers }}
+      initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.initContainers "context" $) | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: %%CONTAINER_NAME%%
+          image: {{ template "%%TEMPLATE_NAME%%.image" . }}
+          imagePullPolicy: {{ .Values.%%MAIN_OBJECT_BLOCK%%.image.pullPolicy }}
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext.enabled }}
+          securityContext:
+            runAsUser: {{ .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext.runAsUser }}
+            runAsNonRoot: {{ .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext.runAsNonRoot }}
+          {{- end }}
+          command:
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.command }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.command "context" $) | nindent 12 }}
+          {{- else }}
+            %%CONTAINER_COMMAND%%
+          {{- end }}
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.args "context" $) | nindent 12 }}
+          {{- end }}
+          env:
+            - name: foo
+              value: bar
+            {{- if .Values.%%MAIN_OBJECT_BLOCK%%.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- if .Values.%%MAIN_OBJECT_BLOCK%%.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.%%MAIN_OBJECT_BLOCK%%.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.extraEnvVarsSecret "context" $) }}
+            {{- end }}
+          ports:
+            - containerPort: foo
+              protocol: bar
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.resources }}
+          resources: {{- toYaml .Values.%%MAIN_OBJECT_BLOCK%%.resources | nindent 12 }}
+          {{- end }}
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.customLivenessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: foo
+              mountPath: bar
+              readOnly: true
+            {{- if .Values.%%MAIN_OBJECT_BLOCK%%.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
+        {{- if .Values.%%MAIN_OBJECT_BLOCK%%.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.sidecars "context" $) | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: foo
+          hostPath:
+            path: bar
+        {{- if .Values.%%MAIN_OBJECT_BLOCK%%.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}

--- a/template/CHART_NAME/templates/daemonset.yaml
+++ b/template/CHART_NAME/templates/daemonset.yaml
@@ -43,8 +43,7 @@ spec:
       priorityClassName: {{ .Values.%%MAIN_OBJECT_BLOCK%%.priorityClassName | quote }}
       {{- end }}
       {{- if .Values.%%MAIN_OBJECT_BLOCK%%.podSecurityContext.enabled }}
-      securityContext:
-        fsGroup: {{ .Values.%%MAIN_OBJECT_BLOCK%%.podSecurityContext.fsGroup }}
+      securityContext: {{- omit .Values.%%MAIN_OBJECT_BLOCK%%.podSecurityContext "enabled" | toYaml | nindent 12 }}
       {{- end }}
       {{- if .Values.%%MAIN_OBJECT_BLOCK%%.initContainers }}
       initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.initContainers "context" $) | nindent 8 }}
@@ -57,9 +56,7 @@ spec:
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.lifecycleHooks "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext.enabled }}
-          securityContext:
-            runAsUser: {{ .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext.runAsUser }}
-            runAsNonRoot: {{ .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext.runAsNonRoot }}
+          securityContext: {{- omit .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           command:
           {{- if .Values.%%MAIN_OBJECT_BLOCK%%.command }}

--- a/template/CHART_NAME/templates/daemonset.yaml
+++ b/template/CHART_NAME/templates/daemonset.yaml
@@ -91,10 +91,20 @@ spec:
           {{- if .Values.%%MAIN_OBJECT_BLOCK%%.resources }}
           resources: {{- toYaml .Values.%%MAIN_OBJECT_BLOCK%%.resources | nindent 12 }}
           {{- end }}
-          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.customLivenessProbe }}
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe.enabled }}
+          livenessProbe: {{- omit .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe "enabled" | toYaml | nindent 12 }}
+            exec:
+              command:
+                - commands
+          {{- else if .Values.%%MAIN_OBJECT_BLOCK%%.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.customReadinessProbe }}
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe.enabled }}
+          readinessProbe: {{- omit .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe "enabled" | toYaml | nindent 12 }}
+            exec:
+              command:
+                - commands
+          {{- else if .Values.%%MAIN_OBJECT_BLOCK%%.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:

--- a/template/CHART_NAME/templates/daemonset.yaml
+++ b/template/CHART_NAME/templates/daemonset.yaml
@@ -36,10 +36,9 @@ spec:
       {{- if .Values.%%MAIN_OBJECT_BLOCK%%.nodeSelector }}
       nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
-      tolerations:
-        {{- if .Values.%%MAIN_OBJECT_BLOCK%%.tolerations }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.tolerations "context" .) | nindent 8 }}
-        {{- end }}
+      {{- if .Values.%%MAIN_OBJECT_BLOCK%%.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.tolerations "context" .) | nindent 8 }}
+      {{- end }}
       {{- if .Values.%%MAIN_OBJECT_BLOCK%%.priorityClassName }}
       priorityClassName: {{ .Values.%%MAIN_OBJECT_BLOCK%%.priorityClassName | quote }}
       {{- end }}

--- a/template/CHART_NAME/templates/deployment.yaml
+++ b/template/CHART_NAME/templates/deployment.yaml
@@ -129,7 +129,6 @@ spec:
           volumeMounts:
             - name: foo
               mountPath: bar
-              readOnly: true
           {{- if .Values.%%MAIN_OBJECT_BLOCK%%.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}

--- a/template/CHART_NAME/templates/deployment.yaml
+++ b/template/CHART_NAME/templates/deployment.yaml
@@ -36,16 +36,9 @@ spec:
       {{- if .Values.%%MAIN_OBJECT_BLOCK%%.nodeSelector }}
       nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
-      tolerations:
-        - effect: NoSchedule
-          key: node.alpha.kubernetes.io/role
-          operator: Exists
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: Exists
-        {{- if .Values.%%MAIN_OBJECT_BLOCK%%.tolerations }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.tolerations "context" .) | nindent 8 }}
-        {{- end }}
+      {{- if .Values.%%MAIN_OBJECT_BLOCK%%.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.tolerations "context" .) | nindent 8 }}
+      {{- end }}
       {{- if .Values.%%MAIN_OBJECT_BLOCK%%.priorityClassName }}
       priorityClassName: {{ .Values.%%MAIN_OBJECT_BLOCK%%.priorityClassName | quote }}
       {{- end }}

--- a/template/CHART_NAME/templates/deployment.yaml
+++ b/template/CHART_NAME/templates/deployment.yaml
@@ -78,6 +78,9 @@ spec:
           env:
             - name: foo
               value: bar
+            {{- if .Values.%%MAIN_OBJECT_BLOCK%%.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
           envFrom:
             {{- if .Values.%%MAIN_OBJECT_BLOCK%%.extraEnvVarsCM }}
             - configMapRef:
@@ -90,10 +93,20 @@ spec:
           {{- if .Values.%%MAIN_OBJECT_BLOCK%%.resources }}
           resources: {{- toYaml .Values.%%MAIN_OBJECT_BLOCK%%.resources | nindent 12 }}
           {{- end }}
-          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.customLivenessProbe }}
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe.enabled }}
+          livenessProbe: {{- omit .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe "enabled" | toYaml | nindent 12 }}
+            exec:
+              command:
+                - commands
+          {{- else if .Values.%%MAIN_OBJECT_BLOCK%%.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.customReadinessProbe }}
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe.enabled }}
+          readinessProbe: {{- omit .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe "enabled" | toYaml | nindent 12 }}
+            exec:
+              command:
+                - commands
+          {{- else if .Values.%%MAIN_OBJECT_BLOCK%%.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:

--- a/template/CHART_NAME/templates/deployment.yaml
+++ b/template/CHART_NAME/templates/deployment.yaml
@@ -11,6 +11,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  replicas: {{ .Values.replicaCount }}
   {{- if .Values.%%MAIN_OBJECT_BLOCK%%.updateStrategy }}
   strategy: {{- toYaml .Values.co%%MAIN_OBJECT_BLOCK%%ector.updateStrategy | nindent 4 }}
   {{- end }}

--- a/template/CHART_NAME/templates/deployment.yaml
+++ b/template/CHART_NAME/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}

--- a/template/CHART_NAME/templates/deployment.yaml
+++ b/template/CHART_NAME/templates/deployment.yaml
@@ -88,19 +88,25 @@ spec:
           {{- if .Values.%%MAIN_OBJECT_BLOCK%%.resources }}
           resources: {{- toYaml .Values.%%MAIN_OBJECT_BLOCK%%.resources | nindent 12 }}
           {{- end }}
-          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe.enabled }}
-          livenessProbe: {{- omit .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe "enabled" | toYaml | nindent 12 }}
-            exec:
-              command:
-                - commands
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            %%httpGet || command || etc%%
+            initialDelaySeconds: {{ .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe.failureThreshold }}
           {{- else if .Values.%%MAIN_OBJECT_BLOCK%%.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe.enabled }}
-          readinessProbe: {{- omit .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe "enabled" | toYaml | nindent 12 }}
-            exec:
-              command:
-                - commands
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            %%httpGet || command || etc%%
+            initialDelaySeconds: {{ .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe.failureThreshold }}
           {{- else if .Values.%%MAIN_OBJECT_BLOCK%%.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}

--- a/template/CHART_NAME/templates/deployment.yaml
+++ b/template/CHART_NAME/templates/deployment.yaml
@@ -32,6 +32,11 @@ spec:
       {{- include "%%TEMPLATE_NAME%%.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.%%MAIN_OBJECT_BLOCK%%.affinity }}
       affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.affinity "context" $) | nindent 8 }}
+     {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.%%MAIN_OBJECT_BLOCK%%.podAffinityPreset "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.%%MAIN_OBJECT_BLOCK%%.podAntiAffinityPreset "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.%%MAIN_OBJECT_BLOCK%%.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
       {{- if .Values.%%MAIN_OBJECT_BLOCK%%.nodeSelector }}
       nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.nodeSelector "context" $) | nindent 8 }}

--- a/template/CHART_NAME/templates/deployment.yaml
+++ b/template/CHART_NAME/templates/deployment.yaml
@@ -51,9 +51,25 @@ spec:
       {{- if .Values.%%MAIN_OBJECT_BLOCK%%.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.%%MAIN_OBJECT_BLOCK%%.podSecurityContext "enabled" | toYaml | nindent 12 }}
       {{- end }}
-      {{- if .Values.%%MAIN_OBJECT_BLOCK%%.initContainers }}
-      initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.initContainers "context" $) | nindent 8 }}
-      {{- end }}
+      initContainers:
+        {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
+        - name: volume-permissions
+          image: {{ include "%%TEMPLATE_NAME%%.volumePermissions.image" . }}
+          imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
+          command:
+            - %%commands%%
+          securityContext:
+            runAsUser: 0
+          {{- if .Values.volumePermissions.resources }}
+          resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: foo
+              mountPath: bar
+        {{- end }}
+        {{- if .Values.%%MAIN_OBJECT_BLOCK%%.initContainers }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.initContainers "context" $) | nindent 8 }}
+        {{- end }}
       containers:
         - name: %%CONTAINER_NAME%%
           image: {{ template "%%TEMPLATE_NAME%%.image" . }}

--- a/template/CHART_NAME/templates/deployment.yaml
+++ b/template/CHART_NAME/templates/deployment.yaml
@@ -49,8 +49,7 @@ spec:
       priorityClassName: {{ .Values.%%MAIN_OBJECT_BLOCK%%.priorityClassName | quote }}
       {{- end }}
       {{- if .Values.%%MAIN_OBJECT_BLOCK%%.podSecurityContext.enabled }}
-      securityContext:
-        fsGroup: {{ .Values.%%MAIN_OBJECT_BLOCK%%.podSecurityContext.fsGroup }}
+      securityContext: {{- omit .Values.%%MAIN_OBJECT_BLOCK%%.podSecurityContext "enabled" | toYaml | nindent 12 }}
       {{- end }}
       {{- if .Values.%%MAIN_OBJECT_BLOCK%%.initContainers }}
       initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.initContainers "context" $) | nindent 8 }}
@@ -63,9 +62,7 @@ spec:
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.lifecycleHooks "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext.enabled }}
-          securityContext:
-            runAsUser: {{ .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext.runAsUser }}
-            runAsNonRoot: {{ .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext.runAsNonRoot }}
+          securityContext: {{- omit .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           command:
           {{- if .Values.%%MAIN_OBJECT_BLOCK%%.command }}

--- a/template/CHART_NAME/templates/deployment.yaml
+++ b/template/CHART_NAME/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       {{- include "%%TEMPLATE_NAME%%.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.%%MAIN_OBJECT_BLOCK%%.affinity }}
       affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.affinity "context" $) | nindent 8 }}
-     {{- else }}
+      {{- else }}
       affinity:
         podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.%%MAIN_OBJECT_BLOCK%%.podAffinityPreset "context" $) | nindent 10 }}
         podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.%%MAIN_OBJECT_BLOCK%%.podAntiAffinityPreset "context" $) | nindent 10 }}

--- a/template/CHART_NAME/templates/deployment.yaml
+++ b/template/CHART_NAME/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       affinity:
         podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.%%MAIN_OBJECT_BLOCK%%.podAffinityPreset "context" $) | nindent 10 }}
         podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.%%MAIN_OBJECT_BLOCK%%.podAntiAffinityPreset "context" $) | nindent 10 }}
-        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.%%MAIN_OBJECT_BLOCK%%.nodeAffinityPreset.values) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.%%MAIN_OBJECT_BLOCK%%.nodeAffinityPreset.type "key" .Values.%%MAIN_OBJECT_BLOCK%%.nodeAffinityPreset.key "values" .Values.%%MAIN_OBJECT_BLOCK%%.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
       {{- if .Values.%%MAIN_OBJECT_BLOCK%%.nodeSelector }}
       nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.nodeSelector "context" $) | nindent 8 }}

--- a/template/CHART_NAME/templates/deployment.yaml
+++ b/template/CHART_NAME/templates/deployment.yaml
@@ -1,0 +1,117 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: %%COMPONENT_NAME%%
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  name: {{ template "common.names.fullname" . }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.%%MAIN_OBJECT_BLOCK%%.updateStrategy }}
+  strategy: {{- toYaml .Values.co%%MAIN_OBJECT_BLOCK%%ector.updateStrategy | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: %%COMPONENT_NAME%%
+  template:
+    metadata:
+      {{- if .Values.%%MAIN_OBJECT_BLOCK%%.podAnnotations }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.podAnnotations "context" $) | nindent 8 }}
+      {{- end }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        app.kubernetes.io/component: %%COMPONENT_NAME%%
+        {{- if .Values.%%MAIN_OBJECT_BLOCK%%.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.podLabels "context" $) | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ template "%%TEMPLATE_NAME%%.serviceAccountName" . }}
+      {{- include "%%TEMPLATE_NAME%%.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.%%MAIN_OBJECT_BLOCK%%.affinity }}
+      affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.affinity "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.%%MAIN_OBJECT_BLOCK%%.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      tolerations:
+        - effect: NoSchedule
+          key: node.alpha.kubernetes.io/role
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+        {{- if .Values.%%MAIN_OBJECT_BLOCK%%.tolerations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.tolerations "context" .) | nindent 8 }}
+        {{- end }}
+      {{- if .Values.%%MAIN_OBJECT_BLOCK%%.priorityClassName }}
+      priorityClassName: {{ .Values.%%MAIN_OBJECT_BLOCK%%.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.%%MAIN_OBJECT_BLOCK%%.podSecurityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.%%MAIN_OBJECT_BLOCK%%.podSecurityContext.fsGroup }}
+      {{- end }}
+      {{- if .Values.%%MAIN_OBJECT_BLOCK%%.initContainers }}
+      initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.initContainers "context" $) | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: %%CONTAINER_NAME%%
+          image: {{ template "%%TEMPLATE_NAME%%.image" . }}
+          imagePullPolicy: {{ .Values.%%MAIN_OBJECT_BLOCK%%.image.pullPolicy }}
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext.enabled }}
+          securityContext:
+            runAsUser: {{ .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext.runAsUser }}
+            runAsNonRoot: {{ .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext.runAsNonRoot }}
+          {{- end }}
+          command:
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.command }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.command "context" $) | nindent 12 }}
+          {{- else }}
+            %%CONTAINER_COMMAND%%
+          {{- end }}
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.args "context" $) | nindent 12 }}
+          {{- end }}
+          env:
+            - name: foo
+              value: bar
+          envFrom:
+            {{- if .Values.%%MAIN_OBJECT_BLOCK%%.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.%%MAIN_OBJECT_BLOCK%%.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.extraEnvVarsSecret "context" $) }}
+            {{- end }}
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.resources }}
+          resources: {{- toYaml .Values.%%MAIN_OBJECT_BLOCK%%.resources | nindent 12 }}
+          {{- end }}
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.customLivenessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: foo
+              mountPath: bar
+              readOnly: true
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.extraVolumeMounts }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
+        {{- if .Values.%%MAIN_OBJECT_BLOCK%%.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.sidecars "context" $) | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: foo
+          hostPath:
+            path: bar
+        {{- if .Values.%%MAIN_OBJECT_BLOCK%%.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}

--- a/template/CHART_NAME/templates/deployment.yaml
+++ b/template/CHART_NAME/templates/deployment.yaml
@@ -64,11 +64,8 @@ spec:
           {{- if .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
-          command:
           {{- if .Values.%%MAIN_OBJECT_BLOCK%%.command }}
-          {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.command "context" $) | nindent 12 }}
-          {{- else }}
-            %%CONTAINER_COMMAND%%
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.command "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.%%MAIN_OBJECT_BLOCK%%.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.args "context" $) | nindent 12 }}

--- a/template/CHART_NAME/templates/extra-list.yaml
+++ b/template/CHART_NAME/templates/extra-list.yaml
@@ -1,0 +1,5 @@
+{{- if .Values.extraDeploy }}
+apiVersion: v1
+kind: List
+items: {{- include "common.tplvalues.render" (dict "value" .Values.extraDeploy "context" $) | nindent 2 }}
+{{- end }}

--- a/template/CHART_NAME/templates/secret.yaml
+++ b/template/CHART_NAME/templates/secret.yaml
@@ -12,4 +12,4 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  foo: bar
+  password-key: b64-password-value

--- a/template/CHART_NAME/templates/secret.yaml
+++ b/template/CHART_NAME/templates/secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: %%COMPONENT_NAME%%
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  name: {{ template "common.names.fullname" . }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  foo: bar

--- a/template/CHART_NAME/templates/service-account.yaml
+++ b/template/CHART_NAME/templates/service-account.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: %%COMPONENT_NAME%%
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  name: {{ template "%%TEMPLATE_NAME%%.serviceAccountName" . }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+  namespace: {{ .Release.Namespace }}

--- a/template/CHART_NAME/templates/service.yaml
+++ b/template/CHART_NAME/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: %%COMPONENT_NAME%%
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  name: {{ template "common.names.fullname" . }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  ports:
+    - name: %%PORT_NAME%%
+      port: foo
+      protocol: bar
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: %%COMPONENT_NAME%%
+  type: ClusterIP

--- a/template/CHART_NAME/templates/service.yaml
+++ b/template/CHART_NAME/templates/service.yaml
@@ -11,6 +11,16 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  type: {{ .Values.service.type }}
+  {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
+  {{- end }}
+  {{ if eq .Values.service.type "LoadBalancer" }}
+  loadBalancerSourceRanges: {{ .Values.service.loadBalancerSourceRanges }}
+  {{ end }}
+  {{- if (and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP))) }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   ports:
     - name: %%PORT_NAME%%
       port: foo

--- a/template/CHART_NAME/templates/statefulset.yaml
+++ b/template/CHART_NAME/templates/statefulset.yaml
@@ -35,6 +35,11 @@ spec:
       {{- include "%%TEMPLATE_NAME%%.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.%%MAIN_OBJECT_BLOCK%%.affinity }}
       affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.%%MAIN_OBJECT_BLOCK%%.podAffinityPreset "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.%%MAIN_OBJECT_BLOCK%%.podAntiAffinityPreset "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.%%MAIN_OBJECT_BLOCK%%.nodeAffinityPreset.type "key" .Values.%%MAIN_OBJECT_BLOCK%%.nodeAffinityPreset.key "values" .Values.%%MAIN_OBJECT_BLOCK%%.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
       {{- if .Values.%%MAIN_OBJECT_BLOCK%%.nodeSelector }}
       nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.nodeSelector "context" $) | nindent 8 }}

--- a/template/CHART_NAME/templates/statefulset.yaml
+++ b/template/CHART_NAME/templates/statefulset.yaml
@@ -48,9 +48,25 @@ spec:
       {{- if .Values.%%MAIN_OBJECT_BLOCK%%.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.%%MAIN_OBJECT_BLOCK%%.podSecurityContext "enabled" | toYaml | nindent 12 }}
       {{- end }}
-      {{- if .Values.%%MAIN_OBJECT_BLOCK%%.initContainers }}
-      initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.initContainers "context" $) | nindent 8 }}
-      {{- end }}
+      initContainers:
+        {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
+        - name: volume-permissions
+          image: {{ include "%%TEMPLATE_NAME%%.volumePermissions.image" . }}
+          imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
+          command:
+            - %%commands%%
+          securityContext:
+            runAsUser: 0
+          {{- if .Values.volumePermissions.resources }}
+          resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: foo
+              mountPath: bar
+        {{- end }}
+        {{- if .Values.%%MAIN_OBJECT_BLOCK%%.initContainers }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.initContainers "context" $) | nindent 8 }}
+        {{- end }}
       containers:
         - name: %%CONTAINER_NAME%%
           image: {{ template "%%TEMPLATE_NAME%%.image" . }}

--- a/template/CHART_NAME/templates/statefulset.yaml
+++ b/template/CHART_NAME/templates/statefulset.yaml
@@ -12,6 +12,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: %%COMPONENT_NAME%%

--- a/template/CHART_NAME/templates/statefulset.yaml
+++ b/template/CHART_NAME/templates/statefulset.yaml
@@ -46,8 +46,7 @@ spec:
       priorityClassName: {{ .Values.%%MAIN_OBJECT_BLOCK%%.priorityClassName | quote }}
       {{- end }}
       {{- if .Values.%%MAIN_OBJECT_BLOCK%%.podSecurityContext.enabled }}
-      securityContext:
-        fsGroup: {{ .Values.%%MAIN_OBJECT_BLOCK%%.podSecurityContext.fsGroup }}
+      securityContext: {{- omit .Values.%%MAIN_OBJECT_BLOCK%%.podSecurityContext "enabled" | toYaml | nindent 12 }}
       {{- end }}
       {{- if .Values.%%MAIN_OBJECT_BLOCK%%.initContainers }}
       initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.initContainers "context" $) | nindent 8 }}
@@ -60,9 +59,7 @@ spec:
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.lifecycleHooks "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext.enabled }}
-          securityContext:
-            runAsUser: {{ .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext.runAsUser }}
-            runAsNonRoot: {{ .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext.runAsNonRoot }}
+          securityContext: {{- omit .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           command:
           {{- if .Values.%%MAIN_OBJECT_BLOCK%%.command }}

--- a/template/CHART_NAME/templates/statefulset.yaml
+++ b/template/CHART_NAME/templates/statefulset.yaml
@@ -61,11 +61,8 @@ spec:
           {{- if .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
-          command:
           {{- if .Values.%%MAIN_OBJECT_BLOCK%%.command }}
-          {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.command "context" $) | nindent 12 }}
-          {{- else }}
-            %%CONTAINER_COMMAND%%
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.command "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.%%MAIN_OBJECT_BLOCK%%.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.args "context" $) | nindent 12 }}

--- a/template/CHART_NAME/templates/statefulset.yaml
+++ b/template/CHART_NAME/templates/statefulset.yaml
@@ -85,19 +85,25 @@ spec:
           {{- if .Values.%%MAIN_OBJECT_BLOCK%%.resources }}
           resources: {{- toYaml .Values.%%MAIN_OBJECT_BLOCK%%.resources | nindent 12 }}
           {{- end }}
-          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe.enabled }}
-          livenessProbe: {{- omit .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe "enabled" | toYaml | nindent 12 }}
-            exec:
-              command:
-                - commands
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            %%httpGet || command || etc%%
+            initialDelaySeconds: {{ .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe.failureThreshold }}
           {{- else if .Values.%%MAIN_OBJECT_BLOCK%%.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe.enabled }}
-          readinessProbe: {{- omit .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe "enabled" | toYaml | nindent 12 }}
-            exec:
-              command:
-                - commands
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            %%httpGet || command || etc%%
+            initialDelaySeconds: {{ .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe.failureThreshold }}
           {{- else if .Values.%%MAIN_OBJECT_BLOCK%%.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}

--- a/template/CHART_NAME/templates/statefulset.yaml
+++ b/template/CHART_NAME/templates/statefulset.yaml
@@ -75,6 +75,9 @@ spec:
           env:
             - name: foo
               value: bar
+            {{- if .Values.%%MAIN_OBJECT_BLOCK%%.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
           envFrom:
             {{- if .Values.%%MAIN_OBJECT_BLOCK%%.extraEnvVarsCM }}
             - configMapRef:
@@ -87,10 +90,20 @@ spec:
           {{- if .Values.%%MAIN_OBJECT_BLOCK%%.resources }}
           resources: {{- toYaml .Values.%%MAIN_OBJECT_BLOCK%%.resources | nindent 12 }}
           {{- end }}
-          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.customLivenessProbe }}
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe.enabled }}
+          livenessProbe: {{- omit .Values.%%MAIN_OBJECT_BLOCK%%.livenessProbe "enabled" | toYaml | nindent 12 }}
+            exec:
+              command:
+                - commands
+          {{- else if .Values.%%MAIN_OBJECT_BLOCK%%.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.customReadinessProbe }}
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe.enabled }}
+          readinessProbe: {{- omit .Values.%%MAIN_OBJECT_BLOCK%%.readinessProbe "enabled" | toYaml | nindent 12 }}
+            exec:
+              command:
+                - commands
+          {{- else if .Values.%%MAIN_OBJECT_BLOCK%%.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:

--- a/template/CHART_NAME/templates/statefulset.yaml
+++ b/template/CHART_NAME/templates/statefulset.yaml
@@ -1,0 +1,122 @@
+apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
+kind: StatefulSet
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: %%COMPONENT_NAME%%
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: %%COMPONENT_NAME%%
+  serviceName: {{ template "common.names.fullname" . }}
+  {{- if .Values.%%MAIN_OBJECT_BLOCK%%.updateStrategy }}
+  updateStrategy: {{- toYaml .Values.%%MAIN_OBJECT_BLOCK%%.updateStrategy | nindent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      {{- if .Values.%%MAIN_OBJECT_BLOCK%%.podAnnotations }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.podAnnotations "context" $) | nindent 8 }}
+      {{- end }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        app.kubernetes.io/component: %%COMPONENT_NAME%%
+        {{- if .Values.%%MAIN_OBJECT_BLOCK%%.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.podLabels "context" $) | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ template "%%TEMPLATE_NAME%%.serviceAccountName" . }}
+      {{- include "%%TEMPLATE_NAME%%.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.%%MAIN_OBJECT_BLOCK%%.affinity }}
+      affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.affinity "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.%%MAIN_OBJECT_BLOCK%%.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      tolerations:
+        - effect: NoSchedule
+          key: node.alpha.kubernetes.io/role
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+        {{- if .Values.%%MAIN_OBJECT_BLOCK%%.tolerations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.tolerations "context" .) | nindent 8 }}
+        {{- end }}
+      {{- if .Values.%%MAIN_OBJECT_BLOCK%%.priorityClassName }}
+      priorityClassName: {{ .Values.%%MAIN_OBJECT_BLOCK%%.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.%%MAIN_OBJECT_BLOCK%%.podSecurityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.%%MAIN_OBJECT_BLOCK%%.podSecurityContext.fsGroup }}
+      {{- end }}
+      {{- if .Values.%%MAIN_OBJECT_BLOCK%%.initContainers }}
+      initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.initContainers "context" $) | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: %%CONTAINER_NAME%%
+          image: {{ template "%%TEMPLATE_NAME%%.image" . }}
+          imagePullPolicy: {{ .Values.%%MAIN_OBJECT_BLOCK%%.image.pullPolicy }}
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext.enabled }}
+          securityContext:
+            runAsUser: {{ .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext.runAsUser }}
+            runAsNonRoot: {{ .Values.%%MAIN_OBJECT_BLOCK%%.containerSecurityContext.runAsNonRoot }}
+          {{- end }}
+          command:
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.command }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.command "context" $) | nindent 12 }}
+          {{- else }}
+            %%CONTAINER_COMMAND%%
+          {{- end }}
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.args "context" $) | nindent 12 }}
+          {{- end }}
+          env:
+            - name: foo
+              value: bar
+          envFrom:
+            {{- if .Values.%%MAIN_OBJECT_BLOCK%%.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.%%MAIN_OBJECT_BLOCK%%.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.extraEnvVarsSecret "context" $) }}
+            {{- end }}
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.resources }}
+          resources: {{- toYaml .Values.%%MAIN_OBJECT_BLOCK%%.resources | nindent 12 }}
+          {{- end }}
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.customLivenessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: foo
+              mountPath: bar
+              readOnly: true
+          {{- if .Values.%%MAIN_OBJECT_BLOCK%%.extraVolumeMounts }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
+        {{- if .Values.%%MAIN_OBJECT_BLOCK%%.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.sidecars "context" $) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.%%MAIN_OBJECT_BLOCK%%.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.sidecars "context" $) | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: foo
+          hostPath:
+            path: bar
+        {{- if .Values.%%MAIN_OBJECT_BLOCK%%.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}

--- a/template/CHART_NAME/templates/statefulset.yaml
+++ b/template/CHART_NAME/templates/statefulset.yaml
@@ -38,16 +38,9 @@ spec:
       {{- if .Values.%%MAIN_OBJECT_BLOCK%%.nodeSelector }}
       nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
-      tolerations:
-        - effect: NoSchedule
-          key: node.alpha.kubernetes.io/role
-          operator: Exists
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: Exists
-        {{- if .Values.%%MAIN_OBJECT_BLOCK%%.tolerations }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.tolerations "context" .) | nindent 8 }}
-        {{- end }}
+      {{- if .Values.%%MAIN_OBJECT_BLOCK%%.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.%%MAIN_OBJECT_BLOCK%%.tolerations "context" .) | nindent 8 }}
+      {{- end }}
       {{- if .Values.%%MAIN_OBJECT_BLOCK%%.priorityClassName }}
       priorityClassName: {{ .Values.%%MAIN_OBJECT_BLOCK%%.priorityClassName | quote }}
       {{- end }}

--- a/template/CHART_NAME/values.yaml
+++ b/template/CHART_NAME/values.yaml
@@ -127,6 +127,39 @@ service:
     enabled: true
     fsGroup: 1001
 
+  ## Pod affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAffinityPreset: ""
+
+  ## Pod anti-affinity preset
+  ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAntiAffinityPreset: soft
+
+  ## Node affinity preset
+  ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ## Allowed values: soft, hard
+  ##
+  nodeAffinityPreset:
+    ## Node affinity type
+    ## Allowed values: soft, hard
+    type: ""
+    ## Node label key to match
+    ## E.g.
+    ## key: "kubernetes.io/e2e-az-name"
+    ##
+    key: ""
+    ## Node label values to match
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+
   ## Affinity for pod assignment. Evaluated as a template.
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ##

--- a/template/CHART_NAME/values.yaml
+++ b/template/CHART_NAME/values.yaml
@@ -16,6 +16,10 @@ commonLabels: {}
 ##
 commonAnnotations: {}
 
+## Kubernetes Cluster Domain
+##
+clusterDomain: cluster.local
+
 ## Extra objects to deploy (value evaluated as a template)
 ##
 extraDeploy: []

--- a/template/CHART_NAME/values.yaml
+++ b/template/CHART_NAME/values.yaml
@@ -1,0 +1,206 @@
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+## Current available global Docker image parameters: imageRegistry and imagePullSecrets
+##
+# global:
+#   imageRegistry: myRegistryName
+#   imagePullSecrets:
+#     - myRegistryKeySecretName
+#   storageClass: myStorageClass
+
+## Add labels to all the deployed resources
+##
+commonLabels: {}
+
+## Add annotations to all the deployed resources
+##
+commonAnnotations: {}
+
+## Extra objects to deploy (value evaluated as a template)
+##
+extraDeploy: []
+
+## %%MAIN_CONTAINER/POD_DESCRIPTION%%
+##
+%%MAIN_OBJECT_BLOCK%%:
+  enabled: true
+  image:
+    registry: docker.io
+    repository: bitnami/%%IMAGE_NAME%%
+    tag: %%IMAGE_TAG%%
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+
+  %%OTHER_PARAMETERS_RELATED_TO_THIS_CONTAINER/POD%%
+
+  ## ConfigMap with %%MAIN_CONTAINER_NAME%% Configuration
+  ##
+  # existingConfigmap:
+
+  ## Command and args for running the container (set to default if not set). Use array form
+  ##
+  command: []
+  args: []
+
+  ## %%MAIN_CONTAINER_NAME%% resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits: {}
+    #   cpu: 200m
+    #   memory: 256Mi
+    requests: {}
+    #   cpu: 200m
+    #   memory: 10Mi
+
+  ## SecurityContext configuration
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ##
+  containerSecurityContext:
+    enabled: true
+    runAsUser: 1001
+    runAsNonRoot: true
+
+  podSecurityContext:
+    enabled: true
+    fsGroup: 1001
+
+  ## Affinity for pod assignment. Evaluated as a template.
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
+
+  ## Node labels for pod assignment. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Tolerations for pod assignment. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## Pod extra labels
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  ##
+  podLabels: {}
+
+  ## Annotations for server pods.
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+
+  ## %%MAIN_CONTAINER_NAME%% pods' priority.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  ##
+  # priorityClassName: ""
+
+  ## lifecycleHooks for the %%MAIN_CONTAINER_NAME%% container to automate configuration before or after startup.
+  ##
+  lifecycleHooks: {}
+
+  ## Custom Liveness probes for %%MAIN_CONTAINER_NAME%%
+  ##
+  customLivenessProbe: {}
+
+  ## Custom Rediness probes %%MAIN_CONTAINER_NAME%%
+  ##
+  customReadinessProbe: {}
+
+  ## Update strategy - only really applicable for deployments with RWO PVs attached
+  ## If replicas = 1, an update can get "stuck", as the previous pod remains attached to the
+  ## PV, and the "incoming" pod can never start. Changing the strategy to "Recreate" will
+  ## terminate the single previous pod, so that the new, incoming pod can attach to the PV
+  ##
+  updateStrategy:
+    type: RollingUpdate
+
+  ## An array to add extra env vars
+  ## For example:
+  ##
+  extraEnvVars: []
+  #  - name: BEARER_AUTH
+  #    value: true
+
+  ## ConfigMap with extra environment variables
+  ##
+  extraEnvVarsCM:
+
+  ## Secret with extra environment variables
+  ##
+  extraEnvVarsSecret:
+
+  ## Extra volumes to add to the deployment
+  ##
+  extraVolumes: []
+
+  ## Extra volume mounts to add to the container
+  ##
+  extraVolumeMounts: []
+
+  ## Add init containers to the %%MAIN_CONTAINER_NAME%% pods.
+  ## Example:
+  ## initContainers:
+  ##   - name: your-image-name
+  ##     image: your-image
+  ##     imagePullPolicy: Always
+  ##     ports:
+  ##       - name: portname
+  ##         containerPort: 1234
+  ##
+  initContainers: {}
+
+  ## Add sidecars to the %%MAIN_CONTAINER_NAME%% pods.
+  ## Example:
+  ## sidecars:
+  ##   - name: your-image-name
+  ##     image: your-image
+  ##     imagePullPolicy: Always
+  ##     ports:
+  ##       - name: portname
+  ##         containerPort: 1234
+  ##
+  sidecars: {}
+
+## %%SECONDARY_CONTAINER/POD_DESCRIPTION%%
+##
+%%SECONDARY_OBJECT_BLOCK%%:
+  %%SAME_STRUCTURE_AS_THE_MAIN_CONTAINER/POD%%
+
+## %%OTHERS_CONTAINER/POD_DESCRIPTION%%
+##
+%%OTHER_OBJECT_BLOCK%%:
+  %%SAME_STRUCTURE_AS_THE_MAIN_CONTAINER/POD%%
+
+## Specifies whether RBAC resources should be created
+##
+rbac:
+  create: true
+
+## Specifies whether a ServiceAccount should be created
+##
+serviceAccount:
+  create: true
+  ## The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the fullname template
+  ##
+  name:
+
+## %%SUBCHART_CONTAINER/POD_DESCRIPTION%%
+##
+%%SUBCHART_NAME%%:
+  enabled: false
+  %%OTHER_PARAMETERS_RELATED_TO_THIS_SUBCHART%%

--- a/template/CHART_NAME/values.yaml
+++ b/template/CHART_NAME/values.yaml
@@ -48,6 +48,25 @@ replicaCount: 1
     # pullSecrets:
     #   - myRegistryKeySecretName
 
+  ## Configure extra options for liveness and readiness probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+  livenessProbe:
+    enabled: true
+    path: "/path"
+    initialDelaySeconds: foo
+    periodSeconds: bar
+    timeoutSeconds: foo
+    failureThreshold: bar
+    successThreshold: foo
+  readinessProbe:
+    enabled: true
+    path: "/path"
+    initialDelaySeconds: foo
+    periodSeconds: bar
+    timeoutSeconds: foo
+    failureThreshold: bar
+    successThreshold: foo
+
   %%OTHER_PARAMETERS_RELATED_TO_THIS_CONTAINER/POD%%
 
   ## ConfigMap with %%MAIN_CONTAINER_NAME%% Configuration

--- a/template/CHART_NAME/values.yaml
+++ b/template/CHART_NAME/values.yaml
@@ -28,6 +28,28 @@ extraDeploy: []
 ##
 replicaCount: 1
 
+service:
+  type: LoadBalancer
+  # HTTP Port
+  port: foo
+  # HTTPS Port
+  httpsPort: bar
+  ## loadBalancerIP for the SuiteCRM Service (optional, cloud specific)
+  ## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
+  ##
+  ## loadBalancerIP:
+  ##
+  ## nodePorts:
+  ##   http: <to set explicitly, choose port between 30000-32767>
+  ##   https: <to set explicitly, choose port between 30000-32767>
+  nodePorts:
+    http: ""
+    https: ""
+  ## Enable client source IP preservation
+  ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+  ##
+  externalTrafficPolicy: Cluster
+
 ## %%MAIN_CONTAINER/POD_DESCRIPTION%%
 ##
 %%MAIN_OBJECT_BLOCK%%:
@@ -211,6 +233,40 @@ replicaCount: 1
 ##
 %%OTHER_OBJECT_BLOCK%%:
   %%SAME_STRUCTURE_AS_THE_MAIN_CONTAINER/POD%%
+
+## Init containers parameters:
+## volumePermissions: Change the owner and group of the persistent volume mountpoint to runAsUser:fsGroup values from the securityContext section.
+##
+volumePermissions:
+  enabled: false
+  image:
+    registry: docker.io
+    repository: bitnami/minideb
+    tag: buster
+    pullPolicy: Always
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    pullSecrets: []
+    ##   - myRegistryKeySecretName
+  ## Init containers' resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    ## We usually recommend not to specify default resources and to leave this as a conscious
+    ## choice for the user. This also increases chances charts run on environments with little
+    ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+    ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    ##
+    limits: {}
+    ##   cpu: 100m
+    ##   memory: 128Mi
+    ##
+    requests: {}
+    ##   cpu: 100m
+    ##   memory: 128Mi
+    ##
 
 ## Specifies whether RBAC resources should be created
 ##

--- a/template/CHART_NAME/values.yaml
+++ b/template/CHART_NAME/values.yaml
@@ -24,6 +24,10 @@ clusterDomain: cluster.local
 ##
 extraDeploy: []
 
+## Number of nodes
+##
+replicaCount: 1
+
 ## %%MAIN_CONTAINER/POD_DESCRIPTION%%
 ##
 %%MAIN_OBJECT_BLOCK%%:

--- a/template/README.md
+++ b/template/README.md
@@ -33,4 +33,4 @@ Some of the items that need to be implemented are:
 
 Also it is necessary to use the `bitnami/common` chart to standarize some of the above items.
 
-:warning: Take into account this is just an example to follow, depending on the specifc use case you will need to remove, add or modify those templates
+:warning: Take into account this is just an example to follow, depending on the specifc use case you will need to remove, add or modify those templates, beyond replacing the placeholders `%%FOO%%`

--- a/template/README.md
+++ b/template/README.md
@@ -1,0 +1,36 @@
+This directory contains a basic scaffolding to serve as the basis for creating a new chart.
+
+Some of the items that need to be implemented are:
+- commonAnnotations
+- commonLabels
+- imagePullSecret
+- extraDeploy
+- resources.requests
+- resources.limits
+- livenessProbe
+- readinessProbe
+- customLivenessProbe
+- customReadinessProbe
+- podLabels
+- affinity
+- nodeSelector
+- tolerations (that would override the default one)
+- podAnnotations
+- priorityClassName
+- lifecycleHooks
+- sidecars
+- initContainers
+- extraEnvVars
+- extraEnvVarsCM
+- extraEnvVarsSecret
+- command (which would override the default one)
+- args (which would override the default one)
+- extraVolumes
+- extraVolumeMounts
+- updateStrategy
+- podSecurityContext
+- containerSecurityContext
+
+Also it is necessary to use the `bitnami/common` chart to standarize some of the above items.
+
+:warning: Take into account this is just an example to follow, depending on the specifc use case you will need to remove, add or modify those templates


### PR DESCRIPTION
**Description of the change**

Add chart scaffolding to serve as a guide when creating new charts

```console
$ tree template
template
├── CHART_NAME
│   ├── Chart.yaml
│   ├── requirements.yaml
│   ├── templates
│   │   ├── clusterrolebinding.yaml
│   │   ├── configmap.yaml
│   │   ├── daemonset.yaml
│   │   ├── deployment.yaml
│   │   ├── extra-list.yaml
│   │   ├── _helpers.tpl
│   │   ├── NOTES.txt
│   │   ├── secret.yaml
│   │   ├── service-account.yaml
│   │   ├── service.yaml
│   │   └── statefulset.yaml
│   └── values.yaml
└── README.md
```