### PR TITLE
[bitnami/metrics-server] Support for extraVolumeMounts and non-privileged metrics readers

### DIFF
--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -17,4 +17,4 @@ name: metrics-server
 sources:
   - https://github.com/bitnami/bitnami-docker-metrics-server
   - https://github.com/kubernetes-incubator/metrics-server
-version: 5.0.2
+version: 5.1.0

--- a/bitnami/metrics-server/README.md
+++ b/bitnami/metrics-server/README.md
@@ -73,10 +73,12 @@ The following tables lists the configurable parameters of the Metrics Server cha
 | `service.type`            | Kubernetes Service type                                                                                                         | `ClusterIP`                                             |
 | `service.port`            | Kubernetes Service port                                                                                                         | `443`                                                   |
 | `service.annotations`     | Annotations for the Service                                                                                                     | {}                                                      |
-| `service.labels`          | Labels for the Service                                                                                                     | {}                                                      |
+| `service.labels`          | Labels for the Service                                                                                                          | {}                                                      |
 | `service.loadBalancerIP`  | LoadBalancer IP if Service type is `LoadBalancer`                                                                               | `nil`                                                   |
 | `service.nodePort`        | NodePort if Service type is `LoadBalancer` or `NodePort`                                                                        | `nil`                                                   |
 | `resources`               | The [resources] to allocate for the container                                                                                   | `{}`                                                    |
+| `extraVolumes`            | Extra volumes                                                                                                                   | `nil`                                                   |
+| `extraVolumeMounts`       | Mount extra volume(s)                                                                                                           | `nil`                                                   |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/metrics-server/templates/NOTES.txt
+++ b/bitnami/metrics-server/templates/NOTES.txt
@@ -25,6 +25,7 @@ Option B:
    You configure the metrics API service outside of this Helm chart
 {{- end -}}
 
+{{- include "metrics-server.validateValues" . }}
 {{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
 
 WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.

--- a/bitnami/metrics-server/templates/_helpers.tpl
+++ b/bitnami/metrics-server/templates/_helpers.tpl
@@ -112,6 +112,29 @@ imagePullSecrets:
 {{- end -}}
 
 {{/*
+Compile all warnings into a single message, and call fail.
+*/}}
+{{- define "metrics-server.validateValues" -}}
+{{- $messages := list -}}
+{{- $messages := append $messages (include "metrics-server.validateValues.extraVolumes" .) -}}
+{{- $messages := without $messages "" -}}
+{{- $message := join "\n" $messages -}}
+
+{{- if $message -}}
+{{-   printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Validate values of metrics-server - Incorrect extra volume settings */}}
+{{- define "metrics-server.validateValues.extraVolumes" -}}
+{{- if and (.Values.extraVolumes) (not .Values.extraVolumeMounts) -}}
+metrics-server: missing-extra-volume-mounts
+    You specified extra volumes but not mount points for them. Please set
+    the extraVolumeMounts value
+{{- end -}}
+{{- end -}}
+
+{{/*
 Renders a value that contains template.
 Usage:
 {{ include "metrics-server.tplValue" ( dict "value" .Values.path.to.the.Value "context" $) }}

--- a/bitnami/metrics-server/templates/cluster-role.yaml
+++ b/bitnami/metrics-server/templates/cluster-role.yaml
@@ -22,4 +22,23 @@ rules:
     verbs:
       - get
       - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels: {{- include "metrics-server.labels" . | nindent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: system:{{ template "metrics-server.fullname" . }}-aggregated-reader
+rules:
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
 {{- end -}}

--- a/bitnami/metrics-server/templates/deployment.yaml
+++ b/bitnami/metrics-server/templates/deployment.yaml
@@ -51,3 +51,9 @@ spec:
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+          volumeMounts: {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- end }}
+      {{- if .Values.extraVolumes }}
+      volumes: {{- toYaml .Values.extraVolumes | nindent 8 }}
+      {{- end }}

--- a/bitnami/metrics-server/values.yaml
+++ b/bitnami/metrics-server/values.yaml
@@ -153,3 +153,13 @@ resources:
   requests: {}
   #   cpu: 250m
   #   memory: 256Mi
+
+## Extra volumes to mount
+## Example Use Case: mount an `emptyDir` to allow running with a `readOnlyRootFilesystem: true`
+#  extraVolumes:
+#  - name: tmpdir
+#    emptyDir: {}
+#
+#  extraVolumeMounts:
+#  - name: tmpdir
+#    mountPath: /tmp


### PR DESCRIPTION
**Description of the change**

1. Adds support for `extraVolumeMounts` so you can mount a `tmpDir` and thus run with a `readOnlyRootFilesystem`
2. Creates the aggregating `ClusterRole` similar to the off-the-shelf [metrics-server rbac manifest](https://github.com/kubernetes-sigs/metrics-server/blob/master/manifests/base/rbac.yaml#L5) to allow non-admin users to see metrics

**Benefits**

Improved security posture through
- compatibility with unprivileged PSPs that don't allow mutable rootFilesystems
- ability for non-privileged users to still view metrics

**Possible drawbacks**

None known

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files