### PR TITLE
[bitnami/mariadb][bitnami/common] Fix bad password validation with existingSecret

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: Infrastructure
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 1.0.0
+appVersion: 1.0.1
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://github.com/bitnami/charts/tree/master/bitnami/common
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -20,4 +20,4 @@ sources:
   - https://github.com/bitnami/charts
   - http://www.bitnami.com/
 type: library
-version: 1.0.0
+version: 1.0.1

--- a/bitnami/common/templates/validations/_mariadb.tpl
+++ b/bitnami/common/templates/validations/_mariadb.tpl
@@ -9,7 +9,7 @@ Params:
   - subchart - Boolean - Optional. Whether MariaDB is used as subchart or not. Default: false
 */}}
 {{- define "common.validations.values.mariadb.passwords" -}}
-  {{- $existingSecret := include "common.mariadb.values.existingSecret" . -}}
+  {{- $existingSecret := include "common.mariadb.values.auth.existingSecret" . -}}
   {{- $enabled := include "common.mariadb.values.enabled" . -}}
   {{- $architecture := include "common.mariadb.values.architecture" . -}}
   {{- $authPrefix := include "common.mariadb.values.key.auth" . -}}
@@ -44,15 +44,15 @@ Params:
 Auxiliar function to get the right value for existingSecret.
 
 Usage:
-{{ include "common.mariadb.values.existingSecret" (dict "context" $) }}
+{{ include "common.mariadb.values.auth.existingSecret" (dict "context" $) }}
 Params:
   - subchart - Boolean - Optional. Whether MariaDB is used as subchart or not. Default: false
 */}}
-{{- define "common.mariadb.values.existingSecret" -}}
+{{- define "common.mariadb.values.auth.existingSecret" -}}
   {{- if .subchart -}}
-    {{- .context.Values.mariadb.existingSecret | quote -}}
+    {{- .context.Values.mariadb.auth.existingSecret | quote -}}
   {{- else -}}
-    {{- .context.Values.existingSecret | quote -}}
+    {{- .context.Values.auth.existingSecret | quote -}}
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

Fix bad password validation when using an `existingSecret` as it was looking on a bad place.

Strangely, in my situation, the error only occurs on `upgrade`, not on `install`.

The change look for the name of the existing secret in `auth` as describe in the mariadb chart's README and `values.yaml`.

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files