### PR TITLE
[bitnami/node] Major version. apiVersion: v2, standardizations and subchart bump

### DIFF
--- a/bitnami/node/Chart.lock
+++ b/bitnami/node/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: mongodb
+  repository: https://charts.bitnami.com/bitnami
+  version: 10.0.5
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.0.1
+digest: sha256:252eac7ed122ed21964eab8c4e75ea4b91590f58a5d8421451697c9eaac80d97
+generated: "2020-11-24T18:50:28.128148+01:00"

--- a/bitnami/node/Chart.yaml
+++ b/bitnami/node/Chart.yaml
@@ -1,21 +1,26 @@
-apiVersion: v1
-name: node
-version: 13.1.2
+annotations:
+  category: Infrastructure
+apiVersion: v2
 appVersion: 10.23.0
+dependencies:
+  - condition: mongodb.install
+    name: mongodb
+    repository: https://charts.bitnami.com/bitnami
+    version: 10.x.x
 description: Event-driven I/O server-side JavaScript environment based on V8
+engine: gotpl
+home: https://github.com/bitnami/charts/tree/master/bitnami/node
+icon: https://bitnami.com/assets/stacks/nodejs/img/nodejs-stack-110x117.png
 keywords:
   - node
   - javascript
   - nodejs
   - git
-home: https://github.com/bitnami/charts/tree/master/bitnami/node
+maintainers:
+  - email: containers@bitnami.com
+    name: Bitnami
+name: node
 sources:
   - https://github.com/bitnami/bitnami-docker-node
   - http://nodejs.org/
-maintainers:
-  - name: Bitnami
-    email: containers@bitnami.com
-engine: gotpl
-icon: https://bitnami.com/assets/stacks/nodejs/img/nodejs-stack-110x117.png
-annotations:
-  category: Infrastructure
+version: 14.0.0

--- a/bitnami/node/Chart.yaml
+++ b/bitnami/node/Chart.yaml
@@ -7,6 +7,11 @@ dependencies:
     name: mongodb
     repository: https://charts.bitnami.com/bitnami
     version: 10.x.x
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
 description: Event-driven I/O server-side JavaScript environment based on V8
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/node

--- a/bitnami/node/Chart.yaml
+++ b/bitnami/node/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Infrastructure
 apiVersion: v2
-appVersion: 10.23.0
+appVersion: 14.15.1
 dependencies:
   - condition: mongodb.install
     name: mongodb

--- a/bitnami/node/README.md
+++ b/bitnami/node/README.md
@@ -58,19 +58,73 @@ The following table lists the configurable parameters of the Node chart and thei
 | `global.imageRegistry`                  | Global Docker image registry                                                | `nil`                                                   |
 | `global.imagePullSecrets`               | Global Docker registry secret names as an array                             | `[]` (does not add image pull secrets to deployed pods) |
 | `global.storageClass`                   | Global storage class for dynamic provisioning                               | `nil`                                                   |
+
+### Common parameters
+
+| Parameter                               | Description                                                                 | Default                                                 |
+|-----------------------------------------|-----------------------------------------------------------------------------|---------------------------------------------------------|
+| `nameOverride`                          | String to partially override node.fullname template                         | `nil`                                                   |
+| `fullnameOverride`                      | String to fully override node.fullname template                             | `nil`                                                   |
+| `commonLabels`                          | Labels to add to all deployed objects                                       | `nil`                                                   |
+| `commonAnnotations`                     | Annotations to add to all deployed objects                                  | `[]`                                                    |
+| `extraDeploy`                           | Array of extra objects to deploy with the release (evaluated as a template) | `nil`                                                   |
+
+## Node parameters
+
+| Parameter                               | Description                                                                 | Default                                                 |
+|-----------------------------------------|-----------------------------------------------------------------------------|---------------------------------------------------------|
 | `image.registry`                        | NodeJS image registry                                                       | `docker.io`                                             |
 | `image.repository`                      | NodeJS image name                                                           | `bitnami/node`                                          |
 | `image.tag`                             | NodeJS image tag                                                            | `{TAG_NAME}`                                            |
 | `image.pullPolicy`                      | NodeJS image pull policy                                                    | `IfNotPresent`                                          |
 | `image.pullSecrets`                     | Specify docker-registry secret names as an array                            | `[]` (does not add image pull secrets to deployed pods) |
