### PR TITLE
[bitnami/rabbitmq] Allow integers for namespace

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 7.7.0
+version: 7.7.1
 appVersion: 3.8.9
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/bitnami/rabbitmq/templates/certs.yaml
+++ b/bitnami/rabbitmq/templates/certs.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "rabbitmq.fullname" . }}-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 type: kubernetes.io/tls
 data:

--- a/bitnami/rabbitmq/templates/configuration.yaml
+++ b/bitnami/rabbitmq/templates/configuration.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "rabbitmq.fullname" . }}-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 data:
   rabbitmq.conf: |-

--- a/bitnami/rabbitmq/templates/ingress.yaml
+++ b/bitnami/rabbitmq/templates/ingress.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "rabbitmq.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
   annotations:
     {{- if .Values.ingress.certManager }}

--- a/bitnami/rabbitmq/templates/networkpolicy.yaml
+++ b/bitnami/rabbitmq/templates/networkpolicy.yaml
@@ -3,7 +3,7 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: {{ include "rabbitmq.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   podSelector:

--- a/bitnami/rabbitmq/templates/pdb.yaml
+++ b/bitnami/rabbitmq/templates/pdb.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "rabbitmq.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   {{- if .Values.pdb.minAvailable }}

--- a/bitnami/rabbitmq/templates/prometheusrule.yaml
+++ b/bitnami/rabbitmq/templates/prometheusrule.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- if .Values.metrics.prometheusRule.namespace }}
   namespace: {{ .Values.metrics.prometheusRule.namespace }}
   {{- else }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   {{- end }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.metrics.prometheusRule.additionalLabels }}

--- a/bitnami/rabbitmq/templates/role.yaml
+++ b/bitnami/rabbitmq/templates/role.yaml
@@ -3,7 +3,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "rabbitmq.fullname" . }}-endpoint-reader
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 rules:
   - apiGroups: [""]

--- a/bitnami/rabbitmq/templates/rolebinding.yaml
+++ b/bitnami/rabbitmq/templates/rolebinding.yaml
@@ -3,7 +3,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "rabbitmq.fullname" . }}-endpoint-reader
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount

--- a/bitnami/rabbitmq/templates/secrets.yaml
+++ b/bitnami/rabbitmq/templates/secrets.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "rabbitmq.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 type: Opaque
 data:

--- a/bitnami/rabbitmq/templates/serviceaccount.yaml
+++ b/bitnami/rabbitmq/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "rabbitmq.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 secrets:
   - name: {{ include "rabbitmq.fullname" . }}

--- a/bitnami/rabbitmq/templates/servicemonitor.yaml
+++ b/bitnami/rabbitmq/templates/servicemonitor.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- if .Values.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.metrics.serviceMonitor.namespace }}
   {{- else }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   {{- end }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.metrics.serviceMonitor.additionalLabels }}
@@ -29,7 +29,7 @@ spec:
       {{- end }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ .Release.Namespace | quote }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
 {{- end }}

--- a/bitnami/rabbitmq/templates/statefulset.yaml
+++ b/bitnami/rabbitmq/templates/statefulset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "rabbitmq.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   serviceName: {{ template "rabbitmq.fullname" . }}-headless

--- a/bitnami/rabbitmq/templates/svc-headless.yaml
+++ b/bitnami/rabbitmq/templates/svc-headless.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "rabbitmq.fullname" . }}-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   clusterIP: None

--- a/bitnami/rabbitmq/templates/svc.yaml
+++ b/bitnami/rabbitmq/templates/svc.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "rabbitmq.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.service.labels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.service.labels "context" $) | nindent 4 }}

--- a/bitnami/rabbitmq/templates/tls-secrets.yaml
+++ b/bitnami/rabbitmq/templates/tls-secrets.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 type: kubernetes.io/tls
 data:


### PR DESCRIPTION
**Description of the change**
Currently, deploying the chart into a namespace constisting only of digits, e.g. "1234", fails.
This patch fixes this.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

