### PR TITLE
[bitname/harbor] Support Harbor proxy cache

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: harbor
-version: 8.1.4
+version: 8.1.5
 appVersion: 2.1.1
 description: Harbor is an an open source trusted cloud native registry project that stores, signs, and scans content
 keywords:

--- a/bitnami/harbor/templates/core/core-cm-envvars.yaml
+++ b/bitnami/harbor/templates/core/core-cm-envvars.yaml
@@ -48,6 +48,7 @@ data:
   PORTAL_URL: {{ include "harbor.portal.url" . | quote }}
   REGISTRY_CONTROLLER_URL: {{ include "harbor.registryCtl.url" . | quote }}
   REGISTRY_CREDENTIAL_USERNAME: {{ .Values.registry.credentials.username | quote }}
+  PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE: "docker-hub,harbor"
   {{- if .Values.core.uaaSecretName }}
   UAA_CA_ROOT: "/etc/core/ca/auth-ca.crt"
   {{- end }}


### PR DESCRIPTION
**Description of the change**

Add an environment variable for Harbor core.
According to [goharbor's source code](https://github.com/goharbor/harbor/blob/a255f3e74daad3345a5b731d31d4d704b66716d4/src/core/config/config.go#L472), we need to add environment variable `PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE` to support [Harbor's proxy cache](https://goharbor.io/docs/2.1.0/administration/configure-proxy-cache/).

Harbor only supports Docker Hub and Harbor registries as proxy cache source, so we only need to add `docker-hub` and `harbor` for this env var.

**Benefits**

Fully support proxy cache for Harbor

**Possible drawbacks**

N/A

**Applicable issues**

  - fixes #4160

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
