### PR TITLE
[bitnami/memcached] Add support for priorityClassName

### DIFF
--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -16,4 +16,4 @@ name: memcached
 sources:
   - https://github.com/bitnami/bitnami-docker-memcached
   - http://memcached.org/
-version: 5.1.0
+version: 5.2.0

--- a/bitnami/memcached/README.md
+++ b/bitnami/memcached/README.md
@@ -85,6 +85,7 @@ The following tables lists the configurable parameters of the Memcached chart an
 | `affinity`                               | Map of node/pod affinities                                                                             | `{}` (The value is evaluated as a template)                  |
 | `nodeSelector`                           | Node labels for pod assignment                                                                         | `{}` (The value is evaluated as a template)                  |
 | `tolerations`                            | Tolerations for pod assignment                                                                         | `[]` (The value is evaluated as a template)                  |
+| `priorityClassName`                      | Controller priorityClassName                                                                           | `nil`                                                        |
 | `metrics.enabled`                        | Start a side-car prometheus exporter                                                                   | `false`                                                      |
 | `metrics.image.registry`                 | Memcached exporter image registry                                                                      | `docker.io`                                                  |
 | `metrics.image.repository`               | Memcached exporter image name                                                                          | `bitnami/memcached-exporter`                                 |

--- a/bitnami/memcached/templates/deployment.yaml
+++ b/bitnami/memcached/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
       {{- if .Values.tolerations }}
       tolerations: {{- include "memcached.tplValue" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}

--- a/bitnami/memcached/templates/statefulset.yaml
+++ b/bitnami/memcached/templates/statefulset.yaml
@@ -32,6 +32,9 @@ spec:
       {{- if .Values.tolerations }}
       tolerations: {{- include "memcached.tplValue" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}

--- a/bitnami/memcached/values-production.yaml
+++ b/bitnami/memcached/values-production.yaml
@@ -129,6 +129,11 @@ nodeSelector: {}
 ##
 tolerations: {}
 
+## Pod priority
+## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+##
+# priorityClassName: ""
+
 ## Persistence - used for dumping and restoring states between recreations
 ## Ref: https://github.com/memcached/memcached/wiki/WarmRestart
 persistence:

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -129,6 +129,11 @@ nodeSelector: {}
 ##
 tolerations: {}
 
+## Pod priority
+## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+##
+# priorityClassName: ""
+
 ## Persistence - used for dumping and restoring states between recreations
 ## Ref: https://github.com/memcached/memcached/wiki/WarmRestart
 persistence:


### PR DESCRIPTION
**Description of the change**

Add support for setting priorityClassName to the standalone and HA
memcached deployments.

**Benefits**

- Give priority to memcached pods over other deployments

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files