### PR TITLE
[bitnami/ghost] set default DeploymentStrategy to Recreate

### DIFF
--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -33,4 +33,4 @@ name: ghost
 sources:
   - https://github.com/bitnami/bitnami-docker-ghost
   - http://www.ghost.org/
-version: 11.2.1
+version: 12.0.0

--- a/bitnami/ghost/README.md
+++ b/bitnami/ghost/README.md
@@ -146,6 +146,7 @@ The following table lists the configurable parameters of the Ghost chart and the
 | `smtpPassword`                              | SMTP password                                                                                                         | `nil`                                                        |
 | `smtpFromAddress`                           | SMTP from address                                                                                                     | `nil`                                                        |
 | `smtpService`                               | SMTP service                                                                                                          | `nil`                                                        |
+| `strategy`                                  | The DeploymentStrategy to use when updating (Recreate or RollingUpdate)                                               | `{ type: Recreate }`                                         |
 | `tolerations`                               | Tolerations for pod assignment                                                                                        | `[]` (The value is evaluated as a template)                  |
 | `updateStrategy`                            | Deployment update strategy                                                                                            | `nil`                                                        |
 

--- a/bitnami/ghost/templates/deployment.yaml
+++ b/bitnami/ghost/templates/deployment.yaml
@@ -14,7 +14,8 @@ metadata:
 spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-  replicas: {{ .Values.replicaCount }}
+  strategy: {{- include "common.tplvalues.render" (dict "value" .Values.strategy "context" $) | nindent 4 }}
+  replicas: 1
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}

--- a/bitnami/ghost/values.yaml
+++ b/bitnami/ghost/values.yaml
@@ -119,6 +119,20 @@ allowEmptyPassword: true
 # smtpFromAddress
 # smtpService:
 
+## DeploymentStrategy to use when updating.
+## Defaults to Recreate as the default persistence.accessMode is ReadWriteOnce
+strategy:
+  type: Recreate
+  ## Set to type: RollingUpdate only if you have ReadWriteMany volumes or your newly
+  ## scheduled pods can’t mount the volume as the old pod still has it mounted
+  # type: RollingUpdate
+
+  ## Additional settings when using type: RollingUpdate
+  ## Each of those settings can be used alone or together with others.
+  # rollingUpdate:
+  #   maxSurge: 25%
+  #   maxUnavailable: 25%
+
 ## Use an existing secrets which already store your password data
 ##
 # existingSecret:


### PR DESCRIPTION
**Description of the change**

This commit enables configuration of the DeploymentStrategy and sets the default DeploymentStrategy to Recreate to match the other default settings.

**Benefits**

The chart can be updated with default settings.

**Possible drawbacks**

Users of ReadWriteMany volumes will need to change the strategy as Recreate is not necessary with RWX volumes.

**Applicable issues**

None.

**Additional information**

Nothing.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files