### PR TITLE
[bitnami/discourse] Allow to specify DISCOURSE_DB_BACKUP_PORT

### DIFF
--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -32,4 +32,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-discourse
   - https://github.com/spinnaker
   - https://www.discourse.org/
-version: 2.0.2
+version: 2.1.1

--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -32,4 +32,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-discourse
   - https://github.com/spinnaker
   - https://www.discourse.org/
-version: 2.0.1
+version: 2.0.2

--- a/bitnami/discourse/README.md
+++ b/bitnami/discourse/README.md
@@ -50,178 +50,179 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Discourse chart and their default values.
 
- Parameter                                  | Description                                                                           | Default                                                      |
-|-------------------------------------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `global.imageRegistry`                    | Global Docker image registry                                                          | `nil`                                                        |
-| `global.imagePullSecrets`                 | Global Docker registry secret names as an array                                       | `[]` (does not add image pull secrets to deployed pods)      |
-| `global.storageClass`                     | Global storage class for dynamic provisioning                                         | `nil`                                                        |
+ | Parameter                 | Description                                     | Default                                                 |
+ | ------------------------- | ----------------------------------------------- | ------------------------------------------------------- |
+ | `global.imageRegistry`    | Global Docker image registry                    | `nil`                                                   |
+ | `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
+ | `global.storageClass`     | Global storage class for dynamic provisioning   | `nil`                                                   |
 
 ### Common parameters
 
-| Parameter                            | Description                                                                                | Default                                                      |
-|--------------------------------------|--------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `replicaCount`                       | Number of Discourse & Sidekiq replicas                                                     | `1`                                                          |
-| `image.registry`                     | Discourse image registry                                                                   | `docker.io`                                                  |
-| `image.repository`                   | Discourse image name                                                                       | `bitnami/discouse`                                           |
-| `image.tag`                          | Discourse image tag                                                                        | `{TAG_NAME}`                                                 |
-| `image.pullPolicy`                   | Discourse image pull policy                                                                | `IfNotPresent`                                               |
-| `image.debug`                        | Specify if debug logs should be enabled                                                    | `false`                                                      |
-| `imagePullSecrets`                   | Specify docker-registry secret names as an array                                           | `[]` (does not add image pull secrets to deployed pods)      |
-| `nameOverride`                       | String to partially override discourse.fullname                                            | `nil`                                                        |
-| `fullnameOverride`                   | String to fully override discourse.fullname                                                | `nil`                                                        |
-| `extraVolumes`                       | Array of extra volumes to be added deployment. Requires setting `extraVolumeMounts`        | `[]` (evaluated as a template)                               |
-| `sidecars`                           | Attach additional sidecar containers to the pod                                            | `[]` (evaluated as a template)                               |
-| `initContainers`                     | Additional init containers to add to the pods                                              | `[]` (evaluated as a template)                               |
-| `serviceAccount.create`              | Whether the service account should be created                                              | `false`                                                      |
-| `serviceAccount.annotations`         | Annotations to add to the service account                                                  | `{}`                                                         |
-| `serviceAccount.name`                | Name to be used for the service account                                                    | `""`                                                         |
-| `podSecurityContext`                 | Pod security context specification                                                         | `{}`                                                         |
-| `persistence.enabled`                | Whether to enable persistence based on Persistent Volume Claims                            | `true`                                                       |
-| `persistence.storageClass`           | PVC Storage Class                                                                          | `nil`                                                        |
-| `persistence.existingClaim`          | Name of an existing PVC to reuse                                                           | `nil`                                                        |
-| `persistence.accessMode`             | PVC Access Mode (RWO, ROX, RWX)                                                            | `ReadWriteOnce`                                              |
-| `persistence.size`                   | Size of the PVC to request                                                                 | `10Gi`                                                       |
-| `updateStrategy`                     | Update strategy of deployment                                                              | `{type: "RollingUpdate"}`                                                         |
-| `podAnnotations`                     | Additional pod annotations                                                                 | `{}`                                                         |
-| `podLabels`                          | Additional pod labels                                                                      | `{}` (evaluated as a template)                               |
-| `commonLabels`                       | Labels to be added to all deployed resources                                               | `{}` (evaluated as a template)                               |
-| `commonAnnotations`                  | Annotations to be added to all deployed resources                                          | `{}` (evaluated as a template)                               |
-| `podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`   | `soft`                                                       |
-| `nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `""`                                                         |
-| `nodeAffinityPreset.key`             | Node label key to match Ignored if `affinity` is set.                                      | `""`                                                         |
-| `nodeAffinityPreset.values`          | Node label values to match. Ignored if `affinity` is set.                                  | `[]`                                                         |
-| `affinity`                           | Affinity for pod assignment                                                                | `{}` (evaluated as a template)                               |
-| `nodeSelector`                       | Node labels for pod assignment.                                                            | `{}` (evaluated as a template)                               |
-| `tolerations`                        | Tolerations for pod assignment.                                                            | `[]` (evaluated as a template)                               |
+| Parameter                    | Description                                                                               | Default                                                 |
+| ---------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `replicaCount`               | Number of Discourse & Sidekiq replicas                                                    | `1`                                                     |
+| `image.registry`             | Discourse image registry                                                                  | `docker.io`                                             |
+| `image.repository`           | Discourse image name                                                                      | `bitnami/discouse`                                      |
+| `image.tag`                  | Discourse image tag                                                                       | `{TAG_NAME}`                                            |
+| `image.pullPolicy`           | Discourse image pull policy                                                               | `IfNotPresent`                                          |
+| `image.debug`                | Specify if debug logs should be enabled                                                   | `false`                                                 |
+| `imagePullSecrets`           | Specify docker-registry secret names as an array                                          | `[]` (does not add image pull secrets to deployed pods) |
+| `nameOverride`               | String to partially override discourse.fullname                                           | `nil`                                                   |
+| `fullnameOverride`           | String to fully override discourse.fullname                                               | `nil`                                                   |
+| `extraVolumes`               | Array of extra volumes to be added deployment. Requires setting `extraVolumeMounts`       | `[]` (evaluated as a template)                          |
+| `sidecars`                   | Attach additional sidecar containers to the pod                                           | `[]` (evaluated as a template)                          |
+| `initContainers`             | Additional init containers to add to the pods                                             | `[]` (evaluated as a template)                          |
+| `serviceAccount.create`      | Whether the service account should be created                                             | `false`                                                 |
+| `serviceAccount.annotations` | Annotations to add to the service account                                                 | `{}`                                                    |
+| `serviceAccount.name`        | Name to be used for the service account                                                   | `""`                                                    |
+| `podSecurityContext`         | Pod security context specification                                                        | `{}`                                                    |
+| `persistence.enabled`        | Whether to enable persistence based on Persistent Volume Claims                           | `true`                                                  |
+| `persistence.storageClass`   | PVC Storage Class                                                                         | `nil`                                                   |
+| `persistence.existingClaim`  | Name of an existing PVC to reuse                                                          | `nil`                                                   |
+| `persistence.accessMode`     | PVC Access Mode (RWO, ROX, RWX)                                                           | `ReadWriteOnce`                                         |
+| `persistence.size`           | Size of the PVC to request                                                                | `10Gi`                                                  |
+| `updateStrategy`             | Update strategy of deployment                                                             | `{type: "RollingUpdate"}`                               |
+| `podAnnotations`             | Additional pod annotations                                                                | `{}`                                                    |
+| `podLabels`                  | Additional pod labels                                                                     | `{}` (evaluated as a template)                          |
+| `commonLabels`               | Labels to be added to all deployed resources                                              | `{}` (evaluated as a template)                          |
+| `commonAnnotations`          | Annotations to be added to all deployed resources                                         | `{}` (evaluated as a template)                          |
+| `podAntiAffinityPreset`      | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                                  |
+| `nodeAffinityPreset.type`    | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                                                    |
+| `nodeAffinityPreset.key`     | Node label key to match Ignored if `affinity` is set.                                     | `""`                                                    |
+| `nodeAffinityPreset.values`  | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                                                    |
+| `affinity`                   | Affinity for pod assignment                                                               | `{}` (evaluated as a template)                          |
+| `nodeSelector`               | Node labels for pod assignment.                                                           | `{}` (evaluated as a template)                          |
+| `tolerations`                | Tolerations for pod assignment.                                                           | `[]` (evaluated as a template)                          |
 
 ### Service parameters
 
