### PR TITLE
[bitnami/external-dns] Major version. Adapt Chart to apiVersion: v2

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -1,21 +1,21 @@
-apiVersion: v1
-name: external-dns
-version: 3.7.0
+annotations:
+  category: DeveloperTools
+apiVersion: v2
 appVersion: 0.7.4
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
+engine: gotpl
+home: https://github.com/bitnami/charts/tree/master/bitnami/external-dns
+icon: https://bitnami.com/assets/stacks/external-dns/img/external-dns-stack-110x117.png
 keywords:
   - external-dns
   - network
   - dns
-home: https://github.com/bitnami/charts/tree/master/bitnami/external-dns
+maintainers:
+  - email: containers@bitnami.com
+    name: Bitnami
+name: external-dns
 sources:
   - https://github.com/kubernetes-sigs/external-dns
   - https://github.com/bitnami/bitnami-docker-external-dns
   - https://github.com/kubernetes-sigs/external-dns
-maintainers:
-  - name: Bitnami
-    email: containers@bitnami.com
-engine: gotpl
-icon: https://bitnami.com/assets/stacks/external-dns/img/external-dns-stack-110x117.png
-annotations:
-  category: DeveloperTools
+version: 4.0.0

--- a/bitnami/external-dns/README.md
+++ b/bitnami/external-dns/README.md
@@ -18,7 +18,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 ## Prerequisites
 
 - Kubernetes 1.12+
-- Helm 2.12+ or Helm 3.0-beta3+
+- Helm 3.0-beta3+
 
 ## Installing the Chart
 
@@ -274,6 +274,27 @@ $ helm install my-release \
 Find more information about how to deal with common errors related to Bitnami’s Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
 
 ## Upgrading
+
+### To 4.0.0
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+**What changes were introduced in this major version?**
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+
+**Considerations when upgrading to this version**
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+**Useful links**
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
 
 ### To 3.0.0
 

--- a/bitnami/external-dns/values-production.yaml
+++ b/bitnami/external-dns/values-production.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/external-dns
-  tag: 0.7.4-debian-10-r29
+  tag: 0.7.4-debian-10-r41
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/external-dns/values.yaml
+++ b/bitnami/external-dns/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/external-dns
-  tag: 0.7.4-debian-10-r29
+  tag: 0.7.4-debian-10-r41
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
**Description of the change**

- Bump `apiVersion` from `v1` to `v2` in _Chart.yaml_
- Fields in _Chart.yaml_ file has been ordered alphabetically
- Move dependency information from the _requirements.yaml_ to the _Chart.yaml_ (if any)
- After running `helm dependency update`, a new _Chart.lock_ file is generated containing the same structure used in the previous _requirements.lock_ (if any)
- Update _README.md_

**Possible drawbacks**

Helm v2 is no longer supported
