### PR TITLE
[bitnami/magento] Major version. Adapt Chart to apiVersion: v2 and Update MariaDB Dependency

### DIFF
--- a/bitnami/magento/Chart.lock
+++ b/bitnami/magento/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: mariadb
+  repository: https://charts.bitnami.com/bitnami
+  version: 9.0.1
+- name: elasticsearch
+  repository: https://charts.bitnami.com/bitnami
+  version: 12.8.2
+digest: sha256:ebb9ed6098da68d72a79783b5429c218cf2fc70020e7e5405da19db5893a7b47
+generated: "2020-11-18T21:52:20.911859493Z"

--- a/bitnami/magento/Chart.yaml
+++ b/bitnami/magento/Chart.yaml
@@ -1,22 +1,31 @@
-apiVersion: v1
-name: magento
-version: 14.0.6
+annotations:
+  category: E-Commerce
+apiVersion: v2
 appVersion: 2.4.1
+dependencies:
+  - condition: mariadb.enabled
+    name: mariadb
+    repository: https://charts.bitnami.com/bitnami
+    version: 9.x.x
+  - condition: elasticsearch.enabled
+    name: elasticsearch
+    repository: https://charts.bitnami.com/bitnami
+    version: 12.x.x
 description: A feature-rich flexible e-commerce solution. It includes transaction options, multi-store functionality, loyalty programs, product categorization and shopper filtering, promotion rules, and more.
+engine: gotpl
+home: https://github.com/bitnami/charts/tree/master/bitnami/magento
+icon: https://bitnami.com/assets/stacks/magento/img/magento-stack-110x117.png
 keywords:
   - magento
   - e-commerce
   - http
   - web
   - php
-home: https://github.com/bitnami/charts/tree/master/bitnami/magento
+maintainers:
+  - email: containers@bitnami.com
+    name: Bitnami
+name: magento
 sources:
   - https://github.com/bitnami/bitnami-docker-magento
   - https://magento.com/
-maintainers:
-  - name: Bitnami
-    email: containers@bitnami.com
-engine: gotpl
-icon: https://bitnami.com/assets/stacks/magento/img/magento-stack-110x117.png
-annotations:
-  category: E-Commerce
+version: 15.0.0

--- a/bitnami/magento/README.md
+++ b/bitnami/magento/README.md
@@ -20,7 +20,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 ## Prerequisites
 
 - Kubernetes 1.12+
-- Helm 2.12+ or Helm 3.0-beta3+
+- Helm 3.0-beta3+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 
@@ -87,22 +87,8 @@ The following table lists the configurable parameters of the Magento chart and t
 | `ingress.secrets[0].name`               | TLS Secret Name                                                                                      | `nil`                                                        |
 | `ingress.secrets[0].certificate`        | TLS Secret Certificate                                                                               | `nil`                                                        |
 | `ingress.secrets[0].key`                | TLS Secret Key                                                                                       | `nil`                                                        |
-| `externalDatabase.host`                 | Host of the external database                                                                        | `nil`                                                        |
-| `externalDatabase.port`                 | Port of the external database                                                                        | `3306`                                                       |
-| `externalDatabase.user`                 | Existing username in the external db                                                                 | `bn_magento`                                                 |
-| `externalDatabase.password`             | Password for the above username                                                                      | `nil`                                                        |
-| `externalDatabase.database`             | Name of the existing database                                                                        | `bitnami_magento`                                            |
 | `externalElasticsearch.host`            | Host of the external elasticsearch server                                                            | `nil`                                                        |
 | `externalElasticsearch.port`            | Port of the external elasticsearch server                                                            | `nil`                                                        |
