### PR TITLE
[bitnami/rabbitmq] Allow for templating in extraSecrets

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -23,4 +23,4 @@ name: rabbitmq
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq
   - https://www.rabbitmq.com
-version: 8.0.2
+version: 8.0.3

--- a/bitnami/rabbitmq/README.md
+++ b/bitnami/rabbitmq/README.md
@@ -143,7 +143,7 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 | `sidecars`                                | Add additional sidecar containers to the RabbitMQ pod                                                                | `{}` (evaluated as a template)                               |
 | `extraVolumeMounts`                       | Optionally specify extra list of additional volumeMounts .                                                           | `{}`                                                         |
 | `extraVolumes`                            | Optionally specify extra list of additional volumes .                                                                | `{}`                                                         |
-| `extraSecrets`                            | Optionally specify extra secrets to be created by the chart.                                                         | `{}`                                                         |
+| `extraSecrets`                            | Optionally specify extra secrets to be created by the chart.                                                         | `{}` (evaluated as a template)                               |
 
 ### Exposure parameters
 
@@ -402,6 +402,13 @@ type: Opaque
 stringData:
   load_definition.json: |-
     {
+      "users": [
+        {
+          "name": "user",
+          "password": "CHANGEME",
+          "tags": "administrator"
+        }
+      ],
       "vhosts": [
         {
           "name": "/"
@@ -414,13 +421,20 @@ Then, specify the `load_definitions` property as an `extraConfiguration` pointin
 
 > Loading a definition will take precedence over any configuration done through [Helm values](#parameters).
 
-If needed, you can use `extraSecrets` to let the chart create the secret for you. This way, you don't need to manually create it before deploying a release. For example :
+If needed, you can use `extraSecrets` to let the chart create the secret for you. This way, you don't need to manually create it before deploying a release. These secrets can also be templated to use supplied chart values. For example:
 
 ```yaml
 extraSecrets:
   load-definition:
     load_definition.json: |
       {
+        "users": [
+          {
+            "name": "{{ .Values.auth.username }}",
+            "password": "{{ .Values.auth.password }}",
+            "tags": "administrator"
+          }
+        ],
         "vhosts": [
           {
             "name": "/"

--- a/bitnami/rabbitmq/templates/secrets.yaml
+++ b/bitnami/rabbitmq/templates/secrets.yaml
@@ -31,5 +31,5 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
 type: Opaque
-stringData: {{- $value | toYaml | nindent 2 }}
+stringData: {{- include "common.tplvalues.render" (dict "value" $value "context" $) | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 -->

**Description of the change**

Allow for the `extraSecrets` value to be templated.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Allows for dynamic values when supplying a load-definition:

Input: 
```yaml
extraSecrets:
  load-definition:
    load_definition.json: |
        {
          "vhosts": [
            {
              "name": "/"
            }
          ],
          "users": [
            {
              "name": "{{ .Values.auth.username}}",
              "password": "{{ .Values.auth.password}}",
              "tags": "administrator"
            }
          ],
          "permissions": [
            {
              "user": "{{ .Values.auth.username}}",
              "vhost": "/",
              "configure": ".*",
              "write": ".*",
              "read": ".*"
            }
          ],
          "policies": [
            {
              "name": "ha-all",
              "apply-to": "all",
              "pattern": ".*",
              "vhost": "/",
              "definition": {
                "ha-mode": "all",
                "ha-sync-mode": "automatic"
              }
            }
          ]
        }
```

Output:
```json
{
  "vhosts": [
    {
      "name": "/"
    }
  ],
  "users": [
    {
      "name": "something",
      "password": "something",
      "tags": "administrator"
    }
  ],
  "permissions": [
    {
      "user": "something",
      "vhost": "/",
      "configure": ".*",
      "write": ".*",
      "read": ".*"
    }
  ],
  "policies": [
    {
      "name": "ha-all",
      "apply-to": "all",
      "pattern": ".*",
      "vhost": "/",
      "definition": {
        "ha-mode": "all",
        "ha-sync-mode": "automatic"
      }
    }
  ]
}
```

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
