### PR TITLE
[bitnami/postgresql-ha] Parameterize postgresql-ha namespace

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -27,4 +27,4 @@ name: postgresql-ha
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 6.0.0
+version: 6.1.0

--- a/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
@@ -85,7 +85,6 @@ spec:
       {{- $postgresqlReplicaCount := int .Values.postgresql.replicaCount }}
       {{- $postgresqlFullname := include "postgresql-ha.postgresql" . }}
       {{- $postgresqlHeadlessServiceName := printf "%s-headless" (include "postgresql-ha.postgresql" .) }}
-      {{- $releaseNamespace := .Release.Namespace }}
       {{- $clusterDomain:= .Values.clusterDomain }}
       containers:
         - name: pgpool
@@ -118,8 +117,12 @@ spec:
                   name: {{ include "postgresql-ha.pgpoolCustomUsersSecretName" . }}
                   key: passwords
             {{- end }}
+            - name: PGPOOL_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: PGPOOL_BACKEND_NODES
-              value: {{range $e, $i := until $postgresqlReplicaCount }}{{ $i }}:{{ $postgresqlFullname }}-{{ $i }}.{{ $postgresqlHeadlessServiceName }}.{{ $releaseNamespace }}.svc.{{ $clusterDomain }}:5432,{{ end }}
+              value: {{range $e, $i := until $postgresqlReplicaCount }}{{ $i }}:{{ $postgresqlFullname }}-{{ $i }}.{{ $postgresqlHeadlessServiceName }}.$(PGPOOL_NAMESPACE).svc.{{ $clusterDomain }}:5432,{{ end }}
             - name: PGPOOL_SR_CHECK_USER
               value: {{ (include "postgresql-ha.postgresqlRepmgrUsername" .) | quote }}
             {{- if .Values.postgresql.usePasswordFile }}

--- a/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
@@ -108,7 +108,6 @@ spec:
           {{- $postgresqlReplicaCount := int .Values.postgresql.replicaCount }}
           {{- $postgresqlFullname := include "postgresql-ha.postgresql" . }}
           {{- $postgresqlHeadlessServiceName := printf "%s-headless" (include "postgresql-ha.postgresql" .) }}
-          {{- $releaseNamespace := .Release.Namespace }}
           {{- $clusterDomain:= .Values.clusterDomain }}
           env:
             - name: BITNAMI_DEBUG
@@ -213,14 +212,18 @@ spec:
               value: {{ ternary "yes" "no" .Values.postgresql.pgHbaTrustAll | quote }}
             - name: REPMGR_MOUNTED_CONF_DIR
               value: "/bitnami/repmgr/conf"
+            - name: REPMGR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: REPMGR_PARTNER_NODES
-              value: {{range $e, $i := until $postgresqlReplicaCount }}{{ $postgresqlFullname }}-{{ $i }}.{{ $postgresqlHeadlessServiceName }}.{{ $releaseNamespace }}.svc.{{ $clusterDomain }},{{ end }}
+              value: {{range $e, $i := until $postgresqlReplicaCount }}{{ $postgresqlFullname }}-{{ $i }}.{{ $postgresqlHeadlessServiceName }}.$(REPMGR_NAMESPACE).svc.{{ $clusterDomain }},{{ end }}
             - name: REPMGR_PRIMARY_HOST
-              value: {{ printf "%s-0.%s.%s.svc.%s" $postgresqlFullname $postgresqlHeadlessServiceName .Release.Namespace $clusterDomain | quote }}
+              value: {{ printf "%s-0.%s.$(REPMGR_NAMESPACE).svc.%s" $postgresqlFullname $postgresqlHeadlessServiceName $clusterDomain | quote }}
             - name: REPMGR_NODE_NAME
               value: "$(MY_POD_NAME)"
             - name: REPMGR_NODE_NETWORK_NAME
-              value: "$(MY_POD_NAME).{{ $postgresqlHeadlessServiceName }}.{{ .Release.Namespace }}.svc.{{ $clusterDomain }}"
+              value: "$(MY_POD_NAME).{{ $postgresqlHeadlessServiceName }}.$(REPMGR_NAMESPACE).svc.{{ $clusterDomain }}"
             - name: REPMGR_LOG_LEVEL
               value: {{ .Values.postgresql.repmgrLogLevel | quote }}
             - name: REPMGR_CONNECT_TIMEOUT


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This creates a dedicated environment variable to retrieve the current namespace, and it pulls this from the pod's definition of what namespace it resides in.  This makes it easier for tools that run `helm template` to properly move things into different namespaces.

**Benefits**

Allows better composability of Bitnami charts with tools like [kapp](https://get-kapp.io/).  This introduces no new variables.

**Possible drawbacks**

Not entirely sure, if existing tools were overwriting the fields this changes then they will continue to function undisturbed.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
