### PR TITLE
[bitnami/thanos] add configmap checksum annotation to query-frontend and storegateway

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 2.7.0
+version: 2.7.1
 appVersion: 0.16.0
 description: Thanos is a highly available metrics system that can be added on top of existing Prometheus deployments, providing a global query view across all Prometheus installations.
 engine: gotpl

--- a/bitnami/thanos/templates/query-frontend/deployment.yaml
+++ b/bitnami/thanos/templates/query-frontend/deployment.yaml
@@ -19,8 +19,11 @@ spec:
     metadata:
       labels: {{- include "thanos.labels" . | nindent 8 }}
         app.kubernetes.io/component: query-frontend
-      {{- if .Values.queryFrontend.podAnnotations }}
+      {{- if or .Values.queryFrontend.podAnnotations (include "thanos.queryFrontend.createConfigmap" .) }}
       annotations:
+        {{- if (include "thanos.queryFrontend.createConfigmap" .) }}
+        checksum/query-frontend-configuration: {{ include (print $.Template.BasePath "/query-frontend/configmap.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.queryFrontend.podAnnotations }}
         {{- include "thanos.tplValue" (dict "value" .Values.queryFrontend.podAnnotations "context" $) | nindent 8 }}
         {{- end }}

--- a/bitnami/thanos/templates/storegateway/statefulset.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset.yaml
@@ -23,6 +23,9 @@ spec:
         app.kubernetes.io/component: storegateway
       annotations:
         checksum/ojbstore-configuration: {{ include (print $.Template.BasePath "/objstore-secret.yaml") . | sha256sum }}
+        {{- if (include "thanos.storegateway.createConfigmap" .) }}
+        checksum/storegateway-configuration: {{ include (print $.Template.BasePath "/storegateway/configmap.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.storegateway.podAnnotations }}
         {{- include "thanos.tplValue" (dict "value" .Values.storegateway.podAnnotations "context" $) | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
**Description of the change**

Similar to the thanos-ruler, we add an annotation to the templates of the thanos-storegateway and thanos-query-frontend so that the pods are restarted whenever the contents of their configmaps changes.

**Benefits**

storegateway and query-frontend are restarted when their configmaps are updated.

**Possible drawbacks**

Can't think of any.

**Applicable issues**

N/A

**Additional information**

<del>

The storegateway supports two caches:
* index cache: https://thanos.io/tip/components/store.md/#memcached-index-cache
* chunk/metadata cache: https://thanos.io/tip/components/store.md/#caching-bucket

Currently, only the first one can be configured in this chart. At a later time, if chunk cache configuration support is added to the chart, the configmap.yaml and its annotation on the statefulset might have to be renamed.

</del>

Looks like the above are covered in the top-level objstore-secret.yaml

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
