### PR TITLE
[bitnami/mongodb-sharded] Delete initScripts from mongos deployment

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -20,4 +20,4 @@ name: mongodb-sharded
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb-sharded
   - https://mongodb.org
-version: 3.0.3
+version: 3.0.4

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-deployment.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-deployment.yaml
@@ -181,25 +181,9 @@ spec:
             - name: secrets
               mountPath: /bitnami/mongodb/secrets/
             {{- end }}
-            {{- if .Values.mongos.initScriptsCM }}
-            - name: custom-init-scripts
-              mountPath: /docker-entrypoint-initdb.d/configmap
-            {{- end }}
-            {{- if .Values.mongos.initScriptsSecret }}
-            - name: custom-init-scripts-secrets
-              mountPath: /docker-entrypoint-initdb.d/secret
-            {{- end }}
             {{- if or .Values.mongos.config .Values.mongos.configCM }}
             - name: config
               mountPath: /bitnami/mongodb/conf/
-            {{- end }}
-            {{- if $.Values.common.initScriptsCM }}
-            - name: custom-init-scripts-cm
-              mountPath: /docker-entrypoint-initdb.d/cm
-            {{- end }}
-            {{- if $.Values.common.initScriptsSecret }}
-            - name: custom-init-scripts-secret
-              mountPath: /docker-entrypoint-initdb.d/secret
             {{- end }}
             {{- if $.Values.common.extraVolumeMounts }}
               {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.common.extraVolumeMounts "context" $ ) | nindent 12 }}
@@ -285,18 +269,6 @@ spec:
         - name: config
           configMap:
             name: {{ include "mongodb-sharded.mongos.configCM" . }}
-        {{- end }}
-        {{- if $.Values.common.initScriptsCM }}
-        - name: custom-init-scripts-cm
-          configMap:
-            name: {{ include "mongodb-sharded.initScriptsCM" . }}
-            defaultMode: 0755
-        {{- end }}
-        {{- if $.Values.common.initScriptsSecret }}
-        - name: custom-init-scripts-secret
-          secret:
-            name: {{ include "mongodb-sharded.initScriptsSecret" . }}
-            defaultMode: 0755
         {{- end }}
         {{- if $.Values.common.extraVolumes }}
           {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.common.extraVolumes "context" $ ) | nindent 8 }}


### PR DESCRIPTION
Signed-off-by: Miguel A. Cabrera Minagorri <macabrera@bitnami.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

It seems that the mongos pod should not be executing init scripts since it is just a routing component. The execution of the initScripts at the mongos pod is throwing errors due to missing database directories.
See: https://docs.mongodb.com/manual/core/sharded-cluster-query-router/
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #4382

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
