### PR TITLE
[bitnami/nginx] Adding sidecar support 

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -25,4 +25,4 @@ name: nginx
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx
   - http://www.nginx.org
-version: 8.0.0
+version: 8.1.0

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -116,6 +116,7 @@ The following tables lists the configurable parameters of the NGINX chart and th
 | `autoscaling.targetMemory`              | Target Memory utilization percentage                                                     | `nil`                                                   |
 | `extraVolumes`                          | Array to add extra volumes                                                               | `[]` (evaluated as a template)                          |
 | `extraVolumeMounts`                     | Array to add extra mount                                                                 | `[]` (evaluated as a template)                          |
+| `sidecars`                              | Attach additional containers to nginx pods                                               | `nil`
 
 ### Custom NGINX application parameters
 

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -239,6 +239,9 @@ spec:
           resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
           {{- end }}
         {{- end }}
+        {{- with .Values.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8}}
+        {{- end }}
       volumes:
         - name: nginx-server-block-paths
           configMap:

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -476,7 +476,7 @@ ldapDaemon:
 #     ports:
 #       - name: portname
 #         containerPort: 1234
-
+sidecars:
 ## Ingress paramaters
 ##
 ingress:

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -467,6 +467,16 @@ ldapDaemon:
   ##
   customReadinessProbe: {}
 
+## Sidecar paramaters
+##
+sidecars:
+  - name: your-image-name
+    image: your-image
+    imagePullPolicy: Always
+    ports:
+      - name: portname
+        containerPort: 1234
+
 ## Ingress paramaters
 ##
 ingress:

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -469,13 +469,13 @@ ldapDaemon:
 
 ## Sidecar paramaters
 ##
-sidecars:
-  - name: your-image-name
-    image: your-image
-    imagePullPolicy: Always
-    ports:
-      - name: portname
-        containerPort: 1234
+# sidecars:
+#   - name: your-image-name
+#     image: your-image
+#     imagePullPolicy: Always
+#     ports:
+#       - name: portname
+#         containerPort: 1234
 
 ## Ingress paramaters
 ##


### PR DESCRIPTION
**Description of the change**

Adding sidecar support to nginx

**Benefits**

The chart will support sidecars for deployments


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
