### PR TITLE
[bitnami/mongodb-sharded] fix: do not create secret when existingSecret

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mongodb-sharded
-version: 2.1.4
+version: 2.1.5
 appVersion: 4.4.1
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications. Sharded topology.
 keywords:

--- a/bitnami/mongodb-sharded/templates/secrets.yaml
+++ b/bitnami/mongodb-sharded/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -26,3 +27,4 @@ data:
   {{- else }}
   mongodb-replica-set-key: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
+{{- end }}


### PR DESCRIPTION
Signed-off-by: darteaga <darteaga@vmware.com>

**Description of the change**

Do not create secret when existingSecret

**Benefits**

We will not have unnecessary secrets in our k8s cluster. 

**Possible drawbacks**

N/A

**Applicable issues**

  - fixes #3826

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
