### PR TITLE
[bitnami/wordpress] - Add back previously removed _helper functions to unbreak post-init configmap

### DIFF
--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -31,4 +31,4 @@ name: wordpress
 sources:
   - https://github.com/bitnami/bitnami-docker-wordpress
   - http://www.wordpress.com/
-version: 10.0.6
+version: 10.0.7

--- a/bitnami/wordpress/templates/_helpers.tpl
+++ b/bitnami/wordpress/templates/_helpers.tpl
@@ -4,23 +4,6 @@
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "wordpress.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-*/}}
 {{- define "wordpress.mariadb.fullname" -}}
 {{- printf "%s-%s" .Release.Name "mariadb" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -58,19 +41,6 @@ Create chart name and version as used by the chart label.
 */}}
 {{- define "wordpress.customHTAccessCM" -}}
 {{- printf "%s" .Values.customHTAccessCM -}}
-{{- end -}}
-
-{{/*
-Renders a value that contains template.
-Usage:
-{{ include "wordpress.tplValue" ( dict "value" .Values.path.to.the.Value "context" $) }}
-*/}}
-{{- define "wordpress.tplValue" -}}
-    {{- if typeIs "string" .value }}
-        {{- tpl .value .context }}
-    {{- else }}
-        {{- tpl (.value | toYaml) .context }}
-    {{- end }}
 {{- end -}}
 
 {{/*

--- a/bitnami/wordpress/templates/_helpers.tpl
+++ b/bitnami/wordpress/templates/_helpers.tpl
@@ -4,6 +4,23 @@
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
+{{- define "wordpress.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
 {{- define "wordpress.mariadb.fullname" -}}
 {{- printf "%s-%s" .Release.Name "mariadb" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -41,6 +58,19 @@ Create chart name and version as used by the chart label.
 */}}
 {{- define "wordpress.customHTAccessCM" -}}
 {{- printf "%s" .Values.customHTAccessCM -}}
+{{- end -}}
+
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "wordpress.tplValue" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "wordpress.tplValue" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
 {{- end -}}
 
 {{/*

--- a/bitnami/wordpress/templates/configmap.yaml
+++ b/bitnami/wordpress/templates/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "wordpress.fullname" . }}-postinit
+  name: {{ include "common.names.fullname" . }}-postinit
 data:
-{{- include "wordpress.tplValue" ( dict "value" .Values.customPostInitScripts "context" $ ) | nindent 2 }}
+{{- include "common.tplvalues.render" (dict "value" .Values.customPostInitScripts "context" $) | nindent 2 }}
 {{- end }}

--- a/bitnami/wordpress/templates/tls-secrets.yaml
+++ b/bitnami/wordpress/templates/tls-secrets.yaml
@@ -8,10 +8,10 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     {{- if $.Values.commonLabels }}
-    {{- include "wordpress.tplValue" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if $.Values.commonAnnotations }}
-  annotations: {{- include "wordpress.tplValue" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 type: kubernetes.io/tls
 data:


### PR DESCRIPTION
**Description of the change**

This PR: https://github.com/bitnami/charts/pull/4373 , which brings new functionality from versions >=9.10.0, requires the declaration of 2 helper scripts, which were removed from **_helpers.tpl** as of version 10.0.0, specifically:
  - wordpress.fullname
  - wordpress.tplValue


This PR is meant to ammend the changes of https://github.com/bitnami/charts/pull/3850, specifically adding back these 2 helper functions, as without them, whenever the `customPostInitScripts` variable is populated, helm chart installation fails.

**Possible drawbacks**

None that I can see