### PR TITLE
[bitnami/discourse] Bump subcharts and common helpers

### DIFF
--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: discourse
 description: A Helm chart for deploying Discourse to Kubernetes
-version: 0.5.1
+version: 1.0.0
 appVersion: 2.5.3
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/discourse

--- a/bitnami/discourse/README.md
+++ b/bitnami/discourse/README.md
@@ -261,8 +261,8 @@ By default, this Chart only deploys a single pod running Discourse. Should you w
 ```console
 $ helm install my-release bitnami/discourse
 ...
-export APP_PASSWORD=$(kubectl get secret --namespace default my-release-discourse -o jsonpath="{.data.discourse-password}" | base64 --decode)
-export APP_DATABASE_PASSWORD=$(kubectl get secret --namespace default my-release-postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode)
+export DISCOURSE_PASSWORD=$(kubectl get secret --namespace default my-release-discourse -o jsonpath="{.data.discourse-password}" | base64 --decode)
+export POSTGRESQL_PASSWORD=$(kubectl get secret --namespace default my-release-postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode)
 ...
 ```
 
@@ -277,7 +277,7 @@ my-release-redis-master-0               1/1     Running   0          5m11s
 
 3. Perform an upgrade specifying the number of replicas and the credentials used.
 ```console
-$ helm upgrade my-release --set replicaCount=2,discourse.password=$APP_PASSWORD,postgresql.postgresqlPassword=$APP_DATABASE_PASSWORD,discourse.skipInstall=true bitnami/discourse
+$ helm upgrade my-release --set replicaCount=2,discourse.password=$DISCOURSE_PASSWORD,postgresql.postgresqlPassword=$POSTGRESQL_PASSWORD,discourse.skipInstall=true bitnami/discourse
 ```
 
 Note that for this to work properly, you need to provide ReadWriteMany PVCs. If you don't have a provisioner for this type of storage, we recommend that you install the NFS provisioner chart (with the correct parameters, such as `persistence.enabled=true` and `persistence.size=10Gi`) and map it to a RWO volume.
@@ -458,6 +458,78 @@ imagePullSecrets:
 1. Install the chart
 
 ## Upgrade
