### PR TITLE
[bitnami/phabricator] Major version. Adapt Chart to apiVersion: v2 and Update MariaDB Dependency

### DIFF
--- a/bitnami/phabricator/Chart.lock
+++ b/bitnami/phabricator/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: mariadb
+  repository: https://charts.bitnami.com/bitnami
+  version: 9.0.1
+digest: sha256:6a5735e0b7e5868bbf3eec9d9d031eb20a5928dd38894899c5bccf2e8f7c5a61
+generated: "2020-11-18T14:19:46.39602979Z"

--- a/bitnami/phabricator/Chart.yaml
+++ b/bitnami/phabricator/Chart.yaml
@@ -3,34 +3,33 @@ annotations:
 apiVersion: v2
 appVersion: 2020.42.0
 dependencies:
-- condition: mariadb.enabled
-  name: mariadb
-  repository: https://charts.bitnami.com/bitnami
-  version: 9.x.x
-description: Collection of open source web applications that help software companies
-  build better software.
+  - condition: mariadb.enabled
+    name: mariadb
+    repository: https://charts.bitnami.com/bitnami
+    version: 9.x.x
+description: Collection of open source web applications that help software companies build better software.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/phabricator
 icon: https://bitnami.com/assets/stacks/phabricator/img/phabricator-stack-110x117.png
 keywords:
-- phabricator
-- http
-- https
-- web
-- application
-- collaboration
-- project management
-- bug tracking
-- code review
-- wiki
-- git
-- mercurial
-- subversion
+  - phabricator
+  - http
+  - https
+  - web
+  - application
+  - collaboration
+  - project management
+  - bug tracking
+  - code review
+  - wiki
+  - git
+  - mercurial
+  - subversion
 maintainers:
-- email: containers@bitnami.com
-  name: Bitnami
+  - email: containers@bitnami.com
+    name: Bitnami
 name: phabricator
 sources:
-- https://github.com/bitnami/bitnami-docker-phabricator
-- https://www.phacility.com/phabricator/
+  - https://github.com/bitnami/bitnami-docker-phabricator
+  - https://www.phacility.com/phabricator/
 version: 10.0.0

--- a/bitnami/phabricator/Chart.yaml
+++ b/bitnami/phabricator/Chart.yaml
@@ -1,30 +1,36 @@
-apiVersion: v1
-name: phabricator
-version: 9.1.19
-appVersion: 2020.42.0
-description: Collection of open source web applications that help software companies build better software.
-keywords:
-  - phabricator
-  - http
-  - https
-  - web
-  - application
-  - collaboration
-  - project management
-  - bug tracking
-  - code review
-  - wiki
-  - git
-  - mercurial
-  - subversion
-home: https://github.com/bitnami/charts/tree/master/bitnami/phabricator
-sources:
-  - https://github.com/bitnami/bitnami-docker-phabricator
-  - https://www.phacility.com/phabricator/
-maintainers:
-  - name: Bitnami
-    email: containers@bitnami.com
-engine: gotpl
-icon: https://bitnami.com/assets/stacks/phabricator/img/phabricator-stack-110x117.png
 annotations:
   category: ProjectManagement
+apiVersion: v2
+appVersion: 2020.42.0
+dependencies:
+- condition: mariadb.enabled
+  name: mariadb
+  repository: https://charts.bitnami.com/bitnami
+  version: 9.x.x
+description: Collection of open source web applications that help software companies
+  build better software.
+engine: gotpl
+home: https://github.com/bitnami/charts/tree/master/bitnami/phabricator
+icon: https://bitnami.com/assets/stacks/phabricator/img/phabricator-stack-110x117.png
+keywords:
+- phabricator
+- http
+- https
+- web
+- application
+- collaboration
+- project management
+- bug tracking
+- code review
+- wiki
+- git
+- mercurial
+- subversion
+maintainers:
+- email: containers@bitnami.com
+  name: Bitnami
+name: phabricator
+sources:
+- https://github.com/bitnami/bitnami-docker-phabricator
+- https://www.phacility.com/phabricator/
+version: 10.0.0

--- a/bitnami/phabricator/README.md
+++ b/bitnami/phabricator/README.md
@@ -20,7 +20,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 ## Prerequisites
 
 - Kubernetes 1.12+
