### PR TITLE
[bitnami/contour] Major version. Adapt Chart to apiVersion: v2

### DIFF
--- a/bitnami/contour/Chart.lock
+++ b/bitnami/contour/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.0.0
+digest: sha256:a2093836b2b6a85d7bf34143d3159b5c413c5e7423bde212de9cb416c985b976
+generated: "2020-11-10T23:42:14.691646871Z"

--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -1,23 +1,29 @@
-apiVersion: v1
-name: contour
-description: Contour Ingress controller for Kubernetes
-version: 2.3.5
+annotations:
+  category: Infrastructure
+apiVersion: v2
 appVersion: 1.10.0
+dependencies:
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
+description: Contour Ingress controller for Kubernetes
+home: https://github.com/bitnami/charts/tree/master/bitnami/contour
+icon: https://bitnami.com/assets/stacks/contour/img/contour-stack-220x234.png
 keywords:
   - ingress
   - envoy
   - contour
-home: https://github.com/bitnami/charts/tree/master/bitnami/contour
-icon: https://bitnami.com/assets/stacks/contour/img/contour-stack-220x234.png
+maintainers:
+  - name: cellebyte
+    url: https://github.com/Cellebyte
+  - email: containers@bitnami.com
+    name: Bitnami
+name: contour
 sources:
   - https://github.com/projectcontour/contour
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/bitnami-docker-contour
   - https://projectcontour.io
-maintainers:
-  - name: cellebyte
-    url: https://github.com/Cellebyte
-  - name: Bitnami
-    email: containers@bitnami.com
-annotations:
-  category: Infrastructure
+version: 3.0.0

--- a/bitnami/contour/README.md
+++ b/bitnami/contour/README.md
@@ -18,7 +18,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 ## Prerequisites
 
 - Kubernetes 1.12+
-- Helm 2.11+ or Helm 3.0-beta3+
+- Helm 3.0-beta3+
 - An Operator for `ServiceType: LoadBalancer` like [MetalLB](../metallb/README.md)
 
 ## Installing the Chart
@@ -293,6 +293,29 @@ Find more information about how to deal with common errors related to Bitnami’
 ## Upgrading
 
 Please carefully read through the guide "Upgrading Contour" at https://projectcontour.io/resources/upgrading/.
+
+### To 3.0.0
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+**What changes were introduced in this major version?**
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- Move dependency information from the *requirements.yaml* to the *Chart.yaml*
+- After running `helm dependency update`, a *Chart.lock* file is generated containing the same structure used in the previous *requirements.lock*
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+
+**Considerations when upgrading to this version**
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+**Useful links**
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
 
 ### To 2.0.0
 

--- a/bitnami/contour/requirements.lock
+++ b/bitnami/contour/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 0.10.0
-digest: sha256:cbe8f782ad7168557b9bb101a4d441d3210e2dda09cd249eb8426d1499ce6afc
-generated: "2020-11-07T05:46:19.040761294Z"

--- a/bitnami/contour/requirements.yaml
+++ b/bitnami/contour/requirements.yaml
@@ -1,6 +1,0 @@
-dependencies:
-  - name: common
-    version: 0.x.x
-    repository: https://charts.bitnami.com/bitnami
-    tags:
-      - bitnami-common

--- a/bitnami/contour/values-production.yaml
+++ b/bitnami/contour/values-production.yaml
@@ -135,7 +135,7 @@ contour:
   image:
     registry: docker.io
     repository: bitnami/contour
-    tag: 1.10.0-debian-10-r0
+    tag: 1.10.0-debian-10-r4
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -315,7 +315,7 @@ envoy:
   image:
     registry: docker.io
     repository: bitnami/envoy
-    tag: 1.15.2-debian-10-r27
+    tag: 1.15.2-debian-10-r30
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/contour/values.yaml
+++ b/bitnami/contour/values.yaml
@@ -133,7 +133,7 @@ contour:
   image:
     registry: docker.io
     repository: bitnami/contour
-    tag: 1.10.0-debian-10-r0
+    tag: 1.10.0-debian-10-r4
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -311,7 +311,7 @@ envoy:
   image:
     registry: docker.io
     repository: bitnami/envoy
-    tag: 1.15.2-debian-10-r27
+    tag: 1.15.2-debian-10-r30
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
**Description of the change**

- Bump `apiVersion` from `v1` to `v2` in _Chart.yaml_
- Fields in _Chart.yaml_ file has been ordered alphabetically
- Move dependency information from the _requirements.yaml_ to the _Chart.yaml_
- After running `helm dependency update`, a new _Chart.lock_ file is generated containing the same structure used in the previous _requirements.lock_
- Update _README.md_

**Possible drawbacks**

Helm v2 is no longer supported