+
+### 1.0.0
+
+This new major version includes the following changes:
+
+* PostgreSQL dependency version was bumped to a new major version `9.X.X`, which includes changes that do no longer guarantee backwards compatibility. Check [PostgreSQL Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/postgresql#900) for more information.
+* Redis dependency version was bumped to a new major version `11.X.X`, which includes breaking changes regarding sentinel. Discourse does not use this type of setup, so no issues are expected to happen in this case. Check [Redis Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/redis#to-1100) for more information.
+* Some non-breaking changes so as to use the `bitnami/common` library chart.
+
+As a consequence, backwards compatibility from previous versions is not guaranteed during the upgrade. To upgrade to this new version `1.0.0` there are two alternatives:
+
+* Install a new Discourse chart, and migrate your Discourse site using the [built-in backup/restore feature](https://meta.discourse.org/t/create-download-and-restore-a-backup-of-your-discourse-database/122710).
+
+* Reuse the PVC used to hold the PostgreSQL data on your previous release. To do so, follow the instructions below.
+
+> NOTE: Please, make sure to create or have a backup of your database before running any of those actions.
+
+1. Old version is up and running
+
+  ```console
+  $ helm ls
+  NAME	    NAMESPACE	REVISION	UPDATED                              	STATUS  	CHART          	APP VERSION
+  discourse 	default  	2       	2020-10-22 12:10:16.454369 +0200 CEST	deployed	discourse-0.5.1	2.5.3
+
+  $ kubectl get pods
+  NAME                                   READY   STATUS    RESTARTS   AGE
+  discourse-discourse-7554ddb864-d55ls   2/2     Running   0          3s
+  discourse-postgresql-0                 1/1     Running   0          16s
+  discourse-redis-master-0               1/1     Running   0          16s
+  ```
+
+2. Export both PostgreSQL and Discourse credentials in order to provide them in the update
+
+  ```console
+  $ export DISCOURSE_PASSWORD=$(kubectl get secret --namespace default discourse-discourse-discourse -o jsonpath="{.data.discourse-password}" | base64 --decode)
+
+  $ export POSTGRESQL_PASSWORD=$(kubectl get secret --namespace default discourse-postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode)
+  ```
+
+  > NOTE: You will need to export Redis credentials as well if your setup makes use of them.
+
+3. Scale down the Discourse deployment and delete the PostgreSQL replicaset. Notice the option `--cascade=false` in the latter.
+
+  ```console
+  $ kubectl scale --replicas 0 deployment.apps/discourse-discourse
+  deployment.apps/discourse-discourse scaled
+
+  $ kubectl delete statefulset.apps/discourse-postgresql --cascade=false
+  statefulset.apps "discourse-postgresql" deleted
+  ```
+
+4. Now the upgrade works
+
+  ```console
+  $ helm upgrade discourse bitnami/discourse --set discourse.password=$DISCOURSE_PASSWORD --set postgresql.postgresqlPassword=$POSTGRESQL_PASSWORD --set skipInstall=true
+  $ helm ls
+  NAME	      NAMESPACE	REVISION	UPDATED                              	STATUS  	CHART      	APP VERSION
+  discourse 	default  	3       	2020-10-22 13:03:33.876084 +0200 CEST	deployed	discourse-1.0.0	2.5.3
+  ```
+
+5. You can kill the existing PostgreSQL pod and the new statefulset is going to create a new one
+
+  ```console
+  $ kubectl delete pod discourse-postgresql-0
+  pod "discourse-postgresql-0" deleted
+
+  $ kubectl get pods
+  NAME                                   READY   STATUS    RESTARTS   AGE
+  discourse-discourse-58fff99578-2xbjq   2/2     Running   3          5m4s
+  discourse-postgresql-0                 1/1     Running   0          3m42s
+  discourse-redis-master-0               1/1     Running   0          4m58s
+  ```
 
 ### 0.4.0
 

--- a/bitnami/discourse/requirements.lock
+++ b/bitnami/discourse/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 0.8.2
+  version: 0.9.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 8.10.14
+  version: 9.8.5
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 10.9.0
-digest: sha256:e5aad0254d7d942688a505bf234f838b71071051b9daca8a8564faf2b616320d
-generated: "2020-10-15T22:19:58.571479673Z"
+  version: 11.2.1
+digest: sha256:8b871ceb656047e13af778226f2bd33c69dec99fa0636001cefae1568e5ec37d
+generated: "2020-10-22T12:39:14.137415+02:00"

--- a/bitnami/discourse/requirements.yaml
+++ b/bitnami/discourse/requirements.yaml
@@ -6,9 +6,9 @@ dependencies:
       - bitnami-common
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 8.X.X
+    version: 9.X.X
     condition: postgresql.enabled
   - name: redis
     repository: https://charts.bitnami.com/bitnami
-    version: 10.X.X
+    version: 11.X.X
     condition: redis.enabled

--- a/bitnami/discourse/templates/NOTES.txt
+++ b/bitnami/discourse/templates/NOTES.txt
@@ -1,3 +1,7 @@
+{{- $secretName := include "discourse.secretName" . -}}
+{{- $postgresqlSecretName := include "discourse.postgresql.secretName" . -}}
+{{- $redisSecretName := include "discourse.redis.secretName" . -}}
+
 {{- if or .Values.postgresql.enabled .Values.externalDatabase.host -}}
 
 {{- if empty (include "discourse.host" .) -}}
@@ -10,51 +14,52 @@ This deployment will be incomplete until you configure Discourse with a resolvab
 1. Get the discourse URL by running:
 
   {{- if contains "NodePort" .Values.service.type }}
-  export APP_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}"):$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "discourse.fullname" . }} -o jsonpath="{.spec.ports[0].nodePort}")
+  export DISCOURSE_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}"):$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "discourse.fullname" . }} -o jsonpath="{.spec.ports[0].nodePort}")
   {{- else if contains "LoadBalancer" .Values.service.type }}
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
         Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "discourse.fullname" . }}'
 
-  export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "discourse.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+  export DISCOURSE_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "discourse.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
   {{- end }}
