### PR TITLE
[bitnami/consul] Major version. Adapt Chart to apiVersion: v2

### DIFF
--- a/bitnami/consul/Chart.lock
+++ b/bitnami/consul/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.0.0
+digest: sha256:a2093836b2b6a85d7bf34143d3159b5c413c5e7423bde212de9cb416c985b976
+generated: "2020-11-10T23:07:13.83942186Z"

--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -1,16 +1,22 @@
-apiVersion: v1
-name: consul
-version: 8.0.4
+annotations:
+  category: DeveloperTools
+apiVersion: v2
 appVersion: 1.8.4
+dependencies:
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
 description: Highly available and distributed service discovery and key-value store designed with support for the modern data center to make distributed systems and configuration easy.
+engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/consul
+icon: https://bitnami.com/assets/stacks/consul/img/consul-stack-220x234.png
+maintainers:
+  - email: containers@bitnami.com
+    name: Bitnami
+name: consul
 sources:
   - https://github.com/bitnami/bitnami-docker-consul
   - https://www.consul.io/
-icon: https://bitnami.com/assets/stacks/consul/img/consul-stack-220x234.png
-maintainers:
-  - name: Bitnami
-    email: containers@bitnami.com
-engine: gotpl
-annotations:
-  category: DeveloperTools
+version: 9.0.0

--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: DeveloperTools
 apiVersion: v2
-appVersion: 1.8.4
+appVersion: 1.8.5
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami

--- a/bitnami/consul/README.md
+++ b/bitnami/consul/README.md
@@ -18,7 +18,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 ## Prerequisites
 
 - Kubernetes 1.12+
-- Helm 2.12+ or Helm 3.0-beta3+
+- Helm 3.0-beta3+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart
@@ -393,7 +393,30 @@ Find more information about how to deal with common errors related to Bitnami’
 
 ## Upgrading
 
-### 8.0.0
+### To 9.0.0
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+**What changes were introduced in this major version?**
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- Move dependency information from the *requirements.yaml* to the *Chart.yaml*
+- After running `helm dependency update`, a *Chart.lock* file is generated containing the same structure used in the previous *requirements.lock*
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+
+**Considerations when upgrading to this version**
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+**Useful links**
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
+
+### To 8.0.0
 
 - Several parameters were renamed or dissapeared in favor of new ones on this major version:
   - `securityContext.*` is deprecated in favor of `podSecurityContext` and `containerSecurityContext`.
@@ -403,7 +426,7 @@ Find more information about how to deal with common errors related to Bitnami’
 - Chart labels were adapted to follow the [Helm charts standard labels](https://helm.sh/docs/chart_best_practices/labels/#standard-labels).
 - This version also introduces `bitnami/common`, a [library chart](https://helm.sh/docs/topics/library_charts/#helm) as a dependency. More documentation about this new utility could be found [here](https://github.com/bitnami/charts/tree/master/bitnami/common#bitnami-common-library-chart). Please, make sure that you have updated the chart dependencies before executing any upgrade.
 
-### 7.0.0
+### To 7.0.0
 
 Consul pods are now deployed in parallel in order to bootstrap the cluster and be discovered.
 

--- a/bitnami/consul/requirements.lock
+++ b/bitnami/consul/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 0.8.1
-digest: sha256:ad106a61ddcf8b78033635f756554bda2de59183ca30ef9b6642a392eb832c3a
-generated: "2020-10-11T20:52:38.627385Z"

--- a/bitnami/consul/requirements.yaml
+++ b/bitnami/consul/requirements.yaml
@@ -1,6 +1,0 @@
-dependencies:
-  - name: common
-    version: 0.x.x
-    repository: https://charts.bitnami.com/bitnami
-    tags:
-      - bitnami-common

--- a/bitnami/consul/values-production.yaml
+++ b/bitnami/consul/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/consul
-  tag: 1.8.4-debian-10-r22
+  tag: 1.8.5-debian-10-r17
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -457,7 +457,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/consul-exporter
-    tag: 0.7.1-debian-10-r73
+    tag: 0.7.1-debian-10-r103
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/consul/values.yaml
+++ b/bitnami/consul/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/consul
-  tag: 1.8.4-debian-10-r22
+  tag: 1.8.5-debian-10-r17
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -457,7 +457,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/consul-exporter
-    tag: 0.7.1-debian-10-r73
+    tag: 0.7.1-debian-10-r103
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**

- Bump `apiVersion` from `v1` to `v2` in _Chart.yaml_
- Fields in _Chart.yaml_ file has been ordered alphabetically
- Move dependency information from the _requirements.yaml_ to the _Chart.yaml_
- After running `helm dependency update`, a new _Chart.lock_ file is generated containing the same structure used in the previous _requirements.lock_
- Update _README.md_

**Possible drawbacks**

Helm v2 is no longer supported
