### PR TITLE
[bitnami/apache] feat: add extraEnvVars

### DIFF
--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: apache
-version: 7.5.1
+version: 7.6.0
 appVersion: 2.4.46
 description: Chart for Apache HTTP Server
 keywords:

--- a/bitnami/apache/README.md
+++ b/bitnami/apache/README.md
@@ -51,71 +51,72 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the Apache chart and their default values.
 
-| Parameter                        | Description                                                                                 | Default                                                      |
-|----------------------------------|---------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `global.imageRegistry`           | Global Docker image registry                                                                | `nil`                                                        |
-| `global.imagePullSecrets`        | Global Docker registry secret names as an array                                             | `[]` (does not add image pull secrets to deployed pods)      |
-| `image.registry`                 | Apache Docker image registry                                                                | `docker.io`                                                  |
-| `image.repository`               | Apache Docker image name                                                                    | `bitnami/apache`                                             |
-| `image.tag`                      | Apache Docker image tag                                                                     | `{TAG_NAME}`                                                 |
-| `image.pullPolicy`               | Apache Docker image pull policy                                                             | `Always`                                                     |
-| `image.pullSecrets`              | Specify Docker registry secret names as an array                                            | `[]` (does not add image pull secrets to deployed pods)      |
-| `git.registry`                   | Git image registry                                                                          | `docker.io`                                                  |
-| `git.repository`                 | Git image name                                                                              | `bitnami/git`                                                |
-| `git.tag`                        | Git image tag                                                                               | `{TAG_NAME}`                                                 |
-| `git.pullPolicy`                 | Git image pull policy                                                                       | `Always`                                                     |
-| `git.pullSecrets`                | Specify docker-registry secret names as an array                                            | `[]` (does not add image pull secrets to deployed pods)      |
-| `replicaCount`                   | Number of replicas of the Apache deployment                                                 | `docker.io`                                                  |
-| `htdocsConfigMap`                | ConfigMap with the server static content                                                    | `nil`                                                        |
-| `htdocsPVC`                      | PVC with the server static content                                                          | `nil`                                                        |
-| `vhostsConfigMap`                | ConfigMap with the virtual hosts content                                                    | `nil`                                                        |
-| `httpdConfConfigMap`             | ConfigMap with the httpd.conf content                                                       | `nil`                                                        |
-| `cloneHtdocsFromGit.enabled`     | Get the server static content from a git repository                                         | `false`                                                      |
-| `cloneHtdocsFromGit.repository`  | Repository to clone static content from                                                     | `nil`                                                        |
-| `cloneHtdocsFromGit.branch`      | Branch inside the git repository                                                            | `nil`                                                        |
-| `cloneHtdocsFromGit.interval`    | Interval for sidecar container pull from the repository                                     | `60`                                                         |
-| `cloneHtdocsFromGit.resources`   | Init container git resource requests/limit                                                  | `{}`                                                         |
-| `podAnnotations`                 | Pod annotations                                                                             | `{}` (evaluated as a template)                               |
-| `podAffinityPreset`              | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`         | `""`                                                         |
-| `podAntiAffinityPreset`          | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`    | `soft`                                                       |
-| `nodeAffinityPreset.type`        | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`   | `""`                                                         |
-| `nodeAffinityPreset.key`         | Node label key to match Ignored if `affinity` is set.                                       | `""`                                                         |
-| `nodeAffinityPreset.values`      | Node label values to match. Ignored if `affinity` is set.                                   | `[]`                                                         |
-| `affinity`                       | Affinity for pod assignment                                                                 | `{}` (evaluated as a template)                               |
-| `nodeSelector`                   | Node labels for pod assignment                                                              | `{}` (evaluated as a template)                               |
-| `tolerations`                    | Tolerations for pod assignment                                                              | `[]` (evaluated as a template)                               |
-| `livenessProbe.enabled`          | Enable liveness probe                                                                       | `true`                                                       |
-| `livenessProbe.path`             | Path to access on the HTTP server                                                           | `/`                                                          |
-| `readinessProbe.enabled`         | Enable readiness probe                                                                      | `true`                                                       |
-| `readinessProbe.path`            | Path to access on the HTTP server                                                           | `/`                                                          |
-| `ingress.enabled`                | Enable ingress controller resource                                                          | `false`                                                      |
-| `ingress.hostname`               | Default host for the ingress resource                                                       | `example.local`                                              |
-| `ingress.certManager`            | Add annotations for cert-manager                                                            | `false`                                                      |
-| `ingress.annotations`            | Ingress annotations                                                                         | `[]`                                                         |
-| `ingress.hosts[0].name`          | Hostname to your Apache installation                                                        | `example.local`                                              |
-| `ingress.hosts[0].path`          | Path within the url structure                                                               | `/`                                                          |
-| `ingress.tls[0].hosts[0]`        | TLS hosts                                                                                   | `example.local`                                              |
-| `ingress.tls[0].secretName`      | TLS Secret (certificates)                                                                   | `example.local-tls`                                          |
-| `ingress.secrets[0].name`        | TLS Secret Name                                                                             | `nil`                                                        |
-| `ingress.secrets[0].certificate` | TLS Secret Certificate                                                                      | `nil`                                                        |
-| `ingress.secrets[0].key`         | TLS Secret Key                                                                              | `nil`                                                        |
-| `metrics.enabled`                | Start a side-car prometheus exporter                                                        | `false`                                                      |
-| `metrics.image.registry`         | Apache exporter image registry                                                              | `docker.io`                                                  |
-| `metrics.image.repository`       | Apache exporter image name                                                                  | `lusotycoon/apache-exporter`                                 |
-| `metrics.image.tag`              | Apache exporter image tag                                                                   | `v0.5.0`                                                     |
-| `metrics.image.pullPolicy`       | Apache exporter image pull policy                                                           | `IfNotPresent`                                               |
-| `metrics.image.pullSecrets`      | Specify Docker registry secret names as an array                                            | `[]` (does not add image pull secrets to deployed pods)      |
-| `metrics.podAnnotations`         | Additional annotations for Metrics exporter pod                                             | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
-| `metrics.resources`              | Exporter resource requests/limit                                                            | {}                                                           |
-| `service.type`                   | Kubernetes Service type                                                                     | `LoadBalancer`                                               |
-| `service.port`                   | Service HTTP port                                                                           | `80`                                                         |
-| `service.httpsPort`              | Service HTTPS port                                                                          | `443`                                                        |
-| `service.nodePorts.http`         | Kubernetes http node port                                                                   | `""`                                                         |
-| `service.nodePorts.https`        | Kubernetes https node port                                                                  | `""`                                                         |
-| `service.externalTrafficPolicy`  | Enable client source IP preservation                                                        | `Cluster`                                                    |
-| `service.loadBalancerIP`         | LoadBalancer service IP address                                                             | `""`                                                         |
-| `extraVolumes`                   | Array to add extra volumes                                                                  | `[]` (evaluated as a template)                               |
-| `extraVolumeMounts`              | Array to add extra mount                                                                    | `[]` (evaluated as a template)                               |
+| Parameter                        | Description                                                                               | Default                                                      |
+|----------------------------------|-------------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `global.imageRegistry`           | Global Docker image registry                                                              | `nil`                                                        |
+| `global.imagePullSecrets`        | Global Docker registry secret names as an array                                           | `[]` (does not add image pull secrets to deployed pods)      |
+| `image.registry`                 | Apache Docker image registry                                                              | `docker.io`                                                  |
+| `image.repository`               | Apache Docker image name                                                                  | `bitnami/apache`                                             |
+| `image.tag`                      | Apache Docker image tag                                                                   | `{TAG_NAME}`                                                 |
+| `image.pullPolicy`               | Apache Docker image pull policy                                                           | `Always`                                                     |
+| `image.pullSecrets`              | Specify Docker registry secret names as an array                                          | `[]` (does not add image pull secrets to deployed pods)      |
+| `git.registry`                   | Git image registry                                                                        | `docker.io`                                                  |
+| `git.repository`                 | Git image name                                                                            | `bitnami/git`                                                |
+| `git.tag`                        | Git image tag                                                                             | `{TAG_NAME}`                                                 |
+| `git.pullPolicy`                 | Git image pull policy                                                                     | `Always`                                                     |
+| `git.pullSecrets`                | Specify docker-registry secret names as an array                                          | `[]` (does not add image pull secrets to deployed pods)      |
+| `replicaCount`                   | Number of replicas of the Apache deployment                                               | `docker.io`                                                  |
+| `htdocsConfigMap`                | ConfigMap with the server static content                                                  | `nil`                                                        |
+| `htdocsPVC`                      | PVC with the server static content                                                        | `nil`                                                        |
+| `vhostsConfigMap`                | ConfigMap with the virtual hosts content                                                  | `nil`                                                        |
+| `httpdConfConfigMap`             | ConfigMap with the httpd.conf content                                                     | `nil`                                                        |
+| `cloneHtdocsFromGit.enabled`     | Get the server static content from a git repository                                       | `false`                                                      |
+| `cloneHtdocsFromGit.repository`  | Repository to clone static content from                                                   | `nil`                                                        |
+| `cloneHtdocsFromGit.branch`      | Branch inside the git repository                                                          | `nil`                                                        |
+| `cloneHtdocsFromGit.interval`    | Interval for sidecar container pull from the repository                                   | `60`                                                         |
+| `cloneHtdocsFromGit.resources`   | Init container git resource requests/limit                                                | `{}`                                                         |
+| `podAnnotations`                 | Pod annotations                                                                           | `{}` (evaluated as a template)                               |
+| `podAffinityPreset`              | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                                                         |
+| `podAntiAffinityPreset`          | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                                       |
+| `nodeAffinityPreset.type`        | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                                                         |
+| `nodeAffinityPreset.key`         | Node label key to match Ignored if `affinity` is set.                                     | `""`                                                         |
+| `nodeAffinityPreset.values`      | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                                                         |
+| `affinity`                       | Affinity for pod assignment                                                               | `{}` (evaluated as a template)                               |
+| `nodeSelector`                   | Node labels for pod assignment                                                            | `{}` (evaluated as a template)                               |
+| `tolerations`                    | Tolerations for pod assignment                                                            | `[]` (evaluated as a template)                               |
+| `livenessProbe.enabled`          | Enable liveness probe                                                                     | `true`                                                       |
+| `livenessProbe.path`             | Path to access on the HTTP server                                                         | `/`                                                          |
+| `readinessProbe.enabled`         | Enable readiness probe                                                                    | `true`                                                       |
+| `readinessProbe.path`            | Path to access on the HTTP server                                                         | `/`                                                          |
+| `ingress.enabled`                | Enable ingress controller resource                                                        | `false`                                                      |
+| `ingress.hostname`               | Default host for the ingress resource                                                     | `example.local`                                              |
+| `ingress.certManager`            | Add annotations for cert-manager                                                          | `false`                                                      |
+| `ingress.annotations`            | Ingress annotations                                                                       | `[]`                                                         |
+| `ingress.hosts[0].name`          | Hostname to your Apache installation                                                      | `example.local`                                              |
+| `ingress.hosts[0].path`          | Path within the url structure                                                             | `/`                                                          |
+| `ingress.tls[0].hosts[0]`        | TLS hosts                                                                                 | `example.local`                                              |
+| `ingress.tls[0].secretName`      | TLS Secret (certificates)                                                                 | `example.local-tls`                                          |
+| `ingress.secrets[0].name`        | TLS Secret Name                                                                           | `nil`                                                        |
+| `ingress.secrets[0].certificate` | TLS Secret Certificate                                                                    | `nil`                                                        |
+| `ingress.secrets[0].key`         | TLS Secret Key                                                                            | `nil`                                                        |
+| `metrics.enabled`                | Start a side-car prometheus exporter                                                      | `false`                                                      |
+| `metrics.image.registry`         | Apache exporter image registry                                                            | `docker.io`                                                  |
+| `metrics.image.repository`       | Apache exporter image name                                                                | `lusotycoon/apache-exporter`                                 |
+| `metrics.image.tag`              | Apache exporter image tag                                                                 | `v0.5.0`                                                     |
+| `metrics.image.pullPolicy`       | Apache exporter image pull policy                                                         | `IfNotPresent`                                               |
+| `metrics.image.pullSecrets`      | Specify Docker registry secret names as an array                                          | `[]` (does not add image pull secrets to deployed pods)      |
+| `metrics.podAnnotations`         | Additional annotations for Metrics exporter pod                                           | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
+| `metrics.resources`              | Exporter resource requests/limit                                                          | {}                                                           |
+| `service.type`                   | Kubernetes Service type                                                                   | `LoadBalancer`                                               |
+| `service.port`                   | Service HTTP port                                                                         | `80`                                                         |
+| `service.httpsPort`              | Service HTTPS port                                                                        | `443`                                                        |
+| `service.nodePorts.http`         | Kubernetes http node port                                                                 | `""`                                                         |
+| `service.nodePorts.https`        | Kubernetes https node port                                                                | `""`                                                         |
+| `service.externalTrafficPolicy`  | Enable client source IP preservation                                                      | `Cluster`                                                    |
+| `service.loadBalancerIP`         | LoadBalancer service IP address                                                           | `""`                                                         |
+| `extraVolumes`                   | Array to add extra volumes                                                                | `[]` (evaluated as a template)                               |
+| `extraVolumeMounts`              | Array to add extra mount                                                                  | `[]` (evaluated as a template)                               |
+| `extraEnvVars`                   | Array to add extra environment variables                                                  | `[]` (evaluated as a template)                               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/apache/templates/deployment.yaml
+++ b/bitnami/apache/templates/deployment.yaml
@@ -78,6 +78,9 @@ spec:
           env:
             - name: BITNAMI_DEBUG
               value: {{ ternary "true" "false" .Values.image.debug | quote }}
+            {{- if .Values.extraEnvVars }}
+              {{- include "apache.tplValue" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -272,6 +272,10 @@ extraVolumes: []
 ##
 extraVolumeMounts: []
 
+## An array to add extra env vars
+##
+extraEnvVars: []
+
 ## Service paramaters
 ##
 service:


### PR DESCRIPTION
Signed-off-by: darteaga <darteaga@vmware.com>

**Description of the change**

Add extraEnvVars to the values YAML.

**Benefits**

We can add custom environment variables to the deployment

**Possible drawbacks**

N/A

**Applicable issues**

  - fixes #4078

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
