### PR TITLE
[bitnami/parse] fix: mongodb upgrade validation

### DIFF
--- a/bitnami/parse/Chart.lock
+++ b/bitnami/parse/Chart.lock
@@ -1,6 +1,9 @@
 dependencies:
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
-  version: 10.0.0
-digest: sha256:2d18ebbed644b888fe29905b6d5d2b0d46a86a97127d6ae63ce7df213dba8546
-generated: "2020-11-12T07:20:39.08169975Z"
+  version: 10.1.1
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.1.1
+digest: sha256:c67c54bc4268385fbb76f42e1acb329a1bfb5b42a324b911149379a65ddb066b
+generated: "2020-11-26T20:18:06.037822+01:00"

--- a/bitnami/parse/Chart.lock
+++ b/bitnami/parse/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
-  version: 10.1.1
+  version: 10.1.2
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.1.1
-digest: sha256:c67c54bc4268385fbb76f42e1acb329a1bfb5b42a324b911149379a65ddb066b
-generated: "2020-11-26T20:18:06.037822+01:00"
+digest: sha256:9eb29620e20671af05d7848d31801ba4ca7ae93435cc61e99ea7bc795aeaf56d
+generated: "2020-11-26T20:40:46.81438+01:00"

--- a/bitnami/parse/Chart.yaml
+++ b/bitnami/parse/Chart.yaml
@@ -6,6 +6,11 @@ dependencies:
   - name: mongodb
     repository: https://charts.bitnami.com/bitnami
     version: 10.x.x
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
 description: Parse is a platform that enables users to add a scalable and powerful backend to launch a full-featured app for iOS, Android, JavaScript, Windows, Unity, and more.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/parse
@@ -25,4 +30,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-parse
   - https://github.com/bitnami/bitnami-docker-parse-dashboard
   - https://parse.com/
-version: 13.0.0
+version: 13.1.0

--- a/bitnami/parse/templates/NOTES.txt
+++ b/bitnami/parse/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{- $dbSecretName := include "parse.mongodb.fullname" . -}}
 
 ******************************************************************
 *** PLEASE BE PATIENT: Parse may take a few minutes to install ***
@@ -98,3 +99,10 @@ service:
 
 {{ include "parse.validateValues" . }}
 {{ include "parse.checkRollingTags" . }}
+
+{{- $passwordValidationErrors := list }}
+
+{{- $dbPasswordValidationErrors := include "common.validations.values.mongodb.passwords" (dict "secret" $dbSecretName "subchart" true "context" $) -}}
+{{- $passwordValidationErrors = append $passwordValidationErrors $dbPasswordValidationErrors -}}
+
+{{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordValidationErrors "context" $) -}}

--- a/bitnami/parse/values.yaml
+++ b/bitnami/parse/values.yaml
@@ -380,6 +380,10 @@ persistence:
 ## https://github.com/bitnami/charts/blob/master/bitnami/mongodb/values.yaml
 ##
 mongodb:
+  # This is necessary for bitnami/common validation purposes. Setting enabled=false will
+  # make no difference in deploying the subchart. Change this when further standardizations
+  # are added (externalDB)
+  enabled: true
   ## MongoDB Authentication parameters
   ##
   auth:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

When performing upgrades, `mongoDB` (subchart) will fail due to password validations on upgrade. The subchart was recently updated to solve this issue using a `bitnami/commons` helper (see https://github.com/bitnami/charts/pull/4497 and https://github.com/bitnami/charts/pull/4498).

This PR includes `bitnami/common` as a dependency in order to solve this issue. 

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
You can perform upgrades on the chart again
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
Not really, but the chart includes `bitnami/common` and no standardizations using it.
<!-- Describe any known limitations with your change -->

**Applicable issues**

NA

**Additional information**

NA

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
