### PR TITLE
[bitnami/nats] Major version. Adapt Chart to apiVersion: v2

### DIFF
--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -1,21 +1,21 @@
-apiVersion: v1
-name: nats
-version: 4.5.8
+annotations:
+  category: Infrastructure
+apiVersion: v2
 appVersion: 2.1.9
 description: An open-source, cloud-native messaging system
+engine: gotpl
+home: https://github.com/bitnami/charts/tree/master/bitnami/nats
+icon: https://bitnami.com/assets/stacks/nats/img/nats-stack-110x117.png
 keywords:
   - nats
   - messaging
   - addressing
   - discovery
-home: https://github.com/bitnami/charts/tree/master/bitnami/nats
+maintainers:
+  - email: containers@bitnami.com
+    name: Bitnami
+name: nats
 sources:
   - https://github.com/bitnami/bitnami-docker-nats
   - https://nats.io/
-maintainers:
-  - name: Bitnami
-    email: containers@bitnami.com
-engine: gotpl
-icon: https://bitnami.com/assets/stacks/nats/img/nats-stack-110x117.png
-annotations:
-  category: Infrastructure
+version: 5.0.0

--- a/bitnami/nats/README.md
+++ b/bitnami/nats/README.md
@@ -18,7 +18,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 ## Prerequisites
 
 - Kubernetes 1.12+
-- Helm 2.12+ or Helm 3.0-beta3+
+- Helm 3.0-beta3+
 
 ## Installing the Chart
 
@@ -260,6 +260,27 @@ however, it is still possible to use the chart to deploy NATS version 1.x.x usin
 ```bash
 helm install nats-v1 --set natsFilename=gnatsd --set image.tag=1.4.1 bitnami/nats
 ```
+
+### To 5.0.0
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+**What changes were introduced in this major version?**
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+
+**Considerations when upgrading to this version**
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+**Useful links**
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
 
 ### To 1.0.0
 

--- a/bitnami/nats/values-production.yaml
+++ b/bitnami/nats/values-production.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/nats
-  tag: 2.1.9-debian-10-r0
+  tag: 2.1.9-debian-10-r8
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -320,7 +320,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/nats-exporter
-    tag: 0.6.2-debian-10-r164
+    tag: 0.6.2-debian-10-r172
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/nats/values.yaml
+++ b/bitnami/nats/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/nats
-  tag: 2.1.9-debian-10-r0
+  tag: 2.1.9-debian-10-r8
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -320,7 +320,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/nats-exporter
-    tag: 0.6.2-debian-10-r164
+    tag: 0.6.2-debian-10-r172
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**

- Bump `apiVersion` from `v1` to `v2` in _Chart.yaml_
- Fields in _Chart.yaml_ file has been ordered alphabetically
- Move dependency information from the _requirements.yaml_ to the _Chart.yaml_ (if any)
- After running `helm dependency update`, a new _Chart.lock_ file is generated containing the same structure used in the previous _requirements.lock_ (if any)
- Update _README.md_

**Possible drawbacks**

Helm v2 is no longer supported