-- Helm 2.12+ or Helm 3.0-beta3+
+- Helm 3.0-beta3+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 
@@ -100,15 +100,24 @@ The above parameters map to the env variables defined in [bitnami/phabricator](h
 
 ### Database parameters
 
-| Parameter                        | Description                                                                                              | Default                                                      |
-|----------------------------------|----------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `mariadb.enabled`                | Deploy MariaDB container(s)                                                                              | `true`                                                       |
-| `mariadb.rootUser.password`      | MariaDB admin password                                                                                   | `nil`                                                        |
-| `externalDatabase.host`          | Host of the external database                                                                            | `localhost`                                                  |
-| `externalDatabase.rootUser`      | Existing username in the external db                                                                     | `bn_wordpress`                                               |
-| `externalDatabase.rootPassword`  | Password for the above username                                                                          | `nil`                                                        |
-| `externalDatabase.database`      | Name of the existing database                                                                            | `bitnami_wordpress`                                          |
-| `externalDatabase.port`          | Database port number                                                                                     | `3306`                                                       |
+| Parameter                                  | Description                                           | Default                                        |
+|--------------------------------------------|-------------------------------------------------------|------------------------------------------------|
+| `mariadb.enabled`                          | Whether to use the MariaDB chart                      | `true`                                         |
+| `mariadb.architecture`                     | MariaDB architecture (`standalone` or `replication`)  | `standalone`                                   |
+| `mariadb.auth.rootPassword`                | Password for the MariaDB `root` user                  | _random 10 character alphanumeric string_      |
+| `mariadb.primary.extraFlags`               | Additional command line flags                         | `true`                                         |
+| `mariadb.primary.persistence.enabled`      | Enable database persistence using PVC                 | `true`                                         |
+| `mariadb.primary.persistence.accessMode`   | Database Persistent Volume Access Modes               | `ReadWriteOnce`                                |
+| `mariadb.primary.persistence.size`         | Database Persistent Volume Size                       | `8Gi`                                          |
+| `mariadb.primary.persistence.existingClaim`| Enable persistence using an existing PVC              | `nil`                                          |
+| `mariadb.primary.persistence.storageClass` | PVC Storage Class                                     | `nil` (uses alpha storage class annotation)    |
+| `mariadb.primary.persistence.hostPath`     | Host mount path for MariaDB volume                    | `nil` (will not mount to a host path)          |
+| `externalDatabase.user`                    | Existing username in the external db                  | `bn_phabricator`                               |
+| `externalDatabase.password`                | Password for the above username                       | `nil`                                          |
+| `externalDatabase.database`                | Name of the existing database                         | `bitnami_phabricator`                          |
+| `externalDatabase.host`                    | Host of the existing database                         | `nil`                                          |
+| `externalDatabase.port`                    | Port of the existing database                         | `3306`                                         |
+| `externalDatabase.existingSecret`          | Name of the database existing Secret Object           | `nil`                                          |
 
 ### Traffic Exposure Parameters
 
@@ -228,6 +237,85 @@ See the [Parameters](#parameters) section to configure the PVC or to disable per
 Find more information about how to deal with common errors related to Bitnami’s Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
 
 ## Upgrading
+
+### To 10.0.0
+
+In this major there were two main changes introduced:
+
+1. Adaptation to Helm v2 EOL
+2. Updated MariaDB dependency version
+
+Please read the update notes carefully.
+
+**1. Adaptation to Helm v2 EOL**
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+**What changes were introduced in this major version?**
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- Move dependency information from the *requirements.yaml* to the *Chart.yaml*
+- After running `helm dependency update`, a *Chart.lock* file is generated containing the same structure used in the previous *requirements.lock*
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+
+**Considerations when upgrading to this version**
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+**Useful links**
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
+
+**2. Updated MariaDB dependency version**
+
+In this major the MariaDB dependency version was also bumped to a new major version that introduces several incompatilibites. Therefore, backwards compatibility is not guaranteed unless an external database is used. Check [MariaDB Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/mariadb#to-800) for more information.
+
+To upgrade to `10.0.0`, it should be done reusing the PVCs used to hold both the MariaDB and Phabricator data on your previous release. To do so, follow the instructions below (the following example assumes that the release name is `phabricator` and that a `rootUser.password` was defined for MariaDB in `values.yaml` when the chart was first installed):
+
+> NOTE: Please, create a backup of your database before running any of those actions. The steps below would be only valid if your application (e.g. any plugins or custom code) is compatible with MariaDB 10.5.x
+
+Obtain the credentials and the names of the PVCs used to hold both the MariaDB and Phabricator data on your current release:
+
+```console
+export PHABRICATOR_HOST=$(kubectl get svc --namespace default phabricator --template "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}")
+export PHABRICATOR_PASSWORD=$(kubectl get secret --namespace default phabricator -o jsonpath="{.data.phabricator-password}" | base64 --decode)
+export MARIADB_ROOT_PASSWORD=$(kubectl get secret --namespace default phabricator-mariadb -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)
+export MARIADB_PVC=$(kubectl get pvc -l app=mariadb,component=master,release=phabricator -o jsonpath="{.items[0].metadata.name}")
+```
+
+Delete the Phabricator deployment and delete the MariaDB statefulset. Notice the option `--cascade=false` in the latter.
+
+```console
+  $ kubectl delete deployments.apps phabricator
+
+  $ kubectl delete statefulsets.apps phabricator-mariadb --cascade=false
+```
+
+Now the upgrade works:
+
+```console
+$ helm upgrade phabricator bitnami/phabricator --set mariadb.primary.persistence.existingClaim=$MARIADB_PVC --set mariadb.auth.rootPassword=$MARIADB_ROOT_PASSWORD --set phabricatorPassword=$PHABRICATOR_PASSWORD --set phabricatorHost=$PHABRICATOR_HOST
+```
+
+You will have to delete the existing MariaDB pod and the new statefulset is going to create a new one
+
+  ```console
+  $ kubectl delete pod phabricator-mariadb-0
+  ```
+
+Finally, you should see the lines below in MariaDB container logs:
+
+```console
+$ kubectl logs $(kubectl get pods -l app.kubernetes.io/instance=phabricator,app.kubernetes.io/name=mariadb,app.kubernetes.io/component=primary -o jsonpath="{.items[0].metadata.name}")
+...
+mariadb 12:13:24.98 INFO  ==> Using persisted data
+mariadb 12:13:25.01 INFO  ==> Running mysql_upgrade
+...
+```
 
 ### To 9.0.0
 

--- a/bitnami/phabricator/requirements.lock
+++ b/bitnami/phabricator/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: mariadb
-  repository: https://charts.bitnami.com/bitnami
-  version: 7.10.4
-digest: sha256:ca14be574c84f1fd3ff519512631427cf30bbbef20c4156a095233871cc30d3b
-generated: "2020-10-11T20:09:27.255656677Z"

--- a/bitnami/phabricator/requirements.yaml
+++ b/bitnami/phabricator/requirements.yaml
@@ -1,5 +1,0 @@
-dependencies:
-  - name: mariadb
-    version: 7.x.x
-    repository: https://charts.bitnami.com/bitnami
-    condition: mariadb.enabled

--- a/bitnami/phabricator/templates/NOTES.txt
+++ b/bitnami/phabricator/templates/NOTES.txt
@@ -20,13 +20,13 @@ host. To configure Phabricator with the URL of your service:
 
   export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "phabricator.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
   export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "phabricator.fullname" . }} -o jsonpath="{.data.phabricator-password}" | base64 --decode)
