### PR TITLE
[bitnami/postgresql-ha] Upgrade repmgr extension

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql-ha
-version: 5.1.0
+version: 5.2.0
 appVersion: 11.9.0
 description: Chart for PostgreSQL with HA architecture (using Replication Manager (repmgr) and Pgpool).
 keywords:

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -523,6 +523,31 @@ $ helm upgrade my-release bitnami/postgresql-ha \
 
 > Note: As general rule, it is always wise to do a backup before the upgrading procedures.
 
+## 5.2.0
+
+A new  version of repmgr (5.2.0) was included. To upgrade to this version, it's necessary to upgrade the repmgr extension installed on the database. To do so, follow the steps below:
+
+- Reduce your PostgreSQL setup to one replica (primary node) and upgrade to `5.2.0`, enabling the repmgr extension upgrade:
+
+```bash
+$ helm upgrade my-release --version 5.2.0 bitnami/postgresql-ha \
+    --set postgresql.password=[POSTGRESQL_PASSWORD] \
+    --set postgresql.repmgrPassword=[REPMGR_PASSWORD] \
+    --set postgresql.replicaCount=1 \
+    --set postgresql.upgradeRepmgrExtension=true
+```
+
+- Scale your PostgreSQL setup to the original number of replicas:
+
+```bash
+$ helm upgrade my-release --version 5.2.0 bitnami/postgresql-ha \
+    --set postgresql.password=[POSTGRESQL_PASSWORD] \
+    --set postgresql.repmgrPassword=[REPMGR_PASSWORD] \
+    --set postgresql.replicaCount=[NUMBER_OF_REPLICAS]
+```
+
+> Note: you need to substitute the placeholders _[POSTGRESQL_PASSWORD]_, and _[REPMGR_PASSWORD]_ with the values obtained from instructions in the installation notes.
+
 ## 5.0.0
 
 This release uses parallel deployment for the postgresql statefullset. This should fix the issues related to not being able to restart the cluster under some contions where the master node is not longer node `-0`.

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -546,7 +546,7 @@ $ helm upgrade my-release --version 5.2.0 bitnami/postgresql-ha \
     --set postgresql.replicaCount=[NUMBER_OF_REPLICAS]
 ```
 
-> Note: you need to substitute the placeholders _[POSTGRESQL_PASSWORD]_, and _[REPMGR_PASSWORD]_ with the values obtained from instructions in the installation notes.
+> Note: you need to substitute the placeholders _[POSTGRESQL_PASSWORD]_, and _[REPMGR_PASSWORD]_ with the values obtained from instructions in the installation notes (`helm get notes RELEASE_NAME`).
 
 ## 5.0.0
 


### PR DESCRIPTION
**Description of the change**

Bumps minor version since a new `postgresql-repmgr` image will be used bumping the repmgr extension to `5.2.0`

**Benefits**

New repmgr extension

**Possible drawbacks**

Requires workaround to upgrade.


**Additional information**

Do not merge until image tags are updated

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files