### PR TITLE
[bitnami/tomcat] feat: allow custom values for liveness and readiness probe

### DIFF
--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: tomcat
-version: 6.6.0
+version: 6.7.0
 appVersion: 9.0.39
 description: Chart for Apache Tomcat
 keywords:

--- a/bitnami/tomcat/README.md
+++ b/bitnami/tomcat/README.md
@@ -100,12 +100,14 @@ The following tables lists the configurable parameters of the Tomcat chart and t
 | `ingress.hosts[0].tlsHosts`          | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`)                | `nil`                                                   |
 | `ingress.hosts[0].tlsSecret`         | TLS Secret (certificates)                                                                           | `tomcat.local-tls`                                      |
 | `extraEnvVars`                       | Extra environment variables to be set on tomcat container                                           | `[]`                                                    |
+| `livenessProbe.enabled`              | Enable liveness probe	                                                                             | `true`                                                  |
 | `livenessProbe.path`                 | HTTP Path to access on the HTTP server to check for liveness                                        | `/`                                                     |
 | `livenessProbe.port`                 | Name or number of the port to access on the container                                               | `http`                                                  |
 | `livenessProbe.initialDelaySeconds`  | Number of seconds after the container has started before probes are initiated                       | `120`                                                   |
 | `livenessProbe.periodSeconds`        | How often (in seconds) to perform the probe                                                         | `10`                                                    |
 | `livenessProbe.failureThreshold`     | Number of times probe can fail before giving up                                                     | `6`                                                     |
 | `livenessProbe.timeoutSeconds`       | Number of seconds after which the probe times out                                                   | `5`                                                     |
+| `readinessProbe.enabled`             | Enable readiness probe	                                                                             | `true`                                                  |
 | `readinessProbe.path`                | HTTP Path to access on the HTTP server to check for readiness                                       | `/`                                                     |
 | `readinessProbe.port`                | Name or number of the port to access on the container                                               | `http`                                                  |
 | `readinessProbe.initialDelaySeconds` | Number of seconds after the container has started before probes are initiated                       | `30`                                                    |

--- a/bitnami/tomcat/README.md
+++ b/bitnami/tomcat/README.md
@@ -100,6 +100,18 @@ The following tables lists the configurable parameters of the Tomcat chart and t
 | `ingress.hosts[0].tlsHosts`          | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`)                | `nil`                                                   |
 | `ingress.hosts[0].tlsSecret`         | TLS Secret (certificates)                                                                           | `tomcat.local-tls`                                      |
 | `extraEnvVars`                       | Extra environment variables to be set on tomcat container                                           | `[]`                                                    |
+| `livenessProbe.path`                 | HTTP Path to access on the HTTP server to check for liveness                                        | `/`                                                     |
+| `livenessProbe.port`                 | Name or number of the port to access on the container                                               | `http`                                                  |
+| `livenessProbe.initialDelaySeconds`  | Number of seconds after the container has started before probes are initiated                       | `120`                                                   |
+| `livenessProbe.periodSeconds`        | How often (in seconds) to perform the probe                                                         | `10`                                                    |
+| `livenessProbe.failureThreshold`     | Number of times probe can fail before giving up                                                     | `6`                                                     |
+| `livenessProbe.timeoutSeconds`       | Number of seconds after which the probe times out                                                   | `5`                                                     |
+| `readinessProbe.path`                | HTTP Path to access on the HTTP server to check for readiness                                       | `/`                                                     |
+| `readinessProbe.port`                | Name or number of the port to access on the container                                               | `http`                                                  |
+| `readinessProbe.initialDelaySeconds` | Number of seconds after the container has started before probes are initiated                       | `30`                                                    |
+| `readinessProbe.periodSeconds`       | How often (in seconds) to perform the probe                                                         | `51`                                                    |
+| `readinessProbe.failureThreshold`    | Number of times probe can fail before giving up                                                     | `3`                                                     |
+| `readinessProbe.timeoutSeconds`      | Number of seconds after which the probe times out                                                   | `3`                                                     |
 
 The above parameters map to the env variables defined in [bitnami/tomcat](http://github.com/bitnami/bitnami-docker-tomcat). For more information please refer to the [bitnami/tomcat](http://github.com/bitnami/bitnami-docker-tomcat) image documentation.
 

--- a/bitnami/tomcat/templates/deployment.yaml
+++ b/bitnami/tomcat/templates/deployment.yaml
@@ -76,6 +76,7 @@ spec:
           ports:
             - name: http
               containerPort: 8080
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: {{ .Values.livenessProbe.path }}
@@ -84,6 +85,8 @@ spec:
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: {{ .Values.readinessProbe.path }}
@@ -92,6 +95,7 @@ spec:
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          {{- end }}
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}

--- a/bitnami/tomcat/templates/deployment.yaml
+++ b/bitnami/tomcat/templates/deployment.yaml
@@ -78,18 +78,20 @@ spec:
               containerPort: 8080
           livenessProbe:
             httpGet:
-              path: /
-              port: http
-            initialDelaySeconds: 120
-            timeoutSeconds: 5
-            failureThreshold: 6
+              path: {{ .Values.livenessProbe.path }}
+              port: {{ .Values.livenessProbe.port }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           readinessProbe:
             httpGet:
-              path: /
-              port: http
-            initialDelaySeconds: 30
-            timeoutSeconds: 3
-            periodSeconds: 51
+              path: {{ .Values.readinessProbe.path }}
+              port: {{ .Values.readinessProbe.port }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}

--- a/bitnami/tomcat/values.yaml
+++ b/bitnami/tomcat/values.yaml
@@ -267,4 +267,3 @@ readinessProbe:
   periodSeconds: 51
   failureThreshold: 3
   timeoutSeconds: 3
-  

--- a/bitnami/tomcat/values.yaml
+++ b/bitnami/tomcat/values.yaml
@@ -249,3 +249,21 @@ ingress:
 ##     value: BAR
 ##
 extraEnvVars: []
+
+## Liveness and Readiness probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+##
+livenessProbe:
+  path: "/"
+  port: http
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  failureThreshold: 6
+  timeoutSeconds: 5
+readinessProbe:
+  path: "/"
+  port: http
+  initialDelaySeconds: 30
+  periodSeconds: 51
+  failureThreshold: 3
+  timeoutSeconds: 3

--- a/bitnami/tomcat/values.yaml
+++ b/bitnami/tomcat/values.yaml
@@ -267,3 +267,4 @@ readinessProbe:
   periodSeconds: 51
   failureThreshold: 3
   timeoutSeconds: 3
+  

--- a/bitnami/tomcat/values.yaml
+++ b/bitnami/tomcat/values.yaml
@@ -254,6 +254,7 @@ extraEnvVars: []
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 ##
 livenessProbe:
+  enabled: true
   path: "/"
   port: http
   initialDelaySeconds: 120
@@ -261,6 +262,7 @@ livenessProbe:
   failureThreshold: 6
   timeoutSeconds: 5
 readinessProbe:
+  enabled: true
   path: "/"
   port: http
   initialDelaySeconds: 30


### PR DESCRIPTION
**Description of the change**

add values for liveness and readiness probe's path, port, initialDelaySeconds, timeoutSeconds, periodSeconds, and failureThreshold fields 

**Benefits**

We are able to pass custom values for liveness and readiness probe

**Possible drawbacks**

N/A

**Applicable issues**

  - fixes #4165 

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
