### PR TITLE
[bitnami/opencart] Fixed secret for external db

### DIFF
--- a/bitnami/opencart/Chart.yaml
+++ b/bitnami/opencart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: opencart
 version: 8.0.2
-appVersion: 3.0.3-6
+appVersion: 3.0.3-7
 description: A free and open source e-commerce platform for online merchants. It provides a professional and reliable foundation for a successful online store.
 keywords:
   - opencart

--- a/bitnami/opencart/Chart.yaml
+++ b/bitnami/opencart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: opencart
-version: 8.0.2
-appVersion: 3.0.3-7
+version: 8.0.3
+appVersion: 3.0.3-6
 description: A free and open source e-commerce platform for online merchants. It provides a professional and reliable foundation for a successful online store.
 keywords:
   - opencart

--- a/bitnami/opencart/templates/externaldb-secrets.yaml
+++ b/bitnami/opencart/templates/externaldb-secrets.yaml
@@ -6,5 +6,5 @@ metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 type: Opaque
 data:
-  db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
+  mariadb-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
**Description of the change**

Affected chart: opencart

By using an external db the wrong secret key will be created: "db-password".
Expected in the deployment.yml key is "mariadb-password"

**Benefits**

Bug will be fixed

**Possible drawbacks**

 &minus;

**Applicable issues**

 &minus;

**Additional information**

 &minus;