### PR TITLE
[bitnami/tomcat] feat: add extra env vars

### DIFF
--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: tomcat
-version: 6.5.3
+version: 6.6.0
 appVersion: 9.0.39
 description: Chart for Apache Tomcat
 keywords:

--- a/bitnami/tomcat/README.md
+++ b/bitnami/tomcat/README.md
@@ -99,6 +99,7 @@ The following tables lists the configurable parameters of the Tomcat chart and t
 | `ingress.hosts[0].tls`               | Utilize TLS backend in ingress                                                                      | `false`                                                 |
 | `ingress.hosts[0].tlsHosts`          | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`)                | `nil`                                                   |
 | `ingress.hosts[0].tlsSecret`         | TLS Secret (certificates)                                                                           | `tomcat.local-tls`                                      |
+| `extraEnvVars`                       | Extra environment variables to be set on tomcat container                                           | `[]`                                                    |
 
 The above parameters map to the env variables defined in [bitnami/tomcat](http://github.com/bitnami/bitnami-docker-tomcat). For more information please refer to the [bitnami/tomcat](http://github.com/bitnami/bitnami-docker-tomcat) image documentation.
 

--- a/bitnami/tomcat/templates/deployment.yaml
+++ b/bitnami/tomcat/templates/deployment.yaml
@@ -70,6 +70,9 @@ spec:
                   key: tomcat-password
             - name: TOMCAT_ALLOW_REMOTE_MANAGEMENT
               value: {{ .Values.tomcatAllowRemoteManagement | quote }}
+          {{-  if .Values.extraEnvVars }}
+            {{- include "tomcat.tplValue" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/bitnami/tomcat/values.yaml
+++ b/bitnami/tomcat/values.yaml
@@ -241,3 +241,11 @@ ingress:
       ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
       ##
       tlsSecret: tomcat.local-tls
+
+## Additional environment variables to set
+## E.g:
+## extraEnvVars:
+##   - name: FOO
+##     value: BAR
+##
+extraEnvVars: []


### PR DESCRIPTION
Signed-off-by: darteaga <darteaga@vmware.com>

**Description of the change**

Add `extraEnvVars` field to the `values.yaml`

**Benefits**

We will be able to pass custom env vars to the tomcat container

**Possible drawbacks**

N/A

**Applicable issues**

  - fixes #4103

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
