### PR TITLE
[bitnami/mariadb] Major version. Adapt Chart to apiVersion: v2

### DIFF
--- a/bitnami/mariadb/Chart.lock
+++ b/bitnami/mariadb/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.0.0
+digest: sha256:a2093836b2b6a85d7bf34143d3159b5c413c5e7423bde212de9cb416c985b976
+generated: "2020-11-10T23:05:57.629551445Z"

--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -1,23 +1,29 @@
-apiVersion: v1
-name: mariadb
-version: 8.0.7
+annotations:
+  category: Database
+apiVersion: v2
 appVersion: 10.5.7
+dependencies:
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
+engine: gotpl
+home: https://github.com/bitnami/charts/tree/master/bitnami/mariadb
+icon: https://bitnami.com/assets/stacks/mariadb/img/mariadb-stack-220x234.png
 keywords:
   - mariadb
   - mysql
   - database
   - sql
   - prometheus
-home: https://github.com/bitnami/charts/tree/master/bitnami/mariadb
-icon: https://bitnami.com/assets/stacks/mariadb/img/mariadb-stack-220x234.png
+maintainers:
+  - email: containers@bitnami.com
+    name: Bitnami
+name: mariadb
 sources:
   - https://github.com/bitnami/bitnami-docker-mariadb
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-maintainers:
-  - name: Bitnami
-    email: containers@bitnami.com
-engine: gotpl
-annotations:
-  category: Database
+version: 9.0.0

--- a/bitnami/mariadb/README.md
+++ b/bitnami/mariadb/README.md
@@ -20,7 +20,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 ## Prerequisites
 
 - Kubernetes 1.12+
-- Helm 2.12+ or Helm 3.0-beta3+
+- Helm 3.0-beta3+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart
@@ -389,6 +389,29 @@ $ helm upgrade my-release bitnami/mariadb --set auth.rootPassword=[ROOT_PASSWORD
 ```
 
 | Note: you need to substitute the placeholder _[ROOT_PASSWORD]_ with the value obtained in the installation notes.
+
+### To 9.0.0
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+**What changes were introduced in this major version?**
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- Move dependency information from the *requirements.yaml* to the *Chart.yaml*
+- After running `helm dependency update`, a *Chart.lock* file is generated containing the same structure used in the previous *requirements.lock*
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+
+**Considerations when upgrading to this version**
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+**Useful links**
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
 
 ### To 8.0.0
 

--- a/bitnami/mariadb/requirements.lock
+++ b/bitnami/mariadb/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 0.10.0
-digest: sha256:cbe8f782ad7168557b9bb101a4d441d3210e2dda09cd249eb8426d1499ce6afc
-generated: "2020-11-04T07:07:28.501630497Z"

--- a/bitnami/mariadb/requirements.yaml
+++ b/bitnami/mariadb/requirements.yaml
@@ -1,6 +1,0 @@
-dependencies:
-  - name: common
-    version: 0.x.x
-    repository: https://charts.bitnami.com/bitnami
-    tags:
-      - bitnami-common

--- a/bitnami/mariadb/values-production.yaml
+++ b/bitnami/mariadb/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/mariadb
-  tag: 10.5.7-debian-10-r0
+  tag: 10.5.7-debian-10-r7
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -711,7 +711,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mysqld-exporter
-    tag: 0.12.1-debian-10-r257
+    tag: 0.12.1-debian-10-r263
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/mariadb/values.yaml
+++ b/bitnami/mariadb/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/mariadb
-  tag: 10.5.7-debian-10-r0
+  tag: 10.5.7-debian-10-r7
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -711,7 +711,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mysqld-exporter
-    tag: 0.12.1-debian-10-r257
+    tag: 0.12.1-debian-10-r263
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**

- Bump `apiVersion` from `v1` to `v2` in _Chart.yaml_
- Fields in _Chart.yaml_ file has been ordered alphabetically
- Move dependency information from the _requirements.yaml_ to the _Chart.yaml_
- After running `helm dependency update`, a new _Chart.lock_ file is generated containing the same structure used in the previous _requirements.lock_
- Update _README.md_

**Possible drawbacks**

Helm v2 is no longer supported