-| `mariadb.enabled`                       | Whether to use the MariaDB chart                                                                     | `true`                                                       |
-| `mariadb.rootUser.password`             | MariaDB admin password                                                                               | `nil`                                                        |
-| `mariadb.db.name`                       | Database name to create                                                                              | `bitnami_magento`                                            |
-| `mariadb.db.user`                       | Database user to create                                                                              | `bn_magento`                                                 |
-| `mariadb.db.password`                   | Password for the database                                                                            | _random 10 character long alphanumeric string_               |
-| `mariadb.replication.enabled`           | MariaDB replication enabled                                                                          | `true`                                                       |
-| `mariadb.master.persistence.enabled`    | Enable persistence using PVC                                                                         | `true`                                                       |
-| `mariadb.master.persistence.accessMode` | Persistent Volume Access Modes                                                                       | `[ReadWriteOnce]`                                            |
-| `mariadb.master.persistence.size`       | Persistent Volume Size                                                                               | `8Gi`                                                        |
 | `elasticsearch.enabled`                 | Use the Elasticsearch chart as search engine                                                         | `true`                                                       |
 | `elasticsearch.image.registry`          | Elasticsearch image registry                                                                         | `docker.io`                                                  |
 | `elasticsearch.image.repository`        | Elasticsearch image name                                                                             | `bitnami/elasticsearch`                                      |
@@ -150,6 +136,29 @@ The following table lists the configurable parameters of the Magento chart and t
 | `metrics.image.pullSecrets`             | Specify docker-registry secret names as an array                                                     | `[]` (does not add image pull secrets to deployed pods)      |
 | `metrics.podAnnotations`                | Additional annotations for Metrics exporter pod                                                      | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
 | `metrics.resources`                     | Exporter resource requests/limit                                                                     | {}                                                           |
