### PR TITLE
[bitnami/cassandra] Cassandra password upgrades common

### DIFF
--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cassandra
-version: 6.0.3
+version: 6.0.4
 appVersion: 3.11.8
 description: Apache Cassandra is a free and open-source distributed database management system designed to handle large amounts of data across many commodity servers, providing high availability with no single point of failure. Cassandra offers robust support for clusters spanning multiple datacenters, with asynchronous masterless replication allowing low latency operations for all clients.
 keywords:

--- a/bitnami/cassandra/requirements.lock
+++ b/bitnami/cassandra/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 0.9.0
-digest: sha256:ccf956b06766e5af946354f49211badc949847abf87d355c5d93224b45adf0bb
-generated: "2020-10-21T23:33:04.916244357Z"
+  version: 0.10.0
+digest: sha256:cbe8f782ad7168557b9bb101a4d441d3210e2dda09cd249eb8426d1499ce6afc
+generated: "2020-10-27T12:53:36.354177+01:00"

--- a/bitnami/cassandra/templates/NOTES.txt
+++ b/bitnami/cassandra/templates/NOTES.txt
@@ -65,7 +65,6 @@ To connect to your database from outside the cluster execute the following comma
 {{- include "common.warnings.rollingTag" .Values.metrics.image }}
 {{- include "cassandra.validateValues" . }}
 
-
 {{- $secretName := include "common.names.fullname" . }}
 {{- $passwordValidationErrors := include "common.validations.values.cassandra.passwords" (dict "secret" $secretName "context" $) -}}
 {{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" (list $passwordValidationErrors) "context" $) -}}

--- a/bitnami/cassandra/templates/NOTES.txt
+++ b/bitnami/cassandra/templates/NOTES.txt
@@ -64,11 +64,8 @@ To connect to your database from outside the cluster execute the following comma
 {{- include "common.warnings.rollingTag" .Values.image }}
 {{- include "common.warnings.rollingTag" .Values.metrics.image }}
 {{- include "cassandra.validateValues" . }}
-{{- if (not .Values.dbUser.existingSecret) -}}
-  {{- $secretName := include "common.names.fullname" . }}
-  {{- $requiredPasswords := list -}}
-  {{- $requiredDBPassword := dict "valueKey" "dbUser.password" "secret" $secretName "field" "cassandra-password" "context" $ -}}
-  {{- $requiredPasswords = append $requiredPasswords $requiredDBPassword -}}
-  {{- $requiredPasswordValidationErrors := include "common.validations.values.multiple.empty" (dict "required" $requiredPasswords "context" $) -}}
-  {{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" (list $requiredPasswordValidationErrors) "context" $) -}}
-{{- end -}}
+
+
+{{- $secretName := include "common.names.fullname" . }}
+{{- $passwordValidationErrors := include "common.validations.values.cassandra.passwords" (dict "secret" $secretName "context" $) -}}
+{{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" (list $passwordValidationErrors) "context" $) -}}


### PR DESCRIPTION
Signed-off-by: joancafom <jcarmona@bitnami.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Bumps the `bitnami/common` version and updates NOTES.txt to make use of the standard approach for checking password on upgrades. 

The current approach prevents any chart depending on Cassandra from upgrading, as the path used to check the passwords is incorrect. This PR also fixes this problem.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
Standardization, charts with Cassandra as a dependency would also check for its passwords on upgrades.
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
None
<!-- Describe any known limitations with your change -->

**Applicable issues**
NA

**Additional information**
PR introducing password validation for Cassandra in bitnami/common #4110
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
