### PR TITLE
[bitnami/mariadb-galera] Adds parallel when bootstrapping from a node other than 0 in the README

### DIFF
--- a/bitnami/mariadb-galera/README.md
+++ b/bitnami/mariadb-galera/README.md
@@ -384,7 +384,7 @@ extraContainers:
 
 > Note: Some of these procedures can lead to data loss, always make a backup beforehand.
 
-To restart the cluster you need to check the state in which it is after being stopped, also you will need the previous password for the `rootUser` and `mariabackup`, and the deployment name. The value of `safe_to_bootstrap` in `/bitnami/mariadb/data/grastate.dat`, will indicate if it is safe to bootstrap form that node. In the case it is other than node 0, it is needed to choose one and force the bootstraping from it.
+To restart the cluster you need to check the state in which it is after being stopped, also you will need the previous password for the `rootUser` and `mariabackup`, and the deployment name. The value of `safe_to_bootstrap` in `/bitnami/mariadb/data/grastate.dat`, will indicate if it is safe to bootstrap form that node. In the case it is other than node 0, it is needed to choose one and force the bootstraping from it. You will notice that in these cases it is needed to start the nodes in `Parallel` by setting `podManagementPolicy`.
 
 #### Checking `safe_to_boostrap`
 
@@ -450,10 +450,10 @@ In this case you will need the node number `N` and run:
 
 ```bash
 helm install my-release bitnami/mariadb-galera \
---set image.pullPolicy=Always \
 --set rootUser.password=XXXX \
 --set galera.mariabackup.password=YYYY \
---set galera.bootstrap.bootstrapFromNode=N
+--set galera.bootstrap.bootstrapFromNode=N \
+--set podManagementPolicy=Parallel
 ```
 
 #### All the nodes with `safe_to_bootstrap: 0`
@@ -462,11 +462,11 @@ In this case the cluster was not stopped cleanly and you need to pick one to for
 
 ```bash
 helm install my-release bitnami/mariadb-galera \
---set image.pullPolicy=Always \
 --set rootUser.password=XXXX \
 --set galera.mariabackup.password=YYYY
 --set galera.bootstrap.bootstrapFromNode=3 \
---set galera.bootstrap.forceSafeToBootstrap=true
+--set galera.bootstrap.forceSafeToBootstrap=true \
+--set podManagementPolicy=Parallel
 ```
 
 ## Persistence


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

In the REAMDE this detail was missing in the instructions for the bootstraping from a node other than 0.

**Benefits**

Clarify this point,


**Applicable issues**

- Adds better instructions for #2260 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [-] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [-] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [-] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
