### PR TITLE
[bitnami/nginx-ingress-controller] Major version. Adapt Chart to apiV…

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Infrastructure
 apiVersion: v2
-appVersion: 0.40.2
+appVersion: 0.41.2
 description: Chart for the nginx Ingress controller
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/nginx-ingress-controller

--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -1,8 +1,11 @@
-apiVersion: v1
-name: nginx-ingress-controller
-version: 5.6.15
+annotations:
+  category: Infrastructure
+apiVersion: v2
 appVersion: 0.40.2
 description: Chart for the nginx Ingress controller
+engine: gotpl
+home: https://github.com/bitnami/charts/tree/master/bitnami/nginx-ingress-controller
+icon: https://bitnami.com/assets/stacks/nginx-ingress-controller/img/nginx-ingress-controller-stack-220x234.png
 keywords:
   - ingress
   - nginx
@@ -10,14 +13,11 @@ keywords:
   - web
   - www
   - reverse proxy
-home: https://github.com/bitnami/charts/tree/master/bitnami/nginx-ingress-controller
-icon: https://bitnami.com/assets/stacks/nginx-ingress-controller/img/nginx-ingress-controller-stack-220x234.png
+maintainers:
+  - email: containers@bitnami.com
+    name: Bitnami
+name: nginx-ingress-controller
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx-ingress-controller
   - https://github.com/kubernetes/ingress-nginx
-maintainers:
-  - name: Bitnami
-    email: containers@bitnami.com
-engine: gotpl
-annotations:
-  category: Infrastructure
+version: 6.0.0

--- a/bitnami/nginx-ingress-controller/README.md
+++ b/bitnami/nginx-ingress-controller/README.md
@@ -20,7 +20,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 ## Prerequisites
 
 - Kubernetes 1.12+
-- Helm 2.12+ or Helm 3.0-beta3+
+- Helm 3.0-beta3+
 
 ## Installing the Chart
 
@@ -234,6 +234,27 @@ Find more information about how to deal with common errors related to Bitnami’
 In this version you can indicate the key to download the GeoLite2 databases using the [parameter](#parameters) `maxmindLicenseKey`.
 
 ## Upgrading
+
+### To 6.0.0
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+**What changes were introduced in this major version?**
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+
+**Considerations when upgrading to this version**
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+**Useful links**
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
 
 ### To 1.0.0
 

--- a/bitnami/nginx-ingress-controller/values-production.yaml
+++ b/bitnami/nginx-ingress-controller/values-production.yaml
@@ -15,7 +15,7 @@ name: controller
 image:
   registry: docker.io
   repository: bitnami/nginx-ingress-controller
-  tag: 0.40.2-debian-10-r27
+  tag: 0.41.2-debian-10-r0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -377,7 +377,7 @@ defaultBackend:
   image:
     registry: docker.io
     repository: bitnami/nginx
-    tag: 1.19.4-debian-10-r4
+    tag: 1.19.4-debian-10-r19
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/nginx-ingress-controller/values.yaml
+++ b/bitnami/nginx-ingress-controller/values.yaml
@@ -15,7 +15,7 @@ name: controller
 image:
   registry: docker.io
   repository: bitnami/nginx-ingress-controller
-  tag: 0.40.2-debian-10-r27
+  tag: 0.41.2-debian-10-r0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -377,7 +377,7 @@ defaultBackend:
   image:
     registry: docker.io
     repository: bitnami/nginx
-    tag: 1.19.4-debian-10-r4
+    tag: 1.19.4-debian-10-r19
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**

- Bump `apiVersion` from `v1` to `v2` in _Chart.yaml_
- Fields in _Chart.yaml_ file has been ordered alphabetically
- Move dependency information from the _requirements.yaml_ to the _Chart.yaml_ (if any)
- After running `helm dependency update`, a new _Chart.lock_ file is generated containing the same structure used in the previous _requirements.lock_ (if any)
- Update _README.md_

**Possible drawbacks**

Helm v2 is no longer supported
