### PR TITLE
[bitnami/kibana] Use common subchart

### DIFF
--- a/bitnami/kibana/Chart.lock
+++ b/bitnami/kibana/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.1.0
+digest: sha256:53383c55a80f2c6d7c546fc466879d53b57b35a3465d46429f7c8d0ccb5b977f
+generated: "2020-11-26T18:48:31.684898+01:00"

--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -2,6 +2,12 @@ annotations:
   category: Analytics
 apiVersion: v2
 appVersion: 7.10.0
+dependencies:
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
 description: Kibana is an open source, browser based analytics and search dashboard for Elasticsearch.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/kibana
@@ -19,4 +25,4 @@ name: kibana
 sources:
   - https://github.com/bitnami/bitnami-docker-kibana
   - https://www.elastic.co/products/kibana
-version: 6.1.0
+version: 6.2.0

--- a/bitnami/kibana/README.md
+++ b/bitnami/kibana/README.md
@@ -64,8 +64,8 @@ The following tables lists the configurable parameters of the kibana chart and t
 | `image.tag`                            | Kibana image tag                                                                                                                                          | `{TAG_NAME}`                                                                                            |
 | `image.pullPolicy`                     | Kibana image pull policy                                                                                                                                  | `IfNotPresent`                                                                                          |
 | `image.pullSecrets`                    | Specify docker-registry secret names as an array                                                                                                          | `[]` (does not add image pull secrets to deployed pods)                                                 |
-| `nameOverride`                         | String to partially override kibana.fullname template with a string (will prepend the release name)                                                       | `nil`                                                                                                   |
-| `fullnameOverride`                     | String to fully override kibana.fullname template with a string                                                                                           | `nil`                                                                                                   |
+| `nameOverride`                         | String to partially override common.names.fullname template with a string (will prepend the release name)                                                 | `nil`                                                                                                   |
+| `fullnameOverride`                     | String to fully override common.names.fullname template with a string                                                                                     | `nil`                                                                                                   |
 | `replicaCount`                         | Number of replicas of the Kibana Pod                                                                                                                      | `1`                                                                                                     |
 | `updateStrategy`                       | Update strategy for deployment (evaluated as a template)                                                                                                  | `{type: "RollingUpdate"}`                                                                               |
 | `schedulerName`                        | Alternative scheduler                                                                                                                                     | `nil`                                                                                                   |
@@ -323,6 +323,10 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 Find more information about how to deal with common errors related to Bitnami’s Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
 
 ## Upgrading
