### PR TITLE
[bitnami/rabbitmq] Fix networkpolicy podSelector labels

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -23,4 +23,4 @@ name: rabbitmq
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq
   - https://www.rabbitmq.com
-version: 8.0.3
+version: 8.0.4

--- a/bitnami/rabbitmq/templates/networkpolicy.yaml
+++ b/bitnami/rabbitmq/templates/networkpolicy.yaml
@@ -23,8 +23,7 @@ spec:
               {{ template "rabbitmq.fullname" . }}-client: "true"
         - podSelector:
             matchLabels:
-              app: {{ template "rabbitmq.name" . }}
-              release: {{ .Release.Name }}
+              {{- include "common.labels.matchLabels" . | nindent 14 }}
         {{- if .Values.networkPolicy.additionalRules }}
         {{- include "common.tplvalues.render" (dict "value" .Values.networkPolicy.additionalRules "context" $) | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
Signed-off-by: Alexis Martinier <amartinier@leadformance.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Update the ingress rules to allow pods from this chart to communicate when `networkPolicy.allowExternal=false` using the podLabels defined by this chart

**Benefits**

<!-- What benefits will be realized by the code change? -->
No need to add `networkPolicy.additionalRules` as a workaround

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #4400

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
