### PR TITLE
[bitnami/common] fix: mongodb validation auth

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: Infrastructure
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 1.1.0
+appVersion: 1.1.1
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://github.com/bitnami/charts/tree/master/bitnami/common
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -20,4 +20,4 @@ sources:
   - https://github.com/bitnami/charts
   - http://www.bitnami.com/
 type: library
-version: 1.1.0
+version: 1.1.1

--- a/bitnami/common/templates/validations/_mongodb.tpl
+++ b/bitnami/common/templates/validations/_mongodb.tpl
@@ -12,13 +12,15 @@ Params:
   {{- $existingSecret := include "common.mongodb.values.auth.existingSecret" . -}}
   {{- $enabled := include "common.mongodb.values.enabled" . -}}
   {{- $authPrefix := include "common.mongodb.values.key.auth" . -}}
-  {{- $authEnabled := include "common.mongodb.values.key.auth.enabled" . -}}
   {{- $architecture := include "common.mongodb.values.architecture" . -}}
   {{- $valueKeyRootPassword := printf "%s.rootPassword" $authPrefix -}}
   {{- $valueKeyUsername := printf "%s.username" $authPrefix -}}
   {{- $valueKeyDatabase := printf "%s.database" $authPrefix -}}
   {{- $valueKeyPassword := printf "%s.password" $authPrefix -}}
   {{- $valueKeyReplicaSetKey := printf "%s.replicaSetKey" $authPrefix -}}
+  {{- $valueKeyAuthEnabled := printf "%s.enabled" $authPrefix -}}
+
+  {{- $authEnabled := include "common.utils.getValueFromKey" (dict "key" $valueKeyAuthEnabled "context" .context) -}}
 
   {{- if and (not $existingSecret) (eq $enabled "true") (eq $authEnabled "true") -}}
     {{- $requiredPasswords := list -}}
@@ -86,22 +88,6 @@ Params:
     mongodb.auth
   {{- else -}}
     auth
-  {{- end -}}
-{{- end -}}
-
-{{/*
-Auxiliar function to get the right value for the key auth enabled
-
-Usage:
-{{ include "common.mongodb.values.key.auth.enabled" (dict "subchart" "true" "context" $) }}
-Params:
-  - subchart - Boolean - Optional. Whether MongoDB is used as subchart or not. Default: false
-*/}}
-{{- define "common.mongodb.values.key.auth.enabled" -}}
-  {{- if .subchart -}}
-    mongodb.auth.enabled
-  {{- else -}}
-    auth.enabled
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Fix validation for mongodb, which was not using the right value of `auth.enabled`
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
Correct validation of the main chart and subchart

**Possible drawbacks**
None

**Applicable issues**
NA

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