-| `nameOverride`                          | String to partially override node.fullname template                         | `nil`                                                   |
-| `fullnameOverride`                      | String to fully override node.fullname template                             | `nil`                                                   |
-| `volumePermissions.enabled`             | Enable init container that changes volume permissions in the data directory | `false`                                                 |
-| `volumePermissions.image.registry`      | Init container volume-permissions image registry                            | `docker.io`                                             |
-| `volumePermissions.image.repository`    | Init container volume-permissions image name                                | `bitnami/minideb`                                       |
-| `volumePermissions.image.tag`           | Init container volume-permissions image tag                                 | `buster`                                                |
-| `volumePermissions.image.pullPolicy`    | Init container volume-permissions image pull policy                         | `Always`                                                |
-| `volumePermissions.resources`           | Init container resource requests/limit                                      | `{}`                                                    |
+| `command`                               | Override default container command (useful when using custom images)        | `['/bin/bash', '-ec', 'npm start']`                     |
+| `args`                                  | Override default container args (useful when using custom images)           | `[]`                                                    |
+| `extraEnvVars`                          | Extra environment variables to be set on Node container                     | `{}`                                                    |
+| `extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars                        | `nil`                                                   |
+| `extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars                           | `nil`                                                   |
+| `mongodb.install`                       | Wheter to install or not the MongoDB chart                                  | `true`                                                  |
+| `externaldb.enabled`                    | Enables or disables external database (ignored if `mongodb.install=true`)   | `false`                                                 |
+| `externaldb.secretName`                 | Secret containing existing database credentials                             | `nil`                                                   |
+| `externaldb.type`                       | Type of database that defines the database secret mapping                   | `osba`                                                  |
+| `externaldb.broker.serviceInstanceName` | The existing ServiceInstance to be used                                     | `nil`                                                   |
+
+## Node deployment parameters
+
+| Parameter                               | Description                                                                 | Default                                                 |
+|-----------------------------------------|-----------------------------------------------------------------------------|---------------------------------------------------------|
+| `replicaCount`                          | Number of Node replicas to deploy                                           | `1`                                                     |
+| `priorityClassName`                     | Node priorityClassName                                                      | `nil`                                                   |
+| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`| `""`                                             |
+| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`| `soft`                                      |
+| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`| `""`                                       |
+| `nodeAffinityPreset.key`                | Node label key to match Ignored if `affinity` is set.                       | `""`                                                    |
+| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                   | `[]`                                                    |
+| `affinity`                              | Affinity for pod assignment                                                 | `{}` (evaluated as a template)                          |
+| `nodeSelector`                          | Node labels for pod assignment                                              | `{}` (evaluated as a template)                          |
+| `tolerations`                           | Tolerations for pod assignment                                              | `[]` (evaluated as a template)                          |
+| `podLabels`                             | Additional labels for Node pods                                             | `{}` (evaluated as a template)                          |
+| `podAnnotations`                        | Annotations for Node pods                                                   | `{}` (evaluated as a template)                          |
+| `podSecurityContext.enabled`            | Enable security context for Node pods                                       | `true`                                                  |
+| `podSecurityContext.fsGroup`            | Group ID for the volumes of the pod                                         | `1001`                                                  |
+| `containerSecurityContext.enabled`      | Node Container securityContext                                              | `false`                                                 |
+| `containerSecurityContext.runAsUser`    | User ID for the Node container                                              | `1001`                                                  |
+| `applicationPort`                       | Port where the application will be running                                  | `3000`                                                  |
+| `resources.limits`                      | The resources limits for the Node container                                 | `{}`                                                    |
+| `resources.requests`                    | The requested resources for the Node container                              | `{}`                                                    |
+| `livenessProbe`                         | Liveness probe configuration for Node                                       | Check `values.yaml` file                                |
+| `readinessProbe`                        | Readiness probe configuration for Node                                      | Check `values.yaml` file                                |
+| `customLivenessProbe`                   | Override default liveness probe                                             | `nil`                                                   |
+| `customReadinessProbe`                  | Override default readiness probe                                            | `nil`                                                   |
+| `extraVolumes`                          | Array to add extra volumes                                                  | `[]` (evaluated as a template)                          |
+| `extraVolumeMounts`                     | Array to add extra mount                                                    | `[]` (evaluated as a template)                          |
+| `initContainers`                        | Add additional init containers to the Node pods                             | `{}` (evaluated as a template)                          |
+| `sidecars`                              | Add additional sidecar containers to the Node pods                          | `{}` (evaluated as a template)                          |
+
+## Node application parameters
+
+| Parameter                               | Description                                                                 | Default                                                 |
+|-----------------------------------------|-----------------------------------------------------------------------------|---------------------------------------------------------|
 | `git.registry`                          | Git image registry                                                          | `docker.io`                                             |
 | `git.repository`                        | Git image name                                                              | `bitnami/git`                                           |
 | `git.tag`                               | Git image tag                                                               | `{TAG_NAME}`                                            |
@@ -78,20 +132,31 @@ The following table lists the configurable parameters of the Node chart and thei
 | `getAppFromExternalRepository`          | Whether to get app from external git repo or not                            | `true`                                                  |
 | `repository`                            | Repo of the application                                                     | `https://github.com/bitnami/sample-mean.git`            |
 | `revision`                              | Revision to checkout                                                        | `master`                                                |
