### PR TITLE
[bitnami/moodle] Major version. Adapt Chart to apiVersion: v2

### DIFF
--- a/bitnami/moodle/Chart.lock
+++ b/bitnami/moodle/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: mariadb
+  repository: https://charts.bitnami.com/bitnami
+  version: 9.0.1
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.0.0
+digest: sha256:27ce5c469bf919f37ff334b30b745ea0c60bfcf5d58eca9545e354b2aa27514a
+generated: "2020-11-12T07:14:12.401294492Z"

--- a/bitnami/moodle/Chart.yaml
+++ b/bitnami/moodle/Chart.yaml
@@ -1,20 +1,28 @@
-apiVersion: v1
-name: moodle
-version: 9.1.2
+annotations:
+  category: E-Learning
+apiVersion: v2
 appVersion: 3.10.0
+dependencies:
+  - condition: mariadb.enabled
+    name: mariadb
+    repository: https://charts.bitnami.com/bitnami
+    version: 9.x.x
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    version: 1.x.x
 description: Moodle is a learning platform designed to provide educators, administrators and learners with a single robust, secure and integrated system to create personalised learning environments
+engine: gotpl
+home: https://github.com/bitnami/charts/tree/master/bitnami/moodle
+icon: https://bitnami.com/assets/stacks/moodle/img/moodle-stack-110x117.png
 keywords:
   - moodle
   - learning
   - php
-home: https://github.com/bitnami/charts/tree/master/bitnami/moodle
+maintainers:
+  - email: containers@bitnami.com
+    name: Bitnami
+name: moodle
 sources:
   - https://github.com/bitnami/bitnami-docker-moodle
   - http://www.moodle.org/
-maintainers:
-  - name: Bitnami
-    email: containers@bitnami.com
-engine: gotpl
-icon: https://bitnami.com/assets/stacks/moodle/img/moodle-stack-110x117.png
-annotations:
-  category: E-Learning
+version: 10.0.0

--- a/bitnami/moodle/README.md
+++ b/bitnami/moodle/README.md
@@ -22,7 +22,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 ## Prerequisites
 
 - Kubernetes 1.12+
-- Helm 2.12+ or Helm 3.0-beta3+
+- Helm 3.0-beta3+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 
@@ -311,6 +311,29 @@ You may want to review the [PV reclaim policy](https://kubernetes.io/docs/tasks/
 Find more information about how to deal with common errors related to Bitnami’s Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
 
 ## Upgrading
+
+### To 10.0.0
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+**What changes were introduced in this major version?**
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- Move dependency information from the *requirements.yaml* to the *Chart.yaml*
+- After running `helm dependency update`, a *Chart.lock* file is generated containing the same structure used in the previous *requirements.lock*
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+
+**Considerations when upgrading to this version**
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+**Useful links**
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
 
 ### To 9.0.0
 

--- a/bitnami/moodle/requirements.lock
+++ b/bitnami/moodle/requirements.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: mariadb
-  repository: https://charts.bitnami.com/bitnami
-  version: 8.0.7
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 0.8.2
-digest: sha256:2ec8d3fa55168da4b91fb6023efbe62da57ac5a5c06cd9228056be9ffcccc57a
-generated: "2020-11-07T05:32:51.846388466Z"

--- a/bitnami/moodle/requirements.yaml
+++ b/bitnami/moodle/requirements.yaml
@@ -1,8 +1,0 @@
-dependencies:
-  - name: mariadb
-    version: 8.x.x
-    repository: https://charts.bitnami.com/bitnami
-    condition: mariadb.enabled
-  - name: common
-    version: 0.8.x
-    repository: https://charts.bitnami.com/bitnami

--- a/bitnami/moodle/values.yaml
+++ b/bitnami/moodle/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/moodle
-  tag: 3.10.0-debian-10-r0
+  tag: 3.10.0-debian-10-r5
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -502,7 +502,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.8.0-debian-10-r204
+    tag: 0.8.0-debian-10-r209
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**

- Bump `apiVersion` from `v1` to `v2` in _Chart.yaml_
- Fields in _Chart.yaml_ file has been ordered alphabetically
- Move dependency information from the _requirements.yaml_ to the _Chart.yaml_
- After running `helm dependency update`, a new _Chart.lock_ file is generated containing the same structure used in the previous _requirements.lock_
- Update _README.md_

**Possible drawbacks**

Helm v2 is no longer supported
