### PR TITLE
[bitnami/airflow] fix: use loadBalancerIP as a fallback for baseUrl

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -32,4 +32,4 @@ name: airflow
 sources:
   - https://github.com/bitnami/bitnami-docker-airflow
   - https://airflow.apache.org/
-version: 7.0.2
+version: 7.0.3

--- a/bitnami/airflow/templates/NOTES.txt
+++ b/bitnami/airflow/templates/NOTES.txt
@@ -1,7 +1,7 @@
 {{- $airflowSecretName := include "airflow.secretName" . -}}
 {{- $postgresqlSecretName := include "airflow.postgresql.secretName" . -}}
 {{- $redisSecretName := include "airflow.redis.secretName" . -}}
-{{- if not .Values.web.baseUrl -}}
+{{- if not (include "airflow.baseUrl" .) -}}
 ###############################################################################
 ### ERROR: You did not provide an external URL in your 'helm install' call ###
 ###############################################################################

--- a/bitnami/airflow/templates/NOTES.txt
+++ b/bitnami/airflow/templates/NOTES.txt
@@ -1,7 +1,8 @@
 {{- $airflowSecretName := include "airflow.secretName" . -}}
 {{- $postgresqlSecretName := include "airflow.postgresql.secretName" . -}}
 {{- $redisSecretName := include "airflow.redis.secretName" . -}}
-{{- if not (include "airflow.baseUrl" .) -}}
+{{- $baseUrl := (include "airflow.baseUrl" .) -}}
+{{- if not $baseUrl -}}
 ###############################################################################
 ### ERROR: You did not provide an external URL in your 'helm install' call ###
 ###############################################################################
@@ -61,7 +62,7 @@ host. To configure Airflow with the URL of your service:
 
 {{- if .Values.ingress.enabled }}
 
-  echo URL  : {{ .Values.web.baseUrl }}
+  echo URL  : {{ $baseUrl }}
 
 {{- else if eq .Values.service.type "ClusterIP" }}
 
@@ -76,7 +77,7 @@ host. To configure Airflow with the URL of your service:
 
 {{- else }}
 
-  echo URL  : {{ .Values.web.baseUrl }}
+  echo URL  : {{ $baseUrl }}
 {{- end }}
 
 2. Get your Airflow login credentials by running:

--- a/bitnami/airflow/templates/_helpers.tpl
+++ b/bitnami/airflow/templates/_helpers.tpl
@@ -276,10 +276,6 @@ Add environmnet variables to configure airflow common values
     secretKeyRef:
       name: {{ include "airflow.secretName" . }}
       key: airflow-fernetKey
-- name: AIRFLOW_WEBSERVER_HOST
-  value: {{ include "common.names.fullname" . }}
-- name: AIRFLOW_WEBSERVER_PORT_NUMBER
-  value: {{ .Values.service.port | quote }}
 - name: AIRFLOW_LOAD_EXAMPLES
   value: {{ ternary "yes" "no" .Values.loadExamples | quote }}
 {{- if .Values.web.image.debug }}

--- a/bitnami/airflow/templates/config/configmap.yaml
+++ b/bitnami/airflow/templates/config/configmap.yaml
@@ -102,6 +102,10 @@ data:
             {{- include "airflow.configure.airflow.common"  . | nindent 12 }}
             {{- include "airflow.configure.database" . | nindent 12 }}
             {{- include "airflow.configure.redis" . | nindent 12 }}