-| Parameter                                 | Description                                                                           | Default                                                      |
-|-------------------------------------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `service.type`                            | Kubernetes Service type                                                               | `LoadBalancer`                                               |
-| `service.port`                            | Service HTTP port                                                                     | `80`                                                         |
-| `service.nodePort`                        | NodePort service IP address                                                           | `nil`                                                        |
-| `service.loadBalancerIP`                  | LoadBalancer service IP address                                                       | `nil`                                                        |
-| `service.externalTrafficPolicy`           | Enable client source IP preservation                                                  | `Cluster`                                                    |
-| `service.annotations`                     | Service annotations                                                                   | `{}` (evaluated as a template)                               |
-| `service.loadBalancerSourceRanges`        | Restricts access for LoadBalancer (only with `service.type: LoadBalancer`)            | `[]`                                                         |
-| `service.extraPorts`                      | Extra ports to expose in the service (normally used with the `sidecar` value)         | `nil`                                                        |
-| `service.nodePorts.http`                  | Kubernetes http node port                                                             | `""`                                                         |
+| Parameter                          | Description                                                                   | Default                        |
+| ---------------------------------- | ----------------------------------------------------------------------------- | ------------------------------ |
+| `service.type`                     | Kubernetes Service type                                                       | `LoadBalancer`                 |
+| `service.port`                     | Service HTTP port                                                             | `80`                           |
+| `service.nodePort`                 | NodePort service IP address                                                   | `nil`                          |
+| `service.loadBalancerIP`           | LoadBalancer service IP address                                               | `nil`                          |
+| `service.externalTrafficPolicy`    | Enable client source IP preservation                                          | `Cluster`                      |
+| `service.annotations`              | Service annotations                                                           | `{}` (evaluated as a template) |
+| `service.loadBalancerSourceRanges` | Restricts access for LoadBalancer (only with `service.type: LoadBalancer`)    | `[]`                           |
+| `service.extraPorts`               | Extra ports to expose in the service (normally used with the `sidecar` value) | `nil`                          |
+| `service.nodePorts.http`           | Kubernetes http node port                                                     | `""`                           |
 
 ### Discourse parameters
 
