### PR TITLE
[bitnami/harbor] Update format and name for _REDIS_URL core

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-harbor-registry
   - https://github.com/bitnami/bitnami-docker-harbor-registryctl
   - https://goharbor.io/
-version: 9.0.0
+version: 9.0.1

--- a/bitnami/harbor/README.md
+++ b/bitnami/harbor/README.md
@@ -683,6 +683,7 @@ The following tables list the configurable parameters of the Harbor chart and th
 | `externalRedis.host`                      | Host of the external redis                                                                                | `localhost` |
 | `externalRedis.port`                      | Port of the external redis                                                                                | `6379`      |
 | `externalRedis.password`                  | Password for the external redis                                                                           | `nil`       |
+| `externalRedis.coreDatabaseIndex`         | Index for core database                                                                                   | `0`         |
 | `externalRedis.jobserviceDatabaseIndex`   | Index for jobservice database                                                                             | `1`         |
 | `externalRedis.registryDatabaseIndex`     | Index for registry database                                                                               | `2`         |
 | `externalRedis.chartmuseumDatabaseIndex`  | Index for chartmuseum database                                                                            | `3`         |

--- a/bitnami/harbor/templates/_helpers.tpl
+++ b/bitnami/harbor/templates/_helpers.tpl
@@ -474,6 +474,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
   {{- end -}}
 {{- end -}}
 
+{{- define "harbor.redis.coreDatabaseIndex" -}}
+  {{- if eq .Values.redis.enabled true -}}
+    {{- printf "%s" "0" }}
+  {{- else -}}
+    {{- .Values.externalRedis.coreDatabaseIndex -}}
+  {{- end -}}
+{{- end -}}
+
 {{- define "harbor.redis.jobserviceDatabaseIndex" -}}
   {{- if eq .Values.redis.enabled true -}}
     {{- printf "%s" "1" }}
@@ -564,12 +572,12 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
   {{- end -}}
 {{- end -}}
 
-{{/*
-host:port,pool_size,password
-100 is the default value of pool size
-*/}}
 {{- define "harbor.redisForCore" -}}
-  {{- printf "%s:%s,100,%s" (include "harbor.redis.host" . ) (include "harbor.redis.port" . ) (include "harbor.redis.rawPassword" . ) -}}
+  {{- if (include "harbor.redis.escapedRawPassword" . ) -}}
+    {{- printf "redis://redis:%s@%s:%s/%s" (include "harbor.redis.escapedRawPassword" . ) (include "harbor.redis.host" . ) (include "harbor.redis.port" . ) (include "harbor.redis.coreDatabaseIndex" . ) -}}
+  {{- else -}}
+    {{- printf "redis://%s:%s/%s" (include "harbor.redis.host" . ) (include "harbor.redis.port" . ) (include "harbor.redis.coreDatabaseIndex" . ) -}}
+  {{- end -}}
 {{- end -}}
 
 {{- define "harbor.portal" -}}

--- a/bitnami/harbor/templates/core/core-secret-envvars.yaml
+++ b/bitnami/harbor/templates/core/core-secret-envvars.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  _REDIS_URL: {{ include "harbor.redisForCore" . | b64enc | quote }}
+  _REDIS_URL_CORE: {{ include "harbor.redisForCore" . | b64enc | quote }}
   _REDIS_URL_REG: {{ include "harbor.redisForGC" . | b64enc | quote }}
   REGISTRY_CREDENTIAL_USERNAME: {{ .Values.registry.credentials.username | b64enc | quote }}
   REGISTRY_CREDENTIAL_PASSWORD: {{ .Values.registry.credentials.password | b64enc | quote }}

--- a/bitnami/harbor/values-production.yaml
+++ b/bitnami/harbor/values-production.yaml
@@ -2289,6 +2289,7 @@ externalRedis:
   ## Redis password
   ##
   password: ''
+  coreDatabaseIndex: '0'
   jobserviceDatabaseIndex: '1'
   registryDatabaseIndex: '2'
   chartmuseumDatabaseIndex: '3'

--- a/bitnami/harbor/values.yaml
+++ b/bitnami/harbor/values.yaml
@@ -2288,6 +2288,7 @@ externalRedis:
   ## Redis password
   ##
   password: ''
+  coreDatabaseIndex: '0'
   jobserviceDatabaseIndex: '1'
   registryDatabaseIndex: '2'
   chartmuseumDatabaseIndex: '3'


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Change environment variable for core redis URL from `_REDIS_URL` to `_REDIS_URL_CORE`, and changes to the newer format with `redis://` as a prefix.  Based on the upstream helm chart and [source](https://github.com/goharbor/harbor/blob/a9805fddd7daa5af8d34ded439234cc62cf9421a/src/core/main.go#L105), it appears that the old format and name are no longer in use.

**Benefits**

This enables OIDC logins to work again, fixing the "state mismatch" issue described in #4154.  

**Possible drawbacks**

None noticed in my testing

**Applicable issues**

  - fixes #4154 

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
