### PR TITLE
[bitname/memcached] Only add secret and env vars when auth is enabled

### DIFF
--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -16,4 +16,4 @@ name: memcached
 sources:
   - https://github.com/bitnami/bitnami-docker-memcached
   - http://memcached.org/
-version: 5.0.0
+version: 5.1.0

--- a/bitnami/memcached/templates/deployment.yaml
+++ b/bitnami/memcached/templates/deployment.yaml
@@ -44,13 +44,17 @@ spec:
           env:
             - name: BITNAMI_DEBUG
               value: {{ ternary "true" "false" .Values.image.debug | quote }}
+            {{- if .Values.memcachedUsername }}
             - name: MEMCACHED_USERNAME
-              value: {{ default "" .Values.memcachedUsername | quote }}
+              value: {{ .Values.memcachedUsername | quote }}
+            {{- end }}
+            {{- if .Values.memcachedPassword }}
             - name: MEMCACHED_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "memcached.fullname" . }}
                   key: memcached-password
+            {{- end }}
             {{- if .Values.extraEnv }}
             {{- toYaml .Values.extraEnv | nindent 12 }}
             {{- end }}

--- a/bitnami/memcached/templates/secrets.yaml
+++ b/bitnami/memcached/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.memcachedPassword }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,4 +6,5 @@ metadata:
   labels: {{- include "memcached.labels" . | nindent 4 }}
 type: Opaque
 data:
-  memcached-password: {{ default "" .Values.memcachedPassword | b64enc | quote }}
+  memcached-password: {{ .Values.memcachedPassword | b64enc | quote }}
+{{- end }}

--- a/bitnami/memcached/templates/statefulset.yaml
+++ b/bitnami/memcached/templates/statefulset.yaml
@@ -51,17 +51,23 @@ spec:
           {{- if .Values.persistence.enabled }}
             - -e/cache-state/memory_file
           {{- end }}
+          {{- if or .Values.extraEnv .Values.memcachedUsername .Values.memcachedPassword }}
           env:
+            {{- if .Values.memcachedUsername }}
             - name: MEMCACHED_USERNAME
-              value: {{ default "" .Values.memcachedUsername | quote }}
+              value: {{ .Values.memcachedUsername | quote }}
+            {{- end }}
+            {{- if .Values.memcachedPassword }}
             - name: MEMCACHED_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "memcached.fullname" . }}
                   key: memcached-password
+            {{- end }}
             {{- if .Values.extraEnv }}
             {{- toYaml .Values.extraEnv | nindent 12 }}
             {{- end }}
+          {{- end }}
           ports:
             - name: memcache
               containerPort: 11211


### PR DESCRIPTION
With this change, the secret for the password is only created if
the password is set. Environment variables for user and passwords
are only added if values are set.

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
