### PR TITLE
[bitnami/parse] Major version. Adapt Chart to apiVersion: v2

### DIFF
--- a/bitnami/parse/Chart.lock
+++ b/bitnami/parse/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: mongodb
+  repository: https://charts.bitnami.com/bitnami
+  version: 10.0.0
+digest: sha256:2d18ebbed644b888fe29905b6d5d2b0d46a86a97127d6ae63ce7df213dba8546
+generated: "2020-11-12T07:20:39.08169975Z"

--- a/bitnami/parse/Chart.yaml
+++ b/bitnami/parse/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: DeveloperTools
 apiVersion: v2
-appVersion: 4.3.0
+appVersion: 4.4.0
 dependencies:
   - name: mongodb
     repository: https://charts.bitnami.com/bitnami

--- a/bitnami/parse/Chart.yaml
+++ b/bitnami/parse/Chart.yaml
@@ -1,8 +1,15 @@
-apiVersion: v1
-name: parse
-version: 12.0.3
+annotations:
+  category: DeveloperTools
+apiVersion: v2
 appVersion: 4.3.0
+dependencies:
+  - name: mongodb
+    repository: https://charts.bitnami.com/bitnami
+    version: 10.x.x
 description: Parse is a platform that enables users to add a scalable and powerful backend to launch a full-featured app for iOS, Android, JavaScript, Windows, Unity, and more.
+engine: gotpl
+home: https://github.com/bitnami/charts/tree/master/bitnami/parse
+icon: https://bitnami.com/assets/stacks/parse/img/parse-stack-220x234.png
 keywords:
   - parse
   - backend
@@ -10,15 +17,12 @@ keywords:
   - platform
   - mbaas
   - mobile
-home: https://github.com/bitnami/charts/tree/master/bitnami/parse
-icon: https://bitnami.com/assets/stacks/parse/img/parse-stack-220x234.png
+maintainers:
+  - email: containers@bitnami.com
+    name: Bitnami
+name: parse
 sources:
   - https://github.com/bitnami/bitnami-docker-parse
   - https://github.com/bitnami/bitnami-docker-parse-dashboard
   - https://parse.com/
-maintainers:
-  - name: Bitnami
-    email: containers@bitnami.com
-engine: gotpl
-annotations:
-  category: DeveloperTools
+version: 13.0.0

--- a/bitnami/parse/README.md
+++ b/bitnami/parse/README.md
@@ -18,7 +18,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 ## Prerequisites
 
 - Kubernetes 1.12+
-- Helm 2.12+ or Helm 3.0-beta3+
+- Helm 3.0-beta3+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 
@@ -223,6 +223,29 @@ Alternatively, you can use a ConfigMap or a Secret with the environment variable
 Find more information about how to deal with common errors related to Bitnami’s Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
 
 ## Upgrading
+
+### To 13.0.0
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+**What changes were introduced in this major version?**
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- Move dependency information from the *requirements.yaml* to the *Chart.yaml*
+- After running `helm dependency update`, a *Chart.lock* file is generated containing the same structure used in the previous *requirements.lock*
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+
+**Considerations when upgrading to this version**
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+**Useful links**
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
 
 ### To 12.0.0
 

--- a/bitnami/parse/requirements.lock
+++ b/bitnami/parse/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: mongodb
-  repository: https://charts.bitnami.com/bitnami
-  version: 9.2.5
-digest: sha256:6fa42aa708608975df214fb41e843f543cf93f2e589166809d7969cafc889360
-generated: "2020-10-21T21:59:39.109236445Z"

--- a/bitnami/parse/requirements.yaml
+++ b/bitnami/parse/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-  - name: mongodb
-    version: 9.x.x
-    repository: https://charts.bitnami.com/bitnami

--- a/bitnami/parse/values.yaml
+++ b/bitnami/parse/values.yaml
@@ -63,7 +63,7 @@ server:
   image:
     registry: docker.io
     repository: bitnami/parse
-    tag: 4.3.0-debian-10-r71
+    tag: 4.4.0-debian-10-r2
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -186,7 +186,7 @@ dashboard:
   image:
     registry: docker.io
     repository: bitnami/parse-dashboard
-    tag: 2.1.0-debian-10-r169
+    tag: 2.1.0-debian-10-r189
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
**Description of the change**

- Bump `apiVersion` from `v1` to `v2` in _Chart.yaml_
- Fields in _Chart.yaml_ file has been ordered alphabetically
- Move dependency information from the _requirements.yaml_ to the _Chart.yaml_
- After running `helm dependency update`, a new _Chart.lock_ file is generated containing the same structure used in the previous _requirements.lock_
- Update _README.md_

**Possible drawbacks**

Helm v2 is no longer supported