+
+### Database parameters
+
+| Parameter                                  | Description                                           | Default                                        |
+|--------------------------------------------|-------------------------------------------------------|------------------------------------------------|
+| `mariadb.enabled`                          | Whether to use the MariaDB chart                      | `true`                                         |
+| `mariadb.architecture`                     | MariaDB architecture (`standalone` or `replication`)  | `standalone`                                   |
+| `mariadb.auth.rootPassword`                | Password for the MariaDB `root` user                  | _random 10 character alphanumeric string_      |
+| `mariadb.auth.database`                    | Database name to create                               | `bitnami_magento`                              |
+| `mariadb.auth.username`                    | Database user to create                               | `bn_magento`                                   |
+| `mariadb.auth.password`                    | Password for the database                             | _random 10 character long alphanumeric string_ |
+| `mariadb.primary.persistence.enabled`      | Enable database persistence using PVC                 | `true`                                         |
+| `mariadb.primary.persistence.accessMode`   | Database Persistent Volume Access Modes               | `ReadWriteOnce`                                |
+| `mariadb.primary.persistence.size`         | Database Persistent Volume Size                       | `8Gi`                                          |
+| `mariadb.primary.persistence.existingClaim`| Enable persistence using an existing PVC              | `nil`                                          |
+| `mariadb.primary.persistence.storageClass` | PVC Storage Class                                     | `nil` (uses alpha storage class annotation)    |
+| `mariadb.primary.persistence.hostPath`     | Host mount path for MariaDB volume                    | `nil` (will not mount to a host path)          |
+| `externalDatabase.user`                    | Existing username in the external db                  | `bn_magento`                                   |
+| `externalDatabase.password`                | Password for the above username                       | `nil`                                          |
+| `externalDatabase.database`                | Name of the existing database                         | `bitnami_magento`                              |
+| `externalDatabase.host`                    | Host of the existing database                         | `nil`                                          |
+| `externalDatabase.port`                    | Port of the existing database                         | `3306`                                         |
+| `externalDatabase.existingSecret`          | Name of the database existing Secret Object           | `nil`                                          |
 
 The above parameters map to the env variables defined in [bitnami/magento](http://github.com/bitnami/bitnami-docker-magento). For more information please refer to the [bitnami/magento](http://github.com/bitnami/bitnami-docker-magento) image documentation.
 
@@ -238,6 +247,86 @@ Currently, Elasticsearch requires some changes in the kernel of the host machine
 You can disable the initContainer using the `elasticsearch.sysctlImage.enabled=false` parameter.
 
 ## Upgrading
+
+### To 8.0.0
+
+In this major there were two main changes introduced:
+
+1. Adaptation to Helm v2 EOL
+2. Updated MariaDB dependency version
+
+Please read the update notes carefully.
+
+**1. Adaptation to Helm v2 EOL**
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+**What changes were introduced in this major version?**
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- Move dependency information from the *requirements.yaml* to the *Chart.yaml*
+- After running `helm dependency update`, a *Chart.lock* file is generated containing the same structure used in the previous *requirements.lock*
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+
+**Considerations when upgrading to this version**
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+**Useful links**
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
+
+**2. Updated MariaDB dependency version**
+
+In this major the MariaDB dependency version was also bumped to a new major version that introduces several incompatilibites. Therefore, backwards compatibility is not guaranteed unless an external database is used. Check [MariaDB Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/mariadb#to-800) for more information.
+
+To upgrade to `8.0.0`, it should be done reusing the PVCs used to hold both the MariaDB and Magento data on your previous release. To do so, follow the instructions below (the following example assumes that the release name is `magento` and that a `rootUser.password` was defined for MariaDB in `values.yaml` when the chart was first installed):
+
+> NOTE: Please, create a backup of your database before running any of those actions. The steps below would be only valid if your application (e.g. any plugins or custom code) is compatible with MariaDB 10.5.x
+
+Obtain the credentials and the names of the PVCs used to hold both the MariaDB and Magento data on your current release:
+
+```console
+export MAGENTO_HOST=$(kubectl get svc --namespace default magento --template "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}")
+export MAGENTO_PASSWORD=$(kubectl get secret --namespace default magento -o jsonpath="{.data.magento-password}" | base64 --decode)
+export MARIADB_ROOT_PASSWORD=$(kubectl get secret --namespace default magento-mariadb -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)
+export MARIADB_PASSWORD=$(kubectl get secret --namespace default magento-mariadb -o jsonpath="{.data.mariadb-password}" | base64 --decode)
+export MARIADB_PVC=$(kubectl get pvc -l app=mariadb,component=master,release=magento -o jsonpath="{.items[0].metadata.name}")
+```
+
+Delete the Redmine deployment and delete the MariaDB statefulset. Notice the option `--cascade=false` in the latter.
+
+```console
+  $ kubectl delete deployments.apps magento
+
+  $ kubectl delete statefulsets.apps magento-mariadb --cascade=false
+```
+
+Now the upgrade works:
+
+```console
+$ helm upgrade magento bitnami/magento --set mariadb.primary.persistence.existingClaim=$MARIADB_PVC --set mariadb.auth.rootPassword=$MARIADB_ROOT_PASSWORD --set mariadb.auth.password=$MARIADB_PASSWORD --set magentoPassword=$MAGENTO_PASSWORD --set magentoHost=$MAGENTO_HOST
+```
+
+You will have to delete the existing MariaDB pod and the new statefulset is going to create a new one
+
+  ```console
+  $ kubectl delete pod magento-mariadb-0
+  ```
+
+Finally, you should see the lines below in MariaDB container logs:
+
+```console
+$ kubectl logs $(kubectl get pods -l app.kubernetes.io/instance=magento,app.kubernetes.io/name=mariadb,app.kubernetes.io/component=primary -o jsonpath="{.items[0].metadata.name}")
+...
+mariadb 12:13:24.98 INFO  ==> Using persisted data
+mariadb 12:13:25.01 INFO  ==> Running mysql_upgrade
+...
+```
 
 ### To 10.0.0
 

--- a/bitnami/magento/README.md
+++ b/bitnami/magento/README.md
@@ -282,11 +282,11 @@ Please read the update notes carefully.
 
 **2. Updated MariaDB dependency version**
 
-In this major the MariaDB and Elasticsearch dependency versions were also bumped to a new major version that introduces several incompatilibites. Therefore, backwards compatibility is not guaranteed. Check [MariaDB Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/mariadb#to-800) for more information.
+In this major the MariaDB and Elasticsearch dependency versions were also bumped to a new major version that introduces several incompatilibites. Therefore, backwards compatibility is not guaranteed. Check [MariaDB Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/mariadb#to-800) for more information. Although it is using the latest `bitnami/mariadb` chart, given Magento `2.4` [current limitations](https://devdocs.magento.com/guides/v2.4/install-gde/system-requirements.html#database), the container image of MariaDB has been bumped to `10.4.x` instead of using the latest `10.5.x`.
 
 To upgrade to `15.0.0`, it should be done reusing the PVCs used to hold data from MariaDB, Elasticsearch and Magento data on your previous release. To do so, follow the instructions below (the following example assumes that the release name is `magento` and that a `rootUser.password` was defined for MariaDB in `values.yaml` when the chart was first installed):
 
-> NOTE: Please, create a backup of your database before running any of those actions. The steps below would be only valid if your application (e.g. any plugins or custom code) is compatible with MariaDB 10.5.x
+> NOTE: Please, create a backup of your database before running any of those actions. The steps below would be only valid if your application (e.g. any plugins or custom code) is compatible with MariaDB 10.4.x
 
 Obtain the credentials and the names of the PVCs used to hold the MariaDB data on your current release:
 

--- a/bitnami/magento/requirements.lock
+++ b/bitnami/magento/requirements.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: mariadb
-  repository: https://charts.bitnami.com/bitnami
-  version: 7.10.4
-- name: elasticsearch
-  repository: https://charts.bitnami.com/bitnami
-  version: 12.8.0
-digest: sha256:2051a09fad83eb1f2354275cf6eb5d57dea803bfaaa045177e6bcb35e3c3b8d9
-generated: "2020-10-21T11:31:44.13602904Z"

--- a/bitnami/magento/requirements.yaml
+++ b/bitnami/magento/requirements.yaml
@@ -1,9 +1,0 @@
-dependencies:
-  - name: mariadb
-    version: 7.x.x
-    repository: https://charts.bitnami.com/bitnami
-    condition: mariadb.enabled
-  - name: elasticsearch
-    version: 12.x.x
-    repository: https://charts.bitnami.com/bitnami
-    condition: elasticsearch.enabled

--- a/bitnami/magento/templates/NOTES.txt
+++ b/bitnami/magento/templates/NOTES.txt
@@ -22,18 +22,16 @@ host. To configure Magento with the URL of your service:
 
   export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "magento.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
   export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "magento.fullname" . }} -o jsonpath="{.data.magento-password}" | base64 --decode)
-  {{- if .Values.mariadb.mariadbRootPassword }}
-  export DATABASE_ROOT_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "magento.mariadb.fullname" . }} -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)
   {{- end }}
