### PR TITLE
[bitnami/mongodb] Fix prometheus rules

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 10.0.0
+version: 10.0.1

--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -510,6 +510,27 @@ As the image run as non-root by default, it is necessary to adjust the ownership
 
 As an alternative, this chart supports using an initContainer to change the ownership of the volume before mounting it in the final destination. You can enable this initContainer by setting `volumePermissions.enabled` to `true`.
 
+## Using Prometheus rules
+
+You can use custom Prometheus rules for Prometheus operator by using the `prometheusRule` parameter, see below a basic configuration example:
+
+```yaml
+metrics:
+  enabled: true
+  prometheusRule:
+    enabled: true
+    rules:
+    - name: rule1
+      rules:
+      - alert: HighRequestLatency
+        expr: job:request_latency_seconds:mean5m{job="myjob"} > 0.5
+        for: 10m
+        labels:
+          severity: page
+        annotations:
+          summary: High request latency
+```
+
 ## Enabling SSL/TLS
 
 This container supports enabling SSL/TLS between nodes in the cluster, as well as between mongo clients and nodes, by setting the MONGODB_EXTRA_FLAGS and MONGODB_CLIENT_EXTRA_FLAGS environment variables, together with the correct MONGODB_ADVERTISED_HOSTNAME.

--- a/bitnami/mongodb/templates/prometheusrule.yaml
+++ b/bitnami/mongodb/templates/prometheusrule.yaml
@@ -10,5 +10,6 @@ metadata:
     {{- end }}
 spec:
   groups:
-    {{- include "common.tplvalues.render" (dict "value" .Values.metrics.prometheusRule.rules "context" $) | nindent 4 }}
+  - rules:
+      {{- include "common.tplvalues.render" (dict "value" .Values.metrics.prometheusRule.rules "context" $) | nindent 4 }}
 {{- end }}

--- a/bitnami/mongodb/templates/prometheusrule.yaml
+++ b/bitnami/mongodb/templates/prometheusrule.yaml
@@ -10,6 +10,5 @@ metadata:
     {{- end }}
 spec:
   groups:
-  - rules:
-      {{- include "common.tplvalues.render" (dict "value" .Values.metrics.prometheusRule.rules "context" $) | nindent 4 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.metrics.prometheusRule.rules "context" $) | nindent 2 }}
 {{- end }}

--- a/bitnami/mongodb/values-production.yaml
+++ b/bitnami/mongodb/values-production.yaml
@@ -90,7 +90,7 @@ auth:
   # existingSecret: name-of-existing-secret
 
 tls:
- ## Enable or disable MongoDB TLS Support 
+ ## Enable or disable MongoDB TLS Support
   enabled: false
  ##
  ## Bitnami Nginx image
@@ -913,8 +913,20 @@ metrics:
     ## Specify the namespace where Prometheus Operator is running
     ##
     # namespace: monitoring
+
     ## Define individual alerting rules as required
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#rulegroup
     ##      https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
+    ##
+    ## This is an example of a rule, you should add the below code block under the "rules" param, removing the brackets
+    ## - name: example
+    ##   rules:
+    ##   - alert: HighRequestLatency
+    ##     expr: job:request_latency_seconds:mean5m{job="myjob"} > 0.5
+    ##     for: 10m
+    ##     labels:
+    ##       severity: page
+    ##     annotations:
+    ##       summary: High request latency
     ##
     rules: {}

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -913,8 +913,20 @@ metrics:
     ## Specify the namespace where Prometheus Operator is running
     ##
     # namespace: monitoring
+
     ## Define individual alerting rules as required
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#rulegroup
     ##      https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
+    ##
+    ## This is an example of a rule, you should add the below code block under the "rules" param, removing the brackets
+    ## - name: example
+    ##   rules:
+    ##   - alert: HighRequestLatency
+    ##     expr: job:request_latency_seconds:mean5m{job="myjob"} > 0.5
+    ##     for: 10m
+    ##     labels:
+    ##       severity: page
+    ##     annotations:
+    ##       summary: High request latency
     ##
     rules: {}


### PR DESCRIPTION
**Description of the change**

Add `- name:` and `rules:` to follow the prometheus rules format, see https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/. Without that, the rules are copied from the _values.yaml_ but without the proper "header".

Example of _my-values.yaml_:
```yaml
metrics:
  enabled: true
  prometheusRule:
    enabled: true
    rules:
    - name: rule1
      rules:
      - alert: HighRequestLatency
        expr: job:request_latency_seconds:mean5m{job="myjob"} > 0.5
        for: 10m
        labels:
          severity: page
        annotations:
          summary: High request latency
```
```console
$ helm template mongodb . -f my-values.yaml -s templates/prometheusrule.yaml
# Source: mongodb/templates/prometheusrule.yaml
apiVersion: monitoring.coreos.com/v1
kind: PrometheusRule
metadata:
  name: mongodb
  namespace: default
  labels:
    app.kubernetes.io/name: mongodb
    helm.sh/chart: mongodb-10.0.1
    app.kubernetes.io/instance: mongodb
    app.kubernetes.io/managed-by: Helm
spec:
  groups:
  - name: rule1
    rules:
    - alert: HighRequestLatency
      annotations:
        summary: High request latency
      expr: job:request_latency_seconds:mean5m{job="myjob"} > 0.5
      for: 10m
      labels:
        severity: page
```

**Applicable issues**

  - fixes #4253

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
