### PR TITLE
[bitnami/postgresql] Fix extraDeploy and other values

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 9.8.5
+version: 9.8.6
 appVersion: 11.9.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/bitnami/postgresql/templates/extra-list.yaml
+++ b/bitnami/postgresql/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.extraDeploy }}
 apiVersion: v1
 kind: List
-items: {{- include "postgresql.tplValue" (dict "value" .Values.extraDeploy "context" $) | nindent 2 }}
+items: {{- include "common.tplvalues.render" (dict "value" .Values.extraDeploy "context" $) | nindent 2 }}
 {{- end }}

--- a/bitnami/postgresql/templates/statefulset-slaves.yaml
+++ b/bitnami/postgresql/templates/statefulset-slaves.yaml
@@ -288,7 +288,7 @@ spec:
             successThreshold: {{ .Values.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           {{- else if .Values.customLivenessProbe }}
-          livenessProbe: {{- include "postgresql.tplValue" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
@@ -304,7 +304,7 @@ spec:
             successThreshold: {{ .Values.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           {{- else if .Values.customReadinessProbe }}
-          readinessProbe: {{- include "postgresql.tplValue" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
             {{- if .Values.usePasswordFile }}

--- a/bitnami/postgresql/templates/statefulset.yaml
+++ b/bitnami/postgresql/templates/statefulset.yaml
@@ -366,7 +366,7 @@ spec:
             successThreshold: {{ .Values.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           {{- else if .Values.customLivenessProbe }}
-          livenessProbe: {{- include "postgresql.tplValue" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
@@ -382,7 +382,7 @@ spec:
             successThreshold: {{ .Values.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           {{- else if .Values.customReadinessProbe }}
-          readinessProbe: {{- include "postgresql.tplValue" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
             {{- if or (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql,sql.gz}") .Values.initdbScriptsConfigMap .Values.initdbScripts }}


### PR DESCRIPTION

**Description of the change**

This PR fixes currently broken values extraDeploy, customLivenessProbe and customReadinessProbe. They use deprecated "postgresql.tplValue" instead of "common.tplvalues.render" and chart has this error:

  Error: template: postgresql/templates/statefulset.yaml:385:30: executing "postgresql/templates/statefulset.yaml" at <include "postgresql.tplValue" (dict "value" .Values.customReadinessProbe "context" $)>: error calling include: template: no template "postgresql.tplValue" associated with template "gotpl"

**Benefits**

Fixes the issue

**Possible drawbacks**

None

**Applicable issues**

Unknown

**Additional information**
N/A


**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