-  {{- end }}
-  export APP_DATABASE_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "magento.mariadb.fullname" . }} -o jsonpath="{.data.mariadb-password}" | base64 --decode)
+  export MARIADB_ROOT_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "magento.mariadb.fullname" . }} -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)
+  export MARIADB_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "magento.mariadb.fullname" . }} -o jsonpath="{.data.mariadb-password}" | base64 --decode)
 
 2. Complete your Magento deployment by running:
 
 {{- if .Values.mariadb.enabled }}
 
   helm upgrade {{ .Release.Name }} bitnami/{{ .Chart.Name }} \
-    --set magentoHost=$APP_HOST,magentoPassword=$APP_PASSWORD{{ if .Values.mariadb.mariadbRootPassword }},mariadb.mariadbRootPassword=$DATABASE_ROOT_PASSWORD{{ end }},mariadb.db.password=$APP_DATABASE_PASSWORD{{- if .Values.global }}{{- if .Values.global.imagePullSecrets }},global.imagePullSecrets={{ .Values.global.imagePullSecrets }}{{- end }}{{- end }}
+    --set magentoHost=$APP_HOST,magentoPassword=$APP_PASSWORD,mariadb.auth.rootPassword=$MARIADB_ROOT_PASSWORD,mariadb.auth.password=$MARIADB_PASSWORD{{- if .Values.global }}{{- if .Values.global.imagePullSecrets }},global.imagePullSecrets={{ .Values.global.imagePullSecrets }}{{- end }}{{- end }}
 {{- else }}
 
   ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##

--- a/bitnami/magento/templates/NOTES.txt
+++ b/bitnami/magento/templates/NOTES.txt
@@ -30,13 +30,13 @@ host. To configure Magento with the URL of your service:
 
 {{- if .Values.mariadb.enabled }}
 
