### PR TITLE
[bitnami/redis] Fix: "sh -c" for volume-permissions initContainer

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: redis
-version: 11.3.0
+version: 11.3.1
 appVersion: 6.0.9
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/bitnami/redis/templates/redis-master-statefulset.yaml
+++ b/bitnami/redis/templates/redis-master-statefulset.yaml
@@ -239,6 +239,8 @@ spec:
         image: "{{ template "redis.volumePermissions.image" . }}"
         imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
         command:
+          - /bin/sh
+          - -cx
           - |
             {{- if eq ( toString ( .Values.volumePermissions.securityContext.runAsUser )) "auto" }}
             chown -R `id -u`:`id -G | cut -d " " -f2` {{ .Values.master.persistence.path }}

--- a/bitnami/redis/templates/redis-node-statefulset.yaml
+++ b/bitnami/redis/templates/redis-node-statefulset.yaml
@@ -345,6 +345,8 @@ spec:
           image: {{ template "redis.volumePermissions.image" . }}
           imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
           command:
+            - /bin/sh
+            - -cx
             - |
               {{- if eq ( toString ( .Values.volumePermissions.securityContext.runAsUser )) "auto" }}
               chown -R `id -u`:`id -G | cut -d " " -f2` {{ .Values.slave.persistence.path }}


### PR DESCRIPTION
Add the /bin/sh -cx command in front of the "chown" stuff to avoid "file
not found" and similar errors. Similar to how it's done in the Postgres
chart.

Signed-off-by: Thorsten Klein <iwilltry42@gmail.com>


**Description of the change**

Small change adding `/bin/sh -cx` in front of the `chown` commands in the `volume-permissions` initContainers of the Redis chart. Without it, I was running into "File not Found" and similar errors when using `volumePermissions.enabled`, as the command consists of several parts, which otherwise will be treated as a single string.

**Benefits**

No more errors :tada: 

**Possible drawbacks**

None that I can think of.

**Applicable issues**

None.

**Additional information**

None.

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