-  export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "discourse.secretName" . }} -o jsonpath="{.data.discourse-password}" | base64 --decode)
-  export APP_DATABASE_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "discourse.postgresql.secretName" . }} -o jsonpath="{.data.postgresql-password}" | base64 --decode)
+  {{ include "common.utils.secret.getvalue" (dict "secret" $secretName "field" "discourse-password" "context" $) }}
+  {{ include "common.utils.secret.getvalue" (dict "secret" $postgresqlSecretName "field" "postgresql-password" "context" $) }}
   {{- if (include "discourse.redis.usePassword" .) }}
-  export APP_REDIS_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "discourse.redis.secretName" . }} -o jsonpath="{.data. {{- include "discourse.redis.secretPasswordKey" . -}} }" | base64 --decode)
+  {{ include "common.utils.secret.getvalue" (dict "secret" $redisSecretName "field" "redis-password" "context" $) }}
   {{- end }}
+
 2. Complete your Discourse deployment by running:
 
 {{- if .Values.postgresql.enabled }}
 
   helm upgrade {{ .Release.Name }} bitnami/{{ .Chart.Name }} \
-    --set discourse.host=$APP_HOST \
-    --set discourse.password=$APP_PASSWORD \
+    --set discourse.host=$DISCOURSE_HOST \
+    --set discourse.password=$DISCOURSE_PASSWORD \
     {{- if .Values.global }}{{- if .Values.global.imagePullSecrets }}
     --set global.imagePullSecrets={{ .Values.global.imagePullSecrets }} \
     {{- end }}{{- end }}
     {{- if and .Values.redis.enabled .Values.redis.usePassword (not .Values.redis.existingSecret) (not .Values.redis.password) }}
-    --set redis.password=$APP_REDIS_PASSWORD \
+    --set redis.password=$REDIS_PASSWORD \
     {{- end }}
-    --set postgresql.postgresqlPassword=$APP_DATABASE_PASSWORD
+    --set postgresql.postgresqlPassword=$POSTGRESQL_PASSWORD
 
 {{- else }}
 
   ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
 
   helm upgrade {{ .Release.Name }} bitnami/{{ .Chart.Name }} \
-    --set discourse.host=$APP_HOST \
-    --set discourse.password=$APP_PASSWORD \
+    --set discourse.host=$DISCOURSE_HOST \
+    --set discourse.password=$DISCOURSE_PASSWORD \
     --set service.type={{ .Values.service.type }} \
     --set externalDatabase.host={{ .Values.externalDatabase.host }} \
     --set externalDatabase.port={{ .Values.externalDatabase.port }} \
     --set externalDatabase.user={{ .Values.externalDatabase.user }} \
-    --set externalDatabase.password=$APP_DATABASE_PASSWORD \
+    --set externalDatabase.password=$POSTGRESQL_PASSWORD \
     --set externalDatabase.database={{ .Values.externalDatabase.database }} \
     {{- if .Values.global }}{{- if .Values.global.imagePullSecrets }}
     --set global.imagePullSecrets={{ .Values.global.imagePullSecrets }} \
     {{- end }}{{- end }}
     {{- if and .Values.redis.enabled .Values.redis.usePassword (not .Values.redis.existingSecret) (not .Values.redis.password) }}
-    --set redis.password=$APP_REDIS_PASSWORD \
+    --set redis.password=$REDIS_PASSWORD \
     {{- end }}
     --set postgresql.enabled=false
 {{- end }}
@@ -72,11 +77,12 @@ This deployment will be incomplete until you configure Discourse with a resolvab
 2. Get your Discourse login credentials by running:
 
   Username: {{ .Values.discourse.username }}
-  export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "discourse.secretName" . }} -o jsonpath="{.data.discourse-password}" | base64 --decode)
-  export APP_DATABASE_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "discourse.postgresql.secretName" . }} -o jsonpath="{.data.postgresql-password}" | base64 --decode)
+  {{ include "common.utils.secret.getvalue" (dict "secret" $secretName "field" "discourse-password" "context" $) }}
+  {{ include "common.utils.secret.getvalue" (dict "secret" $postgresqlSecretName "field" "postgresql-password" "context" $) }}
   {{- if (include "discourse.redis.usePassword" .) }}
