### PR TITLE
[bitnami/postgres] Extra manifests should be top-level

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 9.8.7
+version: 10.0.0
 appVersion: 11.9.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/bitnami/postgresql/templates/extra-list.yaml
+++ b/bitnami/postgresql/templates/extra-list.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.extraDeploy }}
-apiVersion: v1
-kind: List
-items: {{- include "common.tplvalues.render" (dict "value" .Values.extraDeploy "context" $) | nindent 2 }}
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}


### PR DESCRIPTION
**Description of the change**

The "extra manifests" defined with the `extraDeploy` value are now rendered as top-level manifests, instead of being wrapped inside a List.

**Benefits**

This change allows defining Jobs as Helm hooks, which was not possible before - because Helm only looks at top-level manifests to find hooks annotations.

**Additional information**

- I've bumped the major semver component because it won't render the same way - if people used `extraDeploy`.
- There are a lot of charts in this repo defining extra manifests in the same way - do you prefer 1 PR per chart, or a single PR to change it for all charts at once?

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
