### PR TITLE
[bitnami/kiam] Use the latest common version and update prerequisites

### DIFF
--- a/bitnami/kiam/Chart.lock
+++ b/bitnami/kiam/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.0.0
+digest: sha256:a2093836b2b6a85d7bf34143d3159b5c413c5e7423bde212de9cb416c985b976
+generated: "2020-11-12T19:00:03.084330714Z"

--- a/bitnami/kiam/Chart.yaml
+++ b/bitnami/kiam/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
     repository: 'https://charts.bitnami.com/bitnami'
     tags:
       - bitnami-common
-    version: 0.x.x
+    version: 1.x.x
 description: kiam is a proxy that captures AWS Metadata API requests. It allows AWS IAM roles to be set for Kubernetes workloads.
 engine: gotpl
 home: 'https://github.com/uswitch/kiam'
@@ -23,4 +23,4 @@ name: kiam
 sources:
   - 'https://github.com/bitnami/bitnami-docker-kiam'
   - 'https://github.com/uswitch/kiam'
-version: 0.1.0
+version: 0.1.1

--- a/bitnami/kiam/README.md
+++ b/bitnami/kiam/README.md
@@ -22,7 +22,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 ## Prerequisites
 
 - Kubernetes 1.12+ in AWS
-- Helm 2.12+ or Helm 3.0-beta3+
+- Helm 3.0-beta3+
 
 ## Installing the Chart
 


### PR DESCRIPTION
Use the latest common version and update prerequisites. A major is not needed since the major version bump in the common subchart is due to the change in the apiVersion, as the parent chart is already using `apiVersion: v2` there are no breaking changes.

In the same way as the parent chart and the subchart are using `apiVersion: v2`, Helm 2 is not supported anymore and the prerequisites should be modified.