### PR TITLE
[bitnami/suitecrm] Major version. Adapt Chart to apiVersion: v2 and Update MariaDB Dependency

### DIFF
--- a/bitnami/suitecrm/Chart.lock
+++ b/bitnami/suitecrm/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 9.0.1
 digest: sha256:6a5735e0b7e5868bbf3eec9d9d031eb20a5928dd38894899c5bccf2e8f7c5a61
-generated: "2020-11-17T16:21:59.451687995Z"
+generated: "2020-11-19T13:28:24.607144018Z"

--- a/bitnami/suitecrm/Chart.lock
+++ b/bitnami/suitecrm/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: mariadb
+  repository: https://charts.bitnami.com/bitnami
+  version: 9.0.1
+digest: sha256:6a5735e0b7e5868bbf3eec9d9d031eb20a5928dd38894899c5bccf2e8f7c5a61
+generated: "2020-11-17T16:21:59.451687995Z"

--- a/bitnami/suitecrm/Chart.yaml
+++ b/bitnami/suitecrm/Chart.yaml
@@ -3,24 +3,22 @@ annotations:
 apiVersion: v2
 appVersion: 7.11.18
 dependencies:
-- condition: mariadb.enabled
-  name: mariadb
-  repository: https://charts.bitnami.com/bitnami
-  version: 9.x.x
-description: SuiteCRM is a completely open source enterprise-grade Customer Relationship
-  Management (CRM) application. SuiteCRM is a software fork of the popular customer
-  relationship management (CRM) system SugarCRM.
+  - condition: mariadb.enabled
+    name: mariadb
+    repository: https://charts.bitnami.com/bitnami
+    version: 9.x.x
+description: SuiteCRM is a completely open source enterprise-grade Customer Relationship Management (CRM) application. SuiteCRM is a software fork of the popular customer relationship management (CRM) system SugarCRM.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/suitecrm
 icon: https://bitnami.com/assets/stacks/osclass/img/osclass-stack-110x117.png
 keywords:
-- suitecrm
-- CRM
+  - suitecrm
+  - CRM
 maintainers:
-- email: containers@bitnami.com
-  name: Bitnami
+  - email: containers@bitnami.com
+    name: Bitnami
 name: suitecrm
 sources:
-- https://github.com/bitnami/bitnami-docker-suitecrm
-- http://www.suitecrm.com
+  - https://github.com/bitnami/bitnami-docker-suitecrm
+  - http://www.suitecrm.com
 version: 9.0.0

--- a/bitnami/suitecrm/Chart.yaml
+++ b/bitnami/suitecrm/Chart.yaml
@@ -1,19 +1,26 @@
-apiVersion: v1
-name: suitecrm
-version: 8.0.27
-appVersion: 7.11.18
-description: SuiteCRM is a completely open source enterprise-grade Customer Relationship Management (CRM) application. SuiteCRM is a software fork of the popular customer relationship management (CRM) system SugarCRM.
-keywords:
-  - suitecrm
-  - CRM
-home: https://github.com/bitnami/charts/tree/master/bitnami/suitecrm
-sources:
-  - https://github.com/bitnami/bitnami-docker-suitecrm
-  - http://www.suitecrm.com
-maintainers:
-  - name: Bitnami
-    email: containers@bitnami.com
-engine: gotpl
-icon: https://bitnami.com/assets/stacks/osclass/img/osclass-stack-110x117.png
 annotations:
   category: CRM
+apiVersion: v2
+appVersion: 7.11.18
+dependencies:
+- condition: mariadb.enabled
+  name: mariadb
+  repository: https://charts.bitnami.com/bitnami
+  version: 9.x.x
+description: SuiteCRM is a completely open source enterprise-grade Customer Relationship
+  Management (CRM) application. SuiteCRM is a software fork of the popular customer
+  relationship management (CRM) system SugarCRM.
+engine: gotpl
+home: https://github.com/bitnami/charts/tree/master/bitnami/suitecrm
+icon: https://bitnami.com/assets/stacks/osclass/img/osclass-stack-110x117.png
+keywords:
+- suitecrm
+- CRM
+maintainers:
+- email: containers@bitnami.com
+  name: Bitnami
+name: suitecrm
+sources:
+- https://github.com/bitnami/bitnami-docker-suitecrm
+- http://www.suitecrm.com
+version: 8.0.0

