### PR TITLE
[bitnami/dokuwiki] Major version. Adapt Chart to apiVersion: v2

### DIFF
--- a/bitnami/dokuwiki/Chart.lock
+++ b/bitnami/dokuwiki/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.0.0
+digest: sha256:6ef1d114e7164c8396496bbb900b0280272c917fcac22b332a5eab77eb288319
+generated: "2020-11-10T23:16:44.337721025Z"

--- a/bitnami/dokuwiki/Chart.yaml
+++ b/bitnami/dokuwiki/Chart.yaml
@@ -1,8 +1,15 @@
-apiVersion: v1
-name: dokuwiki
-version: 9.4.2
+annotations:
+  category: Wiki
+apiVersion: v2
 appVersion: 20200729.0.0
+dependencies:
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    version: 1.x.x
 description: DokuWiki is a standards-compliant, simple to use wiki optimized for creating documentation. It is targeted at developer teams, workgroups, and small companies. All data is stored in plain text files, so no database is required.
+engine: gotpl
+home: https://github.com/bitnami/charts/tree/master/bitnami/dokuwiki
+icon: https://bitnami.com/assets/stacks/dokuwiki/img/dokuwiki-stack-110x117.png
 keywords:
   - dokuwiki
   - wiki
@@ -10,14 +17,11 @@ keywords:
   - web
   - application
   - php
-home: https://github.com/bitnami/charts/tree/master/bitnami/dokuwiki
+maintainers:
+  - email: containers@bitnami.com
+    name: Bitnami
+name: dokuwiki
 sources:
   - https://github.com/bitnami/bitnami-docker-dokuwiki
   - http://www.dokuwiki.org/
-maintainers:
-  - name: Bitnami
-    email: containers@bitnami.com
-engine: gotpl
-icon: https://bitnami.com/assets/stacks/dokuwiki/img/dokuwiki-stack-110x117.png
-annotations:
-  category: Wiki
+version: 10.0.0

--- a/bitnami/dokuwiki/README.md
+++ b/bitnami/dokuwiki/README.md
@@ -18,7 +18,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 ## Prerequisites
 
 - Kubernetes 1.12+
-- Helm 2.12+ or Helm 3.0-beta3+
+- Helm 3.0-beta3+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 
@@ -293,6 +293,29 @@ kubectl create secret generic my-ca-1 --from-file my-ca-1.crt
 Find more information about how to deal with common errors related to Bitnami’s Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
 
 ## Upgrading
+
+### To 10.0.0
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+**What changes were introduced in this major version?**
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- Move dependency information from the *requirements.yaml* to the *Chart.yaml*
+- After running `helm dependency update`, a *Chart.lock* file is generated containing the same structure used in the previous *requirements.lock*
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+
+**Considerations when upgrading to this version**
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+**Useful links**
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
 
 ### To 7.0.0
 

--- a/bitnami/dokuwiki/requirements.lock
+++ b/bitnami/dokuwiki/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 0.9.0
-digest: sha256:0208ff4295eb19dc46b66011b19a0861949510e0daace36c91d07db2c147e5a3
-generated: "2020-10-21T13:02:48.290906074Z"

--- a/bitnami/dokuwiki/requirements.yaml
+++ b/bitnami/dokuwiki/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-  - name: common
-    version: 0.x.x
-    repository: https://charts.bitnami.com/bitnami

--- a/bitnami/dokuwiki/values.yaml
+++ b/bitnami/dokuwiki/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/dokuwiki
-  tag: 20200729.0.0-debian-10-r60
+  tag: 20200729.0.0-debian-10-r80
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -357,7 +357,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.8.0-debian-10-r187
+    tag: 0.8.0-debian-10-r208
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**

- Bump `apiVersion` from `v1` to `v2` in _Chart.yaml_
- Fields in _Chart.yaml_ file has been ordered alphabetically
- Move dependency information from the _requirements.yaml_ to the _Chart.yaml_
- After running `helm dependency update`, a new _Chart.lock_ file is generated containing the same structure used in the previous _requirements.lock_
- Update _README.md_

**Possible drawbacks**

Helm v2 is no longer supported
