### PR TITLE
[bitnami/metallb] fix rbac metadata naming

### DIFF
--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: metallb
 description: The Metal LB for Kubernetes
-version: 0.1.29
+version: 0.1.30
 appVersion: 0.9.5
 keywords:
   - "load-balancer"

--- a/bitnami/metallb/templates/rbac.yaml
+++ b/bitnami/metallb/templates/rbac.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "metallb.fullname" . }}:controller
+  name: {{ include "metallb.fullname" . }}-controller
   labels: {{- include "metallb.labels" . | nindent 4 }}
 rules:
   - apiGroups:
@@ -40,7 +40,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "metallb.fullname" . }}:speaker
+  name: {{ include "metallb.fullname" . }}-speaker
   labels: {{- include "metallb.labels" . | nindent 4 }}
 rules:
   - apiGroups:
@@ -101,7 +101,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "metallb.fullname" . }}:controller
+  name: {{ include "metallb.fullname" . }}-controller
   labels: {{- include "metallb.labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
@@ -110,12 +110,12 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "metallb.fullname" . }}:controller
+  name: {{ include "metallb.fullname" . }}-controller
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "metallb.fullname" . }}:speaker
+  name: {{ include "metallb.fullname" . }}-speaker
   labels: {{- include "metallb.labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
@@ -124,7 +124,7 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "metallb.fullname" . }}:speaker
+  name: {{ include "metallb.fullname" . }}-speaker
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

```
helm lint .
```
gives:
```
  Error: 1 chart(s) linted, 1 chart(s) failed
  ==> Linting /tmp/702485725/default/metallb/bitnami/metallb/0.1.29/metallb
  [ERROR] templates/rbac.yaml: object name does not conform to Kubernetes naming requirements: "test-release-metallb:controller": invalid metadata name, must match regex ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])+$ and the length must not longer than 253
```

The fix is to replace the colons by hyphens. 

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

No more lint error.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files