### PR TITLE
[bitnami/kubewatch] Major version. Adapt Chart to apiVersion: v2

### DIFF
--- a/bitnami/kubewatch/Chart.yaml
+++ b/bitnami/kubewatch/Chart.yaml
@@ -1,10 +1,11 @@
-name: kubewatch
-version: 1.2.6
-apiVersion: v1
+annotations:
+  category: Infrastructure
+apiVersion: v2
 appVersion: 0.1.0
+description: Kubewatch notifies your slack rooms when changes to your cluster occur
+engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/kubewatch
 icon: https://bitnami.com/assets/stacks/kubewatch/img/kubewatch-stack-220x234.png
-description: Kubewatch notifies your slack rooms when changes to your cluster occur
 keywords:
   - kubernetes
   - slack
@@ -13,13 +14,12 @@ keywords:
   - flock
   - msteams
 maintainers:
-  - name: compleatang
-    email: casey@monax.io
-  - name: Bitnami
-    email: containers@bitnami.com
+  - email: casey@monax.io
+    name: compleatang
+  - email: containers@bitnami.com
+    name: Bitnami
+name: kubewatch
 sources:
   - https://github.com/bitnami/bitnami-docker-kubewatch
   - https://github.com/bitnami-labs/kubewatch
-engine: gotpl
-annotations:
-  category: Infrastructure
+version: 2.0.0

--- a/bitnami/kubewatch/README.md
+++ b/bitnami/kubewatch/README.md
@@ -17,7 +17,7 @@ This chart bootstraps a kubewatch deployment on a [Kubernetes](http://kubernetes
 ## Prerequisites
 
 - Kubernetes 1.12+
-- Helm 2.12+ or Helm 3.0-beta3+
+- Helm 3.0-beta3+
 
 ## Installing the Chart
 
@@ -136,6 +136,27 @@ Invite the Bot to your channel by typing `/join @name_of_your_bot` in the Slack 
 Find more information about how to deal with common errors related to Bitnami’s Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
 
 ## Upgrading
+
+### To 2.0.0
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+**What changes were introduced in this major version?**
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+
+**Considerations when upgrading to this version**
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+**Useful links**
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
 
 ### To 1.0.0
 

--- a/bitnami/kubewatch/values.yaml
+++ b/bitnami/kubewatch/values.yaml
@@ -65,7 +65,7 @@ resourcesToWatch:
 image:
   registry: docker.io
   repository: bitnami/kubewatch
-  tag: 0.1.0-debian-10-r89
+  tag: 0.1.0-debian-10-r107
   pullPolicy: Always
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**

- Bump `apiVersion` from `v1` to `v2` in _Chart.yaml_
- Fields in _Chart.yaml_ file has been ordered alphabetically
- Move dependency information from the _requirements.yaml_ to the _Chart.yaml_ (if any)
- After running `helm dependency update`, a new _Chart.lock_ file is generated containing the same structure used in the previous _requirements.lock_ (if any)
- Update _README.md_

**Possible drawbacks**

Helm v2 is no longer supported