-  helm upgrade {{ .Release.Name }} bitnami/{{ .Chart.Name }} \
+  helm upgrade {{ .Release.Name }} bitnami/{{ .Chart.Name }} --namespace {{ .Release.Namespace }} \
     --set magentoHost=$APP_HOST,magentoPassword=$APP_PASSWORD,mariadb.auth.rootPassword=$MARIADB_ROOT_PASSWORD,mariadb.auth.password=$MARIADB_PASSWORD{{- if .Values.global }}{{- if .Values.global.imagePullSecrets }},global.imagePullSecrets={{ .Values.global.imagePullSecrets }}{{- end }}{{- end }}
 {{- else }}
 
   ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
 
-  helm upgrade {{ .Release.Name }} bitnami/{{ .Chart.Name }} \
+  helm upgrade {{ .Release.Name }} bitnami/{{ .Chart.Name }} --namespace {{ .Release.Namespace }} \
     --set magentoPassword=$APP_PASSWORD,magentoHost=$APP_HOST,service.type={{ .Values.service.type }},mariadb.enabled=false{{- if not (empty .Values.externalDatabase.host) }},externalDatabase.host={{ .Values.externalDatabase.host }}{{- end }}{{- if not (empty .Values.externalDatabase.user) }},externalDatabase.user={{ .Values.externalDatabase.user }}{{- end }}{{- if not (empty .Values.externalDatabase.password) }},externalDatabase.password={{ .Values.externalDatabase.password }}{{- end }}{{- if not (empty .Values.externalDatabase.database) }},externalDatabase.database={{ .Values.externalDatabase.database }}{{- end }}{{- if .Values.global }}{{- if .Values.global.imagePullSecrets }},global.imagePullSecrets={{ .Values.global.imagePullSecrets }}{{- end }}{{- end }}
 {{- end }}
 

--- a/bitnami/magento/templates/_helpers.tpl
+++ b/bitnami/magento/templates/_helpers.tpl
@@ -244,3 +244,64 @@ Return the appropriate apiVersion for deployment.
 {{- print "apps/v1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the MariaDB Hostname
+*/}}
+{{- define "magento.databaseHost" -}}
+{{- if .Values.mariadb.enabled }}
+    {{- if eq .Values.mariadb.architecture "replication" }}
+        {{- printf "%s-%s" (include "magento.mariadb.fullname" .) "primary" | trunc 63 | trimSuffix "-" -}}
+    {{- else -}}
+        {{- printf "%s" (include "magento.mariadb.fullname" .) -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s" .Values.externalDatabase.host -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the MariaDB Port
+*/}}
+{{- define "magento.databasePort" -}}
+{{- if .Values.mariadb.enabled }}
+    {{- printf "3306" -}}
+{{- else -}}
+    {{- printf "%d" (.Values.externalDatabase.port | int ) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the MariaDB Database Name
+*/}}
+{{- define "magento.databaseName" -}}
+{{- if .Values.mariadb.enabled }}
+    {{- printf "%s" .Values.mariadb.auth.database -}}
+{{- else -}}
+    {{- printf "%s" .Values.externalDatabase.database -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the MariaDB User
+*/}}
+{{- define "magento.databaseUser" -}}
+{{- if .Values.mariadb.enabled }}
+    {{- printf "%s" .Values.mariadb.auth.username -}}
+{{- else -}}
+    {{- printf "%s" .Values.externalDatabase.user -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the MariaDB Secret Name
+*/}}
+{{- define "magento.databaseSecretName" -}}
+{{- if .Values.mariadb.enabled }}
+    {{- printf "%s" (include "magento.mariadb.fullname" .) -}}
+{{- else if .Values.externalDatabase.existingSecret -}}
+    {{- printf "%s" .Values.externalDatabase.existingSecret -}}
+{{- else -}}
+    {{- printf "%s-%s" .Release.Name "externaldb" -}}
+{{- end -}}
+{{- end -}}

--- a/bitnami/magento/templates/deployment.yaml
+++ b/bitnami/magento/templates/deployment.yaml
@@ -48,17 +48,18 @@ spec:
               value: "1"
           {{- end }}
             - name: MARIADB_HOST
-          {{- if .Values.mariadb.enabled }}
-              value: {{ template "magento.mariadb.fullname" . }}
-          {{- else }}
-              value: {{ .Values.externalDatabase.host | quote }}
-          {{- end }}
+              value: {{ include "magento.databaseHost" . | quote }}
             - name: MARIADB_PORT_NUMBER
