### PR TITLE
Redis-cluster fixing support TLS for redis-exporter

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -23,4 +23,4 @@ name: redis-cluster
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 4.0.1
+version: 4.0.2

--- a/bitnami/redis-cluster/templates/redis-statefulset.yaml
+++ b/bitnami/redis-cluster/templates/redis-statefulset.yaml
@@ -251,7 +251,7 @@ spec:
             - name: REDIS_ALIAS
               value: {{ template "common.names.fullname" . }}
             - name: REDIS_ADDR
-              value: {{ printf "127.0.0.1:%g" .Values.redis.port | quote }}
+              value: {{ printf "%s://127.0.0.1:%g" (ternary "rediss" "redis" .Values.tls.enabled) .Values.redis.port | quote }}
             {{- if and .Values.usePassword (not .Values.usePasswordFile) }}
             - name: REDIS_PASSWORD
               valueFrom:


### PR DESCRIPTION
**Description of the change**

Change REDIS_ADDR for redis-exporter to work correctly with TLS enabled.

**Benefits**

**Applicable issues**

**Additional information**

to reproduce

tls.enabled: true
metrics.enabled: true
metrics.serviceMonitor.enabled: true

Metrics return
`redis_exporter_last_scrape_error{endpoint="metrics",err="read tcp 127.0.0.1:59360->127.0.0.1:6379: read: connection reset by peer",instance="10.233.2.85:9121",job="redis-ha-redis-cluster-metrics",namespace="redis",pod="redis-ha-redis-cluster-0",service="redis-ha-redis-cluster-metrics"}`

[redis-exporter issue](https://github.com/oliver006/redis_exporter/issues/362)

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
