### PR TITLE
[bitnami/postgresql] Fix slave.extraInitContainers value

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 9.8.6
+version: 9.8.7
 appVersion: 11.9.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/bitnami/postgresql/templates/statefulset-slaves.yaml
+++ b/bitnami/postgresql/templates/statefulset-slaves.yaml
@@ -125,7 +125,7 @@ spec:
             {{- end }}
       {{- end }}
       {{- if .Values.slave.extraInitContainers }}
-      {{- include "common.tplvalues.render" ( dict "value" .Values.master.extraInitContainers "context" $ ) | nindent 8 }}
+      {{- include "common.tplvalues.render" ( dict "value" .Values.slave.extraInitContainers "context" $ ) | nindent 8 }}
       {{- end }}
       {{- end }}
       {{- if .Values.slave.priorityClassName }}

--- a/bitnami/postgresql/templates/statefulset-slaves.yaml
+++ b/bitnami/postgresql/templates/statefulset-slaves.yaml
@@ -125,7 +125,7 @@ spec:
             {{- end }}
       {{- end }}
       {{- if .Values.slave.extraInitContainers }}
-{{ tpl .Values.slave.extraInitContainers . | indent 8 }}
+      {{- include "common.tplvalues.render" ( dict "value" .Values.master.extraInitContainers "context" $ ) | nindent 8 }}
       {{- end }}
       {{- end }}
       {{- if .Values.slave.priorityClassName }}

--- a/bitnami/postgresql/values.yaml
+++ b/bitnami/postgresql/values.yaml
@@ -488,10 +488,16 @@ slave:
   podLabels: {}
   podAnnotations: {}
   priorityClassName: ''
+  ## Extra init containers
+  ## Example
+  ##
+  ## extraInitContainers:
+  ##   - name: do-something
+  ##     image: busybox
+  ##     command: ['do', 'something']
+  ##
   extraInitContainers: []
-    # - name: do-something
-    #   image: busybox
-    #   command: ['do', 'something']
+
   ## Additional PostgreSQL Slave Volume mounts
   ##
   extraVolumeMounts: []

--- a/bitnami/postgresql/values.yaml
+++ b/bitnami/postgresql/values.yaml
@@ -488,7 +488,7 @@ slave:
   podLabels: {}
   podAnnotations: {}
   priorityClassName: ''
-  extraInitContainers: |
+  extraInitContainers: []
     # - name: do-something
     #   image: busybox
     #   command: ['do', 'something']


### PR DESCRIPTION
**Description of the change**

This PR fixes broken value slave.extraInitContainers. Currently, it cannot be set as an array as described in the guide and as master.extraInitContainers value. Result is this error:
`  Error: Failed to render chart: exit status 1: Error: template: postgresql/templates/statefulset-slaves.yaml:128:14: executing "postgresql/templates/statefulset-slaves.yaml" at <.Values.slave.extraInitContainers>: wrong type for value; expected string; got []interface {}`
Fix is to use the same "common.tplvalues.render" function for slave.extraInitContainers as in the case of master.extraInitContainers.

**Benefits**

slave.extraInitContainers works the same way as master.extraInitContainers.

**Possible drawbacks**

Unknown

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