-| `replicaCount`                          | Number of replicas for the application                                      | `1`                                                     |
-| `applicationPort`                       | Port where the application will be running                                  | `3000`                                                  |
-| `extraEnvVars`                          | Any extra environment variables to be pass to the pods                      | `[]`                                                    |
-| `affinity`                              | Map of node/pod affinities                                                  | `{}` (The value is evaluated as a template)             |
-| `nodeSelector`                          | Node labels for pod assignment                                              | `{}` (The value is evaluated as a template)             |
-| `tolerations`                           | Tolerations for pod assignment                                              | `[]` (The value is evaluated as a template)             |
-| `securityContext.enabled`               | Enable security context                                                     | `true`                                                  |
-| `securityContext.fsGroup`               | Group ID for the container                                                  | `1001`                                                  |
-| `securityContext.runAsUser`             | User ID for the container                                                   | `1001`                                                  |
-| `resources`                             | Resource requests and limits                                                | `{}`                                                    |
+
+## Volume permissions parameters
+
+| Parameter                               | Description                                                                 | Default                                                 |
+|-----------------------------------------|-----------------------------------------------------------------------------|---------------------------------------------------------|
+| `volumePermissions.enabled`             | Enable init container that changes volume permissions in the data directory | `false`                                                 |
+| `volumePermissions.image.registry`      | Init container volume-permissions image registry                            | `docker.io`                                             |
+| `volumePermissions.image.repository`    | Init container volume-permissions image name                                | `bitnami/minideb`                                       |
+| `volumePermissions.image.tag`           | Init container volume-permissions image tag                                 | `buster`                                                |
+| `volumePermissions.image.pullPolicy`    | Init container volume-permissions image pull policy                         | `Always`                                                |
+| `volumePermissions.resources`           | Init container resource requests/limit                                      | `{}`                                                    |
+
+### Persistence parameters
+
+| Parameter                               | Description                                                                 | Default                                                 |
+|-----------------------------------------|-----------------------------------------------------------------------------|---------------------------------------------------------|
 | `persistence.enabled`                   | Enable persistence using PVC                                                | `false`                                                 |
 | `persistence.path`                      | Path to persisted directory                                                 | `/app/data`                                             |
 | `persistence.accessMode`                | PVC Access Mode                                                             | `ReadWriteOnce`                                         |
 | `persistence.size`                      | PVC Storage Request                                                         | `1Gi`                                                   |
+
+### Exposure parameters
+
+| Parameter                               | Description                                                                 | Default                                                 |
+|-----------------------------------------|-----------------------------------------------------------------------------|---------------------------------------------------------|
 | `service.type`                          | Kubernetes Service type                                                     | `ClusterIP`                                             |
 | `service.port`                          | Kubernetes Service port                                                     | `80`                                                    |
 | `service.annotations`                   | Annotations for the Service                                                 | {}                                                      |
@@ -107,11 +172,6 @@ The following table lists the configurable parameters of the Node chart and thei
 | `ingress.secrets[0].name`               | TLS Secret Name                                                             | `nil`                                                   |
 | `ingress.secrets[0].certificate`        | TLS Secret Certificate                                                      | `nil`                                                   |
 | `ingress.secrets[0].key`                | TLS Secret Key                                                              | `nil`                                                   |
-| `mongodb.install`                       | Wheter to install or not the MongoDB chart                                  | `true`                                                  |
-| `externaldb.enabled`                    | Enables or disables external database (ignored if `mongodb.install=true`)   | `false`                                                 |
-| `externaldb.secretName`                 | Secret containing existing database credentials                             | `nil`                                                   |
-| `externaldb.type`                       | Type of database that defines the database secret mapping                   | `osba`                                                  |
-| `externaldb.broker.serviceInstanceName` | The existing ServiceInstance to be used                                     | `nil`                                                   |
 
 The above parameters map to the env variables defined in [bitnami/node](http://github.com/bitnami/bitnami-docker-node). For more information please refer to the [bitnami/node](http://github.com/bitnami/bitnami-docker-node) image documentation.
 
@@ -278,6 +338,10 @@ Find more information about how to deal with common errors related to Bitnami’
 - Move dependency information from the *requirements.yaml* to the *Chart.yaml*
 - After running `helm dependency update`, a *Chart.lock* file is generated containing the same structure used in the previous *requirements.lock*
 - The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+- MongoDB dependency version was bumped to a new major version `10.X.X`. Check [MongoDB Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/mongodb#to-1000) for more information.
+- Inclusion of the`bitnami/common` library chart and standardization to include common features found on other charts.
+- `securityContext.*` is deprecated in favor of `podSecurityContext` and `containerSecurityContext`.
+- `replicas` is deprecated in favor of `replicaCount`.
 
 **Considerations when upgrading to this version**
 

--- a/bitnami/node/README.md
+++ b/bitnami/node/README.md
@@ -78,9 +78,9 @@ The following table lists the configurable parameters of the Node chart and thei
 | `getAppFromExternalRepository`          | Whether to get app from external git repo or not                            | `true`                                                  |
 | `repository`                            | Repo of the application                                                     | `https://github.com/bitnami/sample-mean.git`            |
 | `revision`                              | Revision to checkout                                                        | `master`                                                |
-| `replicas`                              | Number of replicas for the application                                      | `1`                                                     |
+| `replicaCount`                          | Number of replicas for the application                                      | `1`                                                     |
 | `applicationPort`                       | Port where the application will be running                                  | `3000`                                                  |
-| `extraEnv`                              | Any extra environment variables to be pass to the pods                      | `[]`                                                    |
+| `extraEnvVars`                          | Any extra environment variables to be pass to the pods                      | `[]`                                                    |
 | `affinity`                              | Map of node/pod affinities                                                  | `{}` (The value is evaluated as a template)             |
 | `nodeSelector`                          | Node labels for pod assignment                                              | `{}` (The value is evaluated as a template)             |
 | `tolerations`                           | Tolerations for pod assignment                                              | `[]` (The value is evaluated as a template)             |
@@ -119,11 +119,11 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 
 ```console
 $ helm install my-release \
-  --set repository=https://github.com/jbianquetti-nami/simple-node-app.git,replicas=2 \
+  --set repository=https://github.com/jbianquetti-nami/simple-node-app.git,replicaCount=2 \
     bitnami/node
 ```
 
-The above command clones the remote git repository to the `/app/` directory  of the container. Additionally it sets the number of `replicas` to `2`.
+The above command clones the remote git repository to the `/app/` directory  of the container. Additionally it sets the number of `replicaCount` to `2`.
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 

--- a/bitnami/node/README.md
+++ b/bitnami/node/README.md
@@ -20,7 +20,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 ## Prerequisites
 
 - Kubernetes 1.12+
-- Helm 2.12+ or Helm 3.0-beta3+
+- Helm 3.0-beta3+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 
@@ -267,6 +267,29 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 Find more information about how to deal with common errors related to Bitnami’s Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
 
 ## Upgrading
+
+### To 14.0.0
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+**What changes were introduced in this major version?**
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- Move dependency information from the *requirements.yaml* to the *Chart.yaml*
+- After running `helm dependency update`, a *Chart.lock* file is generated containing the same structure used in the previous *requirements.lock*
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+
+**Considerations when upgrading to this version**
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+**Useful links**
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
 
 ### To 13.0.0
 

--- a/bitnami/node/requirements.lock
+++ b/bitnami/node/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: mongodb
-  repository: https://charts.bitnami.com/bitnami
-  version: 9.2.6
-digest: sha256:b367aa7ef062caf3e52dd1e7a028a7a7c0a8fbaa020c185d767a448c0007c6de
-generated: "2020-10-27T22:10:05.222046012Z"

--- a/bitnami/node/requirements.yaml
+++ b/bitnami/node/requirements.yaml
@@ -1,5 +1,0 @@
-dependencies:
-  - name: mongodb
-    repository: https://charts.bitnami.com/bitnami
-    version: 9.x.x
-    condition: mongodb.install

--- a/bitnami/node/templates/NOTES.txt
+++ b/bitnami/node/templates/NOTES.txt
@@ -3,21 +3,21 @@
 
 {{- if contains "NodePort" .Values.service.type }}
 
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "node.fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "common.names.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo "Node app URL: http://$NODE_IP:$NODE_PORT/"
 
 {{- else if contains "LoadBalancer" .Values.service.type }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc -w {{ template "node.fullname" . }} --namespace {{ .Release.Namespace }}'
+        Watch the status with: 'kubectl get svc -w {{ template "common.names.fullname" . }} --namespace {{ .Release.Namespace }}'
 
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "node.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo "Node app URL: http://$SERVICE_IP/"
 
 {{- else if contains "ClusterIP"  .Values.service.type }}
 
-  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "node.fullname" . }} {{ .Values.service.port  }}:{{ .Values.service.port }}
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "common.names.fullname" . }} {{ .Values.service.port  }}:{{ .Values.service.port }}
   echo "Node app URL: http://127.0.0.1:{{ .Values.service.port }}/"
 
 {{- end }}

