### PR TITLE
[bitnami/nginx] Adds pdb to nginx

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -25,4 +25,4 @@ name: nginx
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx
   - http://www.nginx.org
-version: 8.1.2
+version: 8.2.0

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -66,6 +66,9 @@ The following tables lists the configurable parameters of the NGINX chart and th
 | `commonLabels`                          | Labels to add to all deployed objects                      | `{}`                                                    |
 | `commonAnnotations`                     | Annotations to add to all deployed objects                 | `{}`                                                    |
 | `extraDeploy`                           | Array of extra objects to deploy with the release          | `[]` (evaluated as a template)                          |
+| `pdb.enabled`                           | Enabled PodDisruptionBudget                                | `false`                                                 |
+| `pdb.minAvailable`                      | Set PDB minAvailable value                                 | `1`                                                     |
+| `pdb.maxUnavailable`                    | Set PDB maxUnavailable value                               | `nil`                                                   |
 
 ### NGINX parameters
 

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -66,7 +66,7 @@ The following tables lists the configurable parameters of the NGINX chart and th
 | `commonLabels`                          | Labels to add to all deployed objects                      | `{}`                                                    |
 | `commonAnnotations`                     | Annotations to add to all deployed objects                 | `{}`                                                    |
 | `extraDeploy`                           | Array of extra objects to deploy with the release          | `[]` (evaluated as a template)                          |
-| `pdb.enabled`                           | Enabled PodDisruptionBudget                                | `false`                                                 |
+| `pdb.create`                            | Created a PodDisruptionBudget                              | `false`                                                 |
 | `pdb.minAvailable`                      | Set PDB minAvailable value                                 | `1`                                                     |
 | `pdb.maxUnavailable`                    | Set PDB maxUnavailable value                               | `nil`                                                   |
 

--- a/bitnami/nginx/ci/values-with-ingress-metrics-and-serverblock.yaml
+++ b/bitnami/nginx/ci/values-with-ingress-metrics-and-serverblock.yaml
@@ -24,3 +24,8 @@ metrics:
   ## Kubeval doesn't recognise ServiceMonitor as a valid K8s object
   # serviceMonitor:
   #   enabled: true
+
+pdb:
+  create: true
+  minAvailable: 3
+  maxUnavailable: 5

--- a/bitnami/nginx/templates/pdb.yaml
+++ b/bitnami/nginx/templates/pdb.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.pdb.create }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
+{{- end }}

--- a/bitnami/nginx/values.schema.json
+++ b/bitnami/nginx/values.schema.json
@@ -76,6 +76,20 @@
           }
         }
       }
+    },
+    "pdb": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "minAvailable": {
+          "type": "integer"
+        },
+        "maxUnavailable": {
+          "type": "integer"
+        }
+      }
     }
   }
 }

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -682,3 +682,15 @@ metrics:
     ##
     # selector:
     #   prometheus: my-prometheus
+
+## Pod Disruption Budget configuration
+## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+##
+pdb:
+  create: false
+  ## Min number of pods that must still be available after the eviction
+  ##
+  minAvailable: 1
+  ## Max number of pods that can be unavailable after the eviction
+  ##
+  # maxUnavailable: 1


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This adds a PodDisruptionBudget option for the nginx.
Copied pdb from cassandra.

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
