### PR TITLE
[bitnami/tensorflow-resnet] Major version. Adapt Chart to apiVersion: v2

### DIFF
--- a/bitnami/tensorflow-resnet/Chart.yaml
+++ b/bitnami/tensorflow-resnet/Chart.yaml
@@ -1,8 +1,11 @@
-apiVersion: v1
-name: tensorflow-resnet
-version: 2.0.20
+annotations:
+  category: MachineLearning
+apiVersion: v2
 appVersion: 2.3.0
 description: Open-source software library serving the ResNet machine learning model.
+engine: gotpl
+home: https://github.com/bitnami/charts/tree/master/bitnami/tensorflow-resnet
+icon: https://bitnami.com/assets/stacks/tensorflow-inception/img/tensorflow-inception-stack-220x234.png
 keywords:
   - tensorflow
   - serving
@@ -10,15 +13,12 @@ keywords:
   - machine
   - learning
   - library
-home: https://github.com/bitnami/charts/tree/master/bitnami/tensorflow-resnet
-icon: https://bitnami.com/assets/stacks/tensorflow-inception/img/tensorflow-inception-stack-220x234.png
+maintainers:
+  - email: containers@bitnami.com
+    name: Bitnami
+name: tensorflow-resnet
 sources:
   - https://github.com/bitnami/bitnami-docker-tensorflow-serving
   - https://github.com/bitnami/bitnami-docker-tensorflow-resnet
   - https://www.tensorflow.org/serving/
-maintainers:
-  - email: containers@bitnami.com
-    name: Bitnami
-engine: gotpl
-annotations:
-  category: MachineLearning
+version: 3.0.0

--- a/bitnami/tensorflow-resnet/README.md
+++ b/bitnami/tensorflow-resnet/README.md
@@ -18,7 +18,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 ## Prerequisites
 
 - Kubernetes 1.12+
-- Helm 2.12+ or Helm 3.0-beta3+
+- Helm 3.0-beta3+
 
 ## Get this chart
 
@@ -136,7 +136,28 @@ Find more information about how to deal with common errors related to Bitnami’
 
 ## Upgrading
 
-### 2.0.0
+### To 3.0.0
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+**What changes were introduced in this major version?**
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+
+**Considerations when upgrading to this version**
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+**Useful links**
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
+
+### To 2.0.0
 
 Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
 Use the workaround below to upgrade from versions previous to 2.0.0. The following example assumes that the release name is tensorflow-resnet:

--- a/bitnami/tensorflow-resnet/values.yaml
+++ b/bitnami/tensorflow-resnet/values.yaml
@@ -14,7 +14,7 @@ server:
   image:
     registry: docker.io
     repository: bitnami/tensorflow-serving
-    tag: 2.3.0-debian-10-r51
+    tag: 2.3.0-debian-10-r69
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -34,7 +34,7 @@ client:
   image:
     registry: docker.io
     repository: bitnami/tensorflow-resnet
-    tag: 2.3.0-debian-10-r52
+    tag: 2.3.0-debian-10-r70
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
**Description of the change**

- Bump `apiVersion` from `v1` to `v2` in _Chart.yaml_
- Fields in _Chart.yaml_ file has been ordered alphabetically
- Move dependency information from the _requirements.yaml_ to the _Chart.yaml_ (if any)
- After running `helm dependency update`, a new _Chart.lock_ file is generated containing the same structure used in the previous _requirements.lock_ (if any)
- Update _README.md_

**Possible drawbacks**

Helm v2 is no longer supported
