### PR TITLE
bitnami/rabbitmq: Setting target port to equal port

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 7.7.1
+version: 7.7.2
 appVersion: 3.8.9
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/bitnami/rabbitmq/templates/svc.yaml
+++ b/bitnami/rabbitmq/templates/svc.yaml
@@ -26,7 +26,7 @@ spec:
   ports:
     - name: amqp
       port: {{ .Values.service.port }}
-      targetPort: amqp
+      targetPort: {{ .Values.service.port }}
       {{- if (eq .Values.service.type "ClusterIP") }}
       nodePort: null
       {{- else if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePort)) }}
@@ -35,7 +35,7 @@ spec:
     {{- if .Values.auth.tls.enabled }}
     - name: amqp-ssl
       port: {{ .Values.service.tlsPort }}
-      targetPort: amqp-ssl
+      targetPort: {{ .Values.service.tlsPort }}
       {{- if (eq .Values.service.type "ClusterIP") }}
       nodePort: null
       {{- else if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.tlsNodePort)) }}
@@ -44,7 +44,7 @@ spec:
     {{- end }}
     - name: epmd
       port: 4369
-      targetPort: epmd
+      targetPort: 4369
       {{- if (eq .Values.service.type "ClusterIP") }}
       nodePort: null
       {{- else if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.epmdNodePort))) }}
@@ -52,7 +52,7 @@ spec:
       {{- end }}
     - name: dist
       port: {{ .Values.service.distPort }}
-      targetPort: dist
+      targetPort: {{ .Values.service.distPort }}
       {{- if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- else if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.distNodePort))) }}
@@ -60,7 +60,7 @@ spec:
       {{- end }}
     - name: http-stats
       port: {{ .Values.service.managerPort }}
-      targetPort: stats
+      targetPort: {{ .Values.service.managerPort }}
       {{- if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- else if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.managerNodePort))) }}
@@ -69,7 +69,7 @@ spec:
     {{- if .Values.metrics.enabled }}
     - name: metrics
       port: {{ .Values.service.metricsPort }}
-      targetPort: metrics
+      targetPort: {{ .Values.service.metricsPort }}
       {{- if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- else if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.metricsNodePort))) }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

GCP k8s does not allow port forwarding to the machine, since it does not recognize amqp as target port.
Setting the target port to equal the port of the relevant protocols.

**Benefits**

GCP k8s will allow port forwarding to the machine

**Possible drawbacks**

None

**Applicable issues**

None 

  - fixes https://github.com/bitnami/charts/issues/4174

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
