### PR TITLE
[bitnami/kafka] Major version. Adapt Chart to apiVersion: v2

### DIFF
--- a/bitnami/kafka/Chart.lock
+++ b/bitnami/kafka/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: zookeeper
+  repository: https://charts.bitnami.com/bitnami
+  version: 6.0.0
+digest: sha256:70df71a3e915c9c070a932f97a5fa2c4d18fc930e122a595651d6ef0a21a3f6c
+generated: "2020-11-11T18:49:18.011960778Z"

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,22 +1,27 @@
-apiVersion: v1
-name: kafka
-version: 11.8.9
+annotations:
+  category: Infrastructure
+apiVersion: v2
 appVersion: 2.6.0
+dependencies:
+  - condition: zookeeper.enabled
+    name: zookeeper
+    repository: https://charts.bitnami.com/bitnami
+    version: 6.x.x
 description: Apache Kafka is a distributed streaming platform.
+engine: gotpl
+home: https://github.com/bitnami/charts/tree/master/bitnami/kafka
+icon: https://bitnami.com/assets/stacks/kafka/img/kafka-stack-110x117.png
 keywords:
   - kafka
   - zookeeper
   - streaming
   - producer
   - consumer
-home: https://github.com/bitnami/charts/tree/master/bitnami/kafka
+maintainers:
+  - email: containers@bitnami.com
+    name: Bitnami
+name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-maintainers:
-  - name: Bitnami
-    email: containers@bitnami.com
-engine: gotpl
-icon: https://bitnami.com/assets/stacks/kafka/img/kafka-stack-110x117.png
-annotations:
-  category: Infrastructure
+version: 12.0.0

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -18,7 +18,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 ## Prerequisites
 
 - Kubernetes 1.12+
-- Helm 2.12+ or Helm 3.0-beta3+
+- Helm 3.0-beta3+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart
@@ -648,6 +648,29 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 Find more information about how to deal with common errors related to Bitnami’s Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
 
 ## Upgrading
+
+### To 12.0.0
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+**What changes were introduced in this major version?**
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- Move dependency information from the *requirements.yaml* to the *Chart.yaml*
+- After running `helm dependency update`, a *Chart.lock* file is generated containing the same structure used in the previous *requirements.lock*
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+
+**Considerations when upgrading to this version**
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+**Useful links**
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
 
 ### To 11.8.0
 

--- a/bitnami/kafka/requirements.lock
+++ b/bitnami/kafka/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: zookeeper
-  repository: https://charts.bitnami.com/bitnami
-  version: 5.22.0
-digest: sha256:0bc3426fe6b293fc1ecb8a9dae9277ea01aebbdc2de017c354f3197c82334f01
-generated: "2020-10-12T04:11:19.996265326Z"

--- a/bitnami/kafka/requirements.yaml
+++ b/bitnami/kafka/requirements.yaml
@@ -1,5 +1,0 @@
-dependencies:
-  - name: zookeeper
-    version: 5.x.x
-    repository: https://charts.bitnami.com/bitnami
-    condition: zookeeper.enabled

--- a/bitnami/kafka/values-production.yaml
+++ b/bitnami/kafka/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/kafka
-  tag: 2.6.0-debian-10-r57
+  tag: 2.6.0-debian-10-r78
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -520,7 +520,7 @@ externalAccess:
     image:
       registry: docker.io
       repository: bitnami/kubectl
-      tag: 1.17.12-debian-10-r30
+      tag: 1.17.13-debian-10-r21
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -690,7 +690,7 @@ metrics:
     image:
       registry: docker.io
       repository: bitnami/kafka-exporter
-      tag: 1.2.0-debian-10-r247
+      tag: 1.2.0-debian-10-r277
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -778,7 +778,7 @@ metrics:
     image:
       registry: docker.io
       repository: bitnami/jmx-exporter
-      tag: 0.14.0-debian-10-r43
+      tag: 0.14.0-debian-10-r64
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/kafka
-  tag: 2.6.0-debian-10-r57
+  tag: 2.6.0-debian-10-r78
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -525,7 +525,7 @@ externalAccess:
     image:
       registry: docker.io
       repository: bitnami/kubectl
-      tag: 1.17.12-debian-10-r30
+      tag: 1.17.13-debian-10-r21
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -695,7 +695,7 @@ metrics:
     image:
       registry: docker.io
       repository: bitnami/kafka-exporter
-      tag: 1.2.0-debian-10-r247
+      tag: 1.2.0-debian-10-r277
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -783,7 +783,7 @@ metrics:
     image:
       registry: docker.io
       repository: bitnami/jmx-exporter
-      tag: 0.14.0-debian-10-r43
+      tag: 0.14.0-debian-10-r64
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
**Description of the change**

- Bump `apiVersion` from `v1` to `v2` in _Chart.yaml_
- Fields in _Chart.yaml_ file has been ordered alphabetically
- Move dependency information from the _requirements.yaml_ to the _Chart.yaml_
- After running `helm dependency update`, a new _Chart.lock_ file is generated containing the same structure used in the previous _requirements.lock_
- Update _README.md_

**Possible drawbacks**

Helm v2 is no longer supported