+            - name: AIRFLOW_WEBSERVER_HOST
+              value: {{ include "common.names.fullname" . }}
+            - name: AIRFLOW_WEBSERVER_PORT_NUMBER
+              value: {{ .Values.service.port | quote }}
             {{- if .Values.extraEnvVars }}
               {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/bitnami/airflow/templates/scheduler/deployment.yaml
+++ b/bitnami/airflow/templates/scheduler/deployment.yaml
@@ -74,6 +74,10 @@ spec:
             {{- include "airflow.configure.database" . | nindent 12 }}
             {{- include "airflow.configure.redis" . | nindent 12 }}
             {{- include "airflow.configure.airflow.kubernetesExecutor" . | nindent 12 }}
+            - name: AIRFLOW_WEBSERVER_HOST
+              value: {{ include "common.names.fullname" . }}
+            - name: AIRFLOW_WEBSERVER_PORT_NUMBER
+              value: {{ .Values.service.port | quote }}
             {{- if .Values.extraEnvVars }}
               {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/bitnami/airflow/templates/web/deployment.yaml
+++ b/bitnami/airflow/templates/web/deployment.yaml
@@ -73,6 +73,10 @@ spec:
             {{- include "airflow.configure.database" . | nindent 12 }}
             {{- include "airflow.configure.redis" . | nindent 12 }}
             {{- include "airflow.configure.airflow.kubernetesExecutor" . | nindent 12 }}
+            - name: AIRFLOW_WEBSERVER_HOST
+              value: '0.0.0.0'
+            - name: AIRFLOW_WEBSERVER_PORT_NUMBER
+              value: {{ .Values.web.containerPort | quote }}
             - name: AIRFLOW_USERNAME
               value: {{ .Values.auth.username }}
             - name: AIRFLOW_PASSWORD

--- a/bitnami/airflow/templates/web/deployment.yaml
+++ b/bitnami/airflow/templates/web/deployment.yaml
@@ -80,9 +80,10 @@ spec:
                 secretKeyRef:
                   name: {{ include "airflow.secretName" . }}
                   key: airflow-password
-            {{- if .Values.web.baseUrl }}
+            {{- $baseUrl := include "airflow.baseUrl" . }}
+            {{- if $baseUrl }}
             - name: AIRFLOW_BASE_URL
-              value: {{ .Values.web.baseUrl }}
+              value: {{ $baseUrl }}
             {{- end }}
             - name: AIRFLOW_LDAP_ENABLE
               value: {{ ternary "yes" "no" .Values.ldap.enabled | quote }}
@@ -138,7 +139,7 @@ spec:
               containerPort: {{ .Values.web.containerPort }}
         {{- if .Values.web.livenessProbe.enabled }}
           livenessProbe:
-          {{- if .Values.web.baseUrl }}
+          {{- if $baseUrl }}
             tcpSocket:
               port: http
           {{- else }}
@@ -153,7 +154,7 @@ spec:
         {{- end }}
         {{- if .Values.web.readinessProbe.enabled }}
           readinessProbe:
-          {{- if .Values.web.baseUrl }}
+          {{- if $baseUrl }}
             tcpSocket:
               port: http
           {{- else }}

--- a/bitnami/airflow/templates/web/service.yaml
+++ b/bitnami/airflow/templates/web/service.yaml
@@ -17,7 +17,7 @@ spec:
   type: {{ .Values.service.type }}
   {{- if eq .Values.service.type "LoadBalancer" }}
   {{- if .Values.service.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ default "" .Values.service.loadBalancerIP | quote }}
   {{- end }}
   {{- end }}
   ports:

--- a/bitnami/airflow/templates/worker/statefulset.yaml
+++ b/bitnami/airflow/templates/worker/statefulset.yaml
@@ -88,6 +88,10 @@ spec:
             {{- include "airflow.configure.airflow.common"  . | nindent 12 }}
             {{- include "airflow.configure.database" . | nindent 12 }}
             {{- include "airflow.configure.redis" . | nindent 12 }}
+            - name: AIRFLOW_WEBSERVER_HOST
+              value: {{ include "common.names.fullname" . }}
+            - name: AIRFLOW_WEBSERVER_PORT_NUMBER
+              value: {{ .Values.service.port | quote }}
             {{- if .Values.extraEnvVars }}
               {{ toYaml .Values.extraEnvVars | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
Signed-off-by: darteaga <darteaga@vmware.com>

**Description of the change**

Sometimes we provide `service.loadBalancerIP` instead of `web.baseUrl` so we need to use it as a fallback when building `AIRFLOW_BASEURL` 

**Benefits**

We can use `service.loadBalancerIP` to configure `AIRFLOW_BASEURL`.

**Possible drawbacks**

N/A
**Applicable issues**

N/A

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
