### PR TITLE
[bitnami/keycloak] Remove 'bindAddress' parameter

### DIFF
--- a/bitnami/keycloak/Chart.lock
+++ b/bitnami/keycloak/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.0.0
+  version: 1.0.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.0.0
-digest: sha256:7b190da1271c819ab4498c76da7135b41f01829dd582e397db13c452d1fc9f55
-generated: "2020-11-18T11:52:49.791779997Z"
+  version: 10.0.2
+digest: sha256:17034b8da90f19edcddc03e03ff55b3d247068b9271be330de516fc9463ca30f
+generated: "2020-11-19T16:42:14.773265506Z"

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 1.0.1
+version: 1.0.2

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -87,7 +87,6 @@ The following tables lists the configurable parameters of the Keycloak chart and
 | `auth.tls.jksSecret`                    | Existing secret containing the truststore and one keystore per Keycloak replica          | `nil`                                                   |
 | `auth.tls.keystorePassword`             | Password to access the keystore when it's password-protected                             | `nil`                                                   |
 | `auth.tls.truststorePassword`           | Password to access the truststore when it's password-protected                           | `nil`                                                   |
-| `bindAddress`                           | Keycloak bind address                                                                    | `0.0.0.0`                                               |
 | `proxyAddressForwarding`                | Enable Proxy Address Forwarding                                                          | `false`                                                 |
 | `serviceDiscovery.enabled`              | Enable Service Discovery for Keycloak (required if `replicaCount` > `1`)                 | `false`                                                 |
 | `serviceDiscovery.protocol`             | Sets the protocol that Keycloak nodes would use to discover new peers                    | `kubernetes.KUBE_PING`                                  |
@@ -266,10 +265,9 @@ Note also that if you disable PostgreSQL per above you MUST supply values for th
 In case you want to add extra environment variables (useful for advanced operations like custom init scripts), you can use the `extraEnvVars` property.
 
 ```yaml
-kong:
-  extraEnvVars:
-    - name: LOG_LEVEL
-      value: error
+extraEnvVars:
+  - name: KEYCLOAK_LOG_LEVEL
+    value: DEBUG
 ```
 
 Alternatively, you can use a ConfigMap or a Secret with the environment variables. To do so, use the `extraEnvVarsCM` or the `extraEnvVarsSecret` values.

--- a/bitnami/keycloak/templates/configmap-env-vars.yaml
+++ b/bitnami/keycloak/templates/configmap-env-vars.yaml
@@ -19,7 +19,6 @@ data:
   KEYCLOAK_DATABASE_PORT: {{ include "keycloak.databasePort" . }}
   KEYCLOAK_DATABASE_NAME: {{ include "keycloak.databaseName" . | quote }}
   KEYCLOAK_DATABASE_USER: {{ include "keycloak.databaseUser" . | quote }}
-  KEYCLOAK_BIND_ADDRESS: {{ .Values.bindAddress | quote }}
   KEYCLOAK_HTTP_PORT: {{ .Values.containerPorts.http | quote }}
   KEYCLOAK_PROXY_ADDRESS_FORWARDING: {{ ternary "true" "false" .Values.proxyAddressForwarding | quote }}
   KEYCLOAK_ENABLE_STATISTICS: {{ ternary "true" "false" .Values.metrics.enabled | quote }}

--- a/bitnami/keycloak/templates/headless-service.yaml
+++ b/bitnami/keycloak/templates/headless-service.yaml
@@ -25,5 +25,6 @@ spec:
       protocol: TCP
       targetPort: https
     {{- end }}
+  publishNotReadyAddresses: true
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: keycloak

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -93,11 +93,6 @@ auth:
     ##
     truststorePassword: ""
 
-## Keycloak bind address
-## ref: https://github.com/bitnami/bitnami-docker-keycloak#port-and-address-binding
-##
-bindAddress: 0.0.0.0
-
 ## Enable Proxy Address Forwarding
 ## ref: https://www.keycloak.org/docs/latest/server_installation/#_setting-up-a-load-balancer-or-proxy
 ##

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -38,7 +38,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: bitnami/keycloak
-  tag: 11.0.3-debian-10-r12
+  tag: 11.0.3-debian-10-r14
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR:

- Improves the example to use **extraEnvVars** parameter.
- Ensure the headless service publish services before they're ready (to improve discovery)
- Removes an unnecessary parameter: **bindAddress**. The value for the flag `-Djboss.bind.address` is now auto-calculated instead.

**Possible drawbacks**

None

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