-  export DATABASE_ROOT_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "phabricator.mariadb.fullname" . }} -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)
+  export MARIADB_ROOT_PASSWORD=$(kubectl get secret --namespace default phabricator-mariadb -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)
   {{- end }}
 
 2. Complete your Phabricator deployment by running:
 
   helm upgrade {{ .Release.Name }} bitnami/phabricator \
-    --set phabricatorHost=$APP_HOST,phabricatorPassword=$APP_PASSWORD,mariadb.rootUser.password=$DATABASE_ROOT_PASSWORD
+    --set phabricatorHost=$APP_HOST,phabricatorPassword=$APP_PASSWORD,mariadb.auth.rootPassword=$MARIADB_ROOT_PASSWORD
 
 {{- else -}}
 1. Get the Phabricator URL by running:

--- a/bitnami/phabricator/templates/_helpers.tpl
+++ b/bitnami/phabricator/templates/_helpers.tpl
@@ -46,20 +46,24 @@ Return the MariaDB Hostname
 */}}
 {{- define "phabricator.databaseHost" -}}
 {{- if .Values.mariadb.enabled }}
-    {{- printf "%s" (include "phabricator.mariadb.fullname" .) -}}
+    {{- if eq .Values.mariadb.architecture "replication" }}
+        {{- printf "%s-%s" (include "phabricator.mariadb.fullname" .) "primary" | trunc 63 | trimSuffix "-" -}}
+    {{- else -}}
+        {{- printf "%s" (include "phabricator.mariadb.fullname" .) -}}
+    {{- end -}}
 {{- else -}}
     {{- printf "%s" .Values.externalDatabase.host -}}
 {{- end -}}
 {{- end -}}
 
 {{/*
-Return the MariaDB root user
+Return the MariaDB User
 */}}
 {{- define "phabricator.databaseUser" -}}
 {{- if .Values.mariadb.enabled }}
