### PR TITLE
[bitnami/rabbitmq] Fix TLS port

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -23,4 +23,4 @@ name: rabbitmq
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq
   - https://www.rabbitmq.com
-version: 8.0.0
+version: 8.0.1

--- a/bitnami/rabbitmq/templates/svc-headless.yaml
+++ b/bitnami/rabbitmq/templates/svc-headless.yaml
@@ -14,7 +14,7 @@ spec:
       port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.portName }}
     {{- if .Values.auth.tls.enabled }}
-    - name: {{ .Values.service.TlsPortName }}
+    - name: {{ .Values.service.tlsPortName }}
       port: {{ .Values.service.tlsPort }}
       targetPort: amqp-tls
     {{- end }}

--- a/bitnami/rabbitmq/templates/svc.yaml
+++ b/bitnami/rabbitmq/templates/svc.yaml
@@ -33,7 +33,7 @@ spec:
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}
     {{- if .Values.auth.tls.enabled }}
-    - name: {{ .Values.service.TlsPortName }}
+    - name: {{ .Values.service.tlsPortName }}
       port: {{ .Values.service.tlsPort }}
       targetPort: amqp-ssl
       {{- if (eq .Values.service.type "ClusterIP") }}


### PR DESCRIPTION
**Description of the change**
Use the correct value for the TLS port name in services.

**Applicable issues**
  - fixes #4305

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
