### PR TITLE
[bitnami/moodle] Fix reading externalDatabase.password from secret

### DIFF
--- a/bitnami/moodle/Chart.yaml
+++ b/bitnami/moodle/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: moodle
-version: 9.0.1
+version: 9.0.2
 appVersion: 3.9.2
 description: Moodle is a learning platform designed to provide educators, administrators and learners with a single robust, secure and integrated system to create personalised learning environments
 keywords:

--- a/bitnami/moodle/templates/externaldb-secrets.yaml
+++ b/bitnami/moodle/templates/externaldb-secrets.yaml
@@ -6,5 +6,5 @@ metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 type: Opaque
 data:
-  db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
+  mariadb-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
**Description of the change**

This change enables the moodle pod to read the value for `externalDatabase.password` from the right field of the `moodle-externaldb` secret.

Fixes bug #4189

**Benefits**

`externalDatabase` will work properly.

**Possible drawbacks**

None.

**Applicable issues**

  - fixes #4189

**Additional information**

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
