### PR TITLE
[bitnami/ghost]: support priorityClassName

### DIFF
--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ghost
-version: 10.1.21
+version: 10.2.0
 appVersion: 3.35.5
 description: A simple, powerful publishing platform that allows you to share your stories with the world
 keywords:

--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: ghost
-version: 10.1.20
+version: 10.1.21
 appVersion: 3.35.5
 description: A simple, powerful publishing platform that allows you to share your stories with the world
 keywords:

--- a/bitnami/ghost/README.md
+++ b/bitnami/ghost/README.md
@@ -146,6 +146,7 @@ The following table lists the configurable parameters of the Ghost chart and the
 | `extraEnvVarsConfigMap`                 | ConfigMap containing extra env vars to be added to all pods (evaluated as a template)              | `nil`                                                                                         |
 | `extraEnvVarsSecret`                    | Secret containing extra env vars to be added to all pods (evaluated as a template)                 | `nil`                                                                                         |
 | `podAnnotations`                        | Additional pod annotations to be added to all pods (evaluated as a template)                       | `{}`                                                                                          |
+| `priorityClassName`                     | Define the priority class name to use for the ghost pods here.                                 | `""`                                                                                          |
 
 The above parameters map to the env variables defined in [bitnami/ghost](http://github.com/bitnami/bitnami-docker-ghost). For more information please refer to the [bitnami/ghost](http://github.com/bitnami/bitnami-docker-ghost) image documentation.
 

--- a/bitnami/ghost/templates/deployment.yaml
+++ b/bitnami/ghost/templates/deployment.yaml
@@ -16,7 +16,9 @@ spec:
       {{- end }}
     spec:
       {{- include "ghost.imagePullSecrets" . | indent 6 }}
-      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}

--- a/bitnami/ghost/templates/deployment.yaml
+++ b/bitnami/ghost/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       {{- end }}
     spec:
       {{- include "ghost.imagePullSecrets" . | indent 6 }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}

--- a/bitnami/ghost/values.yaml
+++ b/bitnami/ghost/values.yaml
@@ -326,7 +326,8 @@ podAnnotations: {}
 
 ## Priority Class Name
 ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
-priorityClassName: ""
+##
+# priorityClassName: ""
 
 ## Add sidecars to the pod
 ## For example:

--- a/bitnami/ghost/values.yaml
+++ b/bitnami/ghost/values.yaml
@@ -324,6 +324,10 @@ affinity: {}
 ##
 podAnnotations: {}
 
+## Priority Class Name
+## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+priorityClassName: ""
+
 ## Add sidecars to the pod
 ## For example:
 ## sidecars:


### PR DESCRIPTION
**Description of the change**

As described [here](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass) priority classes can be a simple and powerful way to mark services more important than others for the scheduler. This change allows setting the priority class name on the ghost pods.

**Benefits**

Users will now be able to utilize existing priority classes with ghost.

**Possible drawbacks**

None: if you don't use priority classes this can be left empty.

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)