### PR TITLE
[bitnami/pytorch] Major version. Adapt Chart to apiVersion: v2

### DIFF
--- a/bitnami/pytorch/Chart.yaml
+++ b/bitnami/pytorch/Chart.yaml
@@ -1,21 +1,21 @@
-apiVersion: v1
-name: pytorch
-version: 1.3.25
+annotations:
+  category: MachineLearning
+apiVersion: v2
 appVersion: 1.7.0
 description: Deep learning platform that accelerates the transition from research prototyping to production deployment
+engine: gotpl
+home: https://github.com/bitnami/charts/tree/master/bitnami/pytorch
+icon: https://bitnami.com/assets/stacks/pytorch/img/pytorch-stack-110x117.png
 keywords:
   - pytorch
   - python
   - machine
   - learning
-home: https://github.com/bitnami/charts/tree/master/bitnami/pytorch
+maintainers:
+  - email: containers@bitnami.com
+    name: Bitnami
+name: pytorch
 sources:
   - https://github.com/bitnami/bitnami-docker-pytorch
   - http://pytorch.org/
-maintainers:
-  - name: Bitnami
-    email: containers@bitnami.com
-engine: gotpl
-icon: https://bitnami.com/assets/stacks/pytorch/img/pytorch-stack-110x117.png
-annotations:
-  category: MachineLearning
+version: 2.0.0

--- a/bitnami/pytorch/README.md
+++ b/bitnami/pytorch/README.md
@@ -18,7 +18,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 ## Prerequisites
 
 - Kubernetes 1.12+
-- Helm 2.12+ or Helm 3.0-beta3+
+- Helm 3.0-beta3+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 
@@ -193,3 +193,26 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 ## Troubleshooting
 
 Find more information about how to deal with common errors related to Bitnami’s Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
+
+## Upgrading
+
+### To 2.0.0
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+**What changes were introduced in this major version?**
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+
+**Considerations when upgrading to this version**
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+**Useful links**
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/

--- a/bitnami/pytorch/values-production.yaml
+++ b/bitnami/pytorch/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/pytorch
-  tag: 1.7.0-debian-10-r0
+  tag: 1.7.0-debian-10-r11
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -47,7 +47,7 @@ image:
 git:
   registry: docker.io
   repository: bitnami/git
-  tag: 2.29.2-debian-10-r0
+  tag: 2.29.2-debian-10-r11
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.

--- a/bitnami/pytorch/values.yaml
+++ b/bitnami/pytorch/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/pytorch
-  tag: 1.7.0-debian-10-r0
+  tag: 1.7.0-debian-10-r11
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -47,7 +47,7 @@ image:
 git:
   registry: docker.io
   repository: bitnami/git
-  tag: 2.29.2-debian-10-r0
+  tag: 2.29.2-debian-10-r11
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**

- Bump `apiVersion` from `v1` to `v2` in _Chart.yaml_
- Fields in _Chart.yaml_ file has been ordered alphabetically
- Move dependency information from the _requirements.yaml_ to the _Chart.yaml_ (if any)
- After running `helm dependency update`, a new _Chart.lock_ file is generated containing the same structure used in the previous _requirements.lock_ (if any)
- Update _README.md_

**Possible drawbacks**

Helm v2 is no longer supported
