### PR TITLE
[bitnami/harbor] Fix SCANNER_REDIS_URL for trivy-scanner

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: harbor
-version: 8.0.0
+version: 8.0.1
 appVersion: 2.1.0
 description: Harbor is an an open source trusted cloud native registry project that stores, signs, and scans content
 keywords:

--- a/bitnami/harbor/templates/trivy/trivy-secret-envvars.yaml
+++ b/bitnami/harbor/templates/trivy/trivy-secret-envvars.yaml
@@ -15,4 +15,6 @@ type: Opaque
 data:
   SCANNER_TRIVY_GITHUB_TOKEN: {{ .Values.trivy.gitHubToken | default "" | b64enc | quote }}
   SCANNER_REDIS_URL: {{ include "harbor.redisForTrivyAdapter" . | b64enc }}
+  SCANNER_STORE_REDIS_URL: {{ include "harbor.redisForTrivyAdapter" . | b64enc }}
+  SCANNER_JOB_QUEUE_REDIS_URL: {{ include "harbor.redisForTrivyAdapter" . | b64enc }}
 {{- end }}

--- a/bitnami/harbor/templates/trivy/trivy-secret-envvars.yaml
+++ b/bitnami/harbor/templates/trivy/trivy-secret-envvars.yaml
@@ -14,6 +14,5 @@ metadata:
 type: Opaque
 data:
   SCANNER_TRIVY_GITHUB_TOKEN: {{ .Values.trivy.gitHubToken | default "" | b64enc | quote }}
-  SCANNER_STORE_REDIS_URL: {{ include "harbor.redisForTrivyAdapter" . | b64enc }}
-  SCANNER_JOB_QUEUE_REDIS_URL: {{ include "harbor.redisForTrivyAdapter" . | b64enc }}
+  SCANNER_REDIS_URL: {{ include "harbor.redisForTrivyAdapter" . | b64enc }}
 {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

The latest harbor-trivy-scanner seems to require the env var `SCANNER_REDIS_URL`, whereas previous versions required `SCANNER_STORE_REDIS_URL` and `SCANNER_JOB_QUEUE_REDIS_URL` (although they were set to the same value)

This change updates the chart v8.x.x for the new env var, which is required to make Trivy work. In the absense of this change, the trivy pod will start, but fail to scan, outputting the following:

```
ERROR: worker.fetch - dial tcp [::1]:6379: connect: connection refused
ERROR: worker.fetch - dial tcp [::1]:6379: connect: connection refused
```

**Benefits**

Trivy works!

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

None

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
`values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