-  export APP_REDIS_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "discourse.redis.secretName" . }} -o jsonpath="{.data. {{- include "discourse.redis.secretPasswordKey" . -}} }" | base64 --decode)
+  {{ include "common.utils.secret.getvalue" (dict "secret" $redisSecretName "field" "redis-password" "context" $) }}
   {{- end }}
+
 {{- end }}
 
 {{- else -}}
@@ -90,34 +96,35 @@ This deployment will be incomplete until you configure Discourse with a resolvab
 1. Complete your Discourse deployment by running:
 
 {{- if contains "NodePort" .Values.service.type }}
-  export APP_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}"):$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "discourse.fullname" . }} -o jsonpath="{.spec.ports[0].nodePort}")
+  export DISCOURSE_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}"):$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "discourse.fullname" . }} -o jsonpath="{.spec.ports[0].nodePort}")
 {{- else if contains "LoadBalancer" .Values.service.type }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
         Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "discourse.fullname" . }}'
 
-  export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "discourse.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+  export DISCOURSE_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "discourse.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
 {{- else }}
 
-  export APP_HOST=127.0.0.1
+  export DISCOURSE_HOST=127.0.0.1
 {{- end }}
-  export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "discourse.secretName" . }} -o jsonpath="{.data.discourse-password}" | base64 --decode)
-  export APP_DATABASE_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "discourse.postgresql.secretName" . }} -o jsonpath="{.data.postgresql-password}" | base64 --decode)
+  {{ include "common.utils.secret.getvalue" (dict "secret" $secretName "field" "discourse-password" "context" $) }}
+  {{ include "common.utils.secret.getvalue" (dict "secret" $postgresqlSecretName "field" "postgresql-password" "context" $) }}
   {{- if (include "discourse.redis.usePassword" .) }}
-  export APP_REDIS_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "discourse.redis.secretName" . }} -o jsonpath="{.data. {{- include "discourse.redis.secretPasswordKey" . -}} }" | base64 --decode)
+  {{ include "common.utils.secret.getvalue" (dict "secret" $redisSecretName "field" "redis-password" "context" $) }}
   {{- end }}
+
 
   ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
 
   helm upgrade {{ .Release.Name }} bitnami/{{ .Chart.Name }} \
-    --set discourse.host=$APP_HOST \
-    --set discourse.password=$APP_PASSWORD \
+    --set discourse.host=$DISCOURSE_HOST \
+    --set discourse.password=$DISCOURSE_PASSWORD \
     --set postgresql.enabled=false \
     {{- if not (empty .Values.externalDatabase.user) }}
     --set externalDatabase.user={{ .Values.externalDatabase.user }} \
     {{- end }}
     {{- if not (empty .Values.externalDatabase.password) }}
-    --set externalDatabase.password=$APP_DATABASE_PASSWORD \
+    --set externalDatabase.password=$POSTGRESQL_PASSWORD \
     {{- end }}
     {{- if not (empty .Values.externalDatabase.database) }}
     --set externalDatabase.database={{ .Values.externalDatabase.database }}
@@ -127,16 +134,9 @@ This deployment will be incomplete until you configure Discourse with a resolvab
     --set global.imagePullSecrets={{ .Values.global.imagePullSecrets }} \
     {{- end }}{{- end }}
     {{- if and .Values.redis.enabled .Values.redis.usePassword (not .Values.redis.existingSecret) (not .Values.redis.password) }}
-    --set redis.password=$APP_REDIS_PASSWORD \
+    --set redis.password=$REDIS_PASSWORD \
     {{- end }}
     --set service.type={{ .Values.service.type }}
-{{- end }}
-
-{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | regexFind "-r\\d+$")) }}
-
-WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
-+info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
-
 {{- end }}
 
 {{ if and .Values.postgresql.enabled (not .Values.postgresql.existingSecret) (eq .Values.postgresql.postgresqlPostgresPassword "bitnami") -}}
@@ -144,3 +144,22 @@ WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.t
 ### WARNING: You did not change the default password for the PostgreSQL root user ###
 #####################################################################################
 {{- end }}