-| Parameter                                 | Description                                                                           | Default                                                      |
-|-------------------------------------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `discourse.host`                          | Discourse host to create application URLs (include the port if =/= 80)                | `""`                                                         |
-| `discourse.siteName`                      | Discourse site name                                                                   | `My Site!`                                                   |
-| `discourse.username`                      | Admin user of the application                                                         | `user`                                                       |
-| `discourse.password`                      | Application password (min length of 10 chars) - ignored if existingSecret is provided | _random 10 character long alphanumeric string_               |
-| `discourse.existingSecret`                | Name of an existing Kubernetes secret                                                 | `nil`                                                        |
-| `discourse.email`                         | Admin user email of the application                                                   | `user@example.com`                                           |
-| `discourse.command`                       | Custom command to override image cmd                                                  | `nil` (evaluated as a template)                              |
-| `discourse.args`                          | Custom args for the custom commad                                                     | `nil` (evaluated as a template)                              |
-| `discourse.containerSecurityContext`      | Container security context specification                                              | `{}`                                                         |
-| `discourse.resources`                     | Discourse container's resource requests and limits                                    | `{}`                                                         |
-| `discourse.livenessProbe.enabled`         | Enable/disable livenessProbe                                                          | `true`                                                       |
-| `discourse.livenessProbe.initialDelaySeconds`| Delay before liveness probe is initiated                                           | `500`                                                        |
-| `discourse.livenessProbe.periodSeconds`   | How often to perform the probe                                                        | `10`                                                         |
-| `discourse.livenessProbe.timeoutSeconds`  | When the probe times out                                                              | `5`                                                          |
-| `discourse.livenessProbe.failureThreshold`| Minimum consecutive failures for the probe                                            | `6`                                                          |
-| `discourse.livenessProbe.successThreshold`| Minimum consecutive successes for the probe                                           | `1`                                                          |
-| `discourse.readinessProbe.enabled`        | Enable/disable readinessProbe                                                         | `true`                                                       |
-| `discourse.readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated                                         | `30`                                                         |
-| `discourse.readinessProbe.periodSeconds`  | How often to perform the probe                                                        | `10`                                                         |
-| `discourse.readinessProbe.timeoutSeconds` | When the probe times out                                                              | `5`                                                          |
-| `discourse.readinessProbe.failureThreshold`| Minimum consecutive failures for the probe                                           | `6`                                                          |
-| `discourse.readinessProbe.successThreshold`| Minimum consecutive successes for the probe                                          | `1`                                                          |
-| `discourse.customLivenessProbe`           | Custom liveness probe to execute (when the main one is disabled)                      | `{}` (evaluated as a template)                               |
-| `discourse.customReadinessProbe`          | Custom readiness probe to execute (when the main one is disabled)                     | `{}` (evaluated as a template)                               |
-| `discourse.extraEnvVars`                  | An array to add extra env vars                                                        | `[]` (evaluated as a template)                               |
-| `discourse.extraEnvVarsCM`                | Array to add extra configmaps                                                         | `[]`                                                         |
-| `discourse.extraEnvVarsSecret`            | Array to add extra environment from a Secret                                          | `nil`                                                        |
-| `discourse.extraVolumeMounts`             | Additional volume mounts (used along with `extraVolumes`)                             | `[]` (evaluated as a template)                               |
-| `discourse.skipInstall`                   | Do not run the Discourse installation wizard                                          | `false`                                                      |
+| Parameter                                      | Description                                                                           | Default                                        |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| `discourse.host`                               | Discourse host to create application URLs (include the port if =/= 80)                | `""`                                           |
+| `discourse.siteName`                           | Discourse site name                                                                   | `My Site!`                                     |
+| `discourse.username`                           | Admin user of the application                                                         | `user`                                         |
+| `discourse.password`                           | Application password (min length of 10 chars) - ignored if existingSecret is provided | _random 10 character long alphanumeric string_ |
+| `discourse.existingSecret`                     | Name of an existing Kubernetes secret                                                 | `nil`                                          |
+| `discourse.email`                              | Admin user email of the application                                                   | `user@example.com`                             |
+| `discourse.command`                            | Custom command to override image cmd                                                  | `nil` (evaluated as a template)                |
+| `discourse.args`                               | Custom args for the custom commad                                                     | `nil` (evaluated as a template)                |
+| `discourse.containerSecurityContext`           | Container security context specification                                              | `{}`                                           |
+| `discourse.resources`                          | Discourse container's resource requests and limits                                    | `{}`                                           |
+| `discourse.livenessProbe.enabled`              | Enable/disable livenessProbe                                                          | `true`                                         |
+| `discourse.livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                                              | `500`                                          |
+| `discourse.livenessProbe.periodSeconds`        | How often to perform the probe                                                        | `10`                                           |
+| `discourse.livenessProbe.timeoutSeconds`       | When the probe times out                                                              | `5`                                            |
+| `discourse.livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe                                            | `6`                                            |
+| `discourse.livenessProbe.successThreshold`     | Minimum consecutive successes for the probe                                           | `1`                                            |
+| `discourse.readinessProbe.enabled`             | Enable/disable readinessProbe                                                         | `true`                                         |
+| `discourse.readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                                             | `30`                                           |
+| `discourse.readinessProbe.periodSeconds`       | How often to perform the probe                                                        | `10`                                           |
+| `discourse.readinessProbe.timeoutSeconds`      | When the probe times out                                                              | `5`                                            |
+| `discourse.readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe                                            | `6`                                            |
+| `discourse.readinessProbe.successThreshold`    | Minimum consecutive successes for the probe                                           | `1`                                            |
+| `discourse.customLivenessProbe`                | Custom liveness probe to execute (when the main one is disabled)                      | `{}` (evaluated as a template)                 |
+| `discourse.customReadinessProbe`               | Custom readiness probe to execute (when the main one is disabled)                     | `{}` (evaluated as a template)                 |
+| `discourse.extraEnvVars`                       | An array to add extra env vars                                                        | `[]` (evaluated as a template)                 |
+| `discourse.extraEnvVarsCM`                     | Array to add extra configmaps                                                         | `[]`                                           |
+| `discourse.extraEnvVarsSecret`                 | Array to add extra environment from a Secret                                          | `nil`                                          |
+| `discourse.extraVolumeMounts`                  | Additional volume mounts (used along with `extraVolumes`)                             | `[]` (evaluated as a template)                 |
+| `discourse.skipInstall`                        | Do not run the Discourse installation wizard                                          | `false`                                        |
 
 ### Sidekiq parameters
 
-| Parameter                                 | Description                                                                           | Default                                                      |
-|-------------------------------------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `sidekiq.containerSecurityContext`        | Container security context specification                                              | `{}`                                                         |
-| `sidekiq.command`                         | Custom command to override image cmd (evaluated as a template)                        | `["/app-entrypoint.sh"]`                                     |
-| `sidekiq.args`                            | Custom args for the custom commad (evaluated as a template)                           | `["nami", "start", "--foreground", "discourse-sidekiq"`      |
-| `sidekiq.resources`                       | Sidekiq container's resource requests and limits                                      | `{}`                                                         |
-| `sidekiq.livenessProbe.enabled`           | Enable/disable livenessProbe                                                          | `true`                                                       |
-| `sidekiq.livenessProbe.initialDelaySeconds`| Delay before liveness probe is initiated                                             | `500`                                                        |
-| `sidekiq.livenessProbe.periodSeconds`     | How often to perform the probe                                                        | `10`                                                         |
-| `sidekiq.livenessProbe.timeoutSeconds`    | When the probe times out                                                              | `5`                                                          |
-| `sidekiq.livenessProbe.failureThreshold`  | Minimum consecutive failures for the probe                                            | `6`                                                          |
-| `sidekiq.livenessProbe.successThreshold`  | Minimum consecutive successes for the probe                                           | `1`                                                          |
-| `sidekiq.readinessProbe.enabled`          | Enable/disable readinessProbe                                                         | `true`                                                       |
-| `sidekiq.readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated                                           | `30`                                                         |
-| `sidekiq.readinessProbe.periodSeconds`    | How often to perform the probe                                                        | `10`                                                         |
-| `sidekiq.readinessProbe.timeoutSeconds`   | When the probe times out                                                              | `5`                                                          |
-| `sidekiq.readinessProbe.failureThreshold` | Minimum consecutive failures for the probe                                            | `6`                                                          |
-| `sidekiq.readinessProbe.successThreshold` | Minimum consecutive successes for the probe                                           | `1`                                                          |
-| `sidekiq.customLivenessProbe`             | Custom liveness probe to execute (when the main one is disabled)                      | `{}` (evaluated as a template)                               |
-| `sidekiq.customReadinessProbe`            | Custom readiness probe to execute (when the main one is disabled)                     | `{}` (evaluated as a template)                               |
-| `sidekiq.extraEnvVars`                    | An array to add extra env vars                                                        | `[]` (evaluated as a template)                               |
-| `sidekiq.extraEnvVarsCM`                  | Array to add extra configmaps                                                         | `[]`                                                         |
-| `sidekiq.extraEnvVarsSecret`              | Array to add extra environment from a Secret                                          | `nil`                                                        |
-| `discourse.extraVolumeMounts`             | Additional volume mounts (used along with `extraVolumes`)                             | `[]` (evaluated as a template)                               |
+| Parameter                                    | Description                                                       | Default                                                 |
+| -------------------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------- |
+| `sidekiq.containerSecurityContext`           | Container security context specification                          | `{}`                                                    |
+| `sidekiq.command`                            | Custom command to override image cmd (evaluated as a template)    | `["/app-entrypoint.sh"]`                                |
+| `sidekiq.args`                               | Custom args for the custom commad (evaluated as a template)       | `["nami", "start", "--foreground", "discourse-sidekiq"` |
+| `sidekiq.resources`                          | Sidekiq container's resource requests and limits                  | `{}`                                                    |
+| `sidekiq.livenessProbe.enabled`              | Enable/disable livenessProbe                                      | `true`                                                  |
+| `sidekiq.livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                          | `500`                                                   |
+| `sidekiq.livenessProbe.periodSeconds`        | How often to perform the probe                                    | `10`                                                    |
+| `sidekiq.livenessProbe.timeoutSeconds`       | When the probe times out                                          | `5`                                                     |
+| `sidekiq.livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe                        | `6`                                                     |
+| `sidekiq.livenessProbe.successThreshold`     | Minimum consecutive successes for the probe                       | `1`                                                     |
+| `sidekiq.readinessProbe.enabled`             | Enable/disable readinessProbe                                     | `true`                                                  |
+| `sidekiq.readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                         | `30`                                                    |
+| `sidekiq.readinessProbe.periodSeconds`       | How often to perform the probe                                    | `10`                                                    |
+| `sidekiq.readinessProbe.timeoutSeconds`      | When the probe times out                                          | `5`                                                     |
+| `sidekiq.readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe                        | `6`                                                     |
+| `sidekiq.readinessProbe.successThreshold`    | Minimum consecutive successes for the probe                       | `1`                                                     |
+| `sidekiq.customLivenessProbe`                | Custom liveness probe to execute (when the main one is disabled)  | `{}` (evaluated as a template)                          |
+| `sidekiq.customReadinessProbe`               | Custom readiness probe to execute (when the main one is disabled) | `{}` (evaluated as a template)                          |
+| `sidekiq.extraEnvVars`                       | An array to add extra env vars                                    | `[]` (evaluated as a template)                          |
+| `sidekiq.extraEnvVarsCM`                     | Array to add extra configmaps                                     | `[]`                                                    |
+| `sidekiq.extraEnvVarsSecret`                 | Array to add extra environment from a Secret                      | `nil`                                                   |
+| `discourse.extraVolumeMounts`                | Additional volume mounts (used along with `extraVolumes`)         | `[]` (evaluated as a template)                          |
 
 ### Ingress parameters
 
-| Parameter                                 | Description                                                                           | Default                                                      |
-|-------------------------------------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `ingress.enabled`                         | Enable ingress controller resource                                                    | `false`                                                      |
-| `ingress.certManager`                     | Add annotations for cert-manager                                                      | `false`                                                      |
-| `ingress.hostname`                        | Default host for the ingress resource                                                 | `discourse.local`                                            |
-| `ingress.tls`                             | Create TLS Secret                                                                     | `false`                                                      |
-| `ingress.annotations`                     | Ingress annotations                                                                   | `{}` (evaluated as a template)                               |
-| `ingress.extraHosts[0].name`              | Additional hostnames to be covered                                                    | `nil`                                                        |
-| `ingress.extraHosts[0].path`              | Additional hostnames to be covered                                                    | `nil`                                                        |
-| `ingress.extraTls[0].hosts[0]`            | TLS configuration for additional hostnames to be covered                              | `nil`                                                        |
-| `ingress.extraTls[0].secretName`          | TLS configuration for additional hostnames to be covered                              | `nil`                                                        |
-| `ingress.secrets[0].name`                 | TLS Secret Name                                                                       | `nil`                                                        |
-| `ingress.secrets[0].certificate`          | TLS Secret Certificate                                                                | `nil`                                                        |
-| `ingress.secrets[0].key`                  | TLS Secret Key                                                                        | `nil`                                                        |
+| Parameter                        | Description                                              | Default                        |
+| -------------------------------- | -------------------------------------------------------- | ------------------------------ |
+| `ingress.enabled`                | Enable ingress controller resource                       | `false`                        |
+| `ingress.certManager`            | Add annotations for cert-manager                         | `false`                        |
+| `ingress.hostname`               | Default host for the ingress resource                    | `discourse.local`              |
+| `ingress.tls`                    | Create TLS Secret                                        | `false`                        |
+| `ingress.annotations`            | Ingress annotations                                      | `{}` (evaluated as a template) |
+| `ingress.extraHosts[0].name`     | Additional hostnames to be covered                       | `nil`                          |
+| `ingress.extraHosts[0].path`     | Additional hostnames to be covered                       | `nil`                          |
+| `ingress.extraTls[0].hosts[0]`   | TLS configuration for additional hostnames to be covered | `nil`                          |
+| `ingress.extraTls[0].secretName` | TLS configuration for additional hostnames to be covered | `nil`                          |
+| `ingress.secrets[0].name`        | TLS Secret Name                                          | `nil`                          |
+| `ingress.secrets[0].certificate` | TLS Secret Certificate                                   | `nil`                          |
+| `ingress.secrets[0].key`         | TLS Secret Key                                           | `nil`                          |
 
 ### Database parameters
 
-| Parameter                                    | Description                                                                           | Default                                                   |
-|----------------------------------------------|---------------------------------------------------------------------------------------|-----------------------------------------------------------|
-| `postgresql.enabled`                         | Deploy PostgreSQL container(s)                                                        | `true`                                                    |
-| `postgresql.postgresqlUsername`              | PostgreSQL user to create (used by Discourse)                                         | `bn_discourse`                                            |
-| `postgresql.postgresqlPassword`              | Password for the Dicourse user - ignored if existingSecret is provided                | _random 10 character long alphanumeric string_            |
-| `postgresql.postgresqlPostgresPassword`      | Password for the admin user ("postgres") - ignored if existingSecret is provided      | `bitnami`                                                 |
-| `postgresql.existingSecret`                  | Name of an existing Kubernetes secret. The secret must have the following keys configured: `postgresql-postgres-password`, `postgresql-password` | `nil` |
-| `postgresql.postgresqlDatabase`              | Name of the database to create                                                        | `bitnami_application`                                     |
-| `postgresql.persistence.enabled`             | Enable database persistence using PVC                                                 | `true`                                                    |
-| `externalDatabase.host`                      | Host of the external database                                                         | `""`                                                      |
-| `externalDatabase.port`                      | Database port number (when using an external db)                                      | `5432`                                                    |
-| `externalDatabase.user`                      | PostgreSQL username (when using an external db)                                       | `bn_discourse`                                            |
-| `externalDatabase.password`                  | Password for the above username (when using an external db)                           | `""`                                                      |
-| `externalDatabase.postgresqlPostgresUser`    | PostgreSQL admin user, used during the installation stage (when using an external db) | `""`                                                      |
-| `externalDatabase.postgresqlPostgresPassword`| Password for PostgreSQL admin user (when using an external db)                        | `""`                                                      |
-| `externalDatabase.existingSecret`            | Name of an existing Kubernetes secret. The secret must have the following keys configured: `postgresql-postgres-password`, `postgresql-password` | `nil` |
-| `externalDatabase.database`                  | Name of the existing database (when using an external db)                             | `bitnami_application`                                     |
+| Parameter                                     | Description                                                                                                                                      | Default                                        |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------- |
+| `postgresql.enabled`                          | Deploy PostgreSQL container(s)                                                                                                                   | `true`                                         |
+| `postgresql.postgresqlUsername`               | PostgreSQL user to create (used by Discourse)                                                                                                    | `bn_discourse`                                 |
+| `postgresql.postgresqlPassword`               | Password for the Dicourse user - ignored if existingSecret is provided                                                                           | _random 10 character long alphanumeric string_ |
+| `postgresql.postgresqlPostgresPassword`       | Password for the admin user ("postgres") - ignored if existingSecret is provided                                                                 | `bitnami`                                      |
+| `postgresql.existingSecret`                   | Name of an existing Kubernetes secret. The secret must have the following keys configured: `postgresql-postgres-password`, `postgresql-password` | `nil`                                          |
+| `postgresql.postgresqlDatabase`               | Name of the database to create                                                                                                                   | `bitnami_application`                          |
+| `postgresql.persistence.enabled`              | Enable database persistence using PVC                                                                                                            | `true`                                         |
+| `postgresql.persistence.enabled`              | Enable database persistence using PVC                                                                                                            | `true`                                         |
+| `externalDatabase.port`                       | Database port number (when using an external db)                                                                                                 | `5432`                                         |
+| `externalDatabase.user`                       | PostgreSQL username (when using an external db)                                                                                                  | `bn_discourse`                                 |
+| `externalDatabase.password`                   | Password for the above username (when using an external db)                                                                                      | `""`                                           |
+| `externalDatabase.postgresqlPostgresUser`     | PostgreSQL admin user, used during the installation stage (when using an external db)                                                            | `""`                                           |
+| `externalDatabase.postgresqlPostgresPassword` | Password for PostgreSQL admin user (when using an external db)                                                                                   | `""`                                           |
+| `externalDatabase.existingSecret`             | Name of an existing Kubernetes secret. The secret must have the following keys configured: `postgresql-postgres-password`, `postgresql-password` | `nil`                                          |
+| `externalDatabase.database`                   | Name of the existing database (when using an external db)                                                                                        | `bitnami_application`                          |
+| `externalDatabase.backupPort`                 | Database port to use when taking a backup via `pg_dump` (when using an external db)                                                              | `5432`                                         |
 
 ### Redis parameters
 
-| Parameter                                 | Description                                                                           | Default                                                      |
-|-------------------------------------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `redis.enabled`                           | Deploy Redis container(s)                                                             | `true`                                                       |
-| `redis.usePassword`                       | Use password authentication                                                           | `false`                                                      |
-| `redis.password`                          | Password for Redis authentication  - ignored if existingSecret is provided            | `nil`                                                        |
-| `redis.existingSecret`                    | Name of an existing Kubernetes secret                                                 | `nil`                                                        |
-| `redis.existingSecretPasswordKey`         | Name of the key pointing to the password in your Kubernetes secret                    | `redis-password`                                             |
-| `redis.cluster.enabled`                   | Whether to use cluster replication                                                    | `false`                                                      |
-| `redis.master.persistence.enabled`        | Enable database persistence using PVC                                                 | `true`                                                       |
-| `externalRedis.host`                      | Host of the external database                                                         | `""`                                                         |
-| `externalRedis.port`                      | Database port number                                                                  | `6379`                                                       |
-| `externalRedis.password`                  | Password for the external Redis                                                       | `nil`                                                        |
-| `externalRedis.existingSecret`            | Name of an existing Kubernetes secret                                                 | `nil`                                                        |
-| `externalRedis.existingSecretPasswordKey` | Name of the key pointing to the password in your Kubernetes secret                    | `redis-password`                                             |
+| Parameter                                 | Description                                                                | Default          |
+| ----------------------------------------- | -------------------------------------------------------------------------- | ---------------- |
+| `redis.enabled`                           | Deploy Redis container(s)                                                  | `true`           |
+| `redis.usePassword`                       | Use password authentication                                                | `false`          |
+| `redis.password`                          | Password for Redis authentication  - ignored if existingSecret is provided | `nil`            |
+| `redis.existingSecret`                    | Name of an existing Kubernetes secret                                      | `nil`            |
+| `redis.existingSecretPasswordKey`         | Name of the key pointing to the password in your Kubernetes secret         | `redis-password` |
+| `redis.cluster.enabled`                   | Whether to use cluster replication                                         | `false`          |
+| `redis.master.persistence.enabled`        | Enable database persistence using PVC                                      | `true`           |
+| `externalRedis.host`                      | Host of the external database                                              | `""`             |
+| `externalRedis.port`                      | Database port number                                                       | `6379`           |
+| `externalRedis.password`                  | Password for the external Redis                                            | `nil`            |
+| `externalRedis.existingSecret`            | Name of an existing Kubernetes secret                                      | `nil`            |
+| `externalRedis.existingSecretPasswordKey` | Name of the key pointing to the password in your Kubernetes secret         | `redis-password` |
 
 The above parameters map to the env variables defined in [bitnami/discourse](http://github.com/bitnami/bitnami-docker-discourse). For more information please refer to the [bitnami/discourse](http://github.com/bitnami/bitnami-docker-discourse) image documentation.
 
@@ -359,6 +360,7 @@ externalDatabase.postgresqlPostgresUser=postgres
 externalDatabase.postgresqlPostgresPassword=rootpassword
 externalDatabase.database=mydatabase
 externalDatabase.port=5432
+externalDatabase.backupPort=5432
 ```
 
 Note also that if you disable PostgreSQL per above you MUST supply values for the `externalDatabase` connection.

--- a/bitnami/discourse/templates/NOTES.txt
+++ b/bitnami/discourse/templates/NOTES.txt
@@ -52,6 +52,7 @@ This deployment will be incomplete until you configure Discourse with a resolvab
     --set service.type={{ .Values.service.type }} \
     --set externalDatabase.host={{ .Values.externalDatabase.host }} \
     --set externalDatabase.port={{ .Values.externalDatabase.port }} \
+    --set externalDatabase.backupPort={{ .Values.externalDatabase.backupPort }} \
     --set externalDatabase.user={{ .Values.externalDatabase.user }} \
     --set externalDatabase.password=$POSTGRESQL_PASSWORD \
     --set externalDatabase.database={{ .Values.externalDatabase.database }} \

--- a/bitnami/discourse/templates/_helpers.tpl
+++ b/bitnami/discourse/templates/_helpers.tpl
@@ -102,6 +102,17 @@ Return the Postgresql port
 {{- end -}}
 
 {{/*
+Return the Postgresql backup port
+*/}}
+{{- define "discourse.databaseBackupPort" -}}
+{{- if .Values.postgresql.enabled }}
+    {{- printf "5432" | quote -}}
+{{- else -}}
+    {{- .Values.externalDatabase.backupPort | quote -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the Postgresql database name
 */}}
 {{- define "discourse.databaseName" -}}

--- a/bitnami/discourse/templates/configmaps.yaml
+++ b/bitnami/discourse/templates/configmaps.yaml
@@ -19,6 +19,7 @@ data:
   REDIS_PORT_NUMBER: {{ template "discourse.redisPort" . }}
   POSTGRESQL_HOST: {{ template "discourse.databaseHost" . }}
   POSTGRESQL_PORT_NUMBER: {{ template "discourse.databasePort" . }}
+  POSTGRESQL_BACKUP_PORT_NUMBER: {{ template "discourse.databaseBackupPort" . }}
   DISCOURSE_POSTGRESQL_NAME: {{ template "discourse.databaseName" . }}
   DISCOURSE_POSTGRESQL_USERNAME: {{ template "discourse.databaseUser" . }}
   POSTGRESQL_ROOT_USER: "postgres"

--- a/bitnami/discourse/values-production.yaml
+++ b/bitnami/discourse/values-production.yaml
@@ -532,6 +532,9 @@ externalDatabase:
   ## Database port
   ##
   port: 5432
+  ## Database port to use when taking a backup via `pg_dump`
+  ##
+  backupPort: 5432
   ## non-root Username for Discourse Database
   ##
   user: bn_discourse

--- a/bitnami/discourse/values.yaml
+++ b/bitnami/discourse/values.yaml
@@ -527,6 +527,9 @@ externalDatabase:
   ## Database port
   ##
   port: 5432
+  ## PostgreSQL port to use when taking a backup via `pg_dump`
+  ##
+  backupPort: 5432
   ## non-root Username for Discourse Database
   ##
   user: bn_discourse


### PR DESCRIPTION
**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes https://github.com/bitnami/charts/issues/4456

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
