### PR TITLE
[bitnami/minio] Sanitize namespace

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 3.7.17
+version: 3.7.18
 appVersion: 2020.10.28
 description: MinIO is an object storage server, compatible with Amazon S3 cloud storage service, mainly used for storing unstructured data (such as photos, videos, log files, etc.)
 keywords:

--- a/bitnami/minio/templates/deployment-standalone.yaml
+++ b/bitnami/minio/templates/deployment-standalone.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "minio.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "minio.labels" . | nindent 4 }}
 spec:
   {{- if .Values.deployment.updateStrategy }}

--- a/bitnami/minio/templates/ingress.yaml
+++ b/bitnami/minio/templates/ingress.yaml
@@ -3,7 +3,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "minio.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "minio.labels" . | nindent 4 }}
 {{- range $key, $value := .Values.ingress.labels }}
     {{ $key }}: {{ $value }}

--- a/bitnami/minio/templates/networkpolicy.yaml
+++ b/bitnami/minio/templates/networkpolicy.yaml
@@ -3,7 +3,7 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: {{ include "minio.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "minio.labels" . | nindent 4 }}
 spec:
   podSelector:

--- a/bitnami/minio/templates/pvc-standalone.yaml
+++ b/bitnami/minio/templates/pvc-standalone.yaml
@@ -3,7 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ include "minio.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "minio.labels" . | nindent 4 }}
 spec:
   accessModes:

--- a/bitnami/minio/templates/secrets.yaml
+++ b/bitnami/minio/templates/secrets.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "minio.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "minio.labels" . | nindent 4 }}
 type: Opaque
 data:

--- a/bitnami/minio/templates/service.yaml
+++ b/bitnami/minio/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "minio.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "minio.labels" . | nindent 4 }}
   {{- if .Values.service.annotations }}
   annotations: {{- include "minio.tplValue" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}

--- a/bitnami/minio/templates/serviceaccount.yaml
+++ b/bitnami/minio/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "minio.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "minio.labels" . | nindent 4 }}
 secrets:
   - name: {{ include "minio.fullname" . }}

--- a/bitnami/minio/templates/statefulset.yaml
+++ b/bitnami/minio/templates/statefulset.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "minio.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "minio.labels" . | nindent 4 }}
 spec:
   selector:

--- a/bitnami/minio/templates/svc-headless.yaml
+++ b/bitnami/minio/templates/svc-headless.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "minio.fullname" . }}-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "minio.labels" . | nindent 4 }}
 spec:
   type: ClusterIP

--- a/bitnami/minio/templates/tls-secrets.yaml
+++ b/bitnami/minio/templates/tls-secrets.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "minio.labels" $ | nindent 4 }}
 type: kubernetes.io/tls
 data:


### PR DESCRIPTION
**Description of the change**
Currently, deploying the chart into a namespace constisting only of digits, e.g. "1234", fails.
This patch fixes this.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

See #4137 