+
+{{- include "common.warnings.rollingTag" .Values.image }}
+
+{{- $passwordValidationErrors := list -}}
+{{- if not .Values.discourse.existingSecret -}}
+    {{- $requiredDiscoursePassword := dict "valueKey" "discourse.password" "secret" $secretName "field" "discourse-password" "context" $ -}}
+    {{- $requiredDiscoursePasswordError := include "common.validations.values.single.empty" $requiredDiscoursePassword -}}
+    {{- $passwordValidationErrors = append $passwordValidationErrors $requiredDiscoursePasswordError -}}
+{{- end -}}
+
+{{- $postgresqlPasswordValidationErrors := include "common.validations.values.postgresql.passwords" (dict "secret" $postgresqlSecretName "subchart" true "context" $) -}}
+{{- $passwordValidationErrors = append $passwordValidationErrors $postgresqlPasswordValidationErrors -}}
+
+{{- if (include "discourse.redis.usePassword" .) }}
+{{- $redisPasswordValidationErrors := include "common.validations.values.redis.passwords" (dict "secret" $redisSecretName "subchart" true "context" $) -}}
+{{- $passwordValidationErrors = append $passwordValidationErrors $redisPasswordValidationErrors -}}
+{{- end }}
+
+{{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordValidationErrors "context" $) -}}

