### PR TITLE
[bitnami/*] Extra manifests should be top-level

### DIFF
--- a/bitnami/aspnet-core/Chart.yaml
+++ b/bitnami/aspnet-core/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: aspnet-core
-version: 0.3.2
+version: 0.3.3
 appVersion: 3.1.9
 description: ASP.NET Core is an open-source framework created by Microsoft for building cloud-enabled, modern applications.
 keywords:

--- a/bitnami/aspnet-core/templates/extra-list.yaml
+++ b/bitnami/aspnet-core/templates/extra-list.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.extraDeploy }}
-apiVersion: v1
-kind: List
-items: {{- include "common.tplvalues.render" (dict "value" .Values.extraDeploy "context" $) | nindent 2 }}
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cassandra
-version: 6.0.5
+version: 6.0.6
 appVersion: 3.11.8
 description: Apache Cassandra is a free and open-source distributed database management system designed to handle large amounts of data across many commodity servers, providing high availability with no single point of failure. Cassandra offers robust support for clusters spanning multiple datacenters, with asynchronous masterless replication allowing low latency operations for all clients.
 keywords:

--- a/bitnami/cassandra/templates/extra-list.yaml
+++ b/bitnami/cassandra/templates/extra-list.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.extraDeploy }}
-apiVersion: v1
-kind: List
-items: {{- include "common.tplvalues.render" (dict "value" .Values.extraDeploy "context" $) | nindent 2 }}
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: consul
-version: 8.0.3
+version: 8.0.4
 appVersion: 1.8.4
 description: Highly available and distributed service discovery and key-value store designed with support for the modern data center to make distributed systems and configuration easy.
 home: https://github.com/bitnami/charts/tree/master/bitnami/consul

--- a/bitnami/consul/templates/extra-list.yaml
+++ b/bitnami/consul/templates/extra-list.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.extraDeploy }}
-apiVersion: v1
-kind: List
-items: {{- include "common.tplvalues.render" (dict "value" .Values.extraDeploy "context" $) | nindent 2 }}
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/bitnami/dokuwiki/Chart.yaml
+++ b/bitnami/dokuwiki/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dokuwiki
-version: 9.4.1
+version: 9.4.2
 appVersion: 20200729.0.0
 description: DokuWiki is a standards-compliant, simple to use wiki optimized for creating documentation. It is targeted at developer teams, workgroups, and small companies. All data is stored in plain text files, so no database is required.
 keywords:

--- a/bitnami/dokuwiki/templates/extra-list.yaml
+++ b/bitnami/dokuwiki/templates/extra-list.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.extraDeploy }}
-apiVersion: v1
-kind: List
-items: {{- include "common.tplvalues.render" (dict "value" .Values.extraDeploy "context" $) | nindent 2 }}
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/bitnami/drupal/Chart.yaml
+++ b/bitnami/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 9.1.2
+version: 9.1.3
 appVersion: 9.0.7
 description: One of the most versatile open source content management systems.
 keywords:

--- a/bitnami/drupal/templates/extra-list.yaml
+++ b/bitnami/drupal/templates/extra-list.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.extraDeploy }}
-apiVersion: v1
-kind: List
-items: {{- include "common.tplvalues.render" (dict "value" .Values.extraDeploy "context" $) | nindent 2 }}
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: harbor
-version: 8.1.3
+version: 8.1.4
 appVersion: 2.1.1
 description: Harbor is an an open source trusted cloud native registry project that stores, signs, and scans content
 keywords:

--- a/bitnami/harbor/templates/extra-list.yaml
+++ b/bitnami/harbor/templates/extra-list.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.extraDeploy }}
-apiVersion: v1
-kind: List
-items: {{- include "common.tplvalues.render" (dict "value" .Values.extraDeploy "context" $) | nindent 2 }}
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/bitnami/joomla/Chart.yaml
+++ b/bitnami/joomla/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: joomla
-version: 8.1.8
+version: 8.1.9
 appVersion: 3.9.22
 description: PHP content management system (CMS) for publishing web content
 keywords:

--- a/bitnami/joomla/templates/extra-list.yaml
+++ b/bitnami/joomla/templates/extra-list.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.extraDeploy }}
-apiVersion: v1
-kind: List
-items: {{- include "common.tplvalues.render" (dict "value" .Values.extraDeploy "context" $) | nindent 2 }}
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kong
-version: 2.0.0
+version: 2.0.1
 appVersion: 2.2.0
 description: Kong is a scalable, open source API layer (aka API gateway or API middleware) that runs in front of any RESTful API. Extra functionalities beyond the core platform are extended through plugins. Kong is built on top of reliable technologies like NGINX and provides an easy-to-use RESTful API to operate and configure the system.
 keywords:

--- a/bitnami/kong/templates/extra-list.yaml
+++ b/bitnami/kong/templates/extra-list.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.extraDeploy }}
-apiVersion: v1
-kind: List
-items: {{- include "common.tplvalues.render" (dict "value" .Values.extraDeploy "context" $) | nindent 2 }}
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/bitnami/moodle/Chart.yaml
+++ b/bitnami/moodle/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: moodle
-version: 9.0.0
+version: 9.0.1
 appVersion: 3.9.2
 description: Moodle is a learning platform designed to provide educators, administrators and learners with a single robust, secure and integrated system to create personalised learning environments
 keywords:

--- a/bitnami/moodle/templates/extra-list.yaml
+++ b/bitnami/moodle/templates/extra-list.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.extraDeploy }}
-apiVersion: v1
-kind: List
-items: {{- include "common.tplvalues.render" (dict "value" .Values.extraDeploy "context" $) | nindent 2 }}
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx
-version: 7.1.4
+version: 7.1.5
 appVersion: 1.19.4
 description: Chart for the nginx server
 keywords:

--- a/bitnami/nginx/templates/extra-list.yaml
+++ b/bitnami/nginx/templates/extra-list.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.extraDeploy }}
-apiVersion: v1
-kind: List
-items: {{- include "common.tplvalues.render" (dict "value" .Values.extraDeploy "context" $) | nindent 2 }}
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/bitnami/opencart/Chart.yaml
+++ b/bitnami/opencart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: opencart
-version: 8.0.1
+version: 8.0.2
 appVersion: 3.0.3-6
 description: A free and open source e-commerce platform for online merchants. It provides a professional and reliable foundation for a successful online store.
 keywords:

--- a/bitnami/opencart/templates/extra-list.yaml
+++ b/bitnami/opencart/templates/extra-list.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.extraDeploy }}
-apiVersion: v1
-kind: List
-items: {{- include "common.tplvalues.render" (dict "value" .Values.extraDeploy "context" $) | nindent 2 }}
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/bitnami/phpbb/Chart.yaml
+++ b/bitnami/phpbb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: phpbb
-version: 8.0.3
+version: 8.0.4
 appVersion: 3.3.1
 description: Community forum that supports the notion of users and groups, file attachments, full-text search, notifications and more.
 keywords:

--- a/bitnami/phpbb/templates/extra-list.yaml
+++ b/bitnami/phpbb/templates/extra-list.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.extraDeploy }}
-apiVersion: v1
-kind: List
-items: {{- include "common.tplvalues.render" (dict "value" .Values.extraDeploy "context" $) | nindent 2 }}
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql-ha
-version: 5.2.2
+version: 5.2.3
 appVersion: 11.9.0
 description: Chart for PostgreSQL with HA architecture (using Replication Manager (repmgr) and Pgpool).
 keywords:

--- a/bitnami/postgresql-ha/templates/extra-list.yaml
+++ b/bitnami/postgresql-ha/templates/extra-list.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.extraDeploy }}
-apiVersion: v1
-kind: List
-items: {{- include "common.tplvalues.render" (dict "value" .Values.extraDeploy "context" $) | nindent 2 }}
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 9.8.7
+version: 9.8.8
 appVersion: 11.9.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/bitnami/postgresql/templates/extra-list.yaml
+++ b/bitnami/postgresql/templates/extra-list.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.extraDeploy }}
-apiVersion: v1
-kind: List
-items: {{- include "common.tplvalues.render" (dict "value" .Values.extraDeploy "context" $) | nindent 2 }}
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/bitnami/prestashop/Chart.yaml
+++ b/bitnami/prestashop/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prestashop
-version: 11.0.2
+version: 11.0.3
 appVersion: 1.7.6-8
 description: A popular open source ecommerce solution. Professional tools are easily accessible to increase online sales including instant guest checkout, abandoned cart reminders and automated Email marketing.
 keywords:

--- a/bitnami/prestashop/templates/extra-list.yaml
+++ b/bitnami/prestashop/templates/extra-list.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.extraDeploy }}
-apiVersion: v1
-kind: List
-items: {{- include "common.tplvalues.render" (dict "value" .Values.extraDeploy "context" $) | nindent 2 }}
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis-cluster
-version: 3.2.10
+version: 3.2.11
 appVersion: 6.0.9
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/bitnami/redis-cluster/templates/extra-list.yaml
+++ b/bitnami/redis-cluster/templates/extra-list.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.extraDeploy }}
-apiVersion: v1
-kind: List
-items: {{- include "common.tplvalues.render" (dict "value" .Values.extraDeploy "context" $) | nindent 2 }}
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/bitnami/testlink/Chart.yaml
+++ b/bitnami/testlink/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: testlink
-version: 8.0.0
+version: 8.0.1
 appVersion: 1.9.20
 description: Web-based test management system that facilitates software quality assurance.
 icon: https://bitnami.com/assets/stacks/testlink/img/testlink-stack-220x234.png

--- a/bitnami/testlink/templates/extra-list.yaml
+++ b/bitnami/testlink/templates/extra-list.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.extraDeploy }}
-apiVersion: v1
-kind: List
-items: {{- include "common.tplvalues.render" (dict "value" .Values.extraDeploy "context" $) | nindent 2 }}
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/bitnami/wavefront/Chart.yaml
+++ b/bitnami/wavefront/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: wavefront
 description: Chart for Wavefront Collector for Kubernetes
 appVersion: 1.2.4
-version: 0.1.5
+version: 0.1.6
 keywords:
   - metric
   - monitoring

--- a/bitnami/wavefront/templates/extra-list.yaml
+++ b/bitnami/wavefront/templates/extra-list.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.extraDeploy }}
-apiVersion: v1
-kind: List
-items: {{- include "common.tplvalues.render" (dict "value" .Values.extraDeploy "context" $) | nindent 2 }}
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/template/CHART_NAME/templates/extra-list.yaml
+++ b/template/CHART_NAME/templates/extra-list.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.extraDeploy }}
-apiVersion: v1
-kind: List
-items: {{- include "common.tplvalues.render" (dict "value" .Values.extraDeploy "context" $) | nindent 2 }}
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}


### PR DESCRIPTION
**Description of the change**

The "extra manifests" defined with the extraDeploy value are now rendered as top-level manifests, instead of being wrapped inside a List.

**Benefits**

This change allows defining Jobs as Helm hooks, which was not possible before - because Helm only looks at top-level manifests to find hooks annotations.

**Possible drawbacks**

None: users won't need to change anything in their values.yaml

**Additional information**

This is a follow-up on #4157 but applied to all charts (instead of just postgresql)

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