-            {{- if .Values.mariadb.enabled }}
-              value: "3306"
-            {{- else }}
-              value: {{ .Values.externalDatabase.port | quote }}
-            {{- end }}
+              value: {{ include "magento.databasePort" . | quote }}
+            - name: MAGENTO_DATABASE_NAME
+              value: {{ include "magento.databaseName" . | quote }}
+            - name: MAGENTO_DATABASE_USER
+              value: {{ include "magento.databaseUser" . | quote }}
+            - name: MAGENTO_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "magento.databaseSecretName" . }}
+                  key: mariadb-password
             - name: ELASTICSEARCH_HOST
             {{- if .Values.elasticsearch.enabled }}
               value: {{ template "magento.elasticsearch.fullname" . }}
@@ -75,28 +76,6 @@ spec:
             {{- else }}
               value: ""
             {{- end }}
-            - name: MAGENTO_DATABASE_NAME
-            {{- if .Values.mariadb.enabled }}
-              value: {{ .Values.mariadb.db.name | quote }}
-            {{- else }}
-              value: {{ .Values.externalDatabase.database | quote }}
-            {{- end }}
-            - name: MAGENTO_DATABASE_USER
-            {{- if .Values.mariadb.enabled }}
-              value: {{ .Values.mariadb.db.user | quote }}
-            {{- else }}
-              value: {{ .Values.externalDatabase.user | quote }}
-            {{- end }}
-            - name: MAGENTO_DATABASE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  {{- if .Values.mariadb.enabled }}
-                  name: {{ template "magento.mariadb.fullname" . }}
-                  key: mariadb-password
-                  {{- else }}
-                  name: {{ template "magento.fullname" . }}-externaldb
-                  key: db-password
-                  {{- end }}
             {{- $port:=.Values.service.port | toString }}
             - name: MAGENTO_HOST
               value: "{{ include "magento.host" . }}{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}"

