### PR TITLE
[bitnami/postgresql] fix: update values to avoid warnings

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 9.8.10
+version: 9.8.11
 appVersion: 11.9.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/bitnami/postgresql/values-production.yaml
+++ b/bitnami/postgresql/values-production.yaml
@@ -266,7 +266,7 @@ ldap:
   search_attr: ""
   search_filter: ""
   scheme: ""
-  tls: false
+  tls: {}
 
 ## Audit settings
 ## https://github.com/bitnami/bitnami-docker-postgresql#auditing

--- a/bitnami/postgresql/values.yaml
+++ b/bitnami/postgresql/values.yaml
@@ -332,7 +332,7 @@ ldap:
   search_attr: ''
   search_filter: ''
   scheme: ''
-  tls: false
+  tls: {}
 
 ## PostgreSQL service configuration
 ##


### PR DESCRIPTION
Signed-off-by: darteaga <darteaga@vmware.com>

**Description of the change**

When using this chart as a sub chart we are getting the following warning:

```
$ helm template airflow bitnami/airflow/ | grep tls
coalesce.go:195: warning: destination for tls is a table. Ignoring non-table value false
```

Due to this https://github.com/helm/helm/issues/4514#issuecomment-475674372.

Updating the values YAML it will disappear.

**Benefits**

We will not see warning related to tls on other charts.

N/A

<!-- Describe any known limitations with your change -->

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
