### PR TITLE
[bitnami/mysql] feat: add annotations for master and slave replicasets

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -19,4 +19,4 @@ name: mysql
 sources:
   - https://github.com/bitnami/bitnami-docker-mysql
   - https://mysql.com
-version: 7.0.1
+version: 7.1.0

--- a/bitnami/mysql/templates/master-statefulset.yaml
+++ b/bitnami/mysql/templates/master-statefulset.yaml
@@ -275,6 +275,12 @@ spec:
           component: master
           release: {{ .Release.Name }}
           heritage: {{ .Release.Service }}
+        {{- with .Values.master.persistence.annotations }}
+        annotations:
+          {{- range $key, $value := . }}
+          {{ $key }}: {{ $value }}
+        {{- end }}
+        {{- end }}
       spec:
         accessModes:
         {{- range .Values.master.persistence.accessModes }}

--- a/bitnami/mysql/templates/slave-statefulset.yaml
+++ b/bitnami/mysql/templates/slave-statefulset.yaml
@@ -251,6 +251,12 @@ spec:
           component: slave
           release: {{ .Release.Name }}
           heritage: {{ .Release.Service }}
+        {{- with .Values.slave.persistence.annotations }}
+        annotations:
+          {{- range $key, $value := . }}
+          {{ $key }}: {{ $value }}
+        {{- end }}
+        {{- end }}
       spec:
         accessModes:
         {{- range .Values.slave.persistence.accessModes }}


### PR DESCRIPTION
**Description of the change**
Adding missing annotations to persistent volume claim template in master and slave statefulsets.

Annotations values are present in value.yaml but not in the chart.

**Benefits**
Use annotations on persistent volume claim template.

**Possible drawbacks**
N/A

**Applicable issues**
N/A

**Please run any tests or examples that can exercise your modified code.**
By adding the following In values.yaml file :
```
master:
  persistence 
    annotations:
      volume.beta.kubernetes.io/storage-class: "default"
slave:
  persistence 
    annotations:
      volume.beta.kubernetes.io/storage-class: "default"
```
Helm rendering with helm command : `helm template .`
```
...
  volumeClaimTemplates:
    - metadata:
        name: data
        labels:
          app: mysql
          component: master
          release: RELEASE-NAME
          heritage: Helm
        annotations:
          volume.beta.kubernetes.io/storage-class: default
...
---
...
  volumeClaimTemplates:
    - metadata:
        name: data
        labels:
          app: mysql
          component: slave
          release: RELEASE-NAME
          heritage: Helm
        annotations:
          volume.beta.kubernetes.io/storage-class: default
...
---
```

**Additional information**
N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