-    {{- printf "root" -}}
+    {{- printf "%s" .Values.mariadb.auth.username -}}
 {{- else -}}
-    {{- printf "%s" .Values.externalDatabase.rootUser -}}
+    {{- printf "%s" .Values.externalDatabase.user -}}
 {{- end -}}
 {{- end -}}
 
@@ -75,11 +79,13 @@ Return the MariaDB Port
 {{- end -}}
 
 {{/*
-Return the MariaDB User
+Return the MariaDB Secret Name
 */}}
 {{- define "phabricator.databaseSecretName" -}}
 {{- if .Values.mariadb.enabled }}
     {{- printf "%s" (include "phabricator.mariadb.fullname" .) -}}
+{{- else if .Values.externalDatabase.existingSecret -}}
+    {{- printf "%s" .Values.externalDatabase.existingSecret -}}
 {{- else -}}
     {{- printf "%s-%s" .Release.Name "externaldb" -}}
 {{- end -}}

--- a/bitnami/phabricator/templates/externaldb-secrets.yaml
+++ b/bitnami/phabricator/templates/externaldb-secrets.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.mariadb.enabled }}
+{{- if (not (or .Values.mariadb.enabled .Values.externalDatabase.existingSecret)) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/bitnami/phabricator/values.yaml
+++ b/bitnami/phabricator/values.yaml
@@ -87,23 +87,27 @@ phabricatorLastName: Last Name
 ##
 mariadb:
   ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+  ##
   enabled: true
-  ## Disable MariaDB replication
-  replication:
-    enabled: false
 
-  ## MariaDB admin password
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
+  ## MariaDB architecture. Allowed values: standalone or replication
   ##
-  # rootUser:
-  #   password:
+  architecture: standalone
 
-  ## Enable persistence using Persistent Volume Claims
-  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  ## MariaDB Authentication parameters
   ##
-  master:
+  auth:
+    ## MariaDB root password
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
+    ##
+    rootPassword: ""
+
+  primary:
     ## Disable local_infile for MariaDB: https://secure.phabricator.com/T13238
     extraFlags: "--local-infile=0"
+    ## Enable persistence using Persistent Volume Claims
+    ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+    ##
     persistence:
       enabled: true
       ## mariadb data Persistent Volume Storage Class
@@ -113,9 +117,16 @@ mariadb:
       ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
       ##   GKE, AWS & OpenStack)
       ##
-      # storageClass: "-"
-      accessMode: ReadWriteOnce
+      storageClass:
+      accessModes:
+        - ReadWriteOnce
       size: 8Gi
+      ## Set path in case you want to use local host path volumes (not recommended in production)
+      ##
+      hostPath:
+      ## Use an existing PVC
+      ##
+      existingClaim:
 
 ## Kubernetes configuration
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer
@@ -228,6 +239,11 @@ podAnnotations: {}
 ## All of these values are only used when mariadb.enabled is set to false
 ##
 externalDatabase:
+  ## Use existing secret (ignores previous password)
+  ## must contain key `mariadb-password`
+  ## NOTE: When it's set, the `externalDatabase.password` parameter is ignored
+  # existingSecret:
+
   ## Database host
   ##
   host: localhost

--- a/bitnami/phabricator/values.yaml
+++ b/bitnami/phabricator/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/phabricator
-  tag: 2020.42.0-debian-10-r26
+  tag: 2020.42.0-debian-10-r28
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -267,7 +267,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.8.0-debian-10-r214
+    tag: 0.8.0-debian-10-r217
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**

- Bump `apiVersion` from `v1` to `v2` in _Chart.yaml_
- Fields in _Chart.yaml_ file has been ordered alphabetically
- Move dependency information from the _requirements.yaml_ to the _Chart.yaml_
- After running `helm dependency update`, a new _Chart.lock_ file is generated containing the same structure used in the previous _requirements.lock_
- Update _README.md_
- Updated MariaDB dependency to the new major.
- Added support for existingSecret for external databases

**Possible drawbacks**

- Helm v2 is no longer supported
- Breaking changes due to MariaDB major bump