### PR TITLE
[bitnami/node] Fix default type for extraEnv

### DIFF
--- a/bitnami/node/Chart.yaml
+++ b/bitnami/node/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node
-version: 13.1.0
+version: 13.1.1
 appVersion: 10.22.1
 description: Event-driven I/O server-side JavaScript environment based on V8
 keywords:

--- a/bitnami/node/README.md
+++ b/bitnami/node/README.md
@@ -80,7 +80,7 @@ The following table lists the configurable parameters of the Node chart and thei
 | `revision`                              | Revision to checkout                                                        | `master`                                                |
 | `replicas`                              | Number of replicas for the application                                      | `1`                                                     |
 | `applicationPort`                       | Port where the application will be running                                  | `3000`                                                  |
-| `extraEnv`                              | Any extra environment variables to be pass to the pods                      | `{}`                                                    |
+| `extraEnv`                              | Any extra environment variables to be pass to the pods                      | `[]`                                                    |
 | `affinity`                              | Map of node/pod affinities                                                  | `{}` (The value is evaluated as a template)             |
 | `nodeSelector`                          | Node labels for pod assignment                                              | `{}` (The value is evaluated as a template)             |
 | `tolerations`                           | Tolerations for pod assignment                                              | `[]` (The value is evaluated as a template)             |

--- a/bitnami/node/values.yaml
+++ b/bitnami/node/values.yaml
@@ -103,7 +103,7 @@ applicationPort: 3000
 
 ## Define custom environment variables to pass to the image here
 ##
-extraEnv: {}
+extraEnv: []
 
 ## Affinity for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity


### PR DESCRIPTION
**Description of the change**

Fix the default value in `extraEnv`

**Possible drawbacks**

This section is not rendered in the _deployment.yaml_ when it is empty so it doesn't matter if the default value is `{}` or `[]` in terms of upgrades since it is not going to be rendered in any case

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #4076

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files