### PR TITLE
[bitnami/postgresql] Lookup password during helm upgrade

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -26,4 +26,4 @@ name: postgresql
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 10.0.1
+version: 10.0.2

--- a/bitnami/postgresql/templates/NOTES.txt
+++ b/bitnami/postgresql/templates/NOTES.txt
@@ -55,5 +55,3 @@ To connect to your database from outside the cluster execute the following comma
 {{- include "common.warnings.rollingTag" .Values.image -}}
 
 {{- $passwordValidationErrors := include "common.validations.values.postgresql.passwords" (dict "secret" (include "postgresql.fullname" .) "context" $) -}}
-
-{{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" (list $passwordValidationErrors) "context" $) -}}

--- a/bitnami/postgresql/templates/secrets.yaml
+++ b/bitnami/postgresql/templates/secrets.yaml
@@ -1,8 +1,38 @@
 {{- if (include "postgresql.createSecret" .) }}
+
+{{- $secretName := include "postgresql.fullname" . }}
+{{- $postgresqlPostgresPassword := "" }}
+{{- $postgresqlPassword := "" }}
+{{- $postgresqlReplicationPassword := "" }}
+
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace $secretName) }}
+{{- if $secret }}
+  {{- if index $secret.data "postgresql-postgres-password" }}
+  {{- $postgresqlPostgresPassword = index $secret.data "postgresql-postgres-password" }}
+  {{- end -}}
+  {{- if index $secret.data "postgresql-password" }}
+  {{- $postgresqlPassword = index $secret.data "postgresql-password" }}
+  {{- end -}}
+  {{- if index $secret.data "postgresql-repliaction-password" }}
+  {{- $postgresqlReplicationPassword = index $secret.data "postgresql-replication-password" }}
+  {{- end -}}
+{{- end -}}
+
+{{- if not $postgresqlPostgresPassword }}
+{{- $postgresqlPostgresPassword = include "postgresql.postgres.password" . | b64enc | quote }}
+{{- end -}}
+{{- if not $postgresqlPassword }}
+{{- $postgresqlPassword = include "postgresql.password" . | b64enc | quote }}
+{{- end -}}
+{{- if not $postgresqlReplicationPassword }}
+{{- $postgresqlReplicationPassword = include "postgresql.replication.password" . | b64enc | quote }}
+{{- end -}}
+
+
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "postgresql.fullname" . }}
+  name: {{ $secretName }}
   labels:
   {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}
@@ -10,10 +40,10 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  postgresql-postgres-password: {{ include "postgresql.postgres.password" . | b64enc | quote }}
-  postgresql-password: {{ include "postgresql.password" . | b64enc | quote }}
+  postgresql-postgres-password: {{ $postgresqlPostgresPassword }}
+  postgresql-password: {{ $postgresqlPassword }}
   {{- if .Values.replication.enabled }}
-  postgresql-replication-password: {{ include "postgresql.replication.password" . | b64enc | quote }}
+  postgresql-replication-password: {{ $postgresqlReplicationPassword }}
   {{- end }}
   {{- if (and .Values.ldap.enabled .Values.ldap.bind_password)}}
   postgresql-ldap-password: {{ .Values.ldap.bind_password | b64enc | quote }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

The postgres chart can't be upgraded without specifying the existing password during the `helm upgrade` command.
With Helm 3.0 a new `lookup` function has been introduced that allows helm to get pre-existing secrets from kubernetes.

This pull requests allows helm to:
 - Create a new secret if it already exists
 - Reuse an existing secret if it's already present

**Benefits**

No need to specify the existing password during `helm upgrade`

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

My knowledge of helm is quite limited. Any comment on how to improve the code is well accepted.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