--- a/bitnami/node/templates/NOTES.txt
+++ b/bitnami/node/templates/NOTES.txt
@@ -1,13 +1,13 @@
 
 1. Get the URL of your Node app  by running:
 
-{{- if contains "NodePort" .Values.service.type }}
+{{- if eq .Values.service.type "NodePort" }}
 
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "common.names.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo "Node app URL: http://$NODE_IP:$NODE_PORT/"
 
-{{- else if contains "LoadBalancer" .Values.service.type }}
+{{- else if eq .Values.service.type "LoadBalancer" }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
         Watch the status with: 'kubectl get svc -w {{ template "common.names.fullname" . }} --namespace {{ .Release.Namespace }}'
@@ -15,7 +15,7 @@
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo "Node app URL: http://$SERVICE_IP/"
 
-{{- else if contains "ClusterIP"  .Values.service.type }}
+{{- else if eq .Values.service.type "ClusterIP" }}
 
   kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "common.names.fullname" . }} {{ .Values.service.port  }}:{{ .Values.service.port }}
   echo "Node app URL: http://127.0.0.1:{{ .Values.service.port }}/"

--- a/bitnami/node/templates/_helpers.tpl
+++ b/bitnami/node/templates/_helpers.tpl
@@ -1,27 +1,4 @@
 {{/* vim: set filetype=mustache: */}}
