### PR TITLE
[bitnami/redmine] Add how to deploy in a different URI to the README.md

### DIFF
--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -36,4 +36,4 @@ name: redmine
 sources:
   - https://github.com/bitnami/bitnami-docker-redmine
   - http://www.redmine.org/
-version: 15.0.0
+version: 15.0.1

--- a/bitnami/redmine/README.md
+++ b/bitnami/redmine/README.md
@@ -330,7 +330,7 @@ Redmine writes uploaded files to a persistent volume. By default that volume can
 
 ### Deploying to a sub-URI
 
-(adapted from https://hub.docker.com/r/bitnami/redmine/)
+(adapted from https://github.com/bitnami/bitnami-docker-redmine)
 
 On certain occasions, you may need that Redmine is available under a specific sub-URI path rather than the root. A common scenario to this problem may arise if you plan to set up your Redmine container behind a reverse proxy. To deploy your Redmine container using a certain sub-URI you just need to follow these steps:
 

--- a/bitnami/redmine/README.md
+++ b/bitnami/redmine/README.md
@@ -36,6 +36,91 @@ The command deploys Redmine on the Kubernetes cluster in the default configurati
 
 > **Tip**: List all releases using `helm list`
 
+## Deploying to a sub-URI
+
+(adapted from https://hub.docker.com/r/bitnami/redmine/)
+
+On certain occasions, you may need that Redmine is available under a specific sub-URI path rather than the root. A common scenario to this problem may arise if you plan to set up your Redmine container behind a reverse proxy. To deploy your Redmine container using a certain sub-URI you just need to follow these steps:
+
+### Create a configmap containing an altered version of init.sh
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redmine-init-configmap
+  namespace: <same-namespace-as-the-chart>
+  labels:
+  ...
+data:
+
+  init.sh: |-
+
+    #!/bin/bash
+
+    # Set default values depending on database variation
+    if [ -n "$REDMINE_DB_POSTGRES" ]; then
+        export REDMINE_DB_PORT_NUMBER=${REDMINE_DB_PORT_NUMBER:-5432}
+        export REDMINE_DB_USERNAME=${REDMINE_DB_USERNAME:-postgres}
+    elif [ -n "$REDMINE_DB_MYSQL" ]; then
+        export REDMINE_DB_PORT_NUMBER=${REDMINE_DB_PORT_NUMBER:-3306}
+        export REDMINE_DB_USERNAME=${REDMINE_DB_USERNAME:-root}
+    fi
+
+    # REPLACE WITH YOUR OWN SUB-URI
+    SUB_URI_PATH='/redmine'
+
+    #Config files where to apply changes
+    config1=/opt/bitnami/redmine/config.ru
+    config2=/opt/bitnami/redmine/config/environment.rb
+
+    if [[ ! -d /opt/bitnami/redmine/conf/ ]]; then
+        sed -i '$ d' ${config1}
+        echo 'map ActionController::Base.config.try(:relative_url_root) || "/" do' >> ${config1}
+        echo 'run Rails.application' >> ${config1}
+        echo 'end' >> ${config1}
+        echo 'Redmine::Utils::relative_url_root = "'${SUB_URI_PATH}'"' >> ${config2}
+    fi
+
+    SUB_URI_PATH=$(echo ${SUB_URI_PATH} | sed -e 's|/|\\/|g')
+    sed -i -e "s/\(relative_url_root\ \=\ \"\).*\(\"\)/\1${SUB_URI_PATH}\2/" ${config2}
+```
+
+### Add this confimap as a volume/volume mount in the chart values
+
+```yaml
+## Extra volumes to add to the deployment
+##
+extraVolumes: 
+  - name: redmine-init-volume
+    configMap:
+      name: redmine-init-configmap
+
+## Extra volume mounts to add to the container
+##
+extraVolumeMounts:
+  - name: "redmine-init-volume"
+    mountPath: "/init.sh"
+    subPath: init.sh
+```
+
+### Change the probes URI
+
+```yaml
+## Configure extra options for liveness and readiness probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+##
+livenessProbe:
+  enabled: true
+  path: /redmine/
+...
+
+readinessProbe:
+  enabled: true
+  path: /redmine/
+...
+```
+
 ## Uninstalling the Chart
 
 To uninstall/delete the `my-release` deployment:


### PR DESCRIPTION
Since extraVolumes and extraVolumeMounts were added to the chart template it is now easier do deploy the chart under a sub-uri. This might be helpful to the community.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
