### PR TITLE
[bitnami/mongodb] ensure password is handled as string

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 10.1.2
+version: 10.1.3

--- a/bitnami/mongodb/templates/secrets.yaml
+++ b/bitnami/mongodb/templates/secrets.yaml
@@ -11,20 +11,20 @@ data:
   {{- if .Values.auth.rootPassword }}
   mongodb-root-password:  {{ .Values.auth.rootPassword | toString | b64enc | quote }}
   {{- else }}
-  mongodb-root-password: {{ randAlphaNum 10 | toString | b64enc | quote }}
+  mongodb-root-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
   {{- if and .Values.auth.username .Values.auth.database }}
   {{- if .Values.auth.password }}
   mongodb-password:  {{ .Values.auth.password | toString | b64enc | quote }}
   {{- else }}
-  mongodb-password: {{ randAlphaNum 10 | toString | b64enc | quote }}
+  mongodb-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
   {{- end }}
   {{- if eq .Values.architecture "replicaset" }}
   {{- if .Values.auth.replicaSetKey }}
   mongodb-replica-set-key:  {{ .Values.auth.replicaSetKey | toString | b64enc | quote }}
   {{- else }}
-  mongodb-replica-set-key: {{ randAlphaNum 10 | toString | b64enc | quote }}
+  mongodb-replica-set-key: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/bitnami/mongodb/templates/secrets.yaml
+++ b/bitnami/mongodb/templates/secrets.yaml
@@ -9,22 +9,22 @@ metadata:
 type: Opaque
 data:
   {{- if .Values.auth.rootPassword }}
-  mongodb-root-password:  {{ .Values.auth.rootPassword | b64enc | quote }}
+  mongodb-root-password:  {{ .Values.auth.rootPassword | toString | b64enc | quote }}
   {{- else }}
-  mongodb-root-password: {{ randAlphaNum 10 | b64enc | quote }}
+  mongodb-root-password: {{ randAlphaNum 10 | toString | b64enc | quote }}
   {{- end }}
   {{- if and .Values.auth.username .Values.auth.database }}
   {{- if .Values.auth.password }}
-  mongodb-password:  {{ .Values.auth.password | b64enc | quote }}
+  mongodb-password:  {{ .Values.auth.password | toString | b64enc | quote }}
   {{- else }}
-  mongodb-password: {{ randAlphaNum 10 | b64enc | quote }}
+  mongodb-password: {{ randAlphaNum 10 | toString | b64enc | quote }}
   {{- end }}
   {{- end }}
   {{- if eq .Values.architecture "replicaset" }}
   {{- if .Values.auth.replicaSetKey }}
-  mongodb-replica-set-key:  {{ .Values.auth.replicaSetKey | b64enc | quote }}
+  mongodb-replica-set-key:  {{ .Values.auth.replicaSetKey | toString | b64enc | quote }}
   {{- else }}
-  mongodb-replica-set-key: {{ randAlphaNum 10 | b64enc | quote }}
+  mongodb-replica-set-key: {{ randAlphaNum 10 | toString | b64enc | quote }}
   {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
fixes https://github.com/helm/charts/issues/23343

The referenced issue went stale but was not addressed. If the password is numeric then b64enc can't encode it. With this change it will be able to encode it. Using toString rather than quote to avoid adding unwanted quotes to the content of the password.

This will also affect other charts using b64enc on a potentially-numeric value, even if the value being entered is entered as a string such as "123"