-{{/*
-Expand the name of the chart.
-*/}}
-{{- define "node.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-*/}}
-{{- define "node.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
 
 {{/*
 Create a default fully qualified app name.
@@ -29,31 +6,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "node.mongodb.fullname" -}}
 {{- printf "%s-%s" .Release.Name "mongodb" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
-{{- define "node.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Common labels
-*/}}
-{{- define "node.labels" -}}
-app.kubernetes.io/name: {{ include "node.name" . }}
-helm.sh/chart: {{ include "node.chart" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end -}}
-
-{{/*
-Labels to use on deploy.spec.selector.matchLabels and svc.spec.selector
-*/}}
-{{- define "node.matchLabels" -}}
-app.kubernetes.io/name: {{ include "node.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{/*
@@ -71,184 +23,42 @@ Custom template to get proper service name
 Return the proper Node image name
 */}}
 {{- define "node.image" -}}
-{{- $registryName := .Values.image.registry -}}
-{{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
-{{- else -}}
-    {{- if $registryName -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s:%s" $repositoryName $tag -}}
-    {{- end -}}
-{{- end -}}
+{{- include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) -}}
 {{- end -}}
 
 {{/*
 Return the proper git image name
 */}}
 {{- define "git.image" -}}
-{{- $registryName := .Values.git.registry -}}
-{{- $repositoryName := .Values.git.repository -}}
-{{- $tag := .Values.git.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
-{{- else -}}
-    {{- if $registryName -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s:%s" $repositoryName $tag -}}
-    {{- end -}}
-{{- end -}}
+{{- include "common.images.image" (dict "imageRoot" .Values.git.image "global" .Values.global) -}}
 {{- end -}}
 
 {{/*
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "node.imagePullSecrets" -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
-Also, we can not use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets:
-{{- range .Values.global.imagePullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- else if or .Values.image.pullSecrets .Values.git.pullSecrets .Values.volumePermissions.image.pullSecrets }}
-imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- range .Values.git.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- range .Values.volumePermissions.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end -}}
-{{- else if or .Values.image.pullSecrets .Values.git.pullSecrets .Values.volumePermissions.image.pullSecrets }}
-imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- range .Values.git.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- range .Values.volumePermissions.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.volumePermissions.image .Values.git.image) "global" .Values.global) -}}
 {{- end -}}
 
 {{/* Check if there are rolling tags in the images */}}
 {{- define "node.checkRollingTags" -}}
-{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
-WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
-+info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
-{{- end }}
-{{- if and (contains "bitnami/" .Values.git.repository) (not (.Values.git.tag | toString | regexFind "-r\\d+$|sha256:")) }}
-WARNING: Rolling tag detected ({{ .Values.git.repository }}:{{ .Values.git.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
-+info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
-{{- end }}
+{{- include "common.warnings.rollingTag" .Values.image }}
+{{- include "common.warnings.rollingTag" .Values.git.image }}
 {{- end -}}
 
 {{/*
 Return the proper image name (for the init container volume-permissions image)
 */}}
 {{- define "node.volumePermissions.image" -}}
-{{- $registryName := .Values.volumePermissions.image.registry -}}
-{{- $repositoryName := .Values.volumePermissions.image.repository -}}
-{{- $tag := .Values.volumePermissions.image.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
-{{- else -}}
-    {{- if $registryName -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s:%s" $repositoryName $tag -}}
-    {{- end -}}
-{{- end -}}
+{{- include "common.images.image" ( dict "imageRoot" .Values.volumePermissions.image "global" .Values.global ) -}}
 {{- end -}}
 
 {{/*
 Return the proper Storage Class
 */}}
 {{- define "node.storageClass" -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
-*/}}
-{{- if .Values.global -}}
-    {{- if .Values.global.storageClass -}}
-        {{- if (eq "-" .Values.global.storageClass) -}}
-            {{- printf "storageClassName: \"\"" -}}
-        {{- else }}
-            {{- printf "storageClassName: %s" .Values.global.storageClass -}}
-        {{- end -}}
-    {{- else -}}
-        {{- if .Values.persistence.storageClass -}}
-              {{- if (eq "-" .Values.persistence.storageClass) -}}
-                  {{- printf "storageClassName: \"\"" -}}
-              {{- else }}
-                  {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
-              {{- end -}}
-        {{- end -}}
-    {{- end -}}
-{{- else -}}
-    {{- if .Values.persistence.storageClass -}}
-        {{- if (eq "-" .Values.persistence.storageClass) -}}
-            {{- printf "storageClassName: \"\"" -}}
-        {{- else }}
-            {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
-        {{- end -}}
-    {{- end -}}
+{{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) -}}
 {{- end -}}
-{{- end -}}
-
-{{/*
-Renders a value that contains template.
-Usage:
-{{ include "node.tplValue" (dict "value" .Values.path.to.the.Value "context" $) }}
-*/}}
-{{- define "node.tplValue" -}}
-    {{- if typeIs "string" .value }}
-        {{- tpl .value .context }}
-    {{- else }}
-        {{- tpl (.value | toYaml) .context }}
-    {{- end }}
-{{- end -}}
-
 
 {{/*
 Compile all warnings into a single message, and call fail.

--- a/bitnami/node/templates/deployment.yaml
+++ b/bitnami/node/templates/deployment.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-  replicas: {{ .Values.replicas }}
+  replicas: {{ .Values.replicaCount }}
   template:
     metadata:
       {{- if .Values.podAnnotations }}
@@ -33,16 +33,17 @@ spec:
       {{- if .Values.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
       {{- end }}
-      {{- if .Values.securityContext.enabled }}
-      securityContext:
-        fsGroup: {{ .Values.securityContext.fsGroup }}
-        runAsUser: {{ .Values.securityContext.runAsUser }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 12 }}
       {{- end }}
       initContainers:
         {{- if .Values.getAppFromExternalRepository }}
         - name: git-clone-repository
           image: {{ include "git.image" . }}
-          imagePullPolicy: {{ .Values.git.pullPolicy | quote }}
+          imagePullPolicy: {{ .Values.git.image.pullPolicy | quote }}
           command:
             - /bin/bash
             - -ec
@@ -70,6 +71,9 @@ spec:
         - name: volume-permissions
           image: {{ include "node.volumePermissions.image" . }}
           imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
+          {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
           command:
             - /bin/bash
             - -ec
@@ -85,10 +89,16 @@ spec:
               mountPath: {{ .Values.persistence.path }}
         {{- end }}
         {{- end }}
+        {{- if .Values.initContainers }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+        {{- end }}
       containers:
         - name: node
           image: {{ template "node.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           env:
             {{- if .Values.mongodb.install }}
             - name: DATABASE_HOST
@@ -145,32 +155,54 @@ spec:
             {{- end }}
             - name: DATA_FOLDER
               value: "/app"
-            {{- if .Values.extraEnv }}
-            {{- toYaml .Values.extraEnv | nindent 12 }}
+            {{- if .Values.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- if .Values.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
             {{- end }}
           workingDir: /app
-          command:
-            - /bin/bash
-            - -ec
-            - |
-              npm start
+          {{- if .Values.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.command "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.applicationPort }}
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /
+              path: {{ .Values.livenessProbe.path }}
               port: http
-            initialDelaySeconds: 60
-            timeoutSeconds: 5
-            failureThreshold: 6
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- else if .Values.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /
+              path: {{ .Values.readinessProbe.path }}
               port: http
-            initialDelaySeconds: 10
-            timeoutSeconds: 3
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- else if .Values.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
@@ -181,6 +213,12 @@ spec:
             {{- end }}
             - name: data
               mountPath: {{ .Values.persistence.path }}
+          {{- if .Values.extraVolumeMounts }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
+        {{- if .Values.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) | nindent 8 }}
+        {{- end }}
       volumes:
         {{- if .Values.getAppFromExternalRepository }}
         - name: app
@@ -193,3 +231,6 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}

--- a/bitnami/node/templates/deployment.yaml
+++ b/bitnami/node/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ template "common.names.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-  	{{- if .Values.commonLabels }}
+    {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
@@ -23,9 +23,14 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
     spec:
-{{- include "node.imagePullSecrets" . | nindent 6 }}
+      {{- include "node.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAffinityPreset "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAntiAffinityPreset "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
@@ -90,7 +95,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- if .Values.initContainers }}
-          {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
         {{- end }}
       containers:
         - name: node

--- a/bitnami/node/templates/deployment.yaml
+++ b/bitnami/node/templates/deployment.yaml
@@ -1,25 +1,25 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "node.fullname" . }}
-  labels: {{- include "node.labels" . | nindent 4 }}
+  name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   selector:
-    matchLabels: {{- include "node.matchLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
   replicas: {{ .Values.replicas }}
   template:
     metadata:
-      labels: {{- include "node.labels" . | nindent 8 }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
     spec:
 {{- include "node.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.affinity }}
-      affinity: {{- include "node.tplValue" (dict "value" .Values.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.nodeSelector }}
-      nodeSelector: {{- include "node.tplValue" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.tolerations }}
-      tolerations: {{- include "node.tplValue" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
@@ -177,7 +177,7 @@ spec:
         - name: data
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ template "node.fullname" . }}-binding
+            claimName: {{ template "common.names.fullname" . }}-binding
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/bitnami/node/templates/deployment.yaml
+++ b/bitnami/node/templates/deployment.yaml
@@ -1,15 +1,27 @@
-apiVersion: apps/v1
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "common.names.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+  	{{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
   replicas: {{ .Values.replicas }}
   template:
     metadata:
+      {{- if .Values.podAnnotations }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+      {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
+        {{- end }}
     spec:
 {{- include "node.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.affinity }}

--- a/bitnami/node/templates/extra-list.yaml
+++ b/bitnami/node/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/bitnami/node/templates/ingress.yaml
+++ b/bitnami/node/templates/ingress.yaml
@@ -3,8 +3,8 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "node.fullname" $ }}
-  labels: {{- include "node.labels" $ | nindent 4 }}
+  name: {{ template "common.names.fullname" $ }}
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
   annotations:
     {{- if .certManager }}
     kubernetes.io/tls-acme: "true"
@@ -19,7 +19,7 @@ spec:
         paths:
           - path: {{ default "/" .path }}
             backend:
-              serviceName: {{ template "node.fullname" $ }}
+              serviceName: {{ template "common.names.fullname" $ }}
               servicePort: 80
   {{- if .tls }}
   tls:

--- a/bitnami/node/templates/ingress.yaml
+++ b/bitnami/node/templates/ingress.yaml
@@ -5,7 +5,7 @@ kind: Ingress
 metadata:
   name: {{ template "common.names.fullname" $ }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
-  	{{- if .Values.commonLabels }}
+    {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   annotations:

--- a/bitnami/node/templates/ingress.yaml
+++ b/bitnami/node/templates/ingress.yaml
@@ -1,16 +1,22 @@
 {{- if .Values.ingress.enabled }}
 {{- range .Values.ingress.hosts }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "common.names.fullname" $ }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
+  	{{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   annotations:
     {{- if .certManager }}
     kubernetes.io/tls-acme: "true"
     {{- end }}
     {{- range $key, $value := .annotations }}
     {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
 spec:
   rules:

--- a/bitnami/node/templates/mongodb-binding.yaml
+++ b/bitnami/node/templates/mongodb-binding.yaml
@@ -2,8 +2,8 @@
 apiVersion: servicecatalog.k8s.io/v1beta1
 kind: ServiceBinding
 metadata:
-  name: {{ template "node.fullname" . }}-binding
-  labels: {{- include "node.labels" . | nindent 4 }}
+  name: {{ template "common.names.fullname" . }}-binding
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   instanceRef:
     name: {{ .Values.externaldb.broker.serviceInstanceName }}

--- a/bitnami/node/templates/mongodb-binding.yaml
+++ b/bitnami/node/templates/mongodb-binding.yaml
@@ -4,6 +4,12 @@ kind: ServiceBinding
 metadata:
   name: {{ template "common.names.fullname" . }}-binding
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+  	{{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   instanceRef:
     name: {{ .Values.externaldb.broker.serviceInstanceName }}

--- a/bitnami/node/templates/mongodb-binding.yaml
+++ b/bitnami/node/templates/mongodb-binding.yaml
@@ -4,7 +4,7 @@ kind: ServiceBinding
 metadata:
   name: {{ template "common.names.fullname" . }}-binding
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-  	{{- if .Values.commonLabels }}
+    {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}

--- a/bitnami/node/templates/pvc.yaml
+++ b/bitnami/node/templates/pvc.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   name: {{ template "common.names.fullname" . }}-binding
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-  	{{- if .Values.commonLabels }}
+    {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}

--- a/bitnami/node/templates/pvc.yaml
+++ b/bitnami/node/templates/pvc.yaml
@@ -2,8 +2,8 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ template "node.fullname" . }}-binding
-  labels: {{- include "node.labels" . | nindent 4 }}
+  name: {{ template "common.names.fullname" . }}-binding
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
   annotations:
     volume.alpha.kubernetes.io/storage-class: {{ ternary "default" (trimPrefix "storageClassName: " (include "node.storageClass" .)) (empty (include "node.storageClass" .)) }}
 spec:

--- a/bitnami/node/templates/pvc.yaml
+++ b/bitnami/node/templates/pvc.yaml
@@ -4,6 +4,12 @@ apiVersion: v1
 metadata:
   name: {{ template "common.names.fullname" . }}-binding
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+  	{{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
   annotations:
     volume.alpha.kubernetes.io/storage-class: {{ ternary "default" (trimPrefix "storageClassName: " (include "node.storageClass" .)) (empty (include "node.storageClass" .)) }}
 spec:

--- a/bitnami/node/templates/svc.yaml
+++ b/bitnami/node/templates/svc.yaml
@@ -3,6 +3,12 @@ kind: Service
 metadata:
   name: {{ template "common.names.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+  	{{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
   {{- if .Values.service.annotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
   {{- end }}

--- a/bitnami/node/templates/svc.yaml
+++ b/bitnami/node/templates/svc.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ template "common.names.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-  	{{- if .Values.commonLabels }}
+    {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
@@ -14,6 +14,10 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  sessionAffinity: {{ default "None" .Values.service.sessionAffinity }}
+  {{- if and .Values.service.clusterIP (eq .Values.service.type "ClusterIP") }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
   {{- if and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP)) }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}

--- a/bitnami/node/templates/svc.yaml
+++ b/bitnami/node/templates/svc.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "node.fullname" . }}
-  labels: {{- include "node.labels" . | nindent 4 }}
+  name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.service.annotations }}
-  annotations: {{- include "node.tplValue" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
@@ -20,4 +20,4 @@ spec:
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
-  selector: {{- include "node.matchLabels" . | nindent 4 }}
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/node/values.yaml
+++ b/bitnami/node/values.yaml
@@ -70,16 +70,24 @@ volumePermissions:
 ## ref: https://hub.docker.com/r/bitnami/git/tags/
 ##
 git:
-  registry: docker.io
-  repository: bitnami/git
-  tag: 2.29.1-debian-10-r5
-  pullPolicy: IfNotPresent
-  ## Optionally specify an array of imagePullSecrets.
-  ## Secrets must be manually created in the namespace.
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## Bitnami git image version
+  ## ref: https://hub.docker.com/r/bitnami/git/tags/
   ##
-  # pullSecrets:
-  #   - myRegistryKeySecretName
+  image:
+    registry: docker.io
+    repository: bitnami/git
+    tag: 2.29.2-debian-10-r23
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    pullSecrets: []
+    #   - myRegistryKeySecretName
 
 ## Enable to download app from external git repository.
 ## Disable it if your docker image already includes your application at /app

--- a/bitnami/node/values.yaml
+++ b/bitnami/node/values.yaml
@@ -128,6 +128,24 @@ nodeSelector: {}
 ##
 tolerations: {}
 
+## Add labels to all the deployed resources
+##
+commonLabels: {}
+
+## Add annotations to all the deployed resources
+##
+commonAnnotations: {}
+
+## Additional pod annotations
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+
+## Additional pod labels
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+##
+podLabels: {}
+
 ## Pod Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 ##

--- a/bitnami/node/values.yaml
+++ b/bitnami/node/values.yaml
@@ -103,15 +103,11 @@ revision: master
 
 ## Specify the number of replicas for the application
 ##
-replicas: 1
+replicaCount: 1
 
 ## Specify the port where your application will be running
 ##
 applicationPort: 3000
-
-## Define custom environment variables to pass to the image here
-##
-extraEnv: []
 
 ## Affinity for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
@@ -146,13 +142,109 @@ podAnnotations: {}
 ##
 podLabels: {}
 
-## Pod Security Context
+## Extra objects to deploy (value evaluated as a template)
+##
+extraDeploy: []
+
+## Configure extra options for liveness and readiness probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+livenessProbe:
+  enabled: true
+  path: "/"
+  initialDelaySeconds: 60
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+readinessProbe:
+  enabled: true
+  path: "/"
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+  successThreshold: 1
+
+## Custom Liveness probes for Node
+##
+customLivenessProbe: {}
+
+## Custom Rediness probes Node
+##
+customReadinessProbe: {}
+
+## Node pods' priority.
+## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+##
+# priorityClassName: ""
+
+## lifecycleHooks for the Node container to automate configuration before or after startup.
+##
+lifecycleHooks: {}
+
+## Add sidecars to the Node pods.
+## Example:
+## sidecars:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+sidecars: {}
+
+## Add init containers to the Node pods.
+## Example:
+## initContainers:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+initContainers: {}
+
+## An array to add extra env vars
+## For example:
+##
+extraEnvVars: []
+#  - name: BEARER_AUTH
+#    value: true
+
+## ConfigMap with extra environment variables
+##
+extraEnvVarsCM:
+
+## Secret with extra environment variables
+##
+extraEnvVarsSecret:
+
+## Command and args for running the container (set to default if not set). Use array form
+##
+command: ['/bin/bash', '-ec', 'npm start']
+args: []
+
+## Extra volumes to add to the deployment
+##
+extraVolumes: []
+
+## Extra volume mounts to add to the container
+##
+extraVolumeMounts: []
+
+## SecurityContext configuration
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 ##
-securityContext:
+containerSecurityContext:
+  enabled: true
+  runAsUser: 1001
+  runAsNonRoot: true
+
+podSecurityContext:
   enabled: true
   fsGroup: 1001
-  runAsUser: 1001
 
 ## Node conatiners' resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/bitnami/node/values.yaml
+++ b/bitnami/node/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/node
-  tag: 10.23.0-debian-10-r0
+  tag: 14.15.1-debian-10-r5
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/node/values.yaml
+++ b/bitnami/node/values.yaml
@@ -109,7 +109,40 @@ replicaCount: 1
 ##
 applicationPort: 3000
 
-## Affinity for pod assignment
+## Pod affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+## Allowed values: soft, hard
+##
+podAffinityPreset: ""
+
+## Pod anti-affinity preset
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+## Allowed values: soft, hard
+##
+podAntiAffinityPreset: soft
+
+## Node affinity preset
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+## Allowed values: soft, hard
+##
+nodeAffinityPreset:
+  ## Node affinity type
+  ## Allowed values: soft, hard
+  type: ""
+  ## Node label key to match
+  ## E.g.
+  ## key: "kubernetes.io/e2e-az-name"
+  ##
+  key: ""
+  ## Node label values to match
+  ## E.g.
+  ## values:
+  ##   - e2e-az1
+  ##   - e2e-az2
+  ##
+  values: []
+
+## Affinity for pod assignment. Evaluated as a template.
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 ##
 affinity: {}
@@ -287,6 +320,16 @@ service:
   ## HTTP Port
   ##
   port: 80
+
+  ## clusterIP: ""
+  ## loadBalancerIP for the Node Service (optional, cloud specific)
+  ## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
+
+  ## Control where client requests go, to the same pod or round-robin
+  ## Values: ClientIP or None
+  ## ref: https://kubernetes.io/docs/user-guide/services/
+  sessionAffinity: "None"
+
   ## Specify the nodePort value for the LoadBalancer and NodePort service types.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
   ##


### PR DESCRIPTION
**Description of the change**

_General_

- Bump application version from `10.X.X` to the latest active LTS `14.X.X`.
- Bump MongoDB subchart major version from `9.X.X` to `10.X.X`, more info at #4296
- Include bitnami/common as a dependency.
- Adapt Chart to common standardizations found in others. More on this in additional information.

_Helm v3 Related_

- Bump `apiVersion` from `v1` to `v2` in _Chart.yaml_
- Fields in _Chart.yaml_ file has been ordered alphabetically
- Move dependency information from the _requirements.yaml_ to the _Chart.yaml_
- After running `helm dependency update`, a new _Chart.lock_ file is generated containing the same structure used in the previous _requirements.lock_
- Update _README.md_

**Benefits**

<!-- What benefits will be realized by the code change? -->

Up-to-date subcomponents, standardization 

**Possible drawbacks**

Helm v2 is no longer supported

**Additional information**
- [X] commonAnnotations
- [X] commonLabels
- [X] podAnnotations
- [X] podLabels
- [x] extraVolumes
- [X] extraVolumeMounts
- [X] podSecurityContext
- [X] containerSecurityContext
- [X] affinity
- [X] podAffinityPreset
- [X] podAntiaffinityPreset
- [X] nodeAffinityPreset
- [X] nodeSelector
- [X] tolerations
- [X] sidecars
- [X] initContainers
- [X] extraEnvVars
- [X] extraEnvVarsCM
- [X] extraEnvVarsSecret
- [X] command 
- [X] args 
- [X] resources
- [X] customLivenessProbe
- [X] customReadinessProbe
- [x] extraDeploy
- [x] priorityClassName
