### PR TITLE
[bitnami/moodle] Fix init containers

### DIFF
--- a/bitnami/moodle/Chart.yaml
+++ b/bitnami/moodle/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: moodle
-version: 9.0.3
+version: 9.0.4
 appVersion: 3.9.2
 description: Moodle is a learning platform designed to provide educators, administrators and learners with a single robust, secure and integrated system to create personalised learning environments
 keywords:

--- a/bitnami/moodle/templates/deployment.yaml
+++ b/bitnami/moodle/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
         - ip: "127.0.0.1"
           hostnames:
             - "status.localhost"
-      initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+      initContainers: {{- if .Values.initContainers -}}{{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}{{- end -}}
         {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
         - name: volume-permissions
           image: {{ include "moodle.volumePermissions.image" . }}


### PR DESCRIPTION
**Description of the change**
When enabling a pre-defined init container such as the `volume-permissions` one while `initContainers` is set to its default value (`[]`), the result is invalid YAML:

```
$ helm template bitnami/moodle --set volumePermissions.enabled=true --debug
...
      initContainers:
        []
        - name: volume-permissions
          image: docker.io/bitnami/minideb:buster
...
```

This PR adds a condition so that the value in `initContainers` is only rendered if it is set/not empty:

```
$ helm template bitnami/moodle --set volumePermissions.enabled=true --debug
...
      initContainers:
        - name: volume-permissions
          image: docker.io/bitnami/minideb:buster
          imagePullPolicy: "Always"
...
```

**Applicable issues**
  - fixes #4206 

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`).