--- a/bitnami/discourse/templates/_helpers.tpl
+++ b/bitnami/discourse/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart
 */}}
 {{- define "discourse.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- include "common.names.name" . -}}
 {{- end -}}
 
 {{/*
@@ -27,43 +27,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "discourse.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
+{{- include "common.names.fullname" . -}}
 {{- end -}}
 
 {{/*
 Create chart name and version as used by the chart label
 */}}
 {{- define "discourse.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Common labels
-*/}}
-{{- define "discourse.labels" -}}
-helm.sh/chart: {{ include "discourse.chart" . }}
-{{ include "discourse.matchLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end -}}
-
-{{/*
-Match labels
-*/}}
-{{- define "discourse.matchLabels" -}}
-app.kubernetes.io/name: {{ include "discourse.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+{{- include "common.names.chart" . -}}
 {{- end -}}
 
 {{/*
@@ -78,45 +49,10 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
-Renders a value that contains template
-Usage:
-{{ include "discourse.tplValue" ( dict "value" .Values.path.to.the.Value "context" $) }}
-*/}}
-{{- define "discourse.tplValue" -}}
-    {{- if typeIs "string" .value }}
-        {{- tpl .value .context }}
-    {{- else }}
-        {{- tpl (.value | toYaml) .context }}
-    {{- end }}
-{{- end -}}
-
-{{/*
 Return the proper Docker image registry secret names
 */}}
 {{- define "discourse.imagePullSecrets" -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
-Also, we can not use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets:
-{{- range .Values.global.imagePullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- else if .Values.image.pullSecrets }}
-imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end -}}
-{{- else if .Values.image.pullSecrets  }}
-imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end -}}
+{{ include "common.images.pullSecrets" (dict "images" (list .Values.image) "global" .Values.global) }}
 {{- end -}}
 
 {{/*
@@ -155,58 +91,14 @@ If not using ClusterIP, or if a host or LoadBalancerIP is not defined, the value
 Return the proper Discourse image name
 */}}
 {{- define "discourse.image" -}}
-{{- $registryName := .Values.image.registry -}}
-{{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
-{{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-{{- end -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
 {{- end -}}
 
 {{/*
 Return the proper Storage Class
 */}}
 {{- define "discourse.storageClass" -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
-*/}}
-{{- if .Values.global -}}
-    {{- if .Values.global.storageClass -}}
-        {{- if (eq "-" .Values.global.storageClass) -}}
-            {{- printf "storageClassName: \"\"" -}}
-        {{- else }}
-            {{- printf "storageClassName: %s" .Values.global.storageClass -}}
-        {{- end -}}
-    {{- else -}}
-        {{- if .Values.persistence.storageClass -}}
-              {{- if (eq "-" .Values.persistence.storageClass) -}}
-                  {{- printf "storageClassName: \"\"" -}}
-              {{- else }}
-                  {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
-              {{- end -}}
-        {{- end -}}
-    {{- end -}}
-{{- else -}}
-    {{- if .Values.persistence.storageClass -}}
-        {{- if (eq "-" .Values.persistence.storageClass) -}}
-            {{- printf "storageClassName: \"\"" -}}
-        {{- else }}
-            {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
-        {{- end -}}
-    {{- end -}}
-{{- end -}}
+{{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/discourse/templates/configmaps.yaml
+++ b/bitnami/discourse/templates/configmaps.yaml
@@ -2,12 +2,12 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "discourse.fullname" . }}
-  labels: {{- include "discourse.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonLabels }}
-  {{- include "discourse.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "discourse.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
   {{- $port:=.Values.service.port | toString }}

--- a/bitnami/discourse/templates/deployment.yaml
+++ b/bitnami/discourse/templates/deployment.yaml
@@ -1,20 +1,20 @@
 {{- if and (include "discourse.host" .) (or .Values.postgresql.enabled .Values.externalDatabase.host) -}}
-apiVersion: apps/v1
+apiVersion: {{ template "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "discourse.fullname" . }}
-  labels: {{- include "discourse.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     component: discourse
     {{- if .Values.commonLabels }}
-    {{- include "discourse.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "discourse.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
-    matchLabels: {{- include "discourse.matchLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       component: discourse
   {{- if .Values.updateStrategy }}
   strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
@@ -26,18 +26,18 @@ spec:
         checksum/secrets-discourse: {{ include (print $.Template.BasePath "/secrets-discourse.yaml") . | sha256sum }}
         checksum/secrets-database: {{ include (print $.Template.BasePath "/secrets-database.yaml") . | sha256sum }}
         checksum/secrets-redis: {{ include (print $.Template.BasePath "/secrets-redis.yaml") . | sha256sum }}
-      labels: {{- include "discourse.labels" . | nindent 8 }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
         component: discourse
         {{- if .Values.podLabels }}
-        {{- include "discourse.tplValue" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
       {{- if .Values.podAnnotations }}
-      annotations: {{- include "discourse.tplValue" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
     spec:
       {{- include "discourse.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.affinity }}
-      affinity: {{- include "discourse.tplValue" (dict "value" .Values.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- else }}
       affinity:
         podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAffinityPreset "context" $) | nindent 10 }}
@@ -45,15 +45,15 @@ spec:
         nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
       {{- if .Values.nodeSelector }}
-      nodeSelector: {{- include "discourse.tplValue" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.tolerations }}
-      tolerations: {{- include "discourse.tplValue" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "discourse.serviceAccountName" . }}
       securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if .Values.initContainers }}
-      initContainers: {{- include "discourse.tplValue" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+      initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
       {{- end }}
       containers:
         - name: discourse
@@ -61,10 +61,10 @@ spec:
           image: {{ template "discourse.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           {{- if .Values.discourse.command }}
-          command: {{- include "discourse.tplValue" (dict "value" .Values.discourse.command "context" $) | nindent 12 }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.discourse.command "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.discourse.args }}
-          args: {{- include "discourse.tplValue" (dict "value" .Values.discourse.args "context" $) | nindent 12 }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.discourse.args "context" $) | nindent 12 }}
           {{- end }}
           env:
             {{- if .Values.image.debug }}
@@ -98,7 +98,7 @@ spec:
                   key: {{ include "discourse.redis.secretPasswordKey" . }}
             {{- end }}
             {{- if .Values.discourse.extraEnvVars }}
-            {{- include "discourse.tplValue" (dict "value" .Values.discourse.extraEnvVars "context" $) | nindent 12 }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.discourse.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           envFrom:
             - configMapRef:
@@ -126,7 +126,7 @@ spec:
             successThreshold: {{ .Values.discourse.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.discourse.livenessProbe.failureThreshold }}
           {{- else if .Values.discourse.customLivenessProbe }}
-          livenessProbe: {{- include "discourse.tplValue" (dict "value" .Values.discourse.customLivenessProbe "context" $) | nindent 12 }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.discourse.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.discourse.readinessProbe.enabled }}
           readinessProbe:
@@ -139,14 +139,14 @@ spec:
             successThreshold: {{ .Values.discourse.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.discourse.readinessProbe.failureThreshold }}
           {{- else if .Values.discourse.customReadinessProbe }}
-          readinessProbe: {{- include "discourse.tplValue" (dict "value" .Values.discourse.customReadinessProbe "context" $) | nindent 12 }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.discourse.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: discourse-data
               mountPath: /bitnami/discourse
               subPath: discourse
             {{- if .Values.discourse.extraVolumeMounts }}
-            {{- include "discourse.tplValue" (dict "value" .Values.discourse.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.discourse.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
           {{- if .Values.discourse.resources }}
           resources: {{- toYaml .Values.discourse.resources | nindent 12 }}
@@ -155,8 +155,8 @@ spec:
           securityContext: {{- toYaml .Values.sidekiq.containerSecurityContext | nindent 12 }}
           image: {{ template "discourse.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-          command: {{- include "discourse.tplValue" (dict "value" .Values.sidekiq.command "context" $) | nindent 12 }}
-          args: {{- include "discourse.tplValue" (dict "value" .Values.sidekiq.args "context" $) | nindent 12 }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.sidekiq.command "context" $) | nindent 12 }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.sidekiq.args "context" $) | nindent 12 }}
           env:
             {{- if .Values.image.debug }}
             - name: NAMI_DEBUG
@@ -184,7 +184,7 @@ spec:
                   key: {{ include "discourse.redis.secretPasswordKey" . }}
             {{- end }}
             {{- if .Values.sidekiq.extraEnvVars }}
-            {{- include "discourse.tplValue" (dict "value" .Values.sidekiq.extraEnvVars "context" $) | nindent 12 }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.sidekiq.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           envFrom:
             - configMapRef:
@@ -207,7 +207,7 @@ spec:
             successThreshold: {{ .Values.sidekiq.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.sidekiq.livenessProbe.failureThreshold }}
           {{- else if .Values.sidekiq.customLivenessProbe }}
-          livenessProbe: {{- include "discourse.tplValue" (dict "value" .Values.sidekiq.customLivenessProbe "context" $) | nindent 12 }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.sidekiq.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.sidekiq.readinessProbe.enabled }}
           readinessProbe:
@@ -219,20 +219,20 @@ spec:
             successThreshold: {{ .Values.sidekiq.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.sidekiq.readinessProbe.failureThreshold }}
           {{- else if .Values.sidekiq.customReadinessProbe }}
-          readinessProbe: {{- include "discourse.tplValue" (dict "value" .Values.sidekiq.customReadinessProbe "context" $) | nindent 12 }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.sidekiq.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: discourse-data
               mountPath: /bitnami/discourse
               subPath: discourse
             {{- if .Values.sidekiq.extraVolumeMounts }}
-            {{- include "discourse.tplValue" (dict "value" .Values.sidekiq.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.sidekiq.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
           {{- if .Values.sidekiq.resources }}
           resources: {{- toYaml .Values.sidekiq.resources | nindent 12 }}
           {{- end }}
         {{- if .Values.sidecars }}
-        {{- include "discourse.tplValue" (dict "value" .Values.sidecars "context" $) | indent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | indent 8 }}
         {{- end }}
       volumes:
         - name: discourse-data
@@ -243,6 +243,6 @@ spec:
           emptyDir: {}
           {{ end }}
         {{- if .Values.extraVolumes }}
-        {{- include "discourse.tplValue" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
 {{- end }}

--- a/bitnami/discourse/templates/ingress.yaml
+++ b/bitnami/discourse/templates/ingress.yaml
@@ -1,20 +1,16 @@
 {{- if .Values.ingress.enabled -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: {{ template "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "discourse.fullname" . }}
-  labels: {{- include "discourse.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonLabels }}
-  {{- include "discourse.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- end }}
   {{- if or .Values.ingress.annotations .Values.ingress.certManager .Values.commonAnnotations }}
   annotations:
   {{- if .Values.commonAnnotations }}
-  {{- include "discourse.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
   {{- if .Values.ingress.annotations }}
   {{- toYaml .Values.ingress.annotations | nindent 4 }}

--- a/bitnami/discourse/templates/pvc.yaml
+++ b/bitnami/discourse/templates/pvc.yaml
@@ -3,12 +3,12 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "discourse.fullname" . }}
-  labels: {{- include "discourse.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonLabels }}
-  {{- include "discourse.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "discourse.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   accessModes:

--- a/bitnami/discourse/templates/secrets-database.yaml
+++ b/bitnami/discourse/templates/secrets-database.yaml
@@ -3,12 +3,12 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "discourse.fullname" . }}-database
-  labels: {{- include "discourse.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonLabels }}
-  {{- include "discourse.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "discourse.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 type: Opaque
 data:

--- a/bitnami/discourse/templates/secrets-discourse.yaml
+++ b/bitnami/discourse/templates/secrets-discourse.yaml
@@ -3,12 +3,12 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "discourse.fullname" . }}-discourse
-  labels: {{- include "discourse.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonLabels }}
-  {{- include "discourse.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "discourse.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 type: Opaque
 data:

--- a/bitnami/discourse/templates/secrets-redis.yaml
+++ b/bitnami/discourse/templates/secrets-redis.yaml
@@ -3,12 +3,12 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "discourse.fullname" . }}-redis
-  labels: {{- include "discourse.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonLabels }}
-  {{- include "discourse.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "discourse.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 type: Opaque
 data:

--- a/bitnami/discourse/templates/service.yaml
+++ b/bitnami/discourse/templates/service.yaml
@@ -2,17 +2,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "discourse.fullname" . }}
-  labels: {{- include "discourse.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonLabels }}
-  {{- include "discourse.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- end }}
   {{- if or .Values.service.annotations .Values.commonAnnotations}}
   annotations:
   {{- if .Values.service.annotations }}
-  {{- include "discourse.tplValue" (dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+  {{- include "common.tplvalues.render" (dict "value" .Values.service.annotations "context" $) | nindent 4 }}
   {{- end }}
   {{- if .Values.commonAnnotations }}
-  {{- include "discourse.tplValue" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
   {{- end }}
   {{- end }}
 spec:
@@ -34,6 +34,6 @@ spec:
       nodePort: null
       {{- end }}
     {{- if .Values.service.extraPorts }}
-    {{- include "discourse.tplValue" (dict "value" .Values.service.extraPorts "context" $) | indent 4 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | indent 4 }}
     {{- end }}
-  selector: {{- include "discourse.matchLabels" . | nindent 4 }}
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/discourse/templates/serviceaccount.yaml
+++ b/bitnami/discourse/templates/serviceaccount.yaml
@@ -3,9 +3,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "discourse.serviceAccountName" . }}
-  labels: {{- include "discourse.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonLabels }}
-  {{- include "discourse.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- end }}
   {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
   annotations:
@@ -13,7 +13,7 @@ metadata:
   {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
   {{- end }}
   {{- if .Values.commonAnnotations }}
-  {{- include "discourse.tplValue" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
   {{- end }}
   {{- end }}
 {{- end -}}

--- a/bitnami/discourse/templates/tls-secrets.yaml
+++ b/bitnami/discourse/templates/tls-secrets.yaml
@@ -4,12 +4,12 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .name }}
-  labels: {{- include "discourse.labels" $ | nindent 4 }}
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
   {{- if $.Values.commonLabels }}
-  {{- include "discourse.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- end }}
   {{- if $.Values.commonAnnotations }}
-  annotations: {{- include "discourse.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 type: kubernetes.io/tls
 data:


### PR DESCRIPTION
Signed-off-by: joancafom <jcarmona@bitnami.com>

**Description of the change**

This PR updates PostgreSQL and Redis subchart to the new major versions. The former includes breaking changes that affect this chart. More info at #3021 and #3658 respectively.

Also, took the chance to implement some standardizations using `bitnami/common` library chart, such as: password validation on upgrade, simplification of `_helper.tpl` & use of standard labels (non-breaking change, this chart already included them but now using `bitnami/common` approach)

**Benefits**

Standardization, up-to-date subcomponents

**Possible drawbacks**

Breaking backwards compatibility

**Applicable issues**

NA

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
