### PR TITLE
[bitnami/rabbitmq] Fixing support for loading definitions

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: rabbitmq
-version: 7.7.1
+version: 7.7.2
 appVersion: 3.8.9
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/bitnami/rabbitmq/README.md
+++ b/bitnami/rabbitmq/README.md
@@ -63,55 +63,55 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 
 ### RabbitMQ parameters
 
-| Parameter                                 | Description                                                                                                          | Default                                                      |
-|-------------------------------------------|----------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `image.registry`                          | RabbitMQ image registry                                                                                              | `docker.io`                                                  |
-| `image.repository`                        | RabbitMQ image name                                                                                                  | `bitnami/rabbitmq`                                           |
-| `image.tag`                               | RabbitMQ image tag                                                                                                   | `{TAG_NAME}`                                                 |
-| `image.pullPolicy`                        | RabbitMQ image pull policy                                                                                           | `IfNotPresent`                                               |
-| `image.pullSecrets`                       | Specify docker-registry secret names as an array                                                                     | `[]` (does not add image pull secrets to deployed pods)      |
-| `image.debug`                             | Set to true if you would like to see extra information on logs                                                       | `false`                                                      |
-| `auth.username`                           | RabbitMQ application username                                                                                        | `user`                                                       |
-| `auth.password`                           | RabbitMQ application password                                                                                        | _random 10 character long alphanumeric string_               |
-| `auth.existingPasswordSecret`             | Existing secret with RabbitMQ credentials                                                                            | `nil` (evaluated as a template)                              |
-| `auth.erlangCookie`                       | Erlang cookie                                                                                                        | _random 32 character long alphanumeric string_               |
-| `auth.existingErlangSecret`               | Existing secret with RabbitMQ Erlang cookie                                                                          | `nil`                                                        |
-| `auth.tls.enabled`                        | Enable TLS support on RabbitMQ                                                                                       | `false`                                                      |
-| `auth.tls.failIfNoPeerCert`               | When set to true, TLS connection will be rejected if client fails to provide a certificate                           | `true`                                                       |
-| `auth.tls.sslOptionsVerify`               | Should [peer verification](https://www.rabbitmq.com/ssl.html#peer-verification) be enabled?                          | `verify_peer`                                                |
-| `auth.tls.caCertificate`                  | Certificate Authority (CA) bundle content                                                                            | `nil`                                                        |
-| `auth.tls.serverCertificate`              | Server certificate content                                                                                           | `nil`                                                        |
-| `auth.tls.serverKey`                      | Server private key content                                                                                           | `nil`                                                        |
-| `auth.tls.existingSecret`                 | Existing secret with certificate content to RabbitMQ credentials                                                     | `nil`                                                        |
-| `logs`                                    | Path of the RabbitMQ server's Erlang log file                                                                        | `-`                                                          |
-| `ulimitNofiles`                           | Max File Descriptor limit                                                                                            | `65536`                                                      |
-| `maxAvailableSchedulers`                  | RabbitMQ maximum available scheduler threads                                                                         | `2`                                                          |
-| `onlineSchedulers`                        | RabbitMQ online scheduler threads                                                                                    | `1`                                                          |
-| `memoryHighWatermark.enabled`             | Enable configuring Memory high watermark on RabbitMQ                                                                 | `false`                                                      |
-| `memoryHighWatermark.type`                | Memory high watermark type. Either `absolute` or `relative`                                                          | `relative`                                                   |
-| `memoryHighWatermark.value`               | Memory high watermark value                                                                                          | `0.4`                                                        |
-| `plugins`                                 | List of plugins to enable                                                                                            | `rabbitmq_management rabbitmq_peer_discovery_k8s`            |
-| `communityPlugins`                        | List of custom plugins (URLs) to be downloaded during container initialization                                       | `nil`                                                        |
-| `extraPlugins`                            | Extra plugins to enable                                                                                              | `nil`                                                        |
-| `clustering.addressType`                  | Switch clustering mode. Either `ip` or `hostname`                                                                    | `hostname`                                                   |
-| `clustering.rebalance`                    | Rebalance master for queues in cluster when new replica is created                                                   | `false`                                                      |
-| `clustering.forceBoot`                    | Rebalance master for queues in cluster when new replica is created                                                   | `false`                                                      |
-| `loadDefinition.enabled`                  | Enable loading a RabbitMQ definitions file to configure RabbitMQ                                                     | `false`                                                      |
-| `loadDefinition.existingSecret`           | Existing secret with the load definitions file                                                                       | `nil`                                                        |
-| `command`                                 | Override default container command (useful when using custom images)                                                 | `nil`                                                        |
-| `args`                                    | Override default container args (useful when using custom images)                                                    | `nil`                                                        |
-| `extraEnvVars`                            | Extra environment variables to add to RabbitMQ pods                                                                  | `[]`                                                         |
-| `extraEnvVarsCM`                          | Name of existing ConfigMap containing extra env vars                                                                 | `nil`                                                        |
-| `extraEnvVarsSecret`                      | Name of existing Secret containing extra env vars (in case of sensitive data)                                        | `nil`                                                        |
-| `extraContainerPorts`                     | Extra ports to be included in container spec, primarily informational                                                | `[]`                                                         |
-| `configuration`                           | RabbitMQ configuration                                                                                               | Check `values.yaml` file                                     |
-| `extraConfiguration`                      | Extra configuration to be appended to RabbitMQ configuration                                                         | Check `values.yaml` file                                     |
-| `advancedConfiguration`                   | Extra configuration (in classic format)                                                                              | Check `values.yaml` file                                     |
-| `ldap.enabled`                            | Enable LDAP support                                                                                                  | `false`                                                      |
-| `ldap.servers`                            | List of LDAP servers hostnames                                                                                       | `[]`                                                         |
-| `ldap.port`                               | LDAP servers port                                                                                                    | `389`                                                        |
-| `ldap.user_dn_pattern`                    | Pattern used to translate the provided username into a value to be used for the LDAP bind                            | `cn=${username},dc=example,dc=org`                           |
-| `ldap.tls.enabled`                        | Enable TLS for LDAP connections (check advancedConfiguration parameter in values.yml)                                | `false`                                                      |
+| Parameter                       | Description                                                                                                                    | Default                                                 |
+|---------------------------------|--------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `image.registry`                | RabbitMQ image registry                                                                                                        | `docker.io`                                             |
+| `image.repository`              | RabbitMQ image name                                                                                                            | `bitnami/rabbitmq`                                      |
+| `image.tag`                     | RabbitMQ image tag                                                                                                             | `{TAG_NAME}`                                            |
+| `image.pullPolicy`              | RabbitMQ image pull policy                                                                                                     | `IfNotPresent`                                          |
+| `image.pullSecrets`             | Specify docker-registry secret names as an array                                                                               | `[]` (does not add image pull secrets to deployed pods) |
+| `image.debug`                   | Set to true if you would like to see extra information on logs                                                                 | `false`                                                 |
+| `auth.username`                 | RabbitMQ application username                                                                                                  | `user`                                                  |
+| `auth.password`                 | RabbitMQ application password                                                                                                  | _random 10 character long alphanumeric string_          |
+| `auth.existingPasswordSecret`   | Existing secret with RabbitMQ credentials                                                                                      | `nil` (evaluated as a template)                         |
+| `auth.erlangCookie`             | Erlang cookie                                                                                                                  | _random 32 character long alphanumeric string_          |
+| `auth.existingErlangSecret`     | Existing secret with RabbitMQ Erlang cookie                                                                                    | `nil`                                                   |
+| `auth.tls.enabled`              | Enable TLS support on RabbitMQ                                                                                                 | `false`                                                 |
+| `auth.tls.failIfNoPeerCert`     | When set to true, TLS connection will be rejected if client fails to provide a certificate                                     | `true`                                                  |
+| `auth.tls.sslOptionsVerify`     | Should [peer verification](https://www.rabbitmq.com/ssl.html#peer-verification) be enabled?                                    | `verify_peer`                                           |
+| `auth.tls.caCertificate`        | Certificate Authority (CA) bundle content                                                                                      | `nil`                                                   |
+| `auth.tls.serverCertificate`    | Server certificate content                                                                                                     | `nil`                                                   |
+| `auth.tls.serverKey`            | Server private key content                                                                                                     | `nil`                                                   |
+| `auth.tls.existingSecret`       | Existing secret with certificate content to RabbitMQ credentials                                                               | `nil`                                                   |
+| `logs`                          | Path of the RabbitMQ server's Erlang log file                                                                                  | `-`                                                     |
+| `ulimitNofiles`                 | Max File Descriptor limit                                                                                                      | `65536`                                                 |
+| `maxAvailableSchedulers`        | RabbitMQ maximum available scheduler threads                                                                                   | `2`                                                     |
+| `onlineSchedulers`              | RabbitMQ online scheduler threads                                                                                              | `1`                                                     |
+| `memoryHighWatermark.enabled`   | Enable configuring Memory high watermark on RabbitMQ                                                                           | `false`                                                 |
+| `memoryHighWatermark.type`      | Memory high watermark type. Either `absolute` or `relative`                                                                    | `relative`                                              |
+| `memoryHighWatermark.value`     | Memory high watermark value                                                                                                    | `0.4`                                                   |
+| `plugins`                       | List of plugins to enable                                                                                                      | `rabbitmq_management rabbitmq_peer_discovery_k8s`       |
+| `communityPlugins`              | List of custom plugins (URLs) to be downloaded during container initialization                                                 | `nil`                                                   |
+| `extraPlugins`                  | Extra plugins to enable                                                                                                        | `nil`                                                   |
+| `clustering.addressType`        | Switch clustering mode. Either `ip` or `hostname`                                                                              | `hostname`                                              |
+| `clustering.rebalance`          | Rebalance master for queues in cluster when new replica is created                                                             | `false`                                                 |
+| `clustering.forceBoot`          | Rebalance master for queues in cluster when new replica is created                                                             | `false`                                                 |
+| `loadDefinition.enabled`        | Enable loading a RabbitMQ definitions file to configure RabbitMQ. Enabling this also means that `auth.password` won't be used. | `false`                                                 |
+| `loadDefinition.existingSecret` | Existing secret with the load definitions file                                                                                 | `nil`                                                   |
+| `command`                       | Override default container command (useful when using custom images)                                                           | `nil`                                                   |
+| `args`                          | Override default container args (useful when using custom images)                                                              | `nil`                                                   |
+| `extraEnvVars`                  | Extra environment variables to add to RabbitMQ pods                                                                            | `[]`                                                    |
+| `extraEnvVarsCM`                | Name of existing ConfigMap containing extra env vars                                                                           | `nil`                                                   |
+| `extraEnvVarsSecret`            | Name of existing Secret containing extra env vars (in case of sensitive data)                                                  | `nil`                                                   |
+| `extraContainerPorts`           | Extra ports to be included in container spec, primarily informational                                                          | `[]`                                                    |
+| `configuration`                 | RabbitMQ configuration                                                                                                         | Check `values.yaml` file                                |
+| `extraConfiguration`            | Extra configuration to be appended to RabbitMQ configuration                                                                   | Check `values.yaml` file                                |
+| `advancedConfiguration`         | Extra configuration (in classic format)                                                                                        | Check `values.yaml` file                                |
+| `ldap.enabled`                  | Enable LDAP support                                                                                                            | `false`                                                 |
+| `ldap.servers`                  | List of LDAP servers hostnames                                                                                                 | `[]`                                                    |
+| `ldap.port`                     | LDAP servers port                                                                                                              | `389`                                                   |
+| `ldap.user_dn_pattern`          | Pattern used to translate the provided username into a value to be used for the LDAP bind                                      | `cn=${username},dc=example,dc=org`                      |
+| `ldap.tls.enabled`              | Enable TLS for LDAP connections (check advancedConfiguration parameter in values.yml)                                          | `false`                                                 |
 
 ### Statefulset parameters
 
@@ -396,6 +396,13 @@ type: Opaque
 stringData:
   load_definition.json: |-
     {
+      "users": [
+        {
+          "name": "user",
+          "password": "secretpassword",
+          "tags": "administrator"
+        }
+      ],
       "vhosts": [
         {
           "name": "/"
@@ -415,6 +422,13 @@ extraSecrets:
   load-definition:
     load_definition.json: |
       {
+        "users": [
+          {
+            "name": "user",
+            "password": "secretpassword",
+            "tags": "administrator"
+          }
+        ],
         "vhosts": [
           {
             "name": "/"
@@ -427,6 +441,10 @@ loadDefinition:
 extraConfiguration: |
   load_definitions = /app/load_definition.json
 ```
+
+The example definition files above contains the bare minumum: When loading definitions no default vhost is created.  Also to set the password for the
+user specified with `auth.username` to anything else than what is set in `configuration` it needs to specified in the
+definitions file as well. The default `configuration` sets the password to CHANGEME.
 
 ### LDAP
 

--- a/bitnami/rabbitmq/requirements.lock
+++ b/bitnami/rabbitmq/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 0.9.0
-digest: sha256:ccf956b06766e5af946354f49211badc949847abf87d355c5d93224b45adf0bb
-generated: "2020-10-21T21:58:28.899053695Z"
+  version: 0.10.0
+digest: sha256:62cdd880ecba8ce147f94177c11135d655ff6548cee448edc098b6cab658a88d
+generated: "2020-11-05T12:30:35.282832+01:00"

--- a/bitnami/rabbitmq/templates/secrets.yaml
+++ b/bitnami/rabbitmq/templates/secrets.yaml
@@ -8,6 +8,7 @@ metadata:
 type: Opaque
 data:
   {{- if not .Values.auth.existingPasswordSecret }}
+  rabbitmq-username: {{ .Values.auth.username | b64enc | quote }}
   {{- if .Values.auth.password }}
   rabbitmq-password: {{ .Values.auth.password | b64enc | quote }}
   {{- else }}

--- a/bitnami/rabbitmq/templates/statefulset.yaml
+++ b/bitnami/rabbitmq/templates/statefulset.yaml
@@ -153,11 +153,16 @@ spec:
                   key: rabbitmq-erlang-cookie
             - name: RABBITMQ_USERNAME
               value: {{ .Values.auth.username | quote }}
+            {{- if .Values.loadDefinition.enabled }}
+            - name: RABBITMQ_LOAD_DEFINITIONS
+              value: "yes"
+            {{- else }}
             - name: RABBITMQ_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "rabbitmq.secretPasswordName" . }}
                   key: rabbitmq-password
+            {{- end }}
             - name: RABBITMQ_PLUGINS
               value: {{ include "rabbitmq.plugins" . | quote }}
             {{- if .Values.communityPlugins }}

--- a/bitnami/rabbitmq/values-production.yaml
+++ b/bitnami/rabbitmq/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/rabbitmq
-  tag: 3.8.9-debian-10-r20
+  tag: 3.8.9-debian-10-r42
 
   ## set to true if you would like to see extra information on logs
   ## it turns BASH and NAMI debugging in minideb

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/rabbitmq
-  tag: 3.8.9-debian-10-r20
+  tag: 3.8.9-debian-10-r42
 
   ## set to true if you would like to see extra information on logs
   ## it turns BASH and NAMI debugging in minideb


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

The change allows for RABBITMQ_PASSWORD to not be set and when RABBITMQ_LOAD_DEFINITIONS is set instead the rabbitmq_initialize function won't try to change the password.

**Benefits**

It will again be possible to load definitions.

**Possible drawbacks**

Any user password needs to be explicitly set in the definition file. If not the password will stay as it is in rabbitmq.conf, which by default is CHANGEME when using the helm chart. I therefore expand the [documentation for loading definitions](https://github.com/bitnami/charts/tree/master/bitnami/rabbitmq#load-definitions) with the requirement to include user credentials in the definitions.  

**Applicable issues**

#3675


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