+
+### To 6.2.0
+
+This version introduces `bitnami/common`, a [library chart](https://helm.sh/docs/topics/library_charts/#helm) as a dependency. More documentation about this new utility could be found [here](https://github.com/bitnami/charts/tree/master/bitnami/common#bitnami-common-library-chart). Please, make sure that you have updated the chart dependencies before executing any upgrade.
 
 ### To 6.0.0
 

--- a/bitnami/kibana/ci/values-with-es.yaml
+++ b/bitnami/kibana/ci/values-with-es.yaml
@@ -1,0 +1,5 @@
+elasticsearch:
+  hosts:
+    - elasticsearch-1
+    - elasticsearch-2
+  port: 9300

--- a/bitnami/kibana/templates/NOTES.txt
+++ b/bitnami/kibana/templates/NOTES.txt
@@ -19,18 +19,17 @@ Replacing "YOUR_ES_HOST" and "YOUR_ES_PORT" placeholders by the proper values of
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "kibana.fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "common.names.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "kibana.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "kibana.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "common.names.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "common.names.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "kibana.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward svc/{{ include "kibana.fullname" . }} 8080:{{ .Values.service.port }}
+  kubectl port-forward svc/{{ include "common.names.fullname" . }} 8080:{{ .Values.service.port }}
 {{- end }}
 
 {{- if or .Values.ingress.enabled (contains "NodePort" .Values.service.type) (contains "LoadBalancer" .Values.service.type) }}
@@ -39,17 +38,12 @@ WARNING: Kibana is externally accessible from the cluster but the dashboard does
 +info https://www.elastic.co/guide/en/elastic-stack-overview/current/setting-up-authentication.html
 {{- end }}
 
-{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
-
-WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
-+info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
-{{- end }}
-
 {{- if .Values.metrics.enabled }}
 
 WARNING: For Prometheus metrics to work, make sure that the kibana-prometheus-exporter plugin is installed:
 +info https://github.com/pjhampton/kibana-prometheus-exporter
 {{- end }}
 
-{{ include "kibana.validateValues" . }}
+{{- include "kibana.validateValues" . }}
+{{- include "kibana.checkRollingTags" . }}
 {{- end }}

--- a/bitnami/kibana/templates/_helpers.tpl
+++ b/bitnami/kibana/templates/_helpers.tpl
@@ -1,40 +1,24 @@
 {{/* vim: set filetype=mustache: */}}
+
 {{/*
-Expand the name of the chart.
+Return the proper Kibana image name
 */}}
-{{- define "kibana.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- define "kibana.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
 {{- end -}}
 
 {{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
+Return the proper image name (for the init container volume-permissions image)
 */}}
-{{- define "kibana.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
+{{- define "kibana.volumePermissions.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.volumePermissions.image "global" .Values.global) }}
 {{- end -}}
 
 {{/*
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "kibana.imagePullSecrets" -}}
-{{- $imagePullSecrets := coalesce .Values.global.imagePullSecrets .Values.image.pullSecrets .Values.volumePermissions.image.pullSecrets -}}
-{{- if $imagePullSecrets }}
-imagePullSecrets:
-{{- range $imagePullSecrets }}
-  - name: {{ . }}
-{{- end -}}
-{{- end -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.volumePermissions.image) "global" .Values.global) -}}
 {{- end -}}
 
 {{/*
@@ -44,36 +28,6 @@ Return true if the deployment should include dashboards
 {{- if or .Values.savedObjects.configmap .Values.savedObjects.urls }}
     {{- true -}}
 {{- end -}}
-{{- end -}}
-
-{{/*
-Return the proper Kibana image name
-*/}}
-{{- define "kibana.image" -}}
-{{- $registryName := .Values.image.registry -}}
-{{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
-{{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
-{{- define "kibana.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -101,7 +55,7 @@ Set Elasticsearch Port.
 Set Elasticsearch PVC.
 */}}
 {{- define "kibana.pvc" -}}
-{{- .Values.persistence.existingClaim | default (include "kibana.fullname" .) -}}
+{{- .Values.persistence.existingClaim | default (include "common.names.fullname" .) -}}
 {{- end -}}
 
 {{/*
@@ -119,29 +73,6 @@ Get the initialization scripts configmap name.
 {{- end -}}
 
 {{/*
-Return the proper image name (for the init container volume-permissions image)
-*/}}
-{{- define "kibana.volumePermissions.image" -}}
-{{- $registryName := .Values.volumePermissions.image.registry -}}
-{{- $repositoryName := .Values.volumePermissions.image.repository -}}
-{{- $tag := .Values.volumePermissions.image.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
-{{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Get the saved objects configmap name.
 */}}
 {{- define "kibana.savedObjectsCM" -}}
@@ -152,63 +83,7 @@ Get the saved objects configmap name.
 Set Elasticsearch Port.
 */}}
 {{- define "kibana.configurationCM" -}}
-{{- .Values.configurationCM | default (printf "%s-conf" (include "kibana.fullname" .)) -}}
-{{- end -}}
-
-{{/*
-Common labels
-*/}}
-{{- define "kibana.labels" -}}
-app.kubernetes.io/name: {{ include "kibana.name" . }}
-helm.sh/chart: {{ include "kibana.chart" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end -}}
-
-{{/*
-Match labels
-*/}}
-{{- define "kibana.matchLabels" -}}
-app.kubernetes.io/name: {{ include "kibana.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end -}}
-
-{{/*
-Return  the proper Storage Class
-*/}}
-{{- define "kibana.storageClass" -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
-*/}}
-{{- if .Values.global -}}
-    {{- if .Values.global.storageClass -}}
-        {{- if (eq "-" .Values.global.storageClass) -}}
-            {{- printf "storageClassName: \"\"" -}}
-        {{- else }}
-            {{- printf "storageClassName: %s" .Values.global.storageClass -}}
-        {{- end -}}
-    {{- else -}}
-        {{- if .Values.persistence.storageClass -}}
-              {{- if (eq "-" .Values.persistence.storageClass) -}}
-                  {{- printf "storageClassName: \"\"" -}}
-              {{- else }}
-                  {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
-              {{- end -}}
-        {{- end -}}
-    {{- end -}}
-{{- else -}}
-    {{- if .Values.persistence.storageClass -}}
-        {{- if (eq "-" .Values.persistence.storageClass) -}}
-            {{- printf "storageClassName: \"\"" -}}
-        {{- else }}
-            {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
-        {{- end -}}
-    {{- end -}}
-{{- end -}}
+{{- .Values.configurationCM | default (printf "%s-conf" (include "common.names.fullname" .)) -}}
 {{- end -}}
 
 {{/*
@@ -263,25 +138,9 @@ kibana: missing-extra-volume-mounts
 {{- end -}}
 
 {{/*
-Return the appropriate apiVersion for deployment.
+Check if there are rolling tags in the images
 */}}
-{{- define "kibana.deployment.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
-{{- print "apps/v1" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Renders a value that contains template.
-Usage:
-{{ include "kibana.tplValue" ( dict "value" .Values.path.to.the.Value "context" $) }}
-*/}}
-{{- define "kibana.tplValue" -}}
-    {{- if typeIs "string" .value }}
-        {{- tpl .value .context }}
-    {{- else }}
-        {{- tpl (.value | toYaml) .context }}
-    {{- end }}
+{{- define "kibana.checkRollingTags" -}}
+{{- include "common.warnings.rollingTag" .Values.image }}
+{{- include "common.warnings.rollingTag" .Values.volumePermissions.image }}
 {{- end -}}

--- a/bitnami/kibana/templates/configmap.yaml
+++ b/bitnami/kibana/templates/configmap.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "kibana.fullname" . }}-conf
-  labels: {{- include "kibana.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}-conf
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
 data:
   kibana.yml: |
     pid.file: /opt/bitnami/kibana/tmp/kibana.pid

--- a/bitnami/kibana/templates/deployment.yaml
+++ b/bitnami/kibana/templates/deployment.yaml
@@ -1,25 +1,25 @@
 {{- if and .Values.elasticsearch.hosts .Values.elasticsearch.port -}}
-apiVersion: {{ template "kibana.deployment.apiVersion" . }}
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
-  name: {{ include "kibana.fullname" . }}
-  labels: {{- include "kibana.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   {{- if .Values.updateStrategy }}
   strategy: {{- tpl (toYaml .Values.updateStrategy) $ | nindent 4 }}
   {{- end }}
   selector:
-    matchLabels: {{- include "kibana.matchLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
   template:
     metadata:
       {{- if .Values.podAnnotations }}
-      annotations: {{- include "kibana.tplValue" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
-      labels: {{- include "kibana.labels" . | nindent 8 }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
         app: kibana
         {{- if .Values.podLabels }}
-        {{- include "kibana.tplValue" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
     spec:
       {{- include "kibana.imagePullSecrets" . | nindent 6 }}
@@ -59,7 +59,7 @@ spec:
             mountPath: /bitnami/kibana
         {{- end }}
         {{- if .Values.initContainers }}
-        {{- include "kibana.tplValue" (dict "value" .Values.initContainers "context" $) | nindent 10 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 10 }}
         {{- end }}
       {{- end }}
       containers:
@@ -78,7 +78,7 @@ spec:
             - name: KIBANA_FORCE_INITSCRIPTS
               value: {{ .Values.forceInitScripts | quote }}
           {{- if .Values.extraEnvVars }}
-          {{- include "kibana.tplValue" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
           {{- end }}
           {{- if or .Values.extraEnvVarsCM .Values.extraEnvVarsSecret }}
           envFrom:
@@ -126,7 +126,7 @@ spec:
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           {{- end }}
           {{- if .Values.resources }}
-          resources: {{- include "kibana.tplValue" (dict "value" .Values.resources "context" $) | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.resources "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: kibana-data
@@ -154,10 +154,10 @@ spec:
               mountPath: /docker-entrypoint-initdb.d/secret
             {{- end }}
             {{- if .Values.extraVolumeMounts }}
-            {{- include "kibana.tplValue" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
       {{- if .Values.sidecars }}
-      {{- include "kibana.tplValue" (dict "value" .Values.sidecars "context" $) | nindent 8 }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | nindent 8 }}
       {{- end }}
       volumes:
         - name: kibana-data
@@ -173,13 +173,13 @@ spec:
         {{- if (include "kibana.importSavedObjects" .) }}
         - name: saved-objects-init-scripts
           configMap:
-            name: {{ include "kibana.fullname" . }}-saved-objects
+            name: {{ include "common.names.fullname" . }}-saved-objects
             defaultMode: 0755
         {{- end }}
         {{- if .Values.plugins }}
         - name: plugins-init-scripts
           configMap:
-            name: {{ include "kibana.fullname" . }}-plugins
+            name: {{ include "common.names.fullname" . }}-plugins
             defaultMode: 0755
         {{- end }}
         {{- if .Values.initScriptsCM }}
@@ -200,6 +200,6 @@ spec:
             name: {{ template "kibana.savedObjectsCM" . }}
         {{- end }}
         {{- if .Values.extraVolumes }}
-        {{- include "kibana.tplValue" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
 {{- end }}

--- a/bitnami/kibana/templates/ingress.yaml
+++ b/bitnami/kibana/templates/ingress.yaml
@@ -1,10 +1,10 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "kibana.fullname" . -}}
+{{- $fullName := include "common.names.fullname" . -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  labels: {{- include "kibana.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
   annotations:
     {{- if .Values.ingress.certManager }}
     kubernetes.io/tls-acme: "true"

--- a/bitnami/kibana/templates/plugins-configmap.yaml
+++ b/bitnami/kibana/templates/plugins-configmap.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "kibana.fullname" . }}-plugins
-  labels: {{- include "kibana.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}-plugins
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
 data:
   install-plugins.sh: |
     #!/bin/bash

--- a/bitnami/kibana/templates/pvc.yaml
+++ b/bitnami/kibana/templates/pvc.yaml
@@ -2,13 +2,13 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ include "kibana.fullname" . }}
-  labels: {{- include "kibana.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
-  {{ include "kibana.storageClass" . }}
+  {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 2 }}
 {{- end -}}

--- a/bitnami/kibana/templates/saved-objects-configmap.yaml
+++ b/bitnami/kibana/templates/saved-objects-configmap.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "kibana.fullname" . }}-saved-objects
-  labels: {{- include "kibana.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}-saved-objects
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
 data:
   import-saved-objects.sh: |
     #!/bin/bash

--- a/bitnami/kibana/templates/service.yaml
+++ b/bitnami/kibana/templates/service.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "kibana.fullname" . }}
-  labels: {{- include "kibana.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
 {{- if or (and .Values.metrics.enabled .Values.metrics.service.annotations) .Values.service.annotations }}
   annotations:
   {{- if and .Values.metrics.enabled .Values.metrics.service.annotations }}
@@ -35,4 +35,4 @@ spec:
 {{- if .Values.service.extraPorts }}
   {{- tpl (toYaml .Values.service.extraPorts) $ | nindent 4 }}
 {{- end }}
-  selector: {{- include "kibana.matchLabels" . | nindent 4 }}
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/kibana/templates/servicemonitor.yaml
+++ b/bitnami/kibana/templates/servicemonitor.yaml
@@ -2,17 +2,17 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "kibana.fullname" . }}
+  name: {{ include "common.names.fullname" . }}
   {{- if .Values.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.metrics.serviceMonitor.namespace }}
   {{- end }}
-  labels: {{- include "kibana.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- range $key, $value := .Values.metrics.serviceMonitor.selector }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
   selector:
-    matchLabels: {{- include "kibana.matchLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
   endpoints:
   - port: http
     path: "/_prometheus/metrics"

--- a/bitnami/kibana/templates/tests/test-connection.yaml
+++ b/bitnami/kibana/templates/tests/test-connection.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ include "kibana.fullname" . }}-test-connection"
-  labels: {{- include "kibana.labels" . | nindent 4 }}
+  name: "{{ include "common.names.fullname" . }}-test-connection"
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app: test-connection
   annotations:
     "helm.sh/hook": test-success
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: bitnami/minideb
       command: ['wget']
-      args: ['{{ include "kibana.fullname" . }}:{{ .Values.service.port }}']
+      args: ['{{ include "common.names.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never

--- a/bitnami/kibana/values-production.yaml
+++ b/bitnami/kibana/values-production.yaml
@@ -27,11 +27,11 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
-## String to partially override kibana.fullname template (will maintain the release name)
+## String to partially override common.names.fullname template (will maintain the release name)
 ##
 # nameOverride:
 
-## String to fully override kibana.fullname template
+## String to fully override common.names.fullname template
 ##
 # fullnameOverride:
 

--- a/bitnami/kibana/values.yaml
+++ b/bitnami/kibana/values.yaml
@@ -27,11 +27,11 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
-## String to partially override kibana.fullname template (will maintain the release name)
+## String to partially override common.names.fullname template (will maintain the release name)
 ##
 # nameOverride:
 
-## String to fully override kibana.fullname template
+## String to fully override common.names.fullname template
 ##
 # fullnameOverride:
 


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

On https://github.com/bitnami/charts/pull/4472 some features from common chart where included in Kibana chart, without including it as dependency. This PR fixes that, and makes uses of the feature included in this subchart to remove tech debt.

**Benefits**

Removes tech debt

**Possible drawbacks**

None

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