--- a/bitnami/suitecrm/Chart.yaml
+++ b/bitnami/suitecrm/Chart.yaml
@@ -23,4 +23,4 @@ name: suitecrm
 sources:
 - https://github.com/bitnami/bitnami-docker-suitecrm
 - http://www.suitecrm.com
-version: 8.0.0
+version: 9.0.0

--- a/bitnami/suitecrm/README.md
+++ b/bitnami/suitecrm/README.md
@@ -237,7 +237,7 @@ export MARIADB_PASSWORD=$(kubectl get secret --namespace default suitecrm-mariad
 export MARIADB_PVC=$(kubectl get pvc -l app=mariadb,component=master,release=suitecrm -o jsonpath="{.items[0].metadata.name}")
 ```
 
-Delete the Redmine deployment and delete the MariaDB statefulset. Notice the option `--cascade=false` in the latter.
+Delete the SuiteCRM deployment and delete the MariaDB statefulset. Notice the option `--cascade=false` in the latter:
 
 ```console
   $ kubectl delete deployments.apps suitecrm

--- a/bitnami/suitecrm/README.md
+++ b/bitnami/suitecrm/README.md
@@ -240,9 +240,9 @@ export MARIADB_PVC=$(kubectl get pvc -l app=mariadb,component=master,release=sui
 Delete the SuiteCRM deployment and delete the MariaDB statefulset. Notice the option `--cascade=false` in the latter:
 
 ```console
-  $ kubectl delete deployments.apps suitecrm
+$ kubectl delete deployments.apps suitecrm
 
-  $ kubectl delete statefulsets.apps suitecrm-mariadb --cascade=false
+$ kubectl delete statefulsets.apps suitecrm-mariadb --cascade=false
 ```
 
 Now the upgrade works:
@@ -253,9 +253,9 @@ $ helm upgrade suitecrm bitnami/suitecrm --set mariadb.primary.persistence.exist
 
 You will have to delete the existing MariaDB pod and the new statefulset is going to create a new one
 
-  ```console
-  $ kubectl delete pod suitecrm-mariadb-0
-  ```
+```console
+$ kubectl delete pod suitecrm-mariadb-0
+```
 
 Finally, you should see the lines below in MariaDB container logs:
 
@@ -267,7 +267,7 @@ mariadb 12:13:25.01 INFO  ==> Running mysql_upgrade
 ...
 ```
 
-### 8.0.0
+### To 8.0.0
 
 Helm performs a lookup for the object based on its group (apps), version (v1), and kind (Deployment). Also known as its GroupVersionKind, or GVK. Changing the GVK is considered a compatibility breaker from Kubernetes' point of view, so you cannot "upgrade" those objects to the new GVK in-place. Earlier versions of Helm 3 did not perform the lookup correctly which has since been fixed to match the spec.
 

--- a/bitnami/suitecrm/README.md
+++ b/bitnami/suitecrm/README.md
@@ -20,7 +20,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 ## Prerequisites
 
 - Kubernetes 1.12+
-- Helm 2.12+ or Helm 3.0-beta3+
+- Helm 3.0-beta3+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 
@@ -74,11 +74,6 @@ The following table lists the configurable parameters of the SuiteCRM chart and 
 | `suitecrmSmtpProtocol`           | SMTP protocol [`ssl`, `tls`]                                                                          | `nil`                                                        |
 | `suitecrmValidateUserIP`         | Whether to validate the user IP address or not                                                        | `no`                                                         |
 | `allowEmptyPassword`             | Allow DB blank passwords                                                                              | `yes`                                                        |
-| `externalDatabase.host`          | Host of the external database                                                                         | `nil`                                                        |
-| `externalDatabase.port`          | Port of the external database                                                                         | `3306`                                                       |
-| `externalDatabase.user`          | Existing username in the external db                                                                  | `bn_suitecrm`                                                |
-| `externalDatabase.password`      | Password for the above username                                                                       | `nil`                                                        |
-| `externalDatabase.database`      | Name of the existing database                                                                         | `bitnami_suitecrm`                                           |
 | `ingress.enabled`                | Enable ingress controller resource                                                                    | `false`                                                      |
 | `ingress.annotations`            | Ingress annotations                                                                                   | `[]`                                                         |
 | `ingress.certManager`            | Add annotations for cert-manager                                                                      | `false`                                                      |
@@ -90,11 +85,6 @@ The following table lists the configurable parameters of the SuiteCRM chart and 
 | `ingress.secrets[0].name`        | TLS Secret Name                                                                                       | `nil`                                                        |
 | `ingress.secrets[0].certificate` | TLS Secret Certificate                                                                                | `nil`                                                        |
 | `ingress.secrets[0].key`         | TLS Secret Key                                                                                        | `nil`                                                        |
-| `mariadb.enabled`                | Whether to use the MariaDB chart                                                                      | `true`                                                       |
-| `mariadb.db.name`                | Database name to create                                                                               | `bitnami_suitecrm`                                           |
-| `mariadb.db.user`                | Database user to create                                                                               | `bn_suitecrm`                                                |
-| `mariadb.db.password`            | Password for the database                                                                             | `nil`                                                        |
-| `mariadb.rootUser.password`      | MariaDB admin password                                                                                | `nil`                                                        |
 | `service.type`                   | Kubernetes Service type                                                                               | `LoadBalancer`                                               |
 | `service.port`                   | Service HTTP port                                                                                     | `80`                                                         |
 | `service.httpsPort`              | Service HTTPS port                                                                                    | `443`                                                        |
@@ -118,6 +108,29 @@ The following table lists the configurable parameters of the SuiteCRM chart and 
 | `metrics.image.pullSecrets`      | Specify docker-registry secret names as an array                                                      | `nil`                                                        |
 | `metrics.podAnnotations`         | Additional annotations for Metrics exporter pod                                                       | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
 | `metrics.resources`              | Exporter resource requests/limit                                                                      | {}                                                           |
+
+### Database parameters
+
+| Parameter                                  | Description                                           | Default                                        |
+|--------------------------------------------|-------------------------------------------------------|------------------------------------------------|
+| `mariadb.enabled`                          | Whether to use the MariaDB chart                      | `true`                                         |
+| `mariadb.architecture`                     | MariaDB architecture (`standalone` or `replication`)  | `standalone`                                   |
+| `mariadb.auth.rootPassword`                | Password for the MariaDB `root` user                  | _random 10 character alphanumeric string_      |
+| `mariadb.auth.database`                    | Database name to create                               | `bitnami_suitecrm`                             |
+| `mariadb.auth.username`                    | Database user to create                               | `bn_suitecrm`                                  |
+| `mariadb.auth.password`                    | Password for the database                             | _random 10 character long alphanumeric string_ |
+| `mariadb.primary.persistence.enabled`      | Enable database persistence using PVC                 | `true`                                         |
+| `mariadb.primary.persistence.accessMode`   | Database Persistent Volume Access Modes               | `ReadWriteOnce`                                |
+| `mariadb.primary.persistence.size`         | Database Persistent Volume Size                       | `8Gi`                                          |
+| `mariadb.primary.persistence.existingClaim`| Enable persistence using an existing PVC              | `nil`                                          |
+| `mariadb.primary.persistence.storageClass` | PVC Storage Class                                     | `nil` (uses alpha storage class annotation)    |
+| `mariadb.primary.persistence.hostPath`     | Host mount path for MariaDB volume                    | `nil` (will not mount to a host path)          |
+| `externalDatabase.user`                    | Existing username in the external db                  | `bn_suitecrm`                                  |
+| `externalDatabase.password`                | Password for the above username                       | `nil`                                          |
+| `externalDatabase.database`                | Name of the existing database                         | `bitnami_suitecrm`                             |
+| `externalDatabase.host`                    | Host of the existing database                         | `nil`                                          |
+| `externalDatabase.port`                    | Port of the existing database                         | `3306`                                         |
+| `externalDatabase.existingSecret`          | Name of the database existing Secret Object           | `nil`                                          |
 
 The above parameters map to the env variables defined in [bitnami/suitecrm](http://github.com/bitnami/bitnami-docker-suitecrm). For more information please refer to the [bitnami/suitecrm](http://github.com/bitnami/bitnami-docker-suitecrm) image documentation.
 
@@ -173,6 +186,86 @@ See the [Parameters](#parameters) section to configure the PVC or to disable per
 Find more information about how to deal with common errors related to Bitnami’s Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
 
 ## Upgrading
+
+### To 9.0.0
+
+In this major there were two main changes introduced:
+
+1. Adaptation to Helm v2 EOL
+2. Updated MariaDB dependency version
+
+Please read the update notes carefully.
+
+**1. Adaptation to Helm v2 EOL**
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+**What changes were introduced in this major version?**
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- Move dependency information from the *requirements.yaml* to the *Chart.yaml*
+- After running `helm dependency update`, a *Chart.lock* file is generated containing the same structure used in the previous *requirements.lock*
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+
+**Considerations when upgrading to this version**
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+**Useful links**
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
+
+**2. Updated MariaDB dependency version**
+
+In this major the MariaDB dependency version was also bumped to a new major version that introduces several incompatilibites. Therefore, backwards compatibility is not guaranteed unless an external database is used. Check [MariaDB Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/mariadb#to-800) for more information.
+
+To upgrade to `9.0.0`, it should be done reusing the PVCs used to hold both the MariaDB and SuiteCRM data on your previous release. To do so, follow the instructions below (the following example assumes that the release name is `suitecrm` and that a `rootUser.password` was defined for MariaDB in `values.yaml` when the chart was first installed):
+
+> NOTE: Please, create a backup of your database before running any of those actions. The steps below would be only valid if your application (e.g. any plugins or custom code) is compatible with MariaDB 10.5.x
+
+Obtain the credentials and the names of the PVCs used to hold both the MariaDB and SuiteCRM data on your current release:
+
+```console
+export SUITECRM_HOST=$(kubectl get svc --namespace default suitecrm --template "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}")
+export SUITECRM_PASSWORD=$(kubectl get secret --namespace default suitecrm -o jsonpath="{.data.suitecrm-password}" | base64 --decode)
+export MARIADB_ROOT_PASSWORD=$(kubectl get secret --namespace default suitecrm-mariadb -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)
+export MARIADB_PASSWORD=$(kubectl get secret --namespace default suitecrm-mariadb -o jsonpath="{.data.mariadb-password}" | base64 --decode)
+export MARIADB_PVC=$(kubectl get pvc -l app=mariadb,component=master,release=suitecrm -o jsonpath="{.items[0].metadata.name}")
+```
+
+Delete the Redmine deployment and delete the MariaDB statefulset. Notice the option `--cascade=false` in the latter.
+
+```console
+  $ kubectl delete deployments.apps suitecrm
+
+  $ kubectl delete statefulsets.apps suitecrm-mariadb --cascade=false
+```
+
+Now the upgrade works:
+
+```console
+$ helm upgrade suitecrm bitnami/suitecrm --set mariadb.primary.persistence.existingClaim=$MARIADB_PVC --set mariadb.auth.rootPassword=$MARIADB_ROOT_PASSWORD --set mariadb.auth.password=$MARIADB_PASSWORD --set suitecrmPassword=$SUITECRM_PASSWORD --set suitecrmHost=$SUITECRM_HOST
+```
+
+You will have to delete the existing MariaDB pod and the new statefulset is going to create a new one
+
+  ```console
+  $ kubectl delete pod suitecrm-mariadb-0
+  ```
+
+Finally, you should see the lines below in MariaDB container logs:
+
+```console
+$ kubectl logs $(kubectl get pods -l app.kubernetes.io/instance=suitecrm,app.kubernetes.io/name=mariadb,app.kubernetes.io/component=primary -o jsonpath="{.items[0].metadata.name}")
+...
+mariadb 12:13:24.98 INFO  ==> Using persisted data
+mariadb 12:13:25.01 INFO  ==> Running mysql_upgrade
+...
+```
 
 ### 8.0.0
 

--- a/bitnami/suitecrm/requirements.lock
+++ b/bitnami/suitecrm/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: mariadb
-  repository: https://charts.bitnami.com/bitnami
-  version: 7.10.4
-digest: sha256:ca14be574c84f1fd3ff519512631427cf30bbbef20c4156a095233871cc30d3b
-generated: "2020-10-12T00:39:25.824419709Z"

--- a/bitnami/suitecrm/requirements.yaml
+++ b/bitnami/suitecrm/requirements.yaml
@@ -1,5 +1,0 @@
-dependencies:
-- name: mariadb
-  version: 7.x.x
-  repository: https://charts.bitnami.com/bitnami
-  condition: mariadb.enabled

--- a/bitnami/suitecrm/templates/NOTES.txt
+++ b/bitnami/suitecrm/templates/NOTES.txt
@@ -22,11 +22,11 @@ host. To configure SuiteCRM with the URL of your service:
 
   export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "suitecrm.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "suitecrm.fullname" . }} -o jsonpath="{.data.suitecrm-password}" | base64 --decode)
-  {{- if .Values.mariadb.mariadbRootPassword }}
-  export DATABASE_ROOT_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "suitecrm.mariadb.fullname" . }} -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)
+  {{- if .Values.mariadb.auth.rootPassword }}
+  export MARIADB_ROOT_PASSWORD=$(kubectl get secret --namespace default suitecrm-mariadb -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)
   {{- end }}
   {{- end }}
-  export APP_DATABASE_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "suitecrm.mariadb.fullname" . }} -o jsonpath="{.data.mariadb-password}" | base64 --decode)
+  export MARIADB_PASSWORD=$(kubectl get secret --namespace default suitecrm-mariadb -o jsonpath="{.data.mariadb-password}" | base64 --decode)
 
 
 2. Complete your SuiteCRM deployment by running:
@@ -34,7 +34,7 @@ host. To configure SuiteCRM with the URL of your service:
 {{- if .Values.mariadb.enabled }}
 
   helm upgrade {{ .Release.Name }} bitnami/suitecrm \
-    --set suitecrmHost=$APP_HOST,suitecrmPassword=$APP_PASSWORD{{ if .Values.mariadb.mariadbRootPassword }},mariadb.mariadbRootPassword=$DATABASE_ROOT_PASSWORD{{ end }},mariadb.db.password=$APP_DATABASE_PASSWORD
+    --set suitecrmHost=$APP_HOST,suitecrmPassword=$APP_PASSWORD{{ if .Values.mariadb.auth.rootPassword }},mariadb.auth.rootPassword=$MARIADB_ROOT_PASSWORD{{ end }},mariadb.auth.password=$MARIADB_PASSWORD
 {{- else }}
 
   ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##

--- a/bitnami/suitecrm/templates/_helpers.tpl
+++ b/bitnami/suitecrm/templates/_helpers.tpl
@@ -185,3 +185,64 @@ Return the appropriate apiVersion for deployment.
 {{- print "apps/v1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the MariaDB Hostname
+*/}}
+{{- define "suitecrm.databaseHost" -}}
+{{- if .Values.mariadb.enabled }}
+    {{- if eq .Values.mariadb.architecture "replication" }}
+        {{- printf "%s-%s" (include "suitecrm.mariadb.fullname" .) "primary" | trunc 63 | trimSuffix "-" -}}
+    {{- else -}}
+        {{- printf "%s" (include "suitecrm.mariadb.fullname" .) -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s" .Values.externalDatabase.host -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the MariaDB Port
+*/}}
+{{- define "suitecrm.databasePort" -}}
+{{- if .Values.mariadb.enabled }}
+    {{- printf "3306" -}}
+{{- else -}}
+    {{- printf "%d" (.Values.externalDatabase.port | int ) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the MariaDB Database Name
+*/}}
+{{- define "suitecrm.databaseName" -}}
+{{- if .Values.mariadb.enabled }}
+    {{- printf "%s" .Values.mariadb.auth.database -}}
+{{- else -}}
+    {{- printf "%s" .Values.externalDatabase.database -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the MariaDB User
+*/}}
+{{- define "suitecrm.databaseUser" -}}
+{{- if .Values.mariadb.enabled }}
+    {{- printf "%s" .Values.mariadb.auth.username -}}
+{{- else -}}
+    {{- printf "%s" .Values.externalDatabase.user -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the MariaDB Secret Name
+*/}}
+{{- define "suitecrm.databaseSecretName" -}}
+{{- if .Values.mariadb.enabled }}
+    {{- printf "%s" (include "suitecrm.mariadb.fullname" .) -}}
+{{- else if .Values.externalDatabase.existingSecret -}}
+    {{- printf "%s" .Values.externalDatabase.existingSecret -}}
+{{- else -}}
+    {{- printf "%s-%s" .Release.Name "externaldb" -}}
+{{- end -}}
+{{- end -}}

--- a/bitnami/suitecrm/templates/deployment.yaml
+++ b/bitnami/suitecrm/templates/deployment.yaml
@@ -43,35 +43,19 @@ spec:
           value: {{ .Values.allowEmptyPassword | quote }}
         - name: SUITECRM_VALIDATE_USER_IP
           value: {{ .Values.suitecrmValidateUserIP | quote }}
-        {{- if .Values.mariadb.enabled }}
         - name: MARIADB_HOST
-          value: {{ template "suitecrm.mariadb.fullname" . }}
+          value: {{ include "suitecrm.databaseHost" . | quote }}
         - name: MARIADB_PORT_NUMBER
-          value: "3306"
+          value: {{ include "suitecrm.databasePort" . | quote }}
         - name: SUITECRM_DATABASE_NAME
-          value: {{ .Values.mariadb.db.name | quote }}
+          value: {{ include "suitecrm.databaseName" . | quote }}
         - name: SUITECRM_DATABASE_USER
-          value: {{ .Values.mariadb.db.user | quote }}
+          value: {{ include "suitecrm.databaseUser" . | quote }}
         - name: SUITECRM_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "suitecrm.mariadb.fullname" . }}
+              name: {{ include "suitecrm.databaseSecretName" . }}
               key: mariadb-password
-        {{- else }}
-        - name: MARIADB_HOST
-          value: {{ .Values.externalDatabase.host | quote }}
-        - name: MARIADB_PORT_NUMBER
-          value: {{ .Values.externalDatabase.port | quote }}
-        - name: SUITECRM_DATABASE_NAME
-          value: {{ .Values.externalDatabase.database | quote }}
-        - name: SUITECRM_DATABASE_USER
-          value: {{ .Values.externalDatabase.user | quote }}
-        - name: SUITECRM_DATABASE_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ printf "%s-%s" .Release.Name "externaldb" }}
-              key: db-password
-        {{- end }}
         - name: SUITECRM_HOST
 {{- $port:=.Values.service.port | toString }}
           value: "{{ include "host" . }}:{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}"

--- a/bitnami/suitecrm/templates/externaldb-secrets.yaml
+++ b/bitnami/suitecrm/templates/externaldb-secrets.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.mariadb.enabled }}
+{{- if (not (or .Values.mariadb.enabled .Values.externalDatabase.existingSecret)) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,5 +10,5 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
-  db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
+  mariadb-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
 {{- end }}

--- a/bitnami/suitecrm/values.yaml
+++ b/bitnami/suitecrm/values.yaml
@@ -74,6 +74,11 @@ allowEmptyPassword: "yes"
 ## External database configuration
 ##
 externalDatabase:
+  ## Use existing secret (ignores previous password)
+  ## must contain key `mariadb-password`
+  ## NOTE: When it's set, the `externalDatabase.password` parameter is ignored
+  # existingSecret:
+
   ## Database host
   host:
 
@@ -106,31 +111,32 @@ externalDatabase:
 ##
 mariadb:
   ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+  ##
   enabled: true
-  ## Disable MariaDB replication
-  replication:
-    enabled: false
 
-  ## Create a database and a database user
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ## MariaDB architecture. Allowed values: standalone or replication
   ##
-  db:
-    name: bitnami_suitecrm
-    user: bn_suitecrm
-    ## If the password is not specified, mariadb will generates a random password
+  architecture: standalone
+
+  ## MariaDB Authentication parameters
+  ##
+  auth:
+    ## MariaDB root password
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
     ##
-    # password:
+    rootPassword: ""
+    ## MariaDB custom user and database
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+    ##
+    database: bitnami_suitecrm
+    username: bn_suitecrm
+    password: ""
 
-  ## MariaDB admin password
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
-  ##
-  # rootUser:
-  #   password:
-
-  ## Enable persistence using Persistent Volume Claims
-  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-  ##
-  master:
+  primary:
+    ## Enable persistence using Persistent Volume Claims
+    ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+    ##
     persistence:
       enabled: true
       ## mariadb data Persistent Volume Storage Class
@@ -140,9 +146,16 @@ mariadb:
       ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
       ##   GKE, AWS & OpenStack)
       ##
-      # storageClass: "-"
-      accessMode: ReadWriteOnce
+      storageClass:
+      accessModes:
+        - ReadWriteOnce
       size: 8Gi
+      ## Set path in case you want to use local host path volumes (not recommended in production)
+      ##
+      hostPath:
+      ## Use an existing PVC
+      ##
+      existingClaim:
 
 service:
   type: LoadBalancer


### PR DESCRIPTION
**Description of the change**

- Bump `apiVersion` from `v1` to `v2` in _Chart.yaml_
- Fields in _Chart.yaml_ file has been ordered alphabetically
- Move dependency information from the _requirements.yaml_ to the _Chart.yaml_
- After running `helm dependency update`, a new _Chart.lock_ file is generated containing the same structure used in the previous _requirements.lock_
- Update _README.md_
- Updated MariaDB dependency to the new major.
- Added support for existingSecret for external databases

**Possible drawbacks**

- Helm v2 is no longer supported
- Breaking changes due to MariaDB major bump