### PR TITLE
[bitnami/common] Major version. Adapt Chart to apiVersion: v2

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -1,11 +1,9 @@
 annotations:
   category: Infrastructure
-apiVersion: v1
+apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-version: 0.10.0
-appVersion: 0.10.0
-description: A Library Helm Chart for grouping common logic between bitnami charts.
-  This chart is not deployable by itself.
+appVersion: 1.0.0
+description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://github.com/bitnami/charts/tree/master/bitnami/common
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
 keywords:
@@ -21,3 +19,5 @@ name: common
 sources:
   - https://github.com/bitnami/charts
   - http://www.bitnami.com/
+type: library
+version: 1.0.0

--- a/bitnami/common/README.md
+++ b/bitnami/common/README.md
@@ -33,7 +33,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 ## Prerequisites
 
 - Kubernetes 1.12+
-- Helm 2.12+ or Helm 3.0-beta3+
+- Helm 3.0-beta3+
 
 ## Parameters
 
@@ -283,6 +283,26 @@ $ helm install test mychart --set path.to.value00="",path.to.value01=""
         export PASSWORD_01=$(kubectl get secret --namespace default secretName -o jsonpath="{.data.password-01}" | base64 --decode)
 ```
 
-## Notable changes
+## Upgrading
 
-N/A
+### To 1.0.0
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+**What changes were introduced in this major version?**
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- Use `type: library`. [Here](https://v3.helm.sh/docs/faq/#library-chart-support) you can find more information.
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+
+**Considerations when upgrading to this version**
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+**Useful links**
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/


### PR DESCRIPTION
**Description of the change**

1. Changes related to the new apiVersion and Helm 2 deprecation:

- Bump `apiVersion` from `v1` to `v2` in _Chart.yaml_
- Use `type: library` in _Chart.yaml_
- Fields in _Chart.yaml_ file has been ordered alphabetically
- Move dependency information from the _requirements.yaml_ to the _Chart.yaml_ (if any)
- After running `helm dependency update`, a new _Chart.lock_ file is generated containing the same structure used in the previous _requirements.lock_ (if any)
- Update _README.md_

2. How the new `type: library` works:

Without the `type: library`, you can install the common chart (although it doesn't deploy any object):
```console
$ helm install common bitnami/common
NAME: common
LAST DEPLOYED: Tue Nov 10 13:01:40 2020
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None

$ helm ls
helm ls
NAME                	NAMESPACE	REVISION	UPDATED                                  	STATUS  	CHART              	APP VERSION
common              	default  	1       	2020-11-10 13:01:40.513720878 +0000 UTC  	deployed	common-0.10.0      	0.10.0

$ kubectl get all --all-namespaces | grep common
# Nothing
```

With the addition of `type: library` to the _Chart.yaml_, the Helm Chart is not installed by `helm install` it can be only used as a sub-chart:
```console
$ helm install common .
Error: library charts are not installable
```

**Possible drawbacks**

Helm v2 is no longer supported
