### PR TITLE
[bitnami/redis]: improve sentinel startup scripts & ping master to confirm availability + add optional ping_sentinel_master health script

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -19,4 +19,4 @@ name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 12.0.1
+version: 12.1.0

--- a/bitnami/redis/templates/configmap-scripts.yaml
+++ b/bitnami/redis/templates/configmap-scripts.yaml
@@ -10,54 +10,63 @@ metadata:
     release: {{ .Release.Name }}
 data:
 {{- if and .Values.cluster.enabled .Values.sentinel.enabled }}
+  get-master-host.sh: |
+    #!/bin/bash
+  {{- if .Values.usePasswordFile }}
+    REDIS_PASSWORD=$(cat $REDIS_PASSWORD_FILE)
+  {{- end }}
+  {{- if .Values.usePassword }}
+    no_auth_warning=$([[ "$(redis-cli --version)" =~ (redis-cli 5.*) ]] && echo --no-auth-warning)
+    redis_auth="-a $REDIS_PASSWORD $no_auth_warning"
+  {{- end }}
+  {{- if .Values.tls.enabled }}
+    redis_auth="$redis_auth --tls --cacert {{ template "redis.tlsCACert" . }}"
+  {{- if .Values.tls.authClients }}
+    redis_auth="$redis_auth --cert {{ template "redis.tlsCert" . }} --key {{ template "redis.tlsCertKey" . }}"
+  {{- end }}
+  {{- end }}
+    sentinel_info_command=$(
+      timeout -s 3 5 \
+      redis-cli $redis_auth \
+      -h {{ template "redis.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} \
+      -p {{ .Values.sentinel.port }} \
+      --raw sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }} \
+      2>/dev/null
+    )
+    if [ $? -ge 1 ]; then
+      exit 1
+    fi
+
+    master_host=$(echo $sentinel_info_command | awk '{print $1}')
+    master_port=$(echo $sentinel_info_command | awk '{print $2}')
+    ping_response=$(
+      timeout -s 3 5 \
+      redis-cli $redis_auth \
+      -h $master_host -p $master_port \
+      ping \
+      2>/dev/null
+    )
+    if [ "$ping_response" != "PONG" ]; then
+      exit 1
+    fi
+    echo $master_host
+
   start-node.sh: |
     #!/bin/bash
-    is_boolean_yes() {
-        local -r bool="${1:-}"
-        # comparison is performed without regard to the case of alphabetic characters
-        shopt -s nocasematch
-        if [[ "$bool" = 1 || "$bool" =~ ^(yes|true)$ ]]; then
-            true
-        else
-            false
-        fi
-    }
+    SCRIPT_DIR="$(dirname "$0")"
+{{- if .Values.usePasswordFile }}
+    REDIS_PASSWORD=$(cat $REDIS_PASSWORD_FILE)
+    REDIS_MASTER_PASSWORD=$(cat $REDIS_MASTER_PASSWORD_FILE)
+{{- end }}
+    REDIS_MASTER_HOST=$($SCRIPT_DIR/get-master-host.sh)
+    if [[ ! $REDIS_MASTER_HOST ]]; then is_master=1; fi
 
-    HEADLESS_SERVICE="{{ template "redis.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
-
-    export REDIS_REPLICATION_MODE="slave"
-    if [[ -z "$(getent ahosts "$HEADLESS_SERVICE" | grep -v "^$(hostname -i) ")" ]]; then
-      if [[ ! -f /data/redisboot.lock ]]; then
-        export REDIS_REPLICATION_MODE="master"
-      else
-        if is_boolean_yes "$REDIS_TLS_ENABLED"; then
-          sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $HEADLESS_SERVICE -p {{ .Values.sentinel.port }} --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} info"
-        else
-          sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $HEADLESS_SERVICE -p {{ .Values.sentinel.port }} info"
-        fi
-        if [[ ! ($($sentinel_info_command)) ]]; then
-           export REDIS_REPLICATION_MODE="master"
-           rm /data/redisboot.lock
-        fi
-      fi
-    fi
-
-    {{- if (eq (.Values.securityContext.runAsUser | int) 0) }}
+  {{- if (eq (.Values.securityContext.runAsUser | int) 0) }}
     useradd redis
     chown -R redis {{ .Values.slave.persistence.path }}
-    {{- end }}
+  {{- end }}
 
-    if [[ -n $REDIS_PASSWORD_FILE ]]; then
-      password_aux=`cat ${REDIS_PASSWORD_FILE}`
-      export REDIS_PASSWORD=$password_aux
-    fi
-
-    if [[ -n $REDIS_MASTER_PASSWORD_FILE ]]; then
-      password_aux=`cat ${REDIS_MASTER_PASSWORD_FILE}`
-      export REDIS_MASTER_PASSWORD=$password_aux
-    fi
-
-    if [[ "$REDIS_REPLICATION_MODE" == "master" ]]; then
+    if [[ $is_master ]]; then
       echo "I am master"
       if [[ ! -f /opt/bitnami/redis/etc/master.conf ]];then
         cp /opt/bitnami/redis/mounted-etc/master.conf /opt/bitnami/redis/etc/master.conf
@@ -66,15 +75,6 @@ data:
       if [[ ! -f /opt/bitnami/redis/etc/replica.conf ]];then
         cp /opt/bitnami/redis/mounted-etc/replica.conf /opt/bitnami/redis/etc/replica.conf
       fi
-
-      if is_boolean_yes "$REDIS_TLS_ENABLED"; then
-        sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $HEADLESS_SERVICE -p {{ .Values.sentinel.port }} --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
-      else
-        sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $HEADLESS_SERVICE -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
-      fi
-      REDIS_SENTINEL_INFO=($($sentinel_info_command))
-      REDIS_MASTER_HOST=${REDIS_SENTINEL_INFO[0]}
-      REDIS_MASTER_PORT_NUMBER=${REDIS_SENTINEL_INFO[1]}
     fi
 
     if [[ ! -f /opt/bitnami/redis/etc/redis.conf ]];then
@@ -95,10 +95,6 @@ data:
     ARGS=("--port" "${REDIS_PORT}")
     {{- end }}
 
-    if [[ "$REDIS_REPLICATION_MODE" == "slave" ]]; then
-      ARGS+=("--slaveof" "${REDIS_MASTER_HOST}" "${REDIS_MASTER_PORT_NUMBER}")
-    fi
-
     {{- if .Values.usePassword }}
     ARGS+=("--requirepass" "${REDIS_PASSWORD}")
     ARGS+=("--masterauth" "${REDIS_MASTER_PASSWORD}")
@@ -106,9 +102,10 @@ data:
     ARGS+=("--protected-mode" "no")
     {{- end }}
 
-    if [[ "$REDIS_REPLICATION_MODE" == "master" ]]; then
+    if [[ $is_master ]]; then
       ARGS+=("--include" "/opt/bitnami/redis/etc/master.conf")
     else
+      ARGS+=("--slaveof" "${REDIS_MASTER_HOST}" "${REDIS_PORT}")
       ARGS+=("--include" "/opt/bitnami/redis/etc/replica.conf")
     fi
 
@@ -119,7 +116,6 @@ data:
     {{- end }}
     {{- end }}
 
-    touch /data/redisboot.lock
     {{- if .Values.slave.command }}
     exec {{ .Values.slave.command }} "${ARGS[@]}"
     {{- else }}
@@ -128,127 +124,78 @@ data:
 
   start-sentinel.sh: |
     #!/bin/bash
-    replace_in_file() {
-        local filename="${1:?filename is required}"
-        local match_regex="${2:?match regex is required}"
-        local substitute_regex="${3:?substitute regex is required}"
-        local posix_regex=${4:-true}
-
-        local result
-
-        # We should avoid using 'sed in-place' substitutions
-        # 1) They are not compatible with files mounted from ConfigMap(s)
-        # 2) We found incompatibility issues with Debian10 and "in-place" substitutions
-        del=$'\001' # Use a non-printable character as a 'sed' delimiter to avoid issues
-        if [[ $posix_regex = true ]]; then
-            result="$(sed -E "s${del}${match_regex}${del}${substitute_regex}${del}g" "$filename")"
-        else
-            result="$(sed "s${del}${match_regex}${del}${substitute_regex}${del}g" "$filename")"
-        fi
-        echo "$result" > "$filename"
-    }
-    sentinel_conf_set() {
+    sentinel_conf_replace() {
         local -r key="${1:?missing key}"
-        local value="${2:-}"
+        local value="${2:?missing value}"
 
-        # Sanitize inputs
-        value="${value//\\/\\\\}"
-        value="${value//&/\\&}"
-        value="${value//\?/\\?}"
-        [[ "$value" = "" ]] && value="\"$value\""
+        result=$(sed "s/$key.*/$key $value/g" /opt/bitnami/redis-sentinel/etc/sentinel.conf)
+        echo "$result" > /opt/bitnami/redis-sentinel/etc/sentinel.conf
+    }
 
-        replace_in_file "/opt/bitnami/redis-sentinel/etc/sentinel.conf" "^#*\s*${key} .*" "${key} ${value}" false
+    sentinel_conf_remove() {
+        local -r key="${1:?missing key}"
+
+        result=$(sed "s/$key.*//g" /opt/bitnami/redis-sentinel/etc/sentinel.conf)
+        echo "$result" > /opt/bitnami/redis-sentinel/etc/sentinel.conf
     }
-    sentinel_conf_add() {
-        echo $'\n'"$@" >> "/opt/bitnami/redis-sentinel/etc/sentinel.conf"
+
+    sentinel_conf_append() {
+      local -r value="${1:?missing value}"
+
+      if [[ ! $(cat /opt/bitnami/redis-sentinel/etc/sentinel.conf | grep "$value") ]]; then
+        printf "\n$value" >> /opt/bitnami/redis-sentinel/etc/sentinel.conf
+      fi
     }
-    is_boolean_yes() {
-        local -r bool="${1:-}"
-        # comparison is performed without regard to the case of alphabetic characters
-        shopt -s nocasematch
-        if [[ "$bool" = 1 || "$bool" =~ ^(yes|true)$ ]]; then
-            true
-        else
-            false
+
+    get_known_sentinel() {
+        response=$(
+          timeout -s 3 5 \
+          getent hosts \
+          {{ template "redis.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
+        )
+
+        if [ $? -ge 1 ]; then
+          return 1
         fi
-    }
-    host_id() {
-      echo "$1" | openssl sha1 | awk '{print $2}'
+        KNOWN_SENTINELS=$(echo "$response" | awk '{print $1}')
     }
 
-    HEADLESS_SERVICE="{{ template "redis.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
-
-    if [[ -n $REDIS_PASSWORD_FILE ]]; then
-      password_aux=`cat ${REDIS_PASSWORD_FILE}`
-      export REDIS_PASSWORD=$password_aux
-    fi
+    SCRIPT_DIR="$(dirname "$0")"
+{{- if .Values.usePasswordFile }}
+    REDIS_PASSWORD=$(cat $REDIS_PASSWORD_FILE)
+{{- end }}
+    REDIS_MASTER_HOST=$($SCRIPT_DIR/get-master-host.sh)
+    if [[ ! $REDIS_MASTER_HOST ]]; then is_master=1; fi
 
     if [[ ! -f /opt/bitnami/redis-sentinel/etc/sentinel.conf ]]; then
       cp /opt/bitnami/redis-sentinel/mounted-etc/sentinel.conf /opt/bitnami/redis-sentinel/etc/sentinel.conf
       {{- if .Values.usePassword }}
-      printf "\nsentinel auth-pass %s %s" "{{ .Values.sentinel.masterSet }}" "$REDIS_PASSWORD" >> /opt/bitnami/redis-sentinel/etc/sentinel.conf
+      sentinel_conf_append "sentinel auth-pass {{ .Values.sentinel.masterSet }} $REDIS_PASSWORD"
       {{- if .Values.sentinel.usePassword }}
-      printf "\nrequirepass %s" "$REDIS_PASSWORD" >> /opt/bitnami/redis-sentinel/etc/sentinel.conf
+      sentinel_conf_append "requirepass $REDIS_PASSWORD"
       {{- end }}
       {{- end }}
       {{- if .Values.sentinel.staticID }}
-      printf "\nsentinel myid %s" "$(host_id "$HOSTNAME")" >> /opt/bitnami/redis-sentinel/etc/sentinel.conf
+      sentinel_conf_append "sentinel myid $(echo $HOSTNAME | openssl sha1 | awk '{ print $2 }')"
       {{- end }}
     fi
 
-    export REDIS_REPLICATION_MODE="slave"
-    if [[ -z "$(getent ahosts "$HEADLESS_SERVICE" | grep -v "^$(hostname -i) ")" ]]; then
-      if [[ ! -f /data/sentinelboot.lock ]]; then
-        export REDIS_REPLICATION_MODE="master"
-      else
-        if is_boolean_yes "$REDIS_SENTINEL_TLS_ENABLED"; then
-          sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $HEADLESS_SERVICE -p {{ .Values.sentinel.port }} --tls --cert ${REDIS_SENTINEL_TLS_CERT_FILE} --key ${REDIS_SENTINEL_TLS_KEY_FILE} --cacert ${REDIS_SENTINEL_TLS_CA_FILE} info"
-        else
-          sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $HEADLESS_SERVICE -p {{ .Values.sentinel.port }} info"
-        fi
-        if [[ ! ($($sentinel_info_command)) ]]; then
-           export REDIS_REPLICATION_MODE="master"
-           rm /data/sentinelboot.lock
-        fi
-      fi
+    if get_known_sentinel; then
+      for known_sentinel in $KNOWN_SENTINELS; do
+        if [[ $is_master ]]; then
+          sentinel_conf_append "sentinel known-replica {{ .Values.sentinel.masterSet }} $known_sentinel {{ .Values.redisPort }}"
+        fi 
+        sentinel_conf_append "sentinel known-sentinel {{ .Values.sentinel.masterSet }} $known_sentinel $REDIS_SENTINEL_PORT"
+      done
     fi
 
-    if [[ "$REDIS_REPLICATION_MODE" == "master" ]]; then
-      REDIS_MASTER_HOST="$(hostname -i)"
-      REDIS_MASTER_PORT_NUMBER="{{ .Values.redisPort }}"
+    if [[ $is_master ]]; then
+      echo "I am master"
+      sentinel_conf_replace "sentinel monitor" "{{ .Values.sentinel.masterSet }} $POD_IP {{ .Values.redisPort }} {{ .Values.sentinel.quorum }}"        
+      sentinel_conf_remove "sentinel known-replica {{ .Values.sentinel.masterSet }} $POD_IP"
     else
-      if is_boolean_yes "$REDIS_SENTINEL_TLS_ENABLED"; then
-        sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $HEADLESS_SERVICE -p {{ .Values.sentinel.port }} --tls --cert ${REDIS_SENTINEL_TLS_CERT_FILE} --key ${REDIS_SENTINEL_TLS_KEY_FILE} --cacert ${REDIS_SENTINEL_TLS_CA_FILE} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
-      else
-        sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $HEADLESS_SERVICE -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
-      fi
-      REDIS_SENTINEL_INFO=($($sentinel_info_command))
-      REDIS_MASTER_HOST=${REDIS_SENTINEL_INFO[0]}
-      REDIS_MASTER_PORT_NUMBER=${REDIS_SENTINEL_INFO[1]}
+      sentinel_conf_replace "sentinel monitor" "{{ .Values.sentinel.masterSet }} $REDIS_MASTER_HOST {{ .Values.redisPort }} {{ .Values.sentinel.quorum }}"
     fi
-    sentinel_conf_set "sentinel monitor" "{{ .Values.sentinel.masterSet }} "$REDIS_MASTER_HOST" "$REDIS_MASTER_PORT_NUMBER" {{ .Values.sentinel.quorum }}"
-
-    add_replica() {
-      if [[ "$1" != "$REDIS_MASTER_HOST" ]]; then
-        sentinel_conf_add "sentinel known-replica {{ .Values.sentinel.masterSet }} $1 {{ .Values.redisPort }}"
-      fi
-    }
-
-    {{- if .Values.sentinel.staticID }}
-    # remove generated known sentinels and replicas
-    tmp="$(sed -e '/^sentinel known-/d' -e '/^$/d' /opt/bitnami/redis-sentinel/etc/sentinel.conf)"
-    echo "$tmp" > /opt/bitnami/redis-sentinel/etc/sentinel.conf
-
-    for node in $(seq 0 {{ .Values.cluster.slaveCount }}); do
-      NAME="{{ template "redis.fullname" . }}-node-$node"
-      IP="$(getent hosts "$NAME.$HEADLESS_SERVICE" | awk ' {print $1 }')"
-      if [[ "$NAME" != "$HOSTNAME" && -n "$IP" ]]; then
-        sentinel_conf_add "sentinel known-sentinel {{ .Values.sentinel.masterSet }} $IP {{ .Values.sentinel.port }} $(host_id "$NAME")"
-        add_replica "$IP"
-      fi
-    done
-    add_replica "$(hostname -i)"
-    {{- end }}
 
     {{- if .Values.tls.enabled }}
     ARGS=("--port" "0")
@@ -262,7 +209,7 @@ data:
     ARGS+=("--tls-dh-params-file" "${REDIS_SENTINEL_TLS_DH_PARAMS_FILE}")
     {{- end }}
     {{- end }}
-    touch /data/sentinelboot.lock
+
     exec redis-server /opt/bitnami/redis-sentinel/etc/sentinel.conf --sentinel {{- if .Values.tls.enabled }} "${ARGS[@]}" {{- end }}
 {{- else }}
   start-master.sh: |

--- a/bitnami/redis/templates/health-configmap.yaml
+++ b/bitnami/redis/templates/health-configmap.yaml
@@ -76,11 +76,10 @@ data:
       exit 1
     fi
 {{- if .Values.sentinel.enabled }}
-  ping_sentinel.sh: |-
+  get_sentinel_master_host.sh: |-
     #!/bin/bash
 {{- if .Values.usePasswordFile }}
-    password_aux=`cat ${REDIS_PASSWORD_FILE}`
-    export REDIS_PASSWORD=$password_aux
+    REDIS_PASSWORD=$(cat $REDIS_PASSWORD_FILE)
 {{- end }}
 {{- if .Values.usePassword }}
     no_auth_warning=$([[ "$(redis-cli --version)" =~ (redis-cli 5.*) ]] && echo --no-auth-warning)
@@ -103,12 +102,80 @@ data:
 {{- else }}
         -p $REDIS_SENTINEL_PORT \
 {{- end }}
+        sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}
+    )
+    echo $response | awk '{print $1}'
+  ping_sentinel_local.sh: |-
+    #!/bin/bash
+{{- if .Values.usePasswordFile }}
+    REDIS_PASSWORD=$(cat $REDIS_PASSWORD_FILE)
+{{- end }}
+{{- if .Values.usePassword }}
+    no_auth_warning=$([[ "$(redis-cli --version)" =~ (redis-cli 5.*) ]] && echo --no-auth-warning)
+{{- end }}
+     response=$(
+      timeout -s 3 $1 \
+      redis-cli \
+{{- if .Values.usePassword }}
+        -a $REDIS_PASSWORD $no_auth_warning \
+{{- end }}
+        -h localhost \
+{{- if .Values.tls.enabled }}
+        -p $REDIS_SENTINEL_TLS_PORT_NUMBER \
+        --tls \
+        --cacert {{ template "redis.tlsCACert" . }} \
+        {{- if .Values.tls.authClients }}
+          --cert {{ template "redis.tlsCert" . }} \
+          --key {{ template "redis.tlsCertKey" . }} \
+        {{- end }}
+{{- else }}
+        -p {{ .Values.sentinel.port }} \
+{{- end }}
         ping
     )
     if [ "$response" != "PONG" ]; then
       echo "$response"
       exit 1
     fi
+  ping_sentinel_master.sh: |-
+    #!/bin/bash
+    script_dir="$(dirname "$0")"
+    REDIS_MASTER_HOST=$($script_dir/get_sentinel_master_host.sh $1)
+{{- if .Values.usePasswordFile }}
+    REDIS_PASSWORD=$(cat $REDIS_PASSWORD_FILE)
+{{- end }}
+{{- if .Values.usePassword }}
+    no_auth_warning=$([[ "$(redis-cli --version)" =~ (redis-cli 5.*) ]] && echo --no-auth-warning)
+{{- end }}
+     response=$(
+      timeout -s 3 $1 \
+      redis-cli \
+{{- if .Values.usePassword }}
+        -a $REDIS_PASSWORD $no_auth_warning \
+{{- end }}
+{{- if .Values.tls.enabled }}
+        --tls \
+        --cacert {{ template "redis.tlsCACert" . }} \
+        {{- if .Values.tls.authClients }}
+          --cert {{ template "redis.tlsCert" . }} \
+          --key {{ template "redis.tlsCertKey" . }} \
+        {{- end }}
+{{- end }}
+        -h $REDIS_MASTER_HOST \
+        -p $REDIS_SENTINEL_PORT \
+        ping
+    )
+
+    if [ "$response" != "PONG" ]; then
+      echo "$response"
+      exit 1
+    fi
+  ping_sentinel_local_and_master.sh: |-
+    script_dir="$(dirname "$0")"
+    exit_status=0
+    "$script_dir/ping_sentinel_local.sh" $1 || exit_status=$?
+    "$script_dir/ping_sentinel_master.sh" $1 || exit_status=$?
+    exit $exit_status
   parse_sentinels.awk: |-
     /ip/ {FOUND_IP=1}
     /port/ {FOUND_PORT=1}

--- a/bitnami/redis/templates/redis-node-statefulset.yaml
+++ b/bitnami/redis/templates/redis-node-statefulset.yaml
@@ -140,11 +140,7 @@ spec:
               command:
                 - sh
                 - -c
-                {{- if .Values.sentinel.enabled }}
                 - /health/ping_liveness_local.sh {{ .Values.slave.livenessProbe.timeoutSeconds }}
-                {{- else }}
-                - /health/ping_liveness_local_and_master.sh {{ .Values.slave.livenessProbe.timeoutSeconds }}
-                {{- end }}
           {{- else if .Values.slave.customLivenessProbe }}
           livenessProbe: {{- toYaml .Values.slave.customLivenessProbe | nindent 12 }}
           {{- end }}
@@ -159,11 +155,7 @@ spec:
               command:
                 - sh
                 - -c
-                {{- if .Values.sentinel.enabled }}
                 - /health/ping_readiness_local.sh {{ .Values.slave.livenessProbe.timeoutSeconds }}
-                {{- else }}
-                - /health/ping_readiness_local_and_master.sh {{ .Values.slave.livenessProbe.timeoutSeconds }}
-                {{- end }}
           {{- else if .Values.slave.customReadinessProbe }}
           readinessProbe: {{- toYaml .Values.slave.customReadinessProbe | nindent 12 }}
           {{- end }}
@@ -188,7 +180,6 @@ spec:
               mountPath: /opt/bitnami/redis/certs
               readOnly: true
             {{- end }}
-        {{- if and .Values.cluster.enabled .Values.sentinel.enabled }}
         - name: sentinel
           image: {{ template "sentinel.image" . }}
           imagePullPolicy: {{ .Values.sentinel.image.pullPolicy | quote }}
@@ -200,6 +191,10 @@ spec:
             - -c
             - /opt/bitnami/scripts/start-scripts/start-sentinel.sh
           env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             {{- if .Values.usePassword }}
             {{- if .Values.usePasswordFile }}
             - name: REDIS_PASSWORD_FILE
@@ -250,7 +245,7 @@ spec:
               command:
                 - sh
                 - -c
-                - /health/ping_sentinel.sh {{ .Values.sentinel.livenessProbe.timeoutSeconds }}
+                - /health/ping_sentinel_local.sh {{ .Values.sentinel.livenessProbe.timeoutSeconds }}
           {{- else if .Values.sentinel.customLivenessProbe }}
           livenessProbe: {{- toYaml .Values.sentinel.customLivenessProbe | nindent 12 }}
           {{- end }}
@@ -265,7 +260,7 @@ spec:
               command:
                 - sh
                 - -c
-                - /health/ping_sentinel.sh {{ .Values.sentinel.livenessProbe.timeoutSeconds }}
+                - /health/ping_sentinel_local.sh {{ .Values.sentinel.livenessProbe.timeoutSeconds }}
           {{- else if .Values.sentinel.customReadinessProbe }}
           readinessProbe: {{- toYaml .Values.sentinel.customReadinessProbe | nindent 12 }}
           {{- end }}
@@ -291,7 +286,6 @@ spec:
               mountPath: /opt/bitnami/redis/certs
               readOnly: true
             {{- end }}
-          {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
           image: {{ template "redis.metrics.image" . }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also, don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open-source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Refactor sentinel startup scripts + adds optional `ping_sentinel_master.sh` health script:
- Containers `redis` and `sentinel` can start as master on any replica to the condition that the current elected master is unreachable. For a master to be considered as down, a `PONG` is not replied after a timeout of 5 seconds.
- `start-sentinel.sh` now resolves all hosts associated with the service hostname and adds `known-sentinel` to the sentinel configuration file to reconnect with peers and join the quorum if a new election is held. If elected master it also adds the resolved hosts as `known-replica` in the sentinel configuration file to switch replication mode in running redis nodes.
- `start_sentinel.sh` unsets `sentinel known-replica` of current pod IP in the sentinel configuration file if elected master. If kept in the configuration file while elected master it would require its Redis to be a replica of itself.
- Adds `POD_IP` env variable in sentinel container which is then set in the sentinel configuration file with the `monitor master` command.
- adds optional `ping_sentinel_master.sh` which can be used in `customReadinessProb` and `customeLivenessProb`. 

**Benefits**

- Improves availability by allowing any node to elect itself as master on startup if none is available.
- Allows for automatic resynchronization of sentinels if the nodes reach a state of desynchronisation. 

**Possible drawbacks**

- Allowing any replica to elect itself as master on startup can lead to a situation where multiple nodes are master at the same time. The situation resolves itself eventually, the time it will take depends on the value `downAfterMilliseconds`.
- If `ping_sentinel_local_and_master.sh` is used as customLivenessProb and value `downAfterMilliseconds` is not properly synced with livenessProb values it will prevent sentinel from doing its jobs properly. A master will be elected regardless, just not as expected. It's not used as default, to be used with caution.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
