### PR TITLE
bitnami/consul Use new replicaCount parameter for expected consul servers

### DIFF
--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: consul
-version: 8.0.2
+version: 8.0.3
 appVersion: 1.8.4
 description: Highly available and distributed service discovery and key-value store designed with support for the modern data center to make distributed systems and configuration easy.
 home: https://github.com/bitnami/charts/tree/master/bitnami/consul

--- a/bitnami/consul/README.md
+++ b/bitnami/consul/README.md
@@ -101,7 +101,7 @@ The following table lists the configurable parameters of the HashiCorp Consul ch
 
 | Parameter                                 | Description                                                                                                          | Default                                                      |
 |-------------------------------------------|----------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `replicaCount`                            | Number of HashiCorp Consul replicas                                                                                  | `1`                                                          |
+| `replicaCount`                            | Number of HashiCorp Consul replicas                                                                                  | `3`                                                          |
 | `updateStrategy`                          | Update strategy type for the statefulset                                                                             | `RollingUpdate`                                              |
 | `rollingUpdatePartition`                  | Partition update strategy                                                                                            | `nil`                                                        |
 | `priorityClassName`                       | HashiCorp Consul priorityClassName                                                                                   | `nil`                                                        |

--- a/bitnami/consul/templates/statefulset.yaml
+++ b/bitnami/consul/templates/statefulset.yaml
@@ -131,7 +131,7 @@ spec:
             - name: CONSUL_DISABLE_KEYRING_FILE
               value: "true"
             - name: CONSUL_BOOTSTRAP_EXPECT
-              value: {{ default 3 .Values.replicas | quote }}
+              value: {{ default 3 .Values.replicaCount | quote }}
             - name: CONSUL_RAFT_MULTIPLIER
               value: {{ .Values.raftMultiplier | quote }}
             - name: CONSUL_DOMAIN


### PR DESCRIPTION
**Description of the change**

With Chart version 8 the parameter `replicas` was renamed to `replicaCount`. However, the old parameter name was still used for the `CONSUL_BOOTSTRAP_EXPECT` variable. This caused Consul to expect 3 servers (and crash indefinitely), when `replicaCount` is set to `1` or `2`. I believe values higher than `3` would actually be no issue, but I have not tested this.


**Applicable issues**

  - fixes #4095

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