--- a/bitnami/magento/templates/externaldb-secrets.yaml
+++ b/bitnami/magento/templates/externaldb-secrets.yaml
@@ -1,4 +1,4 @@
-{{- if (not (or .Values.mariadb.enabled .Values.externalDatabase.existingSecret)) }}
+{{- if not (or .Values.mariadb.enabled .Values.externalDatabase.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/bitnami/magento/templates/externaldb-secrets.yaml
+++ b/bitnami/magento/templates/externaldb-secrets.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.mariadb.enabled }}
+{{- if (not (or .Values.mariadb.enabled .Values.externalDatabase.existingSecret)) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,5 +10,5 @@ metadata:
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 type: Opaque
 data:
-  db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
+  mariadb-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
 {{- end }}

--- a/bitnami/magento/values-production.yaml
+++ b/bitnami/magento/values-production.yaml
@@ -142,6 +142,12 @@ mariadb:
   ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
   ##
   enabled: true
+  ## Override MariaDB default image as 10.5 is not supported https://devdocs.magento.com/guides/v2.4/install-gde/system-requirements.html#database
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb
+  image:
+    registry: docker.io
+    repository: bitnami/mariadb
+    tag: 10.4.17-debian-10-r7
 
   ## MariaDB architecture. Allowed values: standalone or replication
   ##
@@ -195,12 +201,6 @@ elasticsearch:
   ## Whether to deploy a elasticsearch server to use as magento's search engine
   ## To use an external server set this to false and configure the externalElasticsearch parameters
   enabled: true
-  ## Tag for the Bitnami Elasticsearch image to use
-  ## ref: https://github.com/bitnami/bitnami-docker-elasticsearch
-  image:
-    registry: docker.io
-    repository: bitnami/elasticsearch
-    tag: 6.8.12-debian-10-r61
   ## Enable to perform the sysctl operation
   sysctlImage:
     enabled: true
@@ -316,7 +316,7 @@ ingress:
   ##
   ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
-  annotations:
+  annotations: {}
   #  kubernetes.io/ingress.class: nginx
 
   ## The list of hostnames to be covered with this ingress record.
@@ -332,8 +332,8 @@ ingress:
       ## Useful when the Ingress controller supports www-redirection
       ## If not specified, the above host name will be used
       # tlsHosts:
-      # - www.magento.local
-      # - magento.local
+      #   - www.magento.local
+      #   - magento.local
 
       ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
       tlsSecret: magento.local-tls

--- a/bitnami/magento/values-production.yaml
+++ b/bitnami/magento/values-production.yaml
@@ -146,7 +146,7 @@ mariadb:
   ## MariaDB architecture. Allowed values: standalone or replication
   ##
   architecture: standalone
-  
+
   ## MariaDB Authentication parameters
   ##
   auth:

--- a/bitnami/magento/values-production.yaml
+++ b/bitnami/magento/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/magento
-  tag: 2.4.1-debian-10-r2
+  tag: 2.4.1-debian-10-r24
   ## Set to true if you would like to see extra information on logs
   ## It turns BASH and NAMI debugging in minideb
   ## ref:  https://github.com/bitnami/minideb-extras/#turn-on-bash-debugging
@@ -364,7 +364,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.8.0-debian-10-r190
+    tag: 0.8.0-debian-10-r217
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/magento/values-production.yaml
+++ b/bitnami/magento/values-production.yaml
@@ -103,6 +103,11 @@ allowEmptyPassword: "yes"
 ## External database configuration
 ##
 externalDatabase:
+  ## Use existing secret (ignores previous password)
+  ## must contain key `mariadb-password`
+  ## NOTE: When it's set, the `externalDatabase.password` parameter is ignored
+  # existingSecret:
+
   ## Database host
   host:
 
@@ -135,31 +140,32 @@ externalElasticsearch:
 ##
 mariadb:
   ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+  ##
   enabled: true
-  ## Disable MariaDB replication
-  replication:
-    enabled: false
 
-  ## Create a database and a database user
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ## MariaDB architecture. Allowed values: standalone or replication
   ##
-  db:
-    name: bitnami_magento
-    user: bn_magento
-    ## If the password is not specified, mariadb will generates a random password
+  architecture: standalone
+  
+  ## MariaDB Authentication parameters
+  ##
+  auth:
+    ## MariaDB root password
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
     ##
-    # password:
+    rootPassword: ""
+    ## MariaDB custom user and database
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+    ##
+    database: bitnami_magento
+    username: bn_magento
+    password: ""
 
-  ## MariaDB admin password
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
-  ##
-  # rootUser:
-  #   password:
-
-  ## Enable persistence using Persistent Volume Claims
-  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-  ##
-  master:
+  primary:
+    ## Enable persistence using Persistent Volume Claims
+    ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+    ##
     persistence:
       enabled: true
       ## mariadb data Persistent Volume Storage Class
@@ -169,9 +175,16 @@ mariadb:
       ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
       ##   GKE, AWS & OpenStack)
       ##
-      # storageClass: "-"
-      accessMode: ReadWriteOnce
+      storageClass:
+      accessModes:
+        - ReadWriteOnce
       size: 8Gi
+      ## Set path in case you want to use local host path volumes (not recommended in production)
+      ##
+      hostPath:
+      ## Use an existing PVC
+      ##
+      existingClaim:
 
 ##
 ## Elasticsearch chart configuration

--- a/bitnami/magento/values.yaml
+++ b/bitnami/magento/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/magento
-  tag: 2.4.1-debian-10-r2
+  tag: 2.4.1-debian-10-r24
   ## Set to true if you would like to see extra information on logs
   ## It turns BASH and NAMI debugging in minideb
   ## ref:  https://github.com/bitnami/minideb-extras/#turn-on-bash-debugging
@@ -364,7 +364,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.8.0-debian-10-r190
+    tag: 0.8.0-debian-10-r217
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/magento/values.yaml
+++ b/bitnami/magento/values.yaml
@@ -142,7 +142,7 @@ mariadb:
   ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
   ##
   enabled: true
-  ## Tag for the Bitnami MariaDb image to use
+  ## Override MariaDB default image as 10.5 is not supported https://devdocs.magento.com/guides/v2.4/install-gde/system-requirements.html#database
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb
   image:
     registry: docker.io
@@ -201,7 +201,6 @@ elasticsearch:
   ## Whether to deploy a elasticsearch server to use as magento's search engine
   ## To use an external server set this to false and configure the externalElasticsearch parameters
   enabled: true
-
   ## Enable to perform the sysctl operation
   sysctlImage:
     enabled: true

--- a/bitnami/magento/values.yaml
+++ b/bitnami/magento/values.yaml
@@ -142,6 +142,12 @@ mariadb:
   ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
   ##
   enabled: true
+  ## Tag for the Bitnami MariaDb image to use
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb
+  image:
+    registry: docker.io
+    repository: bitnami/mariadb
+    tag: 10.4.17-debian-10-r7
 
   ## MariaDB architecture. Allowed values: standalone or replication
   ##
@@ -195,12 +201,7 @@ elasticsearch:
   ## Whether to deploy a elasticsearch server to use as magento's search engine
   ## To use an external server set this to false and configure the externalElasticsearch parameters
   enabled: true
-  ## Tag for the Bitnami Elasticsearch image to use
-  ## ref: https://github.com/bitnami/bitnami-docker-elasticsearch
-  image:
-    registry: docker.io
-    repository: bitnami/elasticsearch
-    tag: 6.8.12-debian-10-r61
+
   ## Enable to perform the sysctl operation
   sysctlImage:
     enabled: true

--- a/bitnami/magento/values.yaml
+++ b/bitnami/magento/values.yaml
@@ -103,6 +103,11 @@ allowEmptyPassword: "yes"
 ## External database configuration
 ##
 externalDatabase:
+  ## Use existing secret (ignores previous password)
+  ## must contain key `mariadb-password`
+  ## NOTE: When it's set, the `externalDatabase.password` parameter is ignored
+  # existingSecret:
+
   ## Database host
   host:
 
@@ -135,31 +140,32 @@ externalElasticsearch:
 ##
 mariadb:
   ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+  ##
   enabled: true
-  ## Disable MariaDB replication
-  replication:
-    enabled: false
 
-  ## Create a database and a database user
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ## MariaDB architecture. Allowed values: standalone or replication
   ##
-  db:
-    name: bitnami_magento
-    user: bn_magento
-    ## If the password is not specified, mariadb will generates a random password
+  architecture: standalone
+
+  ## MariaDB Authentication parameters
+  ##
+  auth:
+    ## MariaDB root password
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
     ##
-    # password:
+    rootPassword: ""
+    ## MariaDB custom user and database
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+    ##
+    database: bitnami_magento
+    username: bn_magento
+    password: ""
 
-  ## MariaDB admin password
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
-  ##
-  # rootUser:
-  #   password:
-
-  ## Enable persistence using Persistent Volume Claims
-  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-  ##
-  master:
+  primary:
+    ## Enable persistence using Persistent Volume Claims
+    ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+    ##
     persistence:
       enabled: true
       ## mariadb data Persistent Volume Storage Class
@@ -169,9 +175,16 @@ mariadb:
       ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
       ##   GKE, AWS & OpenStack)
       ##
-      # storageClass: "-"
-      accessMode: ReadWriteOnce
+      storageClass:
+      accessModes:
+        - ReadWriteOnce
       size: 8Gi
+      ## Set path in case you want to use local host path volumes (not recommended in production)
+      ##
+      hostPath:
+      ## Use an existing PVC
+      ##
+      existingClaim:
 
 ##
 ## Elasticsearch chart configuration


### PR DESCRIPTION
**Description of the change**

- Bump `apiVersion` from `v1` to `v2` in _Chart.yaml_
- Fields in _Chart.yaml_ file has been ordered alphabetically
- Move dependency information from the _requirements.yaml_ to the _Chart.yaml_
- After running `helm dependency update`, a new _Chart.lock_ file is generated containing the same structure used in the previous _requirements.lock_
- Update _README.md_
- Updated MariaDB dependency to the new bitnami/mariadb major but using MariaDB 10.4
- Bumped Elasticsearch version to 7.10

**Possible drawbacks**

- Helm v2 is no longer supported
- If the user is using MariaDB as the testing database, this major contains breaking changes due to MariaDB major bump