### PR TITLE
[bitnami/apache] Major version. Adapt Chart to apiVersion: v2

### DIFF
--- a/bitnami/apache/Chart.lock
+++ b/bitnami/apache/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.0.0
+digest: sha256:a2093836b2b6a85d7bf34143d3159b5c413c5e7423bde212de9cb416c985b976
+generated: "2020-11-10T14:27:07.401289096Z"

--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -1,8 +1,17 @@
-apiVersion: v1
-name: apache
-version: 7.6.0
+annotations:
+  category: Infrastructure
+apiVersion: v2
 appVersion: 2.4.46
+dependencies:
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
 description: Chart for Apache HTTP Server
+engine: gotpl
+home: https://github.com/bitnami/charts/tree/master/bitnami/apache
+icon: https://bitnami.com/assets/stacks/apache/img/apache-stack-220x234.png
 keywords:
   - apache
   - http
@@ -10,14 +19,11 @@ keywords:
   - www
   - web
   - reverse proxy
-home: https://github.com/bitnami/charts/tree/master/bitnami/apache
-icon: https://bitnami.com/assets/stacks/apache/img/apache-stack-220x234.png
+maintainers:
+  - email: containers@bitnami.com
+    name: Bitnami
+name: apache
 sources:
   - https://github.com/bitnami/bitnami-docker-apache
   - https://httpd.apache.org
-maintainers:
-  - name: Bitnami
-    email: containers@bitnami.com
-engine: gotpl
-annotations:
-  category: Infrastructure
+version: 8.0.0

--- a/bitnami/apache/README.md
+++ b/bitnami/apache/README.md
@@ -22,7 +22,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 ## Prerequisites
 
 - Kubernetes 1.12+
-- Helm 2.12+ or Helm 3.0-beta3+
+- Helm 3.0-beta3+
 
 ## Installing the Chart
 
@@ -189,6 +189,29 @@ This release updates the Bitnami Apache container to `2.4.41-debian-9-r40`, whic
 This release allows you to use your custom static applicaton. In order to do so, check [this section](#deploying-your-custom-web-application).
 
 ## Upgrading
+
+### To 8.0.0
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+**What changes were introduced in this major version?**
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- Move dependency information from the *requirements.yaml* to the *Chart.yaml*
+- After running `helm dependency update`, a *Chart.lock* file is generated containing the same structure used in the previous *requirements.lock*
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+
+**Considerations when upgrading to this version**
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+**Useful links**
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
 
 ### To 2.0.0
 

--- a/bitnami/apache/requirements.lock
+++ b/bitnami/apache/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 0.8.2
-digest: sha256:e46cade51e465220336ad7dc764eca85bc194b99bdd15929508769d623e23105
-generated: "2020-10-20T12:59:51.304842584Z"

--- a/bitnami/apache/requirements.yaml
+++ b/bitnami/apache/requirements.yaml
@@ -1,6 +1,0 @@
-dependencies:
-  - name: common
-    version: 0.x.x
-    repository: https://charts.bitnami.com/bitnami
-    tags:
-      - bitnami-common

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/apache
-  tag: 2.4.46-debian-10-r62
+  tag: 2.4.46-debian-10-r82
   ## Specify a imagePullPolicy
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -36,7 +36,7 @@ image:
 git:
   registry: docker.io
   repository: bitnami/git
-  tag: 2.29.0-debian-10-r0
+  tag: 2.29.2-debian-10-r10
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -235,7 +235,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.8.0-debian-10-r186
+    tag: 0.8.0-debian-10-r207
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**

- Bump `apiVersion` from `v1` to `v2` in _Chart.yaml_
- Fields in _Chart.yaml_ file has been ordered alphabetically
- Move dependency information from the _requirements.yaml_ to the _Chart.yaml_
- After running `helm dependency update`, a new _Chart.lock_ file is generated containing the same structure used in the previous _requirements.lock_
- Update _README.md_

**Possible drawbacks**

Helm v2 is no longer supported
