### PR TITLE
[bitnami/*] Affinity based on common presets (vi)

### DIFF
--- a/bitnami/mxnet/Chart.lock
+++ b/bitnami/mxnet/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.0.1
-digest: sha256:e66388f254b9de6470bca6d8c1c565d1c16a5569beef68a7bc99e486e73ccbdb
-generated: "2020-11-26T11:08:55.460243+01:00"
+  version: 1.1.1
+digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
+generated: "2020-12-09T16:14:39.468185+01:00"

--- a/bitnami/mxnet/Chart.lock
+++ b/bitnami/mxnet/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.0.1
+digest: sha256:e66388f254b9de6470bca6d8c1c565d1c16a5569beef68a7bc99e486e73ccbdb
+generated: "2020-11-26T11:08:55.460243+01:00"

--- a/bitnami/mxnet/Chart.yaml
+++ b/bitnami/mxnet/Chart.yaml
@@ -2,6 +2,12 @@ annotations:
   category: MachineLearning
 apiVersion: v2
 appVersion: 1.7.0
+dependencies:
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
 description: A flexible and efficient library for deep learning
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/mxnet
@@ -18,4 +24,4 @@ name: mxnet
 sources:
   - https://github.com/bitnami/bitnami-docker-mxnet
   - https://mxnet.apache.org/
-version: 2.0.0
+version: 2.1.0

--- a/bitnami/mxnet/README.md
+++ b/bitnami/mxnet/README.md
@@ -47,85 +47,148 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Parameters
 
-The following table lists the configurable parameters of the MinIO chart and their default values.
+The following table lists the configurable parameters of the Mxnet chart and their default values.
 
-| Parameter                            | Description                                                                                                                                               | Default                                                 |
-|--------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `global.imageRegistry`               | Global Docker image registry                                                                                                                              | `nil`                                                   |
-| `global.imagePullSecrets`            | Global Docker registry secret names as an array                                                                                                           | `[]` (does not add image pull secrets to deployed pods) |
-| `global.storageClass`                | Global storage class for dynamic provisioning                                                                                                             | `nil`                                                   |
-| `image.registry`                     | Apache MXNet (Incubating) image registry                                                                                                                  | `docker.io`                                             |
-| `image.repository`                   | Apache MXNet (Incubating) image name                                                                                                                      | `bitnami/mxnet`                                         |
-| `image.tag`                          | Apache MXNet (Incubating) image tag                                                                                                                       | `{TAG_NAME}`                                            |
-| `image.pullPolicy`                   | Image pull policy                                                                                                                                         | `IfNotPresent`                                          |
-| `image.pullSecrets`                  | Specify docker-registry secret names as an array                                                                                                          | `[]` (does not add image pull secrets to deployed pods) |
-| `image.debug`                        | Specify if debug logs should be enabled                                                                                                                   | `false`                                                 |
-| `git.registry`                       | Git image registry                                                                                                                                        | `docker.io`                                             |
-| `git.repository`                     | Git image name                                                                                                                                            | `bitnami/git`                                           |
-| `git.tag`                            | Git image tag                                                                                                                                             | `{TAG_NAME}`                                            |
-| `git.pullPolicy`                     | Git image pull policy                                                                                                                                     | `IfNotPresent`                                          |
-| `git.pullSecrets`                    | Specify docker-registry secret names as an array                                                                                                          | `[]` (does not add image pull secrets to deployed pods) |
-| `nameOverride`                       | String to partially override mxnet.fullname template with a string (will prepend the release name)                                                        | `nil`                                                   |
-| `fullnameOverride`                   | String to fully override mxnet.fullname template with a string                                                                                            | `nil`                                                   |
-| `volumePermissions.enabled`          | Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work) | `false`                                                 |
-| `volumePermissions.image.registry`   | Init container volume-permissions image registry                                                                                                          | `docker.io`                                             |
-| `volumePermissions.image.repository` | Init container volume-permissions image name                                                                                                              | `bitnami/minideb`                                       |
-| `volumePermissions.image.tag`        | Init container volume-permissions image tag                                                                                                               | `buster`                                                |
-| `volumePermissions.image.pullPolicy` | Init container volume-permissions image pull policy                                                                                                       | `Always`                                                |
-| `volumePermissions.resources`        | Init container resource requests/limit                                                                                                                    | `nil`                                                   |
-| `service.type`                       | Kubernetes service type                                                                                                                                   | `ClusterIP`                                             |
-| `entrypoint.file`                    | Main entrypoint to your application. If not speficied, it will be a `sleep infinity` command                                                              | `''`                                                    |
-| `entrypoint.args`                    | Args required by your entrypoint                                                                                                                          | `nil`                                                   |
-| `entrypoint.workDir`                 | Working directory for launching the entrypoint                                                                                                            | `'/app'`                                                |
-| `podManagementPolicy`                | StatefulSet (worker and server nodes) pod management policy                                                                                               | `Parallel`                                              |
-| `mode`                               | Run Apache MXNet (Incubating) in standalone or distributed mode (possible values: `standalone`, `distributed`)                                            | `standalone`                                            |
-| `serverCount`                        | Number of server nodes that will execute your code                                                                                                        | `1`                                                     |
-| `workerCount`                        | Number of worker nodes that will execute your code                                                                                                        | `1`                                                     |
-| `schedulerPort`                      | Apache MXNet (Incubating) scheduler port (only for distributed mode)                                                                                      | `49875`                                                 |
-| `configMap`                          | Config map that contains the files you want to load in Apache MXNet (Incubating)                                                                          | `nil`                                                   |
-| `cloneFilesFromGit.enabled`          | Enable in order to download files from git repository                                                                                                     | `false`                                                 |
-| `cloneFilesFromGit.repository`       | Repository that holds the files                                                                                                                           | `nil`                                                   |
-| `cloneFilesFromGit.revision`         | Revision from the repository to checkout                                                                                                                  | `master`                                                |
-| `commonExtraEnvVars`                 | Extra environment variables to add to server, scheduler and worker nodes                                                                                  | `nil`                                                   |
-| `workerExtraEnvVars`                 | Extra environment variables to add to the worker nodes                                                                                                    | `nil`                                                   |
-| `serverExtraEnvVars`                 | Extra environment variables to add to the server nodes                                                                                                    | `nil`                                                   |
-| `schedulerExtraEnvVars`              | Extra environment variables to add to the scheduler node                                                                                                  | `nil`                                                   |
-| `existingSecret`                     | Name of a secret with sensitive data to mount in the pods                                                                                                 | `nil`                                                   |
-| `nodeSelector`                       | Node labels for pod assignment (this value is evaluated as a template)                                                                                    | `{}`                                                    |
-| `tolerations`                        | Toleration labels for pod assignment (this value is evaluated as a template)                                                                              | `[]`                                                    |
-| `affinity`                           | Map of node/pod affinities (this value is evaluated as a template)                                                                                        | `{}`                                                    |
-| `resources`                          | Pod resources                                                                                                                                             | `{}`                                                    |
-| `securityContext.enabled`            | Enable security context                                                                                                                                   | `true`                                                  |
-| `securityContext.fsGroup`            | Group ID for the container                                                                                                                                | `1001`                                                  |
-| `securityContext.runAsUser`          | User ID for the container                                                                                                                                 | `1001`                                                  |
-| `livenessProbe.enabled`              | Enable/disable the Liveness probe                                                                                                                         | `true`                                                  |
-| `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                                                                                                                  | `5`                                                     |
-| `livenessProbe.periodSeconds`        | How often to perform the probe                                                                                                                            | `5`                                                     |
-| `livenessProbe.timeoutSeconds`       | When the probe times out                                                                                                                                  | `5`                                                     |
-| `livenessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed.                                                              | `1`                                                     |
-| `livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.                                                                | `5`                                                     |
-| `readinessProbe.enabled`             | Enable/disable the Readiness probe                                                                                                                        | `true`                                                  |
-| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                                                                                                                 | `5`                                                     |
-| `readinessProbe.periodSeconds`       | How often to perform the probe                                                                                                                            | `5`                                                     |
-| `readinessProbe.timeoutSeconds`      | When the probe times out                                                                                                                                  | `1`                                                     |
-| `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed.                                                              | `1`                                                     |
-| `readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed after having succeeded.                                                                | `5`                                                     |
-| `persistence.enabled`                | Use a PVC to persist data                                                                                                                                 | `false`                                                 |
-| `persistence.mountPath`              | Path to mount the volume at                                                                                                                               | `/bitnami/mxnet`                                        |
-| `persistence.storageClass`           | Storage class of backing PVC                                                                                                                              | `nil` (uses alpha storage class annotation)             |
-| `persistence.accessMode`             | Use volume as ReadOnly or ReadWrite                                                                                                                       | `ReadWriteOnce`                                         |
-| `persistence.size`                   | Size of data volume                                                                                                                                       | `8Gi`                                                   |
-| `persistence.annotations`            | Persistent Volume annotations                                                                                                                             | `{}`                                                    |
-| `sidecars`                           | Attach additional containers to the pods (scheduler, worker and server nodes)                                                                             | `[]`                                                    |
-| `initContainers`                     | Attach additional init containers to the pods (scheduler, worker and server nodes)                                                                        | `[]`                                                    |
+### Global Parameters
+
+| Parameter                               | Description                                                | Default                                                 |
+|-----------------------------------------|------------------------------------------------------------|---------------------------------------------------------|
+| `global.imageRegistry`                  | Global Docker image registry                               | `nil`                                                   |
+| `global.imagePullSecrets`               | Global Docker registry secret names as an array            | `[]` (does not add image pull secrets to deployed pods) |
+| `global.storageClass`                   | Global storage class for dynamic provisioning              | `nil`                                                   |
+
+### Common parameters
+
+| Parameter                               | Description                                                | Default                                                 |
+|-----------------------------------------|------------------------------------------------------------|---------------------------------------------------------|
+| `nameOverride`                          | String to partially override common.names.fullname         | `nil`                                                   |
+| `fullnameOverride`                      | String to fully override common.names.fullname             | `nil`                                                   |
+
+### Common Mxnet parameters
+
+| Parameter                               | Description                                                                                                    | Default                                                 |
+|-----------------------------------------|----------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `image.registry`                        | Apache MXNet (Incubating) image registry                                                                       | `docker.io`                                             |
+| `image.repository`                      | Apache MXNet (Incubating) image name                                                                           | `bitnami/mxnet`                                         |
+| `image.tag`                             | Apache MXNet (Incubating) image tag                                                                            | `{TAG_NAME}`                                            |
+| `image.pullPolicy`                      | Image pull policy                                                                                              | `IfNotPresent`                                          |
+| `image.pullSecrets`                     | Specify docker-registry secret names as an array                                                               | `[]` (does not add image pull secrets to deployed pods) |
+| `image.debug`                           | Specify if debug logs should be enabled                                                                        | `false`                                                 |
+| `git.registry`                          | Git image registry                                                                                             | `docker.io`                                             |
+| `git.repository`                        | Git image name                                                                                                 | `bitnami/git`                                           |
+| `git.tag`                               | Git image tag                                                                                                  | `{TAG_NAME}`                                            |
+| `git.pullPolicy`                        | Git image pull policy                                                                                          | `IfNotPresent`                                          |
+| `git.pullSecrets`                       | Specify docker-registry secret names as an array                                                               | `[]` (does not add image pull secrets to deployed pods) |
+| `volumePermissions.enabled`             | Enable init container that changes volume permissions in the data directory                                    | `false`                                                 |
+| `volumePermissions.image.registry`      | Init container volume-permissions image registry                                                               | `docker.io`                                             |
+| `volumePermissions.image.repository`    | Init container volume-permissions image name                                                                   | `bitnami/minideb`                                       |
+| `volumePermissions.image.tag`           | Init container volume-permissions image tag                                                                    | `buster`                                                |
+| `volumePermissions.image.pullPolicy`    | Init container volume-permissions image pull policy                                                            | `Always`                                                |
+| `volumePermissions.resources`           | Init container resource requests/limit                                                                         | `nil`                                                   |
+| `entrypoint.file`                       | Main entrypoint to your application. If not speficied, it will be a `sleep infinity` command                   | `''`                                                    |
+| `entrypoint.args`                       | Args required by your entrypoint                                                                               | `nil`                                                   |
+| `entrypoint.workDir`                    | Working directory for launching the entrypoint                                                                 | `'/app'`                                                |
+| `podManagementPolicy`                   | StatefulSet (worker and server nodes) pod management policy                                                    | `Parallel`                                              |
+| `mode`                                  | Run Apache MXNet (Incubating) in standalone or distributed mode (possible values: `standalone`, `distributed`) | `standalone`                                            |
+| `commonExtraEnvVars`                    | Extra environment variables to add to server, scheduler and worker nodes                                       | `nil`                                                   |
+| `configMap`                             | Config map that contains the files you want to load in Apache MXNet (Incubating)                               | `nil`                                                   |
+| `cloneFilesFromGit.enabled`             | Enable in order to download files from git repository                                                          | `false`                                                 |
+| `cloneFilesFromGit.repository`          | Repository that holds the files                                                                                | `nil`                                                   |
+| `cloneFilesFromGit.revision`            | Revision from the repository to checkout                                                                       | `master`                                                |
+| `existingSecret`                        | Name of a secret with sensitive data to mount in the pods                                                      | `nil`                                                   |
+| `service.type`                          | Kubernetes service type                                                                                        | `ClusterIP`                                             |
+| `resources.limits`                      | The resources limits for the Mxnet container                                                                   | `{}`                                                    |
+| `resources.requests`                    | The requested resources for the Mxnet container                                                                | `{}`                                                    |
+| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                            | `""`                                                    |
+| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                       | `soft`                                                  |
+| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                      | `""`                                                    |
+| `nodeAffinityPreset.key`                | Node label key to match Ignored if `affinity` is set.                                                          | `""`                                                    |
+| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                                      | `[]`                                                    |
+| `affinity`                              | Affinity for pod assignment                                                                                    | `{}` (evaluated as a template)                          |
+| `nodeSelector`                          | Node labels for pod assignment                                                                                 | `{}` (evaluated as a template)                          |
+| `tolerations`                           | Tolerations for pod assignment                                                                                 | `[]` (evaluated as a template)                          |
+| `securityContext.enabled`               | Enable security context                                                                                        | `true`                                                  |
+| `securityContext.fsGroup`               | Group ID for the container                                                                                     | `1001`                                                  |
+| `securityContext.runAsUser`             | User ID for the container                                                                                      | `1001`                                                  |
+| `livenessProbe.enabled`                 | Enable/disable the Liveness probe                                                                              | `true`                                                  |
+| `livenessProbe.initialDelaySeconds`     | Delay before liveness probe is initiated                                                                       | `5`                                                     |
+| `livenessProbe.periodSeconds`           | How often to perform the probe                                                                                 | `5`                                                     |
+| `livenessProbe.timeoutSeconds`          | When the probe times out                                                                                       | `5`                                                     |
+| `livenessProbe.successThreshold`        | Minimum consecutive successes for the probe to be considered successful after having failed.                   | `1`                                                     |
+| `livenessProbe.failureThreshold`        | Minimum consecutive failures for the probe to be considered failed after having succeeded.                     | `5`                                                     |
+| `readinessProbe.enabled`                | Enable/disable the Readiness probe                                                                             | `true`                                                  |
+| `readinessProbe.initialDelaySeconds`    | Delay before readiness probe is initiated                                                                      | `5`                                                     |
+| `readinessProbe.periodSeconds`          | How often to perform the probe                                                                                 | `5`                                                     |
+| `readinessProbe.timeoutSeconds`         | When the probe times out                                                                                       | `1`                                                     |
+| `readinessProbe.successThreshold`       | Minimum consecutive successes for the probe to be considered successful after having failed.                   | `1`                                                     |
+| `readinessProbe.failureThreshold`       | Minimum consecutive failures for the probe to be considered failed after having succeeded.                     | `5`                                                     |
+| `persistence.enabled`                   | Use a PVC to persist data                                                                                      | `false`                                                 |
+| `persistence.mountPath`                 | Path to mount the volume at                                                                                    | `/bitnami/mxnet`                                        |
+| `persistence.storageClass`              | Storage class of backing PVC                                                                                   | `nil` (uses alpha storage class annotation)             |
+| `persistence.accessMode`                | Use volume as ReadOnly or ReadWrite                                                                            | `ReadWriteOnce`                                         |
+| `persistence.size`                      | Size of data volume                                                                                            | `8Gi`                                                   |
+| `persistence.annotations`               | Persistent Volume annotations                                                                                  | `{}`                                                    |
+| `sidecars`                              | Attach additional containers to the pods (scheduler, worker and server nodes)                                  | `[]`                                                    |
+| `initContainers`                        | Attach additional init containers to the pods (scheduler, worker and server nodes)                             | `[]`                                                    |
+
+### Mxnet Server parameters (only for distributed mode)
+
+| Parameter                               | Description                                                                                               | Default                                                 |
+|-----------------------------------------|-----------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `server.replicaCount`                   | Number of Server nodes that will execute your code                                                        | `1`                                                     |
+| `server.extraEnvVars`                   | Extra environment variables to add to the Server nodes                                                    | `[]`                                                    |
+| `server.podAffinityPreset`              | Mxnet Server pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`          | `""`                                                    |
+| `server.podAntiAffinityPreset`          | Mxnet Server pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`     | `soft`                                                  |
+| `server.nodeAffinityPreset.type`        | Mxnet Server node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`    | `""`                                                    |
+| `server.nodeAffinityPreset.key`         | Mxnet Server node label key to match Ignored if `affinity` is set.                                        | `""`                                                    |
+| `server.nodeAffinityPreset.values`      | Mxnet Server node label values to match. Ignored if `affinity` is set.                                    | `[]`                                                    |
+| `server.affinity`                       | Mxnet Server affinity for pod assignment                                                                  | `{}` (evaluated as a template)                          |
+| `server.nodeSelector`                   | Mxnet Server node labels for pod assignment                                                               | `{}` (evaluated as a template)                          |
+| `server.tolerations`                    | Mxnet Server tolerations for pod assignment                                                               | `[]` (evaluated as a template)                          |
+| `server.resources.limits`               | The resources limits for the Mxnet Server container                                                       | `{}`                                                    |
+| `server.resources.requests`             | The requested resources for the Mxnet Server container                                                    | `{}`                                                    |
+
+### Mxnet Worker parameters (only for distributed mode)
+
+| Parameter                               | Description                                                                                               | Default                                                 |
+|-----------------------------------------|-----------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `worker.replicaCount`                   | Number of Worker nodes that will execute your code                                                        | `1`                                                     |
+| `worker.extraEnvVars`                   | Extra environment variables to add to the Server nodes                                                    | `[]`                                                    |
+| `worker.podAffinityPreset`              | Mxnet Worker pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`          | `""`                                                    |
+| `worker.podAntiAffinityPreset`          | Mxnet Worker pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`     | `soft`                                                  |
+| `worker.nodeAffinityPreset.type`        | Mxnet Worker node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`    | `""`                                                    |
+| `worker.nodeAffinityPreset.key`         | Mxnet Worker node label key to match Ignored if `affinity` is set.                                        | `""`                                                    |
+| `worker.nodeAffinityPreset.values`      | Mxnet Worker node label values to match. Ignored if `affinity` is set.                                    | `[]`                                                    |
+| `worker.affinity`                       | Mxnet Worker affinity for pod assignment                                                                  | `{}` (evaluated as a template)                          |
+| `worker.nodeSelector`                   | Mxnet Worker node labels for pod assignment                                                               | `{}` (evaluated as a template)                          |
+| `worker.tolerations`                    | Mxnet Worker tolerations for pod assignment                                                               | `[]` (evaluated as a template)                          |
+| `worker.resources.limits`               | The resources limits for the Mxnet Worker container                                                       | `{}`                                                    |
+| `worker.resources.requests`             | The requested resources for the Mxnet Worker container                                                    | `{}`                                                    |
+
+### Mxnet Scheduler parameters (only for distributed mode)
+
+| Parameter                               | Description                                                                                               | Default                                                 |
+|-----------------------------------------|-----------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `scheduler.replicaCount`                | Number of Scheduler nodes that will execute your code                                                     | `1`                                                     |
+| `scheduler.extraEnvVars`                | Extra environment variables to add to the Server nodes                                                    | `[]`                                                    |
+| `scheduler.podAffinityPreset`           | Mxnet Scheduler pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                                                    |
+| `scheduler.podAntiAffinityPreset`       | Mxnet Scheduler pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                                  |
+| `scheduler.nodeAffinityPreset.type`     | Mxnet Scheduler node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                                                    |
+| `scheduler.nodeAffinityPreset.key`      | Mxnet Scheduler node label key to match Ignored if `affinity` is set.                                     | `""`                                                    |
+| `scheduler.nodeAffinityPreset.values`   | Mxnet Scheduler node label values to match. Ignored if `affinity` is set.                                 | `[]`                                                    |
+| `scheduler.affinity`                    | Mxnet Scheduler affinity for pod assignment                                                               | `{}` (evaluated as a template)                          |
+| `scheduler.nodeSelector`                | Mxnet Scheduler node labels for pod assignment                                                            | `{}` (evaluated as a template)                          |
+| `scheduler.tolerations`                 | Mxnet Scheduler tolerations for pod assignment                                                            | `[]` (evaluated as a template)                          |
+| `scheduler.resources.limits`            | The resources limits for the Mxnet Scheduler container                                                    | `{}`                                                    |
+| `scheduler.resources.requests`          | The requested resources for the Mxnet Scheduler container                                                 | `{}`                                                    |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
 $ helm install my-release \
   --set mode=distributed \
-  --set serverCount=2 \
-  --set workerCount=3 \
+  --set server.replicaCount=2 \
+  --set worker.replicaCount=3 \
     bitnami/mxnet
 ```
 
@@ -152,21 +215,24 @@ Bitnami will release a new chart updating its containers if a new version of the
 This chart includes a `values-production.yaml` file where you can find some parameters oriented to production configuration in comparison to the regular `values.yaml`. You can use this file instead of the default one.
 
 - Run Apache MXNet (Incubating) in distributed mode:
+
 ```diff
 - mode: standalone
 + mode: distributed
 ```
 
 - Number of server nodes that will execute your code:
+
 ```diff
-- serverCount: 1
-+ serverCount: 2
+- server.replicaCount: 1
++ server.replicaCount: 2
 ```
 
 - Number of worker nodes that will execute your code:
+
 ```diff
-- workerCount: 1
-+ workerCount: 4
+- worker.replicaCount: 1
++ worker.replicaCount: 4
 ```
 
 ### Loading your files
@@ -289,11 +355,27 @@ As an alternative, this chart supports using an initContainer to change the owne
 
 You can enable this initContainer by setting `volumePermissions.enabled` to `true`.
 
+### Setting Pod's affinity
+
+This chart allows you to set your custom affinity using the `XXX.affinity` paremeter(s). Find more infomation about Pod's affinity in the [kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity).
+
+As an alternative, you can use of the preset configurations for pod affinity, pod anti-affinity, and node affinity available at the [bitnami/common](https://github.com/bitnami/charts/tree/master/bitnami/common#affinities) chart. To do so, set the `XXX.podAffinityPreset`, `XXX.podAntiAffinityPreset`, or `XXX.nodeAffinityPreset` parameters.
+
 ## Troubleshooting
 
 Find more information about how to deal with common errors related to Bitnami’s Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
 
 ## Upgrading
+
+### To 2.1.0
+
+Some parameters dissapeared in favor of new ones:
+
+- `schedulerExtraEnvVars` and `schedulerPort` -> deprecated in favor of `scheduler.extraEnvVars` and `scheduler.port`, respectively.
+- `serverExtraEnvVars` and `serverCount` -> deprecated in favor of `server.extraEnvVars` and `server.replicaCount`, respectively.
+- `workerExtraEnvVars` and `workerCount` -> deprecated in favor of `worker.extraEnvVars` and `worker.replicaCount`, respectively.
+
+This version also introduces `bitnami/common`, a [library chart](https://helm.sh/docs/topics/library_charts/#helm) as a dependency. More documentation about this new utility could be found [here](https://github.com/bitnami/charts/tree/master/bitnami/common#bitnami-common-library-chart). Please, make sure that you have updated the chart dependencies before executing any upgrade.
 
 ### To 2.0.0
 

--- a/bitnami/mxnet/ci/values-production.yaml
+++ b/bitnami/mxnet/ci/values-production.yaml
@@ -6,9 +6,11 @@ volumePermissions:
 
 mode: distributed
 
-serverCount: 2
+server:
+  replicaCount: 2
 
-workerCount: 4
+worker:
+  replicaCount: 4
 
 persistence:
   enabled: true

--- a/bitnami/mxnet/templates/NOTES.txt
+++ b/bitnami/mxnet/templates/NOTES.txt
@@ -1,18 +1,23 @@
 {{- if or .Values.configMap (.Files.Glob "files/*") .Values.cloneFilesFromGit.enabled }}
 {{- if .Values.entrypoint.file }}
 The provided file {{ .Values.entrypoint.file }} is being executed. You can see the logs of each running node with:
+
     kubectl logs [POD_NAME]
 
-and the list of pods:
+and the list of pods with:
+
     kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "mxnet.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"
+
 {{- else }}
 You didn't specify any entrypoint to your code.
 To run it, you can either re-deploy the chart using the `mxnet.entrypoint.file` option to specify your entrypoint, or execute it manually by jumping into the pods:
 
-1. Get the running pods
+1. Get the running pods:
+
     kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "mxnet.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"
 
-2. Get into a pod
+2. Get into a pod:
+
     kubectl exec -ti [POD_NAME] bash
 
 3. Execute your script as you would normally do.
@@ -20,10 +25,12 @@ To run it, you can either re-deploy the chart using the `mxnet.entrypoint.file` 
 {{- else }}
 WARNING: You haven't loaded any file. You can access the Python REPL by jumping into the pods:
 
-1. Get the running pods
+1. Get the running pods:
+
     kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "mxnet.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"
 
-2. Run the Python REPL
+2. Run the Python REPL:
+
     kubectl exec -ti [POD_NAME] python3
 
 This chart allows three different methods to load your files:
@@ -35,11 +42,5 @@ This chart allows three different methods to load your files:
 Examples for the different methods can be found in the README (see https://github.com/bitnami/charts/blob/master/bitnami/mxnet/README.md).
 {{- end }}
 
-{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
-
-WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
-+info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
-
-{{- end }}
-
-{{ include "mxnet.validateValues" . }}
+{{- include "mxnet.validateValues" . }}
+{{- include "mxnet.checkRollingTags" . }}

--- a/bitnami/mxnet/templates/_helpers.tpl
+++ b/bitnami/mxnet/templates/_helpers.tpl
@@ -1,4 +1,5 @@
 {{/* vim: set filetype=mustache: */}}
+
 {{/*
 Expand the name of the chart.
 */}}
@@ -7,69 +8,31 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "mxnet.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
-{{- define "mxnet.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Common labels
-*/}}
-{{- define "mxnet.labels" -}}
-app.kubernetes.io/name: {{ include "mxnet.name" . }}
-helm.sh/chart: {{ include "mxnet.chart" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end -}}
-
-{{/*
-Labels to use on deploy.spec.selector.matchLabels and svc.spec.selector
-*/}}
-{{- define "mxnet.matchLabels" -}}
-app.kubernetes.io/name: {{ include "mxnet.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end -}}
-
-{{/*
 Return the proper Apache MXNet (Incubating) image name
 */}}
 {{- define "mxnet.image" -}}
-{{- $registryName := .Values.image.registry -}}
-{{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
-{{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
 {{- end -}}
+
+{{/*
+Return the proper git image name
+*/}}
+{{- define "git.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.git "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper image name (for the init container volume-permissions image)
+*/}}
+{{- define "mxnet.volumePermissions.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.volumePermissions.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "mxnet.imagePullSecrets" -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.git .Values.volumePermissions.image) "global" .Values.global) -}}
 {{- end -}}
 
 {{/* Validate values of Apache MXNet (Incubating) - number of workers must be greater than 0 */}}
@@ -85,69 +48,21 @@ sleep infinity
   {{- end }}
 {{- end -}}
 
-{{/*
-Return the proper git image name
-*/}}
-{{- define "git.image" -}}
-{{- $registryName := .Values.git.registry -}}
-{{- $repositoryName := .Values.git.repository -}}
-{{- $tag := .Values.git.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
-{{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return the proper Docker Image Registry Secret Names
-*/}}
-{{- define "mxnet.imagePullSecrets" -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
-Also, we can not use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets:
-{{- range .Values.global.imagePullSecrets }}
-  - name: {{ . }}
+{{- define "mxnet.parseEnvVars" -}}
+{{- range $env := . }}
+{{- if $env.value }}
+- name: {{ $env.name }}
+  value: {{ $env.value | quote }}
+{{- else if $env.valueFrom }}
+- name: {{ $env.name }}
+  valueFrom:
+{{ toYaml $env.valueFrom | indent 4 }}
+{{- else }} {{/* Leave this for future compatibility */}}
+-
+{{ toYaml $env | indent 2}}
 {{- end }}
-{{- else if or .Values.image.pullSecrets .Values.git.pullSecrets .Values.volumePermissions.image.pullSecrets }}
-imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
 {{- end }}
-{{- range .Values.git.pullSecrets }}
-  - name: {{ . }}
 {{- end }}
-{{- range .Values.volumePermissions.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end -}}
-{{- else if or .Values.image.pullSecrets .Values.git.pullSecrets .Values.volumePermissions.image.pullSecrets }}
-imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- range .Values.git.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- range .Values.volumePermissions.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end -}}
-{{- end -}}
 
 {{/*
 Compile all warnings into a single message, and call fail.
@@ -176,107 +91,26 @@ mxnet: mode
 
 {{/* Validate values of Apache MXNet (Incubating) - number of workers must be greater than 0 */}}
 {{- define "mxnet.validateValues.workerCount" -}}
-{{- $replicaCount := int .Values.workerCount }}
+{{- $replicaCount := int .Values.worker.replicaCount }}
 {{- if and (eq .Values.mode "distributed") (lt $replicaCount 1) -}}
-mxnet: workerCount
+mxnet: worker.replicaCount
     Worker count must be greater than 0 in distributed mode!!
-    Please set a valid worker count size (--set workerCount=X)
+    Please set a valid worker count size (--set worker.replicaCount=X)
 {{- end -}}
 {{- end -}}
-
-{{- define "mxnet.parseEnvVars" -}}
-{{- range $env := . }}
-{{- if $env.value }}
-- name: {{ $env.name }}
-  value: {{ $env.value | quote }}
-{{- else if $env.valueFrom }}
-- name: {{ $env.name }}
-  valueFrom:
-{{ toYaml $env.valueFrom | indent 4 }}
-{{- else }} {{/* Leave this for future compatibility */}}
--
-{{ toYaml $env | indent 2}}
-{{- end }}
-{{- end }}
-{{- end }}
 
 {{/* Validate values of Apache MXNet (Incubating) - number of workers must be greater than 0 */}}
 {{- define "mxnet.validateValues.serverCount" -}}
-{{- $replicaCount := int .Values.serverCount }}
+{{- $replicaCount := int .Values.server.replicaCount }}
 {{- if and (eq .Values.mode "distributed") (lt $replicaCount 1) -}}
-mxnet: serverCount
+mxnet: server.replicaCount
     Server count must be greater than 0 in distributed mode!!
-    Please set a valid worker count size (--set serverCount=X)
+    Please set a valid worker count size (--set server.replicaCount=X)
 {{- end -}}
 {{- end -}}
 
-{{/*
-Return the proper image name (for the init container volume-permissions image)
-*/}}
-{{- define "mxnet.volumePermissions.image" -}}
-{{- $registryName := .Values.volumePermissions.image.registry -}}
-{{- $repositoryName := .Values.volumePermissions.image.repository -}}
-{{- $tag := .Values.volumePermissions.image.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
-{{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return the proper Storage Class
-*/}}
-{{- define "mxnet.storageClass" -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
-*/}}
-{{- if .Values.global -}}
-    {{- if .Values.global.storageClass -}}
-        {{- if (eq "-" .Values.global.storageClass) -}}
-            {{- printf "storageClassName: \"\"" -}}
-        {{- else }}
-            {{- printf "storageClassName: %s" .Values.global.storageClass -}}
-        {{- end -}}
-    {{- else -}}
-        {{- if .Values.persistence.storageClass -}}
-              {{- if (eq "-" .Values.persistence.storageClass) -}}
-                  {{- printf "storageClassName: \"\"" -}}
-              {{- else }}
-                  {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
-              {{- end -}}
-        {{- end -}}
-    {{- end -}}
-{{- else -}}
-    {{- if .Values.persistence.storageClass -}}
-        {{- if (eq "-" .Values.persistence.storageClass) -}}
-            {{- printf "storageClassName: \"\"" -}}
-        {{- else }}
-            {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
-        {{- end -}}
-    {{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Renders a value that contains template.
-Usage:
-{{ include "mxnet.tplValue" ( dict "value" .Values.path.to.the.Value "context" $) }}
-*/}}
-{{- define "mxnet.tplValue" -}}
-    {{- if typeIs "string" .value }}
-        {{- tpl .value .context }}
-    {{- else }}
-        {{- tpl (.value | toYaml) .context }}
-    {{- end }}
+{{/* Check if there are rolling tags in the images */}}
+{{- define "mxnet.checkRollingTags" -}}
+{{- include "common.warnings.rollingTag" .Values.image }}
+{{- include "common.warnings.rollingTag" .Values.git }}
 {{- end -}}

--- a/bitnami/mxnet/templates/configmap.yaml
+++ b/bitnami/mxnet/templates/configmap.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "mxnet.fullname" . }}-files
-  labels: {{- include "mxnet.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}-files
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
 data:
 {{ (.Files.Glob "files/*").AsConfig | indent 2 }}
 {{- end }}

--- a/bitnami/mxnet/templates/deployment-pvc.yaml
+++ b/bitnami/mxnet/templates/deployment-pvc.yaml
@@ -2,8 +2,8 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ include "mxnet.fullname" . }}{{ if eq .Values.mode "distributed" }}-scheduler{{ end }}
-  labels: {{- include "mxnet.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}{{ if eq .Values.mode "distributed" }}-scheduler{{ end }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   accessModes:
   {{- range .Values.persistence.accessModes }}
@@ -12,5 +12,5 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
-  {{ include "mxnet.storageClass" . }}
+  {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 2 }}
 {{- end }}

--- a/bitnami/mxnet/templates/headless-svc.yaml
+++ b/bitnami/mxnet/templates/headless-svc.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "mxnet.fullname" . }}-headless
-  labels: {{- include "mxnet.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}-headless
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   type: ClusterIP
   clusterIP: None
-  selector: {{- include "mxnet.matchLabels" . | nindent 4 }}
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
 {{- end }}

--- a/bitnami/mxnet/templates/scheduler-deployment.yaml
+++ b/bitnami/mxnet/templates/scheduler-deployment.yaml
@@ -2,27 +2,32 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "mxnet.fullname" . }}-scheduler
-  labels: {{- include "mxnet.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}-scheduler
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: scheduler
 spec:
   replicas: 1
   selector:
-    matchLabels: {{- include "mxnet.matchLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
   template:
     metadata:
-      labels: {{- include "mxnet.labels" . | nindent 8 }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: scheduler
     spec:
-{{- include "mxnet.imagePullSecrets" . | nindent 6 }}
-      {{- if .Values.affinity }}
-      affinity: {{- include "mxnet.tplValue" (dict "value" .Values.affinity "context" $) | nindent 8 }}
+      {{- include "mxnet.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.scheduler.affinity }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.scheduler.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.scheduler.podAffinityPreset "component" "scheduler" "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.scheduler.podAntiAffinityPreset "component" "scheduler" "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.scheduler.nodeAffinityPreset.type "key" .Values.scheduler.nodeAffinityPreset.key "values" .Values.scheduler.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
-      {{- if .Values.nodeSelector }}
-      nodeSelector: {{- include "mxnet.tplValue" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      {{- if .Values.scheduler.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.scheduler.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
-      {{- if .Values.tolerations }}
-      tolerations: {{- include "mxnet.tplValue" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
+      {{- if .Values.scheduler.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.scheduler.tolerations "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
@@ -45,7 +50,7 @@ spec:
               mountPath: /app
         {{- end }}
         {{- if .Values.initContainers }}
-        {{- include "mxnet.tplValue" ( dict "value" .Values.initContainers "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.initContainers "context" $) | nindent 8 }}
         {{- end }}
       {{- end }}
       containers:
@@ -62,28 +67,28 @@ spec:
             - name: DMLC_ROLE
               value: "scheduler"
             - name: DMLC_NUM_WORKER
-              value: {{ .Values.workerCount | quote }}
+              value: {{ .Values.worker.replicaCount | quote }}
             - name: DMLC_NUM_SERVER
-              value: {{ .Values.serverCount | quote }}
+              value: {{ .Values.server.replicaCount | quote }}
             - name: DMLC_PS_ROOT_URI
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
             - name: DMLC_PS_ROOT_PORT
-              value: {{ .Values.schedulerPort | quote }}
+              value: {{ .Values.scheduler.port | quote }}
             {{- if .Values.commonExtraEnvVars }}
             {{- include "mxnet.parseEnvVars" .Values.commonExtraEnvVars | nindent 12 }}
             {{- end }}
-            {{- if .Values.schedulerExtraEnvVars }}
-            {{- include "mxnet.parseEnvVars" .Values.schedulerExtraEnvVars | nindent 12 }}
+            {{- if .Values.scheduler.extraEnvVars }}
+            {{- include "mxnet.parseEnvVars" .Values.scheduler.extraEnvVars | nindent 12 }}
             {{- end }}
           ports:
             - name: mxnet
-              containerPort: {{ .Values.schedulerPort }}
+              containerPort: {{ .Values.scheduler.port }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             tcpSocket:
-              port: {{ .Values.schedulerPort }}
+              port: {{ .Values.scheduler.port }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -93,15 +98,15 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             tcpSocket:
-              port: {{ .Values.schedulerPort }}
+              port: {{ .Values.scheduler.port }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           {{- end }}
-          {{- if .Values.resources }}
-          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.scheduler.resources }}
+          resources: {{- toYaml .Values.scheduler.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
             {{- if .Values.configMap }}
@@ -121,7 +126,7 @@ spec:
               mountPath: /secrets
             {{- end }}
           {{- if .Values.sidecars }}
-          {{- include "mxnet.tplValue" ( dict "value" .Values.sidecars "context" $) | nindent 8 }}
+          {{- include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) | nindent 8 }}
           {{- end }}
       volumes:
         {{- if .Values.existingSecret }}
@@ -136,7 +141,7 @@ spec:
         {{- else if .Files.Glob "files/*" }}
         - name: local-files
           configMap:
-            name: {{ include "mxnet.fullname" . }}-files
+            name: {{ include "common.names.fullname" . }}-files
         {{- else if .Values.cloneFilesFromGit.enabled }}
         - name: git-cloned-files
           emptyDir: {}
@@ -144,7 +149,7 @@ spec:
         - name: data
         {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ include "mxnet.fullname" . }}-scheduler
+            claimName: {{ include "common.names.fullname" . }}-scheduler
         {{- else }}
           emptyDir: {}
         {{- end }}

--- a/bitnami/mxnet/templates/scheduler-service.yaml
+++ b/bitnami/mxnet/templates/scheduler-service.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "mxnet.fullname" . }}-scheduler
-  labels: {{- include "mxnet.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}-scheduler
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: scheduler
   {{- if .Values.service.annotations }}
-  annotations: {{- include "mxnet.tplValue" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
@@ -19,6 +19,6 @@ spec:
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
-  selector: {{- include "mxnet.matchLabels" . | nindent 4 }}
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: scheduler
 {{- end }}

--- a/bitnami/mxnet/templates/server-statefulset.yaml
+++ b/bitnami/mxnet/templates/server-statefulset.yaml
@@ -2,30 +2,35 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "mxnet.fullname" . }}-server
-  labels: {{- include "mxnet.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}-server
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: server
 spec:
   podManagementPolicy: {{ .Values.podManagementPolicy }}
   selector:
-    matchLabels: {{- include "mxnet.matchLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: server
-  replicas: {{ .Values.serverCount }}
-  serviceName: {{ template "mxnet.fullname" . }}-headless
+  replicas: {{ .Values.server.replicaCount }}
+  serviceName: {{ template "common.names.fullname" . }}-headless
   template:
     metadata:
-      labels: {{- include "mxnet.labels" . | nindent 8 }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: server
     spec:
-{{- include "mxnet.imagePullSecrets" . | nindent 6 }}
-      {{- if .Values.affinity }}
-      affinity: {{- include "mxnet.tplValue" (dict "value" .Values.affinity "context" $) | nindent 8 }}
+      {{- include "mxnet.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.server.affinity }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.server.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.server.podAffinityPreset "component" "server" "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.server.podAntiAffinityPreset "component" "server" "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.server.nodeAffinityPreset.type "key" .Values.server.nodeAffinityPreset.key "values" .Values.server.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
-      {{- if .Values.nodeSelector }}
-      nodeSelector: {{- include "mxnet.tplValue" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      {{- if .Values.server.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.server.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
-      {{- if .Values.tolerations }}
-      tolerations: {{- include "mxnet.tplValue" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
+      {{- if .Values.server.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.server.tolerations "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
@@ -66,7 +71,7 @@ spec:
               mountPath: {{ .Values.persistence.mountPath }}
         {{- end }}
         {{- if .Values.initContainers }}
-        {{- include "mxnet.tplValue" ( dict "value" .Values.initContainers "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.initContainers "context" $) | nindent 8 }}
         {{- end }}
       {{- end }}
       containers:
@@ -90,18 +95,18 @@ spec:
             - name: DMLC_ROLE
               value: "server"
             - name: DMLC_NUM_WORKER
-              value: {{ .Values.workerCount | quote }}
+              value: {{ .Values.worker.replicaCount | quote }}
             - name: DMLC_NUM_SERVER
-              value: {{ .Values.serverCount | quote }}
+              value: {{ .Values.server.replicaCount | quote }}
             - name: DMLC_PS_ROOT_URI
-              value: {{ include "mxnet.fullname" . }}-scheduler
+              value: {{ include "common.names.fullname" . }}-scheduler
             - name: DMLC_PS_ROOT_PORT
-              value: {{ .Values.schedulerPort | quote }}
+              value: {{ .Values.scheduler.port | quote }}
             {{- if .Values.commonExtraEnvVars }}
             {{- include "mxnet.parseEnvVars" .Values.commonExtraEnvVars | nindent 12 }}
             {{- end }}
-            {{- if .Values.serverExtraEnvVars }}
-            {{- include "mxnet.parseEnvVars" .Values.serverExtraEnvVars | nindent 12 }}
+            {{- if .Values.server.extraEnvVars }}
+            {{- include "mxnet.parseEnvVars" .Values.server.extraEnvVars | nindent 12 }}
             {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
@@ -129,8 +134,8 @@ spec:
             successThreshold: {{ .Values.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           {{- end }}
-          {{- if .Values.resources }}
-          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.server.resources }}
+          resources: {{- toYaml .Values.server.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
             {{- if .Values.configMap }}
@@ -150,7 +155,7 @@ spec:
               mountPath: /secrets
             {{- end }}
           {{- if .Values.sidecars }}
-          {{- include "mxnet.tplValue" ( dict "value" .Values.sidecars "context" $) | nindent 8 }}
+          {{- include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) | nindent 8 }}
           {{- end }}
       volumes:
         {{- if .Values.existingSecret }}
@@ -165,7 +170,7 @@ spec:
         {{- else if .Files.Glob "files/*" }}
         - name: local-files
           configMap:
-            name: {{ include "mxnet.fullname" . }}-files
+            name: {{ include "common.names.fullname" . }}-files
         {{- else if .Values.cloneFilesFromGit.enabled }}
         - name: git-cloned-files
           emptyDir: {}
@@ -177,13 +182,13 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: data
-        labels: {{- include "mxnet.matchLabels" . | nindent 10 }}
+        labels: {{- include "common.labels.matchLabels" . | nindent 10 }}
         {{- if .Values.persistence.annotations }}
-        annotations: {{- include "mxnet.tplValue" ( dict "value" .Values.persistence.annotations "context" $) | nindent 10 }}
+        annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.persistence.annotations "context" $) | nindent 10 }}
         {{- end }}
       spec:
         accessModes: {{- toYaml .Values.persistence.accessModes | nindent 10 }}
-        {{ include "mxnet.storageClass" . }}
+        {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 8 }}
         resources:
           requests:
             storage: {{ .Values.persistence.size | quote }}

--- a/bitnami/mxnet/templates/standalone-deployment.yaml
+++ b/bitnami/mxnet/templates/standalone-deployment.yaml
@@ -2,28 +2,33 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "mxnet.fullname" . }}
-  labels: {{- include "mxnet.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: standalone
 spec:
   replicas: 1
   selector:
-    matchLabels: {{- include "mxnet.matchLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: standalone
   template:
     metadata:
-      labels: {{- include "mxnet.labels" . | nindent 8 }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: standalone
     spec:
-{{- include "mxnet.imagePullSecrets" . | nindent 6 }}
+      {{- include "mxnet.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.affinity }}
-      affinity: {{- include "mxnet.tplValue" (dict "value" .Values.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAffinityPreset "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAntiAffinityPreset "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
       {{- if .Values.nodeSelector }}
-      nodeSelector: {{- include "mxnet.tplValue" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.tolerations }}
-      tolerations: {{- include "mxnet.tplValue" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" .) | nindent 8 }}
       {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
@@ -64,7 +69,7 @@ spec:
               mountPath: {{ .Values.persistence.mountPath }}
         {{- end }}
         {{- if .Values.initContainers }}
-        {{- include "mxnet.tplValue" ( dict "value" .Values.initContainers "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.initContainers "context" $) | nindent 8 }}
         {{- end }}
       {{- end }}
       containers:
@@ -83,7 +88,7 @@ spec:
             {{- end }}
           ports:
             - name: mxnet
-              containerPort: {{ .Values.schedulerPort }}
+              containerPort: {{ .Values.scheduler.port }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             exec:
@@ -131,7 +136,7 @@ spec:
               mountPath: /secrets
             {{- end }}
         {{- if .Values.sidecars }}
-        {{- include "mxnet.tplValue" ( dict "value" .Values.sidecars "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) | nindent 8 }}
         {{- end }}
       volumes:
         {{- if .Values.existingSecret }}
@@ -146,7 +151,7 @@ spec:
         {{- else if .Files.Glob "files/*" }}
         - name: local-files
           configMap:
-            name: {{ include "mxnet.fullname" . }}-files
+            name: {{ include "common.names.fullname" . }}-files
         {{- else if .Values.cloneFilesFromGit.enabled }}
         - name: git-cloned-files
           emptyDir: {}
@@ -154,7 +159,7 @@ spec:
         - name: data
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ include "mxnet.fullname" . }}
+            claimName: {{ include "common.names.fullname" . }}
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/bitnami/mxnet/templates/worker-statefulset.yaml
+++ b/bitnami/mxnet/templates/worker-statefulset.yaml
@@ -2,30 +2,35 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "mxnet.fullname" . }}-worker
-  labels: {{- include "mxnet.labels" . | nindent 4 }}
+  name: {{ include "common.names.fullname" . }}-worker
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: worker
 spec:
   podManagementPolicy: {{ .Values.podManagementPolicy }}
-  serviceName: {{ template "mxnet.fullname" . }}-headless
+  serviceName: {{ template "common.names.fullname" . }}-headless
   selector:
-    matchLabels: {{- include "mxnet.matchLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: worker
-  replicas: {{ .Values.workerCount }}
+  replicas: {{ .Values.worker.replicaCount }}
   template:
     metadata:
-      labels: {{- include "mxnet.labels" . | nindent 8 }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: worker
     spec:
-{{- include "mxnet.imagePullSecrets" . | nindent 6 }}
-      {{- if .Values.affinity }}
-      affinity: {{- include "mxnet.tplValue" (dict "value" .Values.affinity "context" $) | nindent 8 }}
+      {{- include "mxnet.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.worker.affinity }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.worker.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.worker.podAffinityPreset "component" "worker" "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.worker.podAntiAffinityPreset "component" "worker" "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.worker.nodeAffinityPreset.type "key" .Values.worker.nodeAffinityPreset.key "values" .Values.worker.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
-      {{- if .Values.nodeSelector }}
-      nodeSelector: {{- include "mxnet.tplValue" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      {{- if .Values.worker.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.worker.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
-      {{- if .Values.tolerations }}
-      tolerations: {{- include "mxnet.tplValue" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
+      {{- if .Values.worker.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.worker.tolerations "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
@@ -66,7 +71,7 @@ spec:
               mountPath: {{ .Values.persistence.mountPath }}
         {{- end }}
         {{- if .Values.initContainers }}
-        {{- include "mxnet.tplValue" ( dict "value" .Values.initContainers "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.initContainers "context" $) | nindent 8 }}
         {{- end }}
       {{- end }}
       containers:
@@ -90,18 +95,18 @@ spec:
             - name: DMLC_ROLE
               value: "worker"
             - name: DMLC_NUM_WORKER
-              value: {{ .Values.workerCount | quote }}
+              value: {{ .Values.worker.replicaCount | quote }}
             - name: DMLC_NUM_SERVER
-              value: {{ .Values.serverCount | quote }}
+              value: {{ .Values.server.replicaCount | quote }}
             - name: DMLC_PS_ROOT_URI
-              value: {{ include "mxnet.fullname" . }}-scheduler
+              value: {{ include "common.names.fullname" . }}-scheduler
             - name: DMLC_PS_ROOT_PORT
-              value: {{ .Values.schedulerPort | quote }}
+              value: {{ .Values.scheduler.port | quote }}
             {{- if .Values.commonExtraEnvVars }}
             {{- include "mxnet.parseEnvVars" .Values.commonExtraEnvVars | nindent 12 }}
             {{- end }}
-            {{- if .Values.workerExtraEnvVars }}
-            {{- include "mxnet.parseEnvVars" .Values.workerExtraVars | nindent 12 }}
+            {{- if .Values.worker.extraEnvVars }}
+            {{- include "mxnet.parseEnvVars" .Values.worker.extraEnvVars | nindent 12 }}
             {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
@@ -129,8 +134,8 @@ spec:
             successThreshold: {{ .Values.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           {{- end }}
-          {{- if .Values.resources }}
-          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.worker.resources }}
+          resources: {{- toYaml .Values.worker.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
             {{- if .Values.configMap }}
@@ -150,7 +155,7 @@ spec:
               mountPath: /secrets
             {{- end }}
         {{- if .Values.sidecars }}
-        {{- include "mxnet.tplValue" ( dict "value" .Values.sidecars "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) | nindent 8 }}
         {{- end }}
       volumes:
         {{- if .Values.existingSecret }}
@@ -165,7 +170,7 @@ spec:
         {{- else if .Files.Glob "files/*" }}
         - name: local-files
           configMap:
-            name: {{ include "mxnet.fullname" . }}-files
+            name: {{ include "common.names.fullname" . }}-files
         {{- else if .Values.cloneFilesFromGit.enabled }}
         - name: git-cloned-files
           emptyDir: {}
@@ -177,13 +182,13 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: data
-        labels: {{- include "mxnet.matchLabels" . | nindent 10 }}
+        labels: {{- include "common.labels.matchLabels" . | nindent 10 }}
         {{- if .Values.persistence.annotations }}
-        annotations: {{- include "mxnet.tplValue" ( dict "value" .Values.persistence.annotations "context" $) | nindent 10 }}
+        annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.persistence.annotations "context" $) | nindent 10 }}
         {{- end }}
       spec:
         accessModes: {{- toYaml .Values.persistence.accessModes | nindent 10 }}
-        {{ include "mxnet.storageClass" . }}
+        {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 8 }}
         resources:
           requests:
             storage: {{ .Values.persistence.size | quote }}

--- a/bitnami/mxnet/values-production.yaml
+++ b/bitnami/mxnet/values-production.yaml
@@ -8,6 +8,14 @@
 #     - myRegistryKeySecretName
 #   storageClass: myStorageClass
 
+## String to partially override common.names.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override common.names.fullname template
+##
+# fullnameOverride:
+
 ## Bitnami Apache MXNet (Incubating) image version
 ## ref: https://hub.docker.com/r/bitnami/mxnet/tags/
 ##
@@ -46,14 +54,6 @@ git:
   ##
   # pullSecrets:
   #   - myRegistryKeySecretName
-
-## String to partially override mxnet.fullname template (will maintain the release name)
-##
-# nameOverride:
-
-## String to fully override mxnet.fullname template
-##
-# fullnameOverride:
 
 ## Init containers parameters:
 ## volumePermissions: Change the owner and group of the persistent volume mountpoint to runAsUser:fsGroup values from the securityContext section.
@@ -117,14 +117,6 @@ entrypoint:
 ##
 mode: distributed
 
-## Number of server nodes (only for distributed mode)
-##
-serverCount: 2
-
-## Number of worker nodes (only for distributed mode)
-##
-workerCount: 4
-
 ## Pointer a to a secret to mount sensitive data
 ##
 # existingSecret:
@@ -132,11 +124,6 @@ workerCount: 4
 ## Name of an existing config map containing all the files you want to load in Apache MXNet (Incubating)
 ##
 # configMap:
-
-## The port used to communicate with the scheduler
-## MASTER_PORT will be set to this value
-##
-schedulerPort: 9092
 
 ## Enable in order to download files from git repository.
 ##
@@ -146,47 +133,279 @@ cloneFilesFromGit:
   # revision: master
 
 ## Additional environment variables for all node types
+## Example:
+## commonExtraEnvVars:
+##   - name: PS_VERBOSE
+##     value: "1"
 ##
-# commonExtraEnvVars:
-#   - name: PS_VERBOSE
-#     value: "1"
-
-## Additional environment variables for worker nodes
-##
-# workerExtraEnvVars:
-#   - name: PS_VERBOSE
-#     value: "1"
-
-## Additional environment variables for server nodes
-##
-# serverExtraEnvVars:
-#   - name: PS_VERBOSE
-#     value: "1"
-
-## Additional environment variables for the scheduler node
-##
-# schedulerExtraEnvVars:
-#   - name: PS_VERBOSE
-#     value: "1"
+commonExtraEnvVars: []
 
 ## StatefulSet pod management policy
 ##
 podManagementPolicy: Parallel
 
-## Node labels for pod assignment (this value is evaluated as a template)
-## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+## Pod affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+## Allowed values: soft, hard
+##
+podAffinityPreset: ""
+
+## Pod anti-affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+## Allowed values: soft, hard
+##
+podAntiAffinityPreset: soft
+
+## Node affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+## Allowed values: soft, hard
+##
+nodeAffinityPreset:
+  ## Node affinity type
+  ## Allowed values: soft, hard
+  type: ""
+  ## Node label key to match
+  ## E.g.
+  ## key: "kubernetes.io/e2e-az-name"
+  ##
+  key: ""
+  ## Node label values to match
+  ## E.g.
+  ## values:
+  ##   - e2e-az1
+  ##   - e2e-az2
+  ##
+  values: []
+
+## Affinity for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
+##
+affinity: {}
+
+## Node labels for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##
 nodeSelector: {}
 
-## Tolerations for pod assignment (this value is evaluated as a template)
-## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+## Tolerations for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
 tolerations: []
 
-## Affinity for pod assignment (this value is evaluated as a template)
-## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## Scheduler configuration (only for distributed mode)
 ##
-affinity: {}
+scheduler:
+  ## The port used to communicate with the scheduler
+  ## MASTER_PORT will be set to this value
+  ##
+  port: 9092
+  ## An array to add extra env vars
+  ## Example:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
+  ## Configure resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits: {}
+    #   cpu: 250m
+    #   memory: 256Mi
+    requests: {}
+    #   cpu: 250m
+    #   memory: 256Mi
+  ## Pod affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAffinityPreset: ""
+  ## Pod anti-affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAntiAffinityPreset: soft
+  ## Node affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ## Allowed values: soft, hard
+  ##
+  nodeAffinityPreset:
+    ## Node affinity type
+    ## Allowed values: soft, hard
+    type: ""
+    ## Node label key to match
+    ## E.g.
+    ## key: "kubernetes.io/e2e-az-name"
+    ##
+    key: ""
+    ## Node label values to match
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+  ## Affinity for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Note: configsvr.podAffinityPreset, configsvr.podAntiAffinityPreset, and configsvr.nodeAffinityPreset will be ignored when it's set
+  ##
+  affinity: {}
+  ## Node labels for pod assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+  ## Tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+## Server configuration (only for distributed mode)
+##
+server:
+  ## Number of server nodes
+  ##
+  replicaCount: 2
+  ## An array to add extra env vars
+  ## Example:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
+  ## Configure resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits: {}
+    #   cpu: 250m
+    #   memory: 256Mi
+    requests: {}
+    #   cpu: 250m
+    #   memory: 256Mi
+  ## Pod affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAffinityPreset: ""
+  ## Pod anti-affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAntiAffinityPreset: soft
+  ## Node affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ## Allowed values: soft, hard
+  ##
+  nodeAffinityPreset:
+    ## Node affinity type
+    ## Allowed values: soft, hard
+    type: ""
+    ## Node label key to match
+    ## E.g.
+    ## key: "kubernetes.io/e2e-az-name"
+    ##
+    key: ""
+    ## Node label values to match
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+  ## Affinity for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Note: configsvr.podAffinityPreset, configsvr.podAntiAffinityPreset, and configsvr.nodeAffinityPreset will be ignored when it's set
+  ##
+  affinity: {}
+  ## Node labels for pod assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+  ## Tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+## Worker configuration (only for distributed mode)
+##
+worker:
+  ## Number of worker nodes
+  ##
+  replicaCount: 4
+  ## An array to add extra env vars
+  ## Example:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
+  ## Configure resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits: {}
+    #   cpu: 250m
+    #   memory: 256Mi
+    requests: {}
+    #   cpu: 250m
+    #   memory: 256Mi
+  ## Pod affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAffinityPreset: ""
+  ## Pod anti-affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAntiAffinityPreset: soft
+  ## Node affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ## Allowed values: soft, hard
+  ##
+  nodeAffinityPreset:
+    ## Node affinity type
+    ## Allowed values: soft, hard
+    type: ""
+    ## Node label key to match
+    ## E.g.
+    ## key: "kubernetes.io/e2e-az-name"
+    ##
+    key: ""
+    ## Node label values to match
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+  ## Affinity for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Note: configsvr.podAffinityPreset, configsvr.podAntiAffinityPreset, and configsvr.nodeAffinityPreset will be ignored when it's set
+  ##
+  affinity: {}
+  ## Node labels for pod assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+  ## Tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/bitnami/mxnet/values.yaml
+++ b/bitnami/mxnet/values.yaml
@@ -8,6 +8,14 @@
 #     - myRegistryKeySecretName
 #   storageClass: myStorageClass
 
+## String to partially override common.names.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override common.names.fullname template
+##
+# fullnameOverride:
+
 ## Bitnami Apache MXNet (Incubating) image version
 ## ref: https://hub.docker.com/r/bitnami/mxnet/tags/
 ##
@@ -46,14 +54,6 @@ git:
   ##
   # pullSecrets:
   #   - myRegistryKeySecretName
-
-## String to partially override mxnet.fullname template (will maintain the release name)
-##
-# nameOverride:
-
-## String to fully override mxnet.fullname template
-##
-# fullnameOverride:
 
 ## Init containers parameters:
 ## volumePermissions: Change the owner and group of the persistent volume mountpoint to runAsUser:fsGroup values from the securityContext section.
@@ -117,14 +117,6 @@ entrypoint:
 ##
 mode: standalone
 
-## Number of server nodes (only for distributed mode)
-##
-serverCount: 1
-
-## Number of worker nodes (only for distributed mode)
-##
-workerCount: 1
-
 ## Pointer a to a secret to mount sensitive data
 ##
 # existingSecret:
@@ -132,11 +124,6 @@ workerCount: 1
 ## Name of an existing config map containing all the files you want to load in Apache MXNet (Incubating)
 ##
 # configMap:
-
-## The port used to communicate with the scheduler
-## MASTER_PORT will be set to this value
-##
-schedulerPort: 9092
 
 ## Enable in order to download files from git repository.
 ##
@@ -146,47 +133,279 @@ cloneFilesFromGit:
   # revision: master
 
 ## Additional environment variables for all node types
+## Example:
+## commonExtraEnvVars:
+##   - name: PS_VERBOSE
+##     value: "1"
 ##
-# commonExtraEnvVars:
-#   - name: PS_VERBOSE
-#     value: "1"
-
-## Additional environment variables for worker nodes
-##
-# workerExtraEnvVars:
-#   - name: PS_VERBOSE
-#     value: "1"
-
-## Additional environment variables for server nodes
-##
-# serverExtraEnvVars:
-#   - name: PS_VERBOSE
-#     value: "1"
-
-## Additional environment variables for the scheduler node
-##
-# schedulerExtraEnvVars:
-#   - name: PS_VERBOSE
-#     value: "1"
+commonExtraEnvVars: []
 
 ## StatefulSet pod management policy
 ##
 podManagementPolicy: Parallel
 
-## Node labels for pod assignment (this value is evaluated as a template)
-## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+## Pod affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+## Allowed values: soft, hard
+##
+podAffinityPreset: ""
+
+## Pod anti-affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+## Allowed values: soft, hard
+##
+podAntiAffinityPreset: soft
+
+## Node affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+## Allowed values: soft, hard
+##
+nodeAffinityPreset:
+  ## Node affinity type
+  ## Allowed values: soft, hard
+  type: ""
+  ## Node label key to match
+  ## E.g.
+  ## key: "kubernetes.io/e2e-az-name"
+  ##
+  key: ""
+  ## Node label values to match
+  ## E.g.
+  ## values:
+  ##   - e2e-az1
+  ##   - e2e-az2
+  ##
+  values: []
+
+## Affinity for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
+##
+affinity: {}
+
+## Node labels for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##
 nodeSelector: {}
 
-## Tolerations for pod assignment (this value is evaluated as a template)
-## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+## Tolerations for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
 tolerations: []
 
-## Affinity for pod assignment (this value is evaluated as a template)
-## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## Scheduler configuration (only for distributed mode)
 ##
-affinity: {}
+scheduler:
+  ## The port used to communicate with the scheduler
+  ## MASTER_PORT will be set to this value
+  ##
+  port: 9092
+  ## An array to add extra env vars
+  ## Example:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
+  ## Configure resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits: {}
+    #   cpu: 250m
+    #   memory: 256Mi
+    requests: {}
+    #   cpu: 250m
+    #   memory: 256Mi
+  ## Pod affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAffinityPreset: ""
+  ## Pod anti-affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAntiAffinityPreset: soft
+  ## Node affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ## Allowed values: soft, hard
+  ##
+  nodeAffinityPreset:
+    ## Node affinity type
+    ## Allowed values: soft, hard
+    type: ""
+    ## Node label key to match
+    ## E.g.
+    ## key: "kubernetes.io/e2e-az-name"
+    ##
+    key: ""
+    ## Node label values to match
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+  ## Affinity for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Note: configsvr.podAffinityPreset, configsvr.podAntiAffinityPreset, and configsvr.nodeAffinityPreset will be ignored when it's set
+  ##
+  affinity: {}
+  ## Node labels for pod assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+  ## Tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+## Server configuration (only for distributed mode)
+##
+server:
+  ## Number of server nodes
+  ##
+  replicaCount: 1
+  ## An array to add extra env vars
+  ## Example:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
+  ## Configure resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits: {}
+    #   cpu: 250m
+    #   memory: 256Mi
+    requests: {}
+    #   cpu: 250m
+    #   memory: 256Mi
+  ## Pod affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAffinityPreset: ""
+  ## Pod anti-affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAntiAffinityPreset: soft
+  ## Node affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ## Allowed values: soft, hard
+  ##
+  nodeAffinityPreset:
+    ## Node affinity type
+    ## Allowed values: soft, hard
+    type: ""
+    ## Node label key to match
+    ## E.g.
+    ## key: "kubernetes.io/e2e-az-name"
+    ##
+    key: ""
+    ## Node label values to match
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+  ## Affinity for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Note: configsvr.podAffinityPreset, configsvr.podAntiAffinityPreset, and configsvr.nodeAffinityPreset will be ignored when it's set
+  ##
+  affinity: {}
+  ## Node labels for pod assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+  ## Tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+## Worker configuration (only for distributed mode)
+##
+worker:
+  ## Number of worker nodes
+  ##
+  replicaCount: 1
+  ## An array to add extra env vars
+  ## Example:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
+  ## Configure resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits: {}
+    #   cpu: 250m
+    #   memory: 256Mi
+    requests: {}
+    #   cpu: 250m
+    #   memory: 256Mi
+  ## Pod affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAffinityPreset: ""
+  ## Pod anti-affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAntiAffinityPreset: soft
+  ## Node affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ## Allowed values: soft, hard
+  ##
+  nodeAffinityPreset:
+    ## Node affinity type
+    ## Allowed values: soft, hard
+    type: ""
+    ## Node label key to match
+    ## E.g.
+    ## key: "kubernetes.io/e2e-az-name"
+    ##
+    key: ""
+    ## Node label values to match
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+  ## Affinity for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Note: configsvr.podAffinityPreset, configsvr.podAntiAffinityPreset, and configsvr.nodeAffinityPreset will be ignored when it's set
+  ##
+  affinity: {}
+  ## Node labels for pod assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+  ## Tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/bitnami/node-exporter/Chart.lock
+++ b/bitnami/node-exporter/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.1.1
+digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
+generated: "2020-11-27T13:12:10.855729+01:00"

--- a/bitnami/node-exporter/Chart.lock
+++ b/bitnami/node-exporter/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 1.1.1
 digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
-generated: "2020-11-27T13:12:10.855729+01:00"
+generated: "2020-12-09T16:15:07.983788+01:00"

--- a/bitnami/node-exporter/Chart.yaml
+++ b/bitnami/node-exporter/Chart.yaml
@@ -2,6 +2,12 @@ annotations:
   category: Analytics
 apiVersion: v2
 appVersion: 1.0.1
+dependencies:
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
 description: Prometheus exporter for hardware and OS metrics exposed by UNIX kernels, with pluggable metric collectors.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/node-exporter
@@ -18,4 +24,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-node-exporter
   - https://github.com/prometheus/node_exporter
   - https://prometheus.io/
-version: 2.0.0
+version: 2.1.0

--- a/bitnami/node-exporter/README.md
+++ b/bitnami/node-exporter/README.md
@@ -56,13 +56,13 @@ The following table lists the configurable parameters of the Node Exporter chart
 | `global.imagePullSecrets`               | Global Docker registry secret names as an array                                                          | `[]` (does not add image pull secrets to deployed pods)                   |
 | `global.storageClass`                   | Global storage class for dynamic provisioning                                                            | `nil`                                                                     |
 | `global.labels`                         | Additional labels to apply to all resource                                                               | `{}`                                                                      |
-| `nameOverride`                          | String to partially override `node-exporter.name` template with a string (will prepend the release name) | `nil`                                                                     |
-| `fullnameOverride`                      | String to fully override `node-exporter.fullname` template with a string                                 | `nil`                                                                     |
+| `nameOverride`                          | String to partially override `common.names.fullname` template with a string                              | `nil`                                                                     |
+| `fullnameOverride`                      | String to fully override `common.names.fullname` template with a string                                  | `nil`                                                                     |
 | `rbac.create`                           | Wether to create & use RBAC resources or not                                                             | `true`                                                                    |
 | `rbac.apiVersion`                       | Version of the RBAC API                                                                                  | `v1beta1`                                                                 |
 | `rbac.pspEnabled`                       | PodSecurityPolicy                                                                                        | `true`                                                                    |
 | `serviceAccount.create`                 | Specify whether to create a ServiceAccount for Node Exporter                                             | `true`                                                                    |
-| `serviceAccount.name`                   | The name of the ServiceAccount to create                                                                 | Generated using the `node-exporter.fullname` template                     |
+| `serviceAccount.name`                   | The name of the ServiceAccount to create                                                                 | Generated using the `common.names.fullname` template                      |
 | `image.registry`                        | Node Exporter image registry                                                                             | `docker.io`                                                               |
 | `image.repository`                      | Node Exporter Image name                                                                                 | `bitnami/node-exporter`                                                   |
 | `image.tag`                             | Node Exporter Image tag                                                                                  | `{TAG_NAME}`                                                              |
@@ -91,9 +91,14 @@ The following table lists the configurable parameters of the Node Exporter chart
 | `resources`                             | Resource requests/limit                                                                                  | `{}`                                                                      |
 | `podLabels`                             | Pod labels                                                                                               | `{}`                                                                      |
 | `podAnnotations`                        | Pod annotations                                                                                          | `{}`                                                                      |
-| `affinity`                              | Map of node/pod affinities                                                                               | `{} (The value is evaluated as a template)`                               |
-| `nodeSelector`                          | Node labels for pod assignment (this value is evaluated as a template)                                   | `{} (The value is evaluated as a template)`                               |
-| `tolerations`                           | List of node taints to tolerate (this value is evaluated as a template)                                  | `[] (The value is evaluated as a template)`                               |
+| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                      | `""`                                                                      |
+| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                 | `soft`                                                                    |
+| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                | `""`                                                                      |
+| `nodeAffinityPreset.key`                | Node label key to match Ignored if `affinity` is set.                                                    | `""`                                                                      |
+| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                                | `[]`                                                                      |
+| `affinity`                              | Affinity for pod assignment                                                                              | `{}` (evaluated as a template)                                            |
+| `nodeSelector`                          | Node labels for pod assignment                                                                           | `{}` (evaluated as a template)                                            |
+| `tolerations`                           | Tolerations for pod assignment                                                                           | `[]` (evaluated as a template)                                            |
 | `livenessProbe.enabled`                 | Turn on and off liveness probe                                                                           | `true`                                                                    |
 | `livenessProbe.initialDelaySeconds`     | Delay before liveness probe is initiated                                                                 | `120`                                                                     |
 | `livenessProbe.periodSeconds`           | How often to perform the probe                                                                           | `10`                                                                      |
@@ -136,6 +141,12 @@ It is strongly recommended to use immutable tags in a production environment. Th
 
 Bitnami will release a new chart updating its containers if a new version of the main container, significant changes, or critical vulnerabilities exist.
 
+### Setting Pod's affinity
+
+This chart allows you to set your custom affinity using the `XXX.affinity` paremeter(s). Find more infomation about Pod's affinity in the [kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity).
+
+As an alternative, you can use of the preset configurations for pod affinity, pod anti-affinity, and node affinity available at the [bitnami/common](https://github.com/bitnami/charts/tree/master/bitnami/common#affinities) chart. To do so, set the `podAffinityPreset`, `XpodAntiAffinityPreset`, or `nodeAffinityPreset` parameters.
+
 ## Troubleshooting
 
 Find more information about how to deal with common errors related to Bitnami’s Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
@@ -146,22 +157,26 @@ Find more information about how to deal with common errors related to Bitnami’
 $ helm upgrade my-release bitnami/node-exporter
 ```
 
+### To 2.1.0
+
+This version introduces `bitnami/common`, a [library chart](https://helm.sh/docs/topics/library_charts/#helm) as a dependency. More documentation about this new utility could be found [here](https://github.com/bitnami/charts/tree/master/bitnami/common#bitnami-common-library-chart). Please, make sure that you have updated the chart dependencies before executing any upgrade.
+
 ### To 2.0.0
 
 [On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
 
-**What changes were introduced in this major version?**
+#### What changes were introduced in this major version?
 
 - Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
 - The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
 
-**Considerations when upgrading to this version**
+#### Considerations when upgrading to this version
 
 - If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
 - If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
 - If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
 
-**Useful links**
+#### Useful links
 
 - https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
 - https://helm.sh/docs/topics/v2_v3_migration/

--- a/bitnami/node-exporter/templates/NOTES.txt
+++ b/bitnami/node-exporter/templates/NOTES.txt
@@ -2,32 +2,32 @@
 
 Watch the Node Exporter DaemonSet status using the command:
 
-    kubectl get ds -w --namespace {{ .Release.Namespace }} -l app.kubernetes.io/name={{ template "node-exporter.name" . }},app.kubernetes.io/instance={{ .Release.Name }}
+    kubectl get ds -w --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }}
 
 Node Exporter can be accessed via port "{{ .Values.service.port }}" on the following DNS name from within your cluster:
 
-    {{ template "node-exporter.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+    {{ template "common.names.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 
 To access Node Exporter from outside the cluster execute the following commands:
 
 {{- if contains "LoadBalancer" .Values.service.type }}
 
     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-    Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "node-exporter.fullname" . }}'
+    Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "common.names.fullname" . }}'
 
 {{- $port:=.Values.service.port | toString }}
 
-    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "node-exporter.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
     echo "URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}/"
 
 {{- else if contains "ClusterIP"  .Values.service.type }}
 
     echo "URL: http://127.0.0.1:9100/"
-    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "node-exporter.fullname" . }} 9100:{{ .Values.service.port }}
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "common.names.fullname" . }} 9100:{{ .Values.service.port }}
 
 {{- else if contains "NodePort" .Values.service.type }}
 
-    export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "node-exporter.fullname" . }})
+    export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "common.names.fullname" . }})
     export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
     echo "URL: http://$NODE_IP:$NODE_PORT/"
 

--- a/bitnami/node-exporter/templates/_helpers.tpl
+++ b/bitnami/node-exporter/templates/_helpers.tpl
@@ -1,16 +1,17 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
-Renders a value that contains template.
-Usage:
-{{ include "node-exporter.tplValue" ( dict "value" .Values.path.to.the.Value "context" $) }}
+Return the proper Node Exporter image name
 */}}
-{{- define "node-exporter.tplValue" -}}
-    {{- if typeIs "string" .value }}
-        {{- tpl .value .context }}
-    {{- else }}
-        {{- tpl (.value | toYaml) .context }}
-    {{- end }}
+{{- define "node-exporter.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names for Node Exporter image
+*/}}
+{{- define "node-exporter.imagePullSecrets" -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.image) "global" .Values.global) -}}
 {{- end -}}
 
 {{/*
@@ -25,132 +26,13 @@ Return the appropriate apiVersion for PodSecurityPolicy.
 {{- end -}}
 
 {{/*
-Return the appropriate apiVersion for Deployment.
-*/}}
-{{- define "deployment.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
-{{- print "apps/v1" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Expand the name of the chart.
-*/}}
-{{- define "node-exporter.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "node-exporter.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
-{{- define "node-exporter.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Common labels
-*/}}
-{{- define "node-exporter.labels" -}}
-app.kubernetes.io/name: {{ include "node-exporter.name" . }}
-helm.sh/chart: {{ include "node-exporter.chart" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- if .Values.global.labels }}
-{{ toYaml .Values.global.labels }}
-{{- end }}
-{{- end -}}
-
-{{/*
-matchLabels
-*/}}
-{{- define "node-exporter.matchLabels" -}}
-app.kubernetes.io/name: {{ include "node-exporter.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end -}}
-
-{{/*
 Create the name of the service account to use
 */}}
 {{- define "node-exporter.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
-    {{ default (include "node-exporter.fullname" .) .Values.serviceAccount.name }}
+    {{ default (include "common.names.fullname" .) .Values.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.serviceAccount.name }}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return the proper Docker Image Registry Secret Names for Node Exporter image
-*/}}
-{{- define "node-exporter.imagePullSecrets" -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
-Also, we can not use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets:
-{{- range .Values.global.imagePullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- else if .Values.image.pullSecrets }}
-imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end -}}
-{{- else if .Values.image.pullSecrets }}
-imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return the proper Node Exporter image name
-*/}}
-{{- define "node-exporter.image" -}}
-{{- $registryName := .Values.image.registry -}}
-{{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
-{{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
 {{- end -}}
 
@@ -158,10 +40,7 @@ Also, we can't use a single if because lazy evaluation is not an option
 Check if there are rolling tags in the images
 */}}
 {{- define "node-exporter.checkRollingTags" -}}
-{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
-WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
-+info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
-{{- end }}
+{{- include "common.warnings.rollingTag" .Values.image }}
 {{- end -}}
 
 {{/*

--- a/bitnami/node-exporter/templates/daemonset.yaml
+++ b/bitnami/node-exporter/templates/daemonset.yaml
@@ -1,29 +1,42 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ template "node-exporter.fullname" . }}
+  name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "node-exporter.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   selector:
-    matchLabels: {{- include "node-exporter.matchLabels" . | nindent 6 }}
-  updateStrategy:
-{{ toYaml .Values.updateStrategy | indent 4 }}
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+  updateStrategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   minReadySeconds: {{ .Values.minReadySeconds }}
   template:
     metadata:
       {{- if .Values.podAnnotations }}
-      annotations: {{- include "node-exporter.tplValue" ( dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+      annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
-      labels: {{- include "node-exporter.labels" . | nindent 8 }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
         {{- if .Values.podLabels }}
-{{ toYaml .Values.podLabels | indent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
     spec:
+      {{- include "node-exporter.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ template "node-exporter.serviceAccountName" . }}
-{{- include "node-exporter.imagePullSecrets" . | indent 6 }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAffinityPreset "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAntiAffinityPreset "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" .) | nindent 8 }}
       {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
@@ -32,7 +45,7 @@ spec:
         runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
       {{- end }}
       containers:
-        - name: {{ template "node-exporter.name" . }}
+        - name: node-exporter
           image: {{ template "node-exporter.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
@@ -50,16 +63,14 @@ spec:
             - name: metrics
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
-          livenessProbe:
+          livenessProbe: {{- include "common.tplvalues.render" ( dict "value" .Values.livenessProbe "context" $) | nindent 12 }}
             httpGet:
               path: /
               port: metrics
-{{ toYaml .Values.livenessProbe | indent 12 }}
-          readinessProbe:
+          readinessProbe: {{- include "common.tplvalues.render" ( dict "value" .Values.readinessProbe "context" $) | nindent 12 }}
             httpGet:
               path: /
               port: metrics
-{{ toYaml .Values.readinessProbe | indent 12 }}
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
@@ -71,19 +82,10 @@ spec:
               mountPath: /host/sys
               readOnly: true
             {{- if .Values.extraVolumeMounts }}
-{{ toYaml .Values.extraVolumeMounts | indent 12}}
+            {{- include "common.tplvalues.render" ( dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
       hostNetwork: {{ .Values.hostNetwork }}
       hostPID: true
-      {{- if .Values.nodeSelector }}
-      nodeSelector: {{- include "node-exporter.tplValue" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
-      {{- end }}
-      {{- if .Values.tolerations }}
-      tolerations: {{- include "node-exporter.tplValue" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
-      {{- end }}
-      {{- if .Values.affinity }}
-      affinity: {{- include "node-exporter.tplValue" (dict "value" .Values.affinity "context" $) | nindent 8 }}
-      {{- end }}
       volumes:
         - name: proc
           hostPath:
@@ -92,5 +94,5 @@ spec:
           hostPath:
             path: /sys
         {{- if .Values.extraVolumes }}
-{{ toYaml .Values.extraVolumes | indent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}

--- a/bitnami/node-exporter/templates/psp-clusterrole.yaml
+++ b/bitnami/node-exporter/templates/psp-clusterrole.yaml
@@ -2,12 +2,12 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ template "node-exporter.fullname" . }}-psp
-  labels: {{- include "node-exporter.labels" . | nindent 4 }}
+  name: {{ template "common.names.fullname" . }}-psp
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
 rules:
   - apiGroups: ['extensions']
     resources: ['podsecuritypolicies']
     verbs: ['use']
     resourceNames:
-      - {{ template "node-exporter.fullname" . }}
+      - {{ template "common.names.fullname" . }}
 {{- end }}

--- a/bitnami/node-exporter/templates/psp-clusterrolebinding.yaml
+++ b/bitnami/node-exporter/templates/psp-clusterrolebinding.yaml
@@ -2,12 +2,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "node-exporter.fullname" . }}-psp
-  labels: {{- include "node-exporter.labels" . | nindent 4 }}
+  name: {{ template "common.names.fullname" . }}-psp
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "node-exporter.fullname" . }}-psp
+  name: {{ template "common.names.fullname" . }}-psp
 subjects:
   - kind: ServiceAccount
     name: {{ template "node-exporter.serviceAccountName" . }}

--- a/bitnami/node-exporter/templates/psp.yaml
+++ b/bitnami/node-exporter/templates/psp.yaml
@@ -2,8 +2,8 @@
 apiVersion: {{ template "podSecurityPolicy.apiVersion" . }}
 kind: PodSecurityPolicy
 metadata:
-  name: {{ template "node-exporter.fullname" . }}
-  labels: {{- include "node-exporter.labels" . | nindent 4 }}
+  name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   privileged: false
   allowPrivilegeEscalation: false

--- a/bitnami/node-exporter/templates/service.yaml
+++ b/bitnami/node-exporter/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "node-exporter.fullname" . }}
+  name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- if .Values.service.addPrometheusScrapeAnnotation }}
@@ -10,7 +10,7 @@ metadata:
     {{- with .Values.service.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  labels: {{- include "node-exporter.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
     {{- end }}
@@ -36,4 +36,4 @@ spec:
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
-  selector: {{- include "node-exporter.matchLabels" . | nindent 4 }}
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/node-exporter/templates/serviceaccount.yaml
+++ b/bitnami/node-exporter/templates/serviceaccount.yaml
@@ -4,5 +4,5 @@ kind: ServiceAccount
 metadata:
   name: {{ template "node-exporter.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "node-exporter.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
 {{- end }}

--- a/bitnami/node-exporter/templates/servicemonitor.yaml
+++ b/bitnami/node-exporter/templates/servicemonitor.yaml
@@ -2,13 +2,13 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "node-exporter.fullname" . }}
+  name: {{ template "common.names.fullname" . }}
   {{- if .Values.serviceMonitor.namespace }}
   namespace: {{ .Values.serviceMonitor.namespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
-  labels: {{- include "node-exporter.labels" . | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- range $key, $value := .Values.serviceMonitor.selector }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -17,7 +17,7 @@ spec:
   jobLabel: {{ .Values.serviceMonitor.jobLabel }}
   {{- end }}
   selector:
-    matchLabels: {{- include "node-exporter.matchLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
   endpoints:
     - port: metrics
       {{- if .Values.serviceMonitor.interval }}
@@ -27,10 +27,10 @@ spec:
       scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
       {{- end }}
       {{- if .Values.serviceMonitor.relabelings }}
-      relabelings: {{- include "node-exporter.tplValue" ( dict "value" .Values.serviceMonitor.relabelings "context" $) | nindent 8 }}
+      relabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.serviceMonitor.relabelings "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.serviceMonitor.metricRelabelings }}
-      metricRelabelings: {{- include "node-exporter.tplValue" ( dict "value" .Values.serviceMonitor.metricRelabelings "context" $) | nindent 8 }}
+      metricRelabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.serviceMonitor.metricRelabelings "context" $) | nindent 8 }}
       {{- end }}
   namespaceSelector:
     matchNames:

--- a/bitnami/node-exporter/values.yaml
+++ b/bitnami/node-exporter/values.yaml
@@ -11,11 +11,11 @@ global:
   labels: {}
   #   foo: bar
 
-## String to partially override node-exporter.fullname template (will maintain the release name)
+## String to partially override common.names.fullname template (will maintain the release name)
 ##
 # nameOverride:
 
-## String to fully override node-exporter.fullname template
+## String to fully override common.names.fullname template
 ##
 # fullnameOverride:
 
@@ -41,7 +41,7 @@ serviceAccount:
   ##
   create: true
   ## The name of the ServiceAccount to use.
-  ## If not set and create is true, a name is generated using the node-exporter.fullname template
+  ## If not set and create is true, a name is generated using the common.names.fullname template
   # name:
 
 ## Bitnami Node Exporter image version
@@ -166,18 +166,52 @@ podLabels: {}
 ##
 podAnnotations: {}
 
-## Affinity for pod assignment
-## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## Pod affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+## Allowed values: soft, hard
+##
+podAffinityPreset: ""
+
+## Pod anti-affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+## Allowed values: soft, hard
+##
+podAntiAffinityPreset: soft
+
+## Node affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+## Allowed values: soft, hard
+##
+nodeAffinityPreset:
+  ## Node affinity type
+  ## Allowed values: soft, hard
+  type: ""
+  ## Node label key to match
+  ## E.g.
+  ## key: "kubernetes.io/e2e-az-name"
+  ##
+  key: ""
+  ## Node label values to match
+  ## E.g.
+  ## values:
+  ##   - e2e-az1
+  ##   - e2e-az2
+  ##
+  values: []
+
+## Affinity for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
 ##
 affinity: {}
 
-## Node labels for pod assignment
-## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+## Node labels for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##
 nodeSelector: {}
 
-## Tolerations for pod assignment
-## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+## Tolerations for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
 tolerations: []
 

--- a/bitnami/phpmyadmin/Chart.lock
+++ b/bitnami/phpmyadmin/Chart.lock
@@ -6,4 +6,4 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 9.1.2
 digest: sha256:a2e41ea64175a575ec8ab0d6747231eba30ecb9e175564dfce42c6bad6fc77d7
-generated: "2020-12-09T01:02:13.340809847Z"
+generated: "2020-12-09T16:14:58.723502+01:00"

--- a/bitnami/phpmyadmin/Chart.yaml
+++ b/bitnami/phpmyadmin/Chart.yaml
@@ -29,4 +29,4 @@ name: phpmyadmin
 sources:
   - https://github.com/bitnami/bitnami-docker-phpmyadmin
   - https://www.phpmyadmin.net/
-version: 7.1.0
+version: 8.0.0

--- a/bitnami/phpmyadmin/README.md
+++ b/bitnami/phpmyadmin/README.md
@@ -44,72 +44,135 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Parameters
 
-The following table lists the configurable parameters of the phpMyAdmin chart and their default values.
+The following tables lists the configurable parameters of the phpMyAdmin chart and their default values per section/component:
 
-| Parameter                                 | Description                                                                                             | Default                                                      |
-|-------------------------------------------|---------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `global.imageRegistry`                    | Global Docker image registry                                                                            | `nil`                                                        |
-| `global.imagePullSecrets`                 | Global Docker registry secret names as an array                                                         | `[]` (does not add image pull secrets to deployed pods)      |
-| `image.registry`                          | phpMyAdmin image registry                                                                               | `docker.io`                                                  |
-| `image.repository`                        | phpMyAdmin image name                                                                                   | `bitnami/phpmyadmin`                                         |
-| `image.tag`                               | phpMyAdmin image tag                                                                                    | `{TAG_NAME}`                                                 |
-| `image.pullPolicy`                        | Image pull policy                                                                                       | `IfNotPresent`                                               |
-| `image.pullSecrets`                       | Specify docker-registry secret names as an array                                                        | `[]` (does not add image pull secrets to deployed pods)      |
-| `nameOverride`                            | String to partially override phpmyadmin.fullname template with a string (will prepend the release name) | `nil`                                                        |
-| `fullnameOverride`                        | String to fully override phpmyadmin.fullname template with a string                                     | `nil`                                                        |
-| `service.type`                            | Type of service for phpMyAdmin frontend                                                                 | `ClusterIP`                                                  |
-| `service.port`                            | Port to expose service                                                                                  | `80`                                                         |
-| `db.allowArbitraryServer`                 | Enable connection to arbitrary MySQL server                                                             | `true`                                                       |
-| `db.port`                                 | Database port to use to connect                                                                         | `3306`                                                       |
-| `db.chartName`                            | Database suffix if included in the same release                                                         | `nil`                                                        |
-| `db.host`                                 | Database host to connect to                                                                             | `nil`                                                        |
-| `db.bundleTestDB`                         | Deploy a MariaDB instance for testing purposes                                                          | `false`                                                      |
-| `db.enableSsl`                            | Enable SSL for the connection between phpMyAdmin and the database                                       | `false`                                                      |
-| `db.ssl.clientKey`                        | Client key file when using SSL                                                                          | `nil`                                                        |
-| `db.ssl.clientCertificate`                | Client certificate file when using SSL                                                                  | `nil`                                                        |
-| `db.ssl.caCertificate`                    | CA file when using SSL                                                                                  | `nil`                                                        |
-| `db.ssl.ciphers`                          | List of allowable ciphers for connections when using SSL                                                | `nil`                                                        |
-| `db.ssl.verify`                           | Enable SSL certificate validation                                                                       | `true`                                                       |
-| `ingress.enabled`                         | Enable ingress controller resource                                                                      | `false`                                                      |
-| `ingress.certManager`                     | Add annotations for cert-manager                                                                        | `false`                                                      |
-| `ingress.rewriteTarget`                   | Add annotations to redirect traffic to `/`                                                              | `true`                                                       |
-| `ingress.annotations`                     | Ingress annotations                                                                                     | `{}`                                                         |
-| `ingress.hosts[0].name`                   | Hostname to your PHPMyAdmin installation                                                                | `phpmyadmin.local`                                           |
-| `ingress.hosts[0].path`                   | Path within the url structure                                                                           | `/`                                                          |
-| `ingress.hosts[0].tls`                    | Utilize TLS backend in ingress                                                                          | `false`                                                      |
-| `ingress.hosts[0].tlsHosts`               | Array of TLS hosts for ingress record (defaults to `ingress.hosts[0].name` if `nil`)                    | `nil`                                                        |
-| `ingress.hosts[0].tlsSecret`              | TLS Secret (certificates)                                                                               | `phpmyadmin.local-tls-secret`                                |
-| `extraEnvVars`                            | Any extra environment variables to be passed to the pod (evaluated as a template)                       | `{}`                                                         |
-| `extraEnvVarsCM`                          | Name of a Config Map containing extra environment variables to be passed to the pod (evaluated as a template) | `nil`                                                  |
-| `extraEnvVarsSecret`                      | Secret with extra environment variables                                                                 | `nil`                                                        |
-| `podSecurityContext`                      | phpMyAdmin pods' Security Context                                                                       | `{ fsGroup: "1001" }`                                        |
-| `containerSecurityContext`                | phpMyAdmin containers' Security Context                                                                 | `{ runAsUser: "1001" }`                                      |
-| `resources.limits`                        | The resources limits for the PhpMyAdmin container                                                       | `{}`                                                         |
-| `resources.requests`                      | The requested resources for the PhpMyAdmin container                                                    | `{}`                                                         |
-| `livenessProbe`                           | Liveness probe configuration for PhpMyAdmin                                                             | `Check values.yaml file`                                     |
-| `readinessProbe`                          | Readiness probe configuration for PhpMyAdmin                                                            | `Check values.yaml file`                                     |
-| `nodeSelector`                            | Node labels for pod assignment                                                                          | `{}`                                                         |
-| `tolerations`                             | List of node taints to tolerate                                                                         | `[]`                                                         |
-| `affinity`                                | Map of node/pod affinities                                                                              | `{}`                                                         |
-| `podLabels`                               | Pod labels                                                                                              | `{}`                                                         |
-| `podAnnotations`                          | Pod annotations                                                                                         | `{}`                                                         |
-| `metrics.enabled`                         | Start a side-car prometheus exporter                                                                    | `false`                                                      |
-| `metrics.image.registry`                  | Apache exporter image registry                                                                          | `docker.io`                                                  |
-| `metrics.image.repository`                | Apache exporter image name                                                                              | `bitnami/apache-exporter`                                    |
-| `metrics.image.tag`                       | Apache exporter image tag                                                                               | `{TAG_NAME}`                                                 |
-| `metrics.image.pullPolicy`                | Image pull policy                                                                                       | `IfNotPresent`                                               |
-| `metrics.image.pullSecrets`               | Specify docker-registry secret names as an array                                                        | `[]` (does not add image pull secrets to deployed pods)      |
-| `metrics.podAnnotations`                  | Additional annotations for Metrics exporter pod                                                         | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
-| `metrics.resources`                       | Exporter resource requests/limit                                                                        | `{}`                                                         |
-| `metrics.serviceMonitor.enabled`          | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                            | `false`                                                      |
-| `metrics.serviceMonitor.namespace`        | Namespace where servicemonitor resource should be created                                               | `nil`                                                        |
-| `metrics.serviceMonitor.interval`         | Specify the interval at which metrics should be scraped                                                 | `30s`                                                        |
-| `metrics.serviceMonitor.jobLabel`         | The name of the label on the target service to use as the job name in prometheus.                       | `nil`                                                        |
-| `metrics.serviceMonitor.scrapeTimeout`    | Specify the timeout after which the scrape is ended                                                     | `nil`                                                        |
-| `metrics.serviceMonitor.relabellings`     | Specify Relabellings to add to the scrape endpoint                                                      | `nil`                                                        |
-| `metrics.serviceMonitor.metricRelabelings`| Specify Metric Relabellings to add to the scrape endpoint                                               | `nil`                                                        |
-| `metrics.serviceMonitor.honorLabels`      | honorLabels chooses the metric's labels on collisions with target labels.                               | `false`                                                      |
-| `metrics.serviceMonitor.additionalLabels` | Used to pass Labels that are required by the Installed Prometheus Operator                              | `{}`                                                         |
+### Global parameters
+
+| Parameter                               | Description                                                | Default                                                 |
+|-----------------------------------------|------------------------------------------------------------|---------------------------------------------------------|
+| `global.imageRegistry`                  | Global Docker image registry                               | `nil`                                                   |
+| `global.imagePullSecrets`               | Global Docker registry secret names as an array            | `[]` (does not add image pull secrets to deployed pods) |
+
+### Common parameters
+
+| Parameter                               | Description                                                | Default                                                 |
+|-----------------------------------------|------------------------------------------------------------|---------------------------------------------------------|
+| `nameOverride`                          | String to partially override common.names.fullname         | `nil`                                                   |
+| `fullnameOverride`                      | String to fully override common.names.fullname             | `nil`                                                   |
+| `commonLabels`                          | Labels to add to all deployed objects                      | `{}`                                                    |
+| `commonAnnotations`                     | Annotations to add to all deployed objects                 | `{}`                                                    |
+| `clusterDomain`                         | Default Kubernetes cluster domain                          | `cluster.local`                                         |
+| `extraDeploy`                           | Array of extra objects to deploy with the release          | `[]` (evaluated as a template)                          |
+
+### phpMyAdmin parameters
+
+| Parameter                               | Description                                                                              | Default                                                 |
+|-----------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `image.registry`                        | phpMyAdmin image registry                                                                | `docker.io`                                             |
+| `image.repository`                      | phpMyAdmin image name                                                                    | `bitnami/phpmyadmin`                                    |
+| `image.tag`                             | phpMyAdmin image tag                                                                     | `{TAG_NAME}`                                            |
+| `image.pullPolicy`                      | Image pull policy                                                                        | `IfNotPresent`                                          |
+| `image.pullSecrets`                     | Specify docker-registry secret names as an array                                         | `[]` (does not add image pull secrets to deployed pods) |
+| `command`                               | Override default container command (useful when using custom images)                     | `nil`                                                   |
+| `args`                                  | Override default container args (useful when using custom images)                        | `nil`                                                   |
+| `extraEnvVars`                          | Extra environment variables to be set on PhpMyAdmin container                            | `{}`                                                    |
+| `extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars                                     | `nil`                                                   |
+| `extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars                                        | `nil`                                                   |
+
+### phpMyAdmin deployment parameters
+
+| Parameter                               | Description                                                                              | Default                                                 |
+|-----------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `containerPorts.http`                   | HTTP port to expose at container level                                                   | `8080`                                                  |
+| `containerPorts.https`                  | HTTPS port to expose at container level                                                  | `8443`                                                  |
+| `podSecurityContext`                    | PhpMyAdmin pods' Security Context                                                        | Check `values.yaml` file                                |
+| `containerSecurityContext`              | PhpMyAdmin containers' Security Context                                                  | Check `values.yaml` file                                |
+| `resources.limits`                      | The resources limits for the PhpMyAdmin container                                        | `{}`                                                    |
+| `resources.requests`                    | The requested resources for the PhpMyAdmin container                                     | `{"memory": "512Mi", "cpu": "300m"}`                    |
+| `leavinessProbe`                        | Leaviness probe configuration for PhpMyAdmin                                             | Check `values.yaml` file                                |
+| `readinessProbe`                        | Readiness probe configuration for PhpMyAdmin                                             | Check `values.yaml` file                                |
+| `customLivenessProbe`                   | Override default liveness probe                                                          | `nil`                                                   |
+| `customReadinessProbe`                  | Override default readiness probe                                                         | `nil`                                                   |
+| `updateStrategy`                        | Strategy to use to update Pods                                                           | Check `values.yaml` file                                |
+| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`      | `""`                                                    |
+| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `soft`                                                  |
+| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`| `""`                                                    |
+| `nodeAffinityPreset.key`                | Node label key to match. Ignored if `affinity` is set.                                   | `""`                                                    |
+| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                | `[]`                                                    |
+| `affinity`                              | Affinity for pod assignment                                                              | `{}` (evaluated as a template)                          |
+| `nodeSelector`                          | Node labels for pod assignment                                                           | `{}` (evaluated as a template)                          |
+| `tolerations`                           | Tolerations for pod assignment                                                           | `[]` (evaluated as a template)                          |
+| `podLabels`                             | Extra labels for PhpMyAdmin pods                                                         | `{}` (evaluated as a template)                          |
+| `podAnnotations`                        | Annotations for PhpMyAdmin pods                                                          | `{}` (evaluated as a template)                          |
+| `extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for PhpMyAdmin container(s)     | `[]`                                                    |
+| `extraVolumes`                          | Optionally specify extra list of additional volumes for PhpMyAdmin pods                  | `[]`                                                    |
+| `initContainers`                        | Add additional init containers to the PhpMyAdmin pods                                    | `{}` (evaluated as a template)                          |
+| `sidecars`                              | Add additional sidecar containers to the PhpMyAdmin pods                                 | `{}` (evaluated as a template)                          |
+
+### Exposure parameters
+
+| Parameter                               | Description                                                                              | Default                                                 |
+|-----------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `service.type`                          | Kubernetes Service type                                                                  | `LoadBalancer`                                          |
+| `service.port`                          | Service HTTP port                                                                        | `80`                                                    |
+| `service.httpsPort`                     | Service HTTPS port                                                                       | `""`                                                    |
+| `service.nodePorts.http`                | Kubernetes http node port                                                                | `""`                                                    |
+| `service.nodePorts.https`               | Kubernetes https node port                                                               | `""`                                                    |
+| `service.clusterIP`                     | PhpMyAdmin service clusterIP IP                                                          | `None`                                                  |
+| `service.externalTrafficPolicy`         | Enable client source IP preservation                                                     | `Cluster`                                               |
+| `service.loadBalancerIP`                | loadBalancerIP if service type is `LoadBalancer`                                         | `nil`                                                   |
+| `service.loadBalancerSourceRanges`      | Address that are allowed when service is LoadBalancer                                    | `[]`                                                    |
+| `service.annotations`                   | Annotations for PhpMyAdmin service                                                       | `{}` (evaluated as a template)                          |
+| `ingress.enabled`                       | Enable ingress controller resource                                                       | `false`                                                 |
+| `ingress.certManager`                   | Add annotations for cert-manager                                                         | `false`                                                 |
+| `ingress.hostname`                      | Default host for the ingress resource                                                    | `phpmyadmin.local`                                      |
+| `ingress.tls`                           | Enable TLS configuration for the hostname defined at `ingress.hostname` parameter        | `false`                                                 |
+| `ingress.annotations`                   | Ingress annotations                                                                      | `{}` (evaluated as a template)                          |
+| `ingress.extraHosts[0].name`            | Additional hostnames to be covered                                                       | `nil`                                                   |
+| `ingress.extraHosts[0].path`            | Additional hostnames to be covered                                                       | `nil`                                                   |
+| `ingress.extraTls[0].hosts[0]`          | TLS configuration for additional hostnames to be covered                                 | `nil`                                                   |
+| `ingress.extraTls[0].secretName`        | TLS configuration for additional hostnames to be covered                                 | `nil`                                                   |
+| `ingress.secrets[0].name`               | TLS Secret Name                                                                          | `nil`                                                   |
+| `ingress.secrets[0].certificate`        | TLS Secret Certificate                                                                   | `nil`                                                   |
+| `ingress.secrets[0].key`                | TLS Secret Key                                                                           | `nil`                                                   |
+
+### Database parameters
+
+| Parameter                               | Description                                                                              | Default                                                 |
+|-----------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `db.allowArbitraryServer`               | Enable connection to arbitrary MySQL server                                              | `true`                                                  |
+| `db.port`                               | Database port to use to connect                                                          | `3306`                                                  |
+| `db.chartName`                          | Database suffix if included in the same release                                          | `nil`                                                   |
+| `db.host`                               | Database host to connect to                                                              | `nil`                                                   |
+| `db.bundleTestDB`                       | Deploy a MariaDB instance for testing purposes                                           | `false`                                                 |
+| `db.enableSsl`                          | Enable SSL for the connection between phpMyAdmin and the database                        | `false`                                                 |
+| `db.ssl.clientKey`                      | Client key file when using SSL                                                           | `nil`                                                   |
+| `db.ssl.clientCertificate`              | Client certificate file when using SSL                                                   | `nil`                                                   |
+| `db.ssl.caCertificate`                  | CA file when using SSL                                                                   | `nil`                                                   |
+| `db.ssl.ciphers`                        | List of allowable ciphers for connections when using SSL                                 | `nil`                                                   |
+| `db.ssl.verify`                         | Enable SSL certificate validation                                                        | `true`                                                  |
+
+### Metrics parameters
+
+| Parameter                                 | Description                                                                            | Default                                                      |
+|-------------------------------------------|----------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `metrics.enabled`                         | Start a side-car prometheus exporter                                                   | `false`                                                      |
+| `metrics.image.registry`                  | Apache exporter image registry                                                         | `docker.io`                                                  |
+| `metrics.image.repository`                | Apache exporter image name                                                             | `bitnami/apache-exporter`                                    |
+| `metrics.image.tag`                       | Apache exporter image tag                                                              | `{TAG_NAME}`                                                 |
+| `metrics.image.pullPolicy`                | Image pull policy                                                                      | `IfNotPresent`                                               |
+| `metrics.image.pullSecrets`               | Specify docker-registry secret names as an array                                       | `[]` (does not add image pull secrets to deployed pods)      |
+| `metrics.podAnnotations`                  | Additional annotations for Metrics exporter pod                                        | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
+| `metrics.resources`                       | Exporter resource requests/limit                                                       | `{}`                                                         |
+| `metrics.serviceMonitor.enabled`          | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator           | `false`                                                      |
+| `metrics.serviceMonitor.namespace`        | Namespace where servicemonitor resource should be created                              | `nil`                                                        |
+| `metrics.serviceMonitor.interval`         | Specify the interval at which metrics should be scraped                                | `30s`                                                        |
+| `metrics.serviceMonitor.jobLabel`         | The name of the label on the target service to use as the job name in prometheus.      | `nil`                                                        |
+| `metrics.serviceMonitor.scrapeTimeout`    | Specify the timeout after which the scrape is ended                                    | `nil`                                                        |
+| `metrics.serviceMonitor.relabellings`     | Specify Relabellings to add to the scrape endpoint                                     | `nil`                                                        |
+| `metrics.serviceMonitor.metricRelabelings`| Specify Metric Relabellings to add to the scrape endpoint                              | `nil`                                                        |
+| `metrics.serviceMonitor.honorLabels`      | honorLabels chooses the metric's labels on collisions with target labels.              | `false`                                                      |
+| `metrics.serviceMonitor.additionalLabels` | Used to pass Labels that are required by the Installed Prometheus Operator             | `{}`                                                         |
 
 For more information please refer to the [bitnami/phpmyadmin](http://github.com/bitnami/bitnami-docker-Phpmyadmin) image documentation.
 
@@ -138,11 +201,122 @@ It is strongly recommended to use immutable tags in a production environment. Th
 
 Bitnami will release a new chart updating its containers if a new version of the main container, significant changes, or critical vulnerabilities exist.
 
+### Ingress
+
+This chart provides support for ingress resources. If you have an ingress controller installed on your cluster, such as [nginx-ingress-controller](https://github.com/bitnami/charts/tree/master/bitnami/nginx-ingress-controller) or [contour](https://github.com/bitnami/charts/tree/master/bitnami/contour) you can utilize the ingress controller to serve your application.
+
+To enable ingress integration, please set `ingress.enabled` to `true`.
+
+#### Hosts
+
+Most likely you will only want to have one hostname that maps to this phpMyAdmin installation. If that's your case, the property `ingress.hostname` will set it. However, it is possible to have more than one host. To facilitate this, the `ingress.extraHosts` object can be specified as an array. You can also use `ingress.extraTLS` to add the TLS configuration for extra hosts.
+
+For each host indicated at `ingress.extraHosts`, please indicate a `name`, `path`, and any `annotations` that you may want the ingress controller to know about.
+
+For annotations, please see [this document](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md). Not all annotations are supported by all ingress controllers, but this document does a good job of indicating which annotation is supported by many popular ingress controllers.
+
+### TLS Secrets
+
+This chart will facilitate the creation of TLS secrets for use with the ingress controller, however, this is not required. There are three common use cases:
+
+- Helm generates/manages certificate secrets.
+- User generates/manages certificates separately.
+- An additional tool (like [cert-manager](https://github.com/jetstack/cert-manager/)) manages the secrets for the application.
+
+In the first two cases, it's needed a certificate and a key. We would expect them to look like this:
+
+- certificate files should look like (and there can be more than one certificate if there is a certificate chain)
+
+    ```console
+    -----BEGIN CERTIFICATE-----
+    MIID6TCCAtGgAwIBAgIJAIaCwivkeB5EMA0GCSqGSIb3DQEBCwUAMFYxCzAJBgNV
+    ...
+    jScrvkiBO65F46KioCL9h5tDvomdU1aqpI/CBzhvZn1c0ZTf87tGQR8NK7v7
+    -----END CERTIFICATE-----
+    ```
+
+- keys should look like:
+
+    ```console
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEogIBAAKCAQEAvLYcyu8f3skuRyUgeeNpeDvYBCDcgq+LsWap6zbX5f8oLqp4
+    ...
+    wrj2wDbCDCFmfqnSJ+dKI3vFLlEz44sAV8jX/kd4Y6ZTQhlLbYc=
+    -----END RSA PRIVATE KEY-----
+    ```
+
+If you are going to use Helm to manage the certificates, please copy these values into the `certificate` and `key` values for a given `ingress.secrets` entry.
+
+If you are going to manage TLS secrets outside of Helm, please know that you can create a TLS secret (named `phpmyadmin.local-tls` for example).
+
+### Adding extra environment variables
+
+In case you want to add extra environment variables (useful for advanced operations like custom init scripts), you can use the `extraEnvVars` property.
+
+```yaml
+extraEnvVars:
+  - name: LOG_LEVEL
+    value: DEBUG
+```
+
+Alternatively, you can use a ConfigMap or a Secret with the environment variables. To do so, use the `extraEnvVarsCM` or the `extraEnvVarsSecret` values.
+
+### Sidecars and Init Containers
+
+If you have a need for additional containers to run within the same pod as the PhpMyAdmin app (e.g. an additional metrics or logging exporter), you can do so via the `sidecars` config parameter. Simply define your container according to the Kubernetes container spec.
+
+```yaml
+sidecars:
+  - name: your-image-name
+    image: your-image
+    imagePullPolicy: Always
+    ports:
+      - name: portname
+       containerPort: 1234
+```
+
+Similarly, you can add extra init containers using the `initContainers` parameter.
+
+```yaml
+initContainers:
+  - name: your-image-name
+    image: your-image
+    imagePullPolicy: Always
+    ports:
+      - name: portname
+        containerPort: 1234
+```
+
+### Deploying extra resources
+
+There are cases where you may want to deploy extra objects, such a ConfigMap containing your app's configuration or some extra deployment with a micro service used by your app. For covering this case, the chart allows adding the full specification of other objects using the `extraDeploy` parameter.
+
+### Setting Pod's affinity
+
+This chart allows you to set your custom affinity using the `XXX.affinity` paremeter(s). Find more infomation about Pod's affinity in the [kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity).
+
+As an alternative, you can use of the preset configurations for pod affinity, pod anti-affinity, and node affinity available at the [bitnami/common](https://github.com/bitnami/charts/tree/master/bitnami/common#affinities) chart. To do so, set the `podAffinityPreset`, `XpodAntiAffinityPreset`, or `nodeAffinityPreset` parameters.
+
 ## Troubleshooting
 
 Find more information about how to deal with common errors related to Bitnami’s Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
 
 ## Upgrading
+
+### To 8.0.0
+
+- Chart labels were adapted to follow the [Helm charts standard labels](https://helm.sh/docs/chart_best_practices/labels/#standard-labels).
+
+Consequences:
+
+- Backwards compatibility is not guaranteed. However, you can easily workaround this issue by removing PhpMyAdmin deployment before upgrading (the following example assumes that the release name is `phpmyadmin`):
+
+```console
+$ export MARIADB_ROOT_PASSWORD=$(kubectl get secret --namespace default phpmyadmin-mariadb -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)
+$ export MARIADB_PASSWORD=$(kubectl get secret --namespace default phpmyadmin-mariadb -o jsonpath="{.data.mariadb-password}" | base64 --decode)
+$ kubectl delete deployments.apps phpmyadmin
+$ helm upgrade phpmyadmin bitnami/phpmyadmin --set mariadb.auth.rootPassword=$MARIADB_ROOT_PASSWORD,mariadb.auth.password=$MARIADB_PASSWORD
+```
 
 ### To 7.0.0
 

--- a/bitnami/phpmyadmin/README.md
+++ b/bitnami/phpmyadmin/README.md
@@ -162,8 +162,11 @@ The following tables lists the configurable parameters of the phpMyAdmin chart a
 | `metrics.image.tag`                       | Apache exporter image tag                                                              | `{TAG_NAME}`                                                 |
 | `metrics.image.pullPolicy`                | Image pull policy                                                                      | `IfNotPresent`                                               |
 | `metrics.image.pullSecrets`               | Specify docker-registry secret names as an array                                       | `[]` (does not add image pull secrets to deployed pods)      |
-| `metrics.podAnnotations`                  | Additional annotations for Metrics exporter pod                                        | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
 | `metrics.resources`                       | Exporter resource requests/limit                                                       | `{}`                                                         |
+| `metrics.service.type`                    | Prometheus metrics service type                                                        | `LoadBalancer`                                               |
+| `metrics.service.port`                    | Prometheus metrics service port                                                        | `9117`                                                       |
+| `metrics.service.loadBalancerIP`          | Load Balancer IP if the Prometheus metrics server type is `LoadBalancer`               | `nil`                                                        |
+| `metrics.service.annotations`             | Annotations for Prometheus metrics service                                             | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
 | `metrics.serviceMonitor.enabled`          | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator           | `false`                                                      |
 | `metrics.serviceMonitor.namespace`        | Namespace where servicemonitor resource should be created                              | `nil`                                                        |
 | `metrics.serviceMonitor.interval`         | Specify the interval at which metrics should be scraped                                | `30s`                                                        |

--- a/bitnami/phpmyadmin/ci/metrics-and-ingress-values.yaml
+++ b/bitnami/phpmyadmin/ci/metrics-and-ingress-values.yaml
@@ -4,3 +4,5 @@ ingress:
   enabled: true
   tls: true
   hostname: phpmyadmin.local
+metrics:
+  enabled: true

--- a/bitnami/phpmyadmin/ci/values-with-ingress.yaml
+++ b/bitnami/phpmyadmin/ci/values-with-ingress.yaml
@@ -1,0 +1,6 @@
+service:
+  type: ClusterIP
+ingress:
+  enabled: true
+  tls: true
+  hostname: phpmyadmin.local

--- a/bitnami/phpmyadmin/templates/NOTES.txt
+++ b/bitnami/phpmyadmin/templates/NOTES.txt
@@ -1,4 +1,6 @@
 
+** Please be patient while the chart is being deployed **
+
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
   You should be able to access your new phpMyAdmin installation through
@@ -23,9 +25,9 @@
   echo "phpMyAdmin URL: http://$SERVICE_IP:{{ .Values.service.port }}"
 
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "phpmyadmin.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  echo "phpMyAdmin URL: http://127.0.0.1:8080"
-  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "phpmyadmin.fullname" . }} 8080:80
+
+  echo "phpMyAdmin URL: http://127.0.0.1:{{ .Values.service.port }}"
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "common.names.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
 
 {{- end }}
 
@@ -51,33 +53,12 @@ $ helm upgrade {{.Release.Name}} bitnami/phpmyadmin --set db.host=mydb
 {{- end }}
 
 {{- include "phpmyadmin.validateValues" . -}}
+{{- include "phpmyadmin.checkRollingTags" . -}}
 
-{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
-
-WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
-+info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
-
+{{- $passwordValidationErrors := list -}}
+{{- if .Values.mariadb.enabled }}
+    {{- $mariadbSecretName := include "magento.databaseSecretName" . -}}
+    {{- $mariadbPasswordValidationErrors := include "common.validations.values.mariadb.passwords" (dict "secret" $mariadbSecretName "subchart" true "context" $) -}}
+    {{- $passwordValidationErrors = append $passwordValidationErrors $mariadbPasswordValidationErrors -}}
 {{- end }}
-
-** Please be patient while the chart is being deployed **
-
-{{- if and (not .Values.mariadb.existingSecret) .Values.db.bundleTestDB -}}
-  {{- $requiredPasswords := list -}}
-  {{- $secretName := include "mariadb.fullname" . -}}
-
-  {{- $requiredRootMariadbPassword := dict "valueKey" "mariadb.auth.rootPassword" "secret" $secretName "field" "mariadb-root-password" -}}
-  {{- $requiredPasswords = append $requiredPasswords $requiredRootMariadbPassword -}}
-
-  {{- if not (empty .Values.mariadb.auth.user) -}}
-    {{- $requiredMariadbPassword := dict "valueKey" "mariadb.auth.password" "secret" $secretName "field" "mariadb-password" -}}
-    {{- $requiredPasswords = append $requiredPasswords $requiredMariadbPassword -}}
-  {{- end -}}
-
-  {{- if eq .Values.mariadb.architecture "replication" -}}
-    {{- $requiredReplicationPassword := dict "valueKey" "mariadb.auth.replicationPassword" "secret" $secretName "field" "mariadb-replication-password" -}}
-    {{- $requiredPasswords = append $requiredPasswords $requiredReplicationPassword -}}
-  {{- end -}}
-
-  {{- $passwordErrors := include "common.validations.values.multiple.empty" (dict "required" $requiredPasswords "context" $) -}}
-  {{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordErrors "context" $) -}}
-{{- end -}}
+{{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordValidationErrors "context" $) -}}

--- a/bitnami/phpmyadmin/templates/NOTES.txt
+++ b/bitnami/phpmyadmin/templates/NOTES.txt
@@ -2,27 +2,27 @@
 ** Please be patient while the chart is being deployed **
 
 1. Get the application URL by running these commands:
+
 {{- if .Values.ingress.enabled }}
+
   You should be able to access your new phpMyAdmin installation through
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ if $.Values.ingress.host }}{{.Values.ingress.host}}{{else}}your-cluster-ip{{end}}{{ $.Values.ingress.path }}
-  {{if not $.Values.ingress.host}}
 
-  Find out your cluster ip address by running:
-  $ kubectl cluster-info
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.hostname }}/
 
-  {{ end }}
-{{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "phpmyadmin.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo "phpMyAdmin URL: http://$NODE_IP:$NODE_PORT"
-
-{{- else if contains "LoadBalancer" .Values.service.type }}
+{{- else if eq .Values.service.type "LoadBalancer" }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-         You can watch the status of by running 'kubectl get svc -w {{ template "phpmyadmin.fullname" . }}'
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ include "common.names.fullname" . }}'
 
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "phpmyadmin.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo "phpMyAdmin URL: http://$SERVICE_IP:{{ .Values.service.port }}"
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "common.names.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  {{- $port:=.Values.service.port | toString }}
+  echo "phpMyAdmin URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}/"
+
+{{- else if contains "NodePort" .Values.service.type }}
+
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "common.names.fullname" . }}'
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo "phpMyAdmin URL: http://$NODE_IP:$NODE_PORT"
 
 {{- else if contains "ClusterIP" .Values.service.type }}
 

--- a/bitnami/phpmyadmin/templates/_helpers.tpl
+++ b/bitnami/phpmyadmin/templates/_helpers.tpl
@@ -1,42 +1,32 @@
 {{/* vim: set filetype=mustache: */}}
+
 {{/*
-Expand the name of the chart.
+Return the proper PHPMyAdmin image name
 */}}
-{{- define "phpmyadmin.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- define "phpmyadmin.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper image name (for the metrics image)
+*/}}
+{{- define "phpmyadmin.metrics.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.metrics.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "phpmyadmin.imagePullSecrets" -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.metrics.image) "global" .Values.global) -}}
 {{- end -}}
 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
 */}}
-{{- define "phpmyadmin.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-*/}}
-{{- define "mariadb.fullname" -}}
+{{- define "phpmyadmin.mariadb.fullname" -}}
 {{- printf "%s-%s" .Release.Name "mariadb" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
-{{- define "phpmyadmin.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -45,100 +35,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "phpmyadmin.dbfullname" -}}
 {{- printf "%s-%s" .Release.Name .Values.db.chartName | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Return the proper PHPMyAdmin image name
-*/}}
-{{- define "phpmyadmin.image" -}}
-{{- $registryName := .Values.image.registry -}}
-{{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
-{{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return the proper image name (for the metrics image)
-*/}}
-{{- define "phpmyadmin.metrics.image" -}}
-{{- $registryName := .Values.metrics.image.registry -}}
-{{- $repositoryName := .Values.metrics.image.repository -}}
-{{- $tag := .Values.metrics.image.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
-{{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return the proper Docker Image Registry Secret Names
-*/}}
-{{- define "phpmyadmin.imagePullSecrets" -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
-Also, we can not use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets:
-{{- range .Values.global.imagePullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- else if or .Values.image.pullSecrets .Values.metrics.image.pullSecrets }}
-imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- range .Values.metrics.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end -}}
-{{- else if or .Values.image.pullSecrets .Values.metrics.image.pullSecrets }}
-imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- range .Values.metrics.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Renders a value that contains template.
-Usage:
-{{ include "phpmyadmin.tplValue" ( dict "value" .Values.path.to.the.Value "context" $) }}
-*/}}
-{{- define "phpmyadmin.tplValue" -}}
-    {{- if typeIs "string" .value }}
-        {{- tpl .value .context }}
-    {{- else }}
-        {{- tpl (.value | toYaml) .context }}
-    {{- end }}
 {{- end -}}
 
 {{/*
@@ -163,4 +59,12 @@ phpMyAdmin: db.ssl
     between phpMyAdmin and the database but no key/certificates were provided
     (--set db.ssl.clientKey="xxxx", --set db.ssl.clientCertificate="yyyy")
 {{- end -}}
+{{- end -}}
+
+{{/*
+Check if there are rolling tags in the images
+*/}}
+{{- define "phpmyadmin.checkRollingTags" -}}
+{{- include "common.warnings.rollingTag" .Values.image }}
+{{- include "common.warnings.rollingTag" .Values.metrics.image }}
 {{- end -}}

--- a/bitnami/phpmyadmin/templates/certs.yaml
+++ b/bitnami/phpmyadmin/templates/certs.yaml
@@ -2,12 +2,14 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "phpmyadmin.fullname" . }}-certs
-  labels:
-    app.kubernetes.io/name: {{ include "phpmyadmin.fullname" . }}
-    helm.sh/chart: {{ include "phpmyadmin.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+  name: {{ printf "%s-certs" (include "common.names.fullname" .) }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   {{- if not (empty .Values.db.ssl.clientKey) }}

--- a/bitnami/phpmyadmin/templates/deployment.yaml
+++ b/bitnami/phpmyadmin/templates/deployment.yaml
@@ -157,7 +157,7 @@ spec:
         - name: metrics
           image: {{ template "phpmyadmin.metrics.image" . }}
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
-          command: [ '/bin/apache_exporter', '--scrape_uri', 'http://status.localhost:8080/server-status/?auto']
+          command: ['/bin/apache_exporter', '--scrape_uri', 'http://status.localhost:8080/server-status/?auto']
           ports:
             - name: metrics
               containerPort: 9117
@@ -184,7 +184,7 @@ spec:
         {{- if .Values.db.enableSsl }}
         - name: ssl-certs
           secret:
-            secretName: {{ template "phpmyadmin.fullname" . }}-certs
+            secretName: {{ printf "%s-certs" (include "common.names.fullname" .) }}
             items:
               {{- if not (empty .Values.db.ssl.clientKey) }}
               - key: server_key.pem

--- a/bitnami/phpmyadmin/templates/deployment.yaml
+++ b/bitnami/phpmyadmin/templates/deployment.yaml
@@ -1,70 +1,81 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "phpmyadmin.fullname" . }}
-  labels:
-    app.kubernetes.io/name: {{ include "phpmyadmin.fullname" . }}
-    helm.sh/chart: {{ include "phpmyadmin.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+  name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
-  replicas: 1
   selector:
-    matchLabels:
-      app.kubernetes.io/name: {{ include "phpmyadmin.fullname" . }}
-      app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+  strategy: {{- include "common.tplvalues.render" (dict "value" .Values.updateStrategy "context" $ ) | nindent 4 }}
   template:
     metadata:
-      labels:
-        app.kubernetes.io/name: {{ include "phpmyadmin.fullname" . }}
-        helm.sh/chart: {{ include "phpmyadmin.chart" . }}
-        app.kubernetes.io/instance: {{ .Release.Name | quote }}
-  {{- if .Values.podLabels }}
-{{ toYaml .Values.podLabels | indent 8 }}
-  {{- end }}
-{{- if or .Values.podAnnotations .Values.metrics.enabled }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.podLabels "context" $) | nindent 8 }}
+        {{- end }}
+      {{- if or .Values.podAnnotations .Values.metrics.enabled }}
       annotations:
-  {{- if .Values.podAnnotations }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
-  {{- end }}
-  {{- if .Values.metrics.podAnnotations }}
-{{ toYaml .Values.metrics.podAnnotations | indent 8 }}
-  {{- end }}
-{{- end }}
+        {{- if .Values.podAnnotations }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.metrics.podAnnotations }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
+    {{- end }}
     spec:
-{{- include "phpmyadmin.imagePullSecrets" . | indent 6 }}
-      {{- with .Values.nodeSelector }}
-      nodeSelector: {{ toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.affinity }}
-      affinity: {{ toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.tolerations }}
-      tolerations: {{ toYaml . | nindent 8 }}
-      {{- end }}
-      {{- if .Values.podSecurityContext }}
-      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- end }}
+      {{- include "phpmyadmin.imagePullSecrets" . | nindent 6 }}
       hostAliases:
         - ip: "127.0.0.1"
           hostnames:
             - "status.localhost"
+      {{- if .Values.affinity }}
+      affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAffinityPreset "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAntiAffinityPreset "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" .) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.initContainers }}
+      initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ template "phpmyadmin.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.containerSecurityContext }}
-          securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.command "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 12 }}
           {{- end }}
           env:
             - name: DATABASE_PORT_NUMBER
               value: {{ .Values.db.port | quote }}
             {{- if .Values.db.chartName }}
             - name: DATABASE_HOST
-              value: "{{ template "phpmyadmin.dbfullname" . }}"
+              value: {{ (include "phpmyadmin.dbfullnamee" .) | quote }}
             {{- else if .Values.db.bundleTestDB }}
             - name: DATABASE_HOST
-              value: "{{ template "mariadb.fullname" . }}"
+              value: {{ (include "phpmyadmin.mariadb.fullname" .) | quote }}
             {{- else }}
             - name: DATABASE_HOST
               value: {{ .Values.db.host | quote }}
@@ -101,39 +112,48 @@ spec:
               value: {{ ternary "yes" "no" .Values.db.ssl.verify | quote }}
             {{- end }}
             {{- if .Values.extraEnvVars }}
-            {{- include "phpmyadmin.tplValue" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
+          {{- if or .Values.extraEnvVarsCM .Values.extraEnvVarsSecret }}
           envFrom:
-          {{- if .Values.extraEnvVarsCM }}
+            {{- if .Values.extraEnvVarsCM }}
             - configMapRef:
-                name: {{- include "phpmyadmin.tplValue" (dict "value" .Values.extraEnvVarsCM "context" $) | nindent 18 }}
-          {{- end }}
-          {{- if .Values.extraEnvVarsSecret }}
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecret }}
             - secretRef:
-                name: {{- include "phpmyadmin.tplValue" (dict "value" .Values.extraEnvVarsSecret "context" $) | nindent 18 }}
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
+            {{- end }}
           {{- end }}
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: {{ .Values.containerPorts.http }}
               protocol: TCP
             - name: https
-              containerPort: 8443
+              containerPort: {{ .Values.containerPorts.https }}
               protocol: TCP
-          {{- if .Values.livenessProbe }}
-          livenessProbe: {{- include "phpmyadmin.tplValue" (dict "value" .Values.livenessProbe "context" $) | nindent 12 }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
+          {{- else if .Values.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.readinessProbe }}
-          readinessProbe: {{- include "phpmyadmin.tplValue" (dict "value" .Values.readinessProbe "context" $) | nindent 12 }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 12 }}
+          {{- else if .Values.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
-          {{- if .Values.db.enableSsl }}
           volumeMounts:
-          - name: ssl-certs
-            mountPath: /db_certs
-          {{- end }}
-{{- if .Values.metrics.enabled }}
+            {{- if .Values.db.enableSsl }}
+            - name: ssl-certs
+              mountPath: /db_certs
+            {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
+        {{- if .Values.metrics.enabled }}
         - name: metrics
           image: {{ template "phpmyadmin.metrics.image" . }}
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
@@ -154,11 +174,14 @@ spec:
             initialDelaySeconds: 5
             timeoutSeconds: 1
           {{- if .Values.metrics.resources }}
-          resources: {{ toYaml .Values.metrics.resources | nindent 12 }}
+          resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
           {{- end }}
-{{- end }}
-{{- if .Values.db.enableSsl }}
+        {{- end }}
+        {{- if .Values.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) | nindent 8 }}
+        {{- end }}
       volumes:
+        {{- if .Values.db.enableSsl }}
         - name: ssl-certs
           secret:
             secretName: {{ template "phpmyadmin.fullname" . }}-certs
@@ -175,4 +198,7 @@ spec:
               - key: ca_certificate.pem
                 path: ca_certificate.pem
               {{- end }}
-{{- end }}
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}

--- a/bitnami/phpmyadmin/templates/extra-list.yaml
+++ b/bitnami/phpmyadmin/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/bitnami/phpmyadmin/templates/ingress.yaml
+++ b/bitnami/phpmyadmin/templates/ingress.yaml
@@ -1,47 +1,53 @@
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.ingress.enabled }}
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: {{ template "phpmyadmin.fullname" . }}
-  labels:
-    app.kubernetes.io/name: {{ include "phpmyadmin.fullname" . }}
-    helm.sh/chart: {{ include "phpmyadmin.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+  name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.ingress.annotations .Values.commonAnnotations .Values.ingress.certManager }}
   annotations:
     {{- if .Values.ingress.certManager }}
     kubernetes.io/tls-acme: "true"
     {{- end }}
-    {{- if .Values.ingress.rewriteTarget }}
-    ingress.kubernetes.io/rewrite-target: /
-    nginx.ingress.kubernetes.io/rewrite-target: /
-    {{- end }}
     {{- if .Values.ingress.annotations }}
-    {{- include "phpmyadmin.tplValue" (dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.annotations "context" $ ) | nindent 4 }}
     {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   rules:
-  {{- range .Values.ingress.hosts }}
+    {{- if .Values.ingress.hostname }}
+    - host: {{ .Values.ingress.hostname }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ include "common.names.fullname" . }}
+              servicePort: http
+    {{- end }}
+    {{- range .Values.ingress.extraHosts }}
     - host: {{ .name }}
       http:
         paths:
           - path: {{ default "/" .path }}
             backend:
-              serviceName: {{ template "phpmyadmin.fullname" $ }}
+              serviceName: {{ include "common.names.fullname" $ }}
               servicePort: http
     {{- end }}
+  {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
   tls:
-  {{- range .Values.ingress.hosts }}
-    {{- if .tls }}
+    {{- if .Values.ingress.tls }}
     - hosts:
-    {{- if .tlsHosts }}
-      {{- range $host := .tlsHosts }}
-        - {{ $host }}
-      {{- end }}
-    {{- else }}
-        - {{ .name }}
+        - {{ .Values.ingress.hostname }}
+      secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
     {{- end }}
-      secretName: {{ .tlsSecret }}
+    {{- if .Values.ingress.extraTls }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.extraTls "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/bitnami/phpmyadmin/templates/metrics-svc.yaml
+++ b/bitnami/phpmyadmin/templates/metrics-svc.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-metrics" (include "common.names.fullname" .) }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.metrics.service.annotations .Values.commonAnnotations }}
+  annotations: 
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.metrics.service.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.metrics.service.annotations "context" $) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  type: {{ .Values.metrics.service.type }}
+  {{ if and (eq .Values.metrics.service.type "LoadBalancer") .Values.metrics.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.metrics.service.loadBalancerIP }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.metrics.service.port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector: {{- include "common.labels.matchLabels" $ | nindent 4 }}
+{{- end }}

--- a/bitnami/phpmyadmin/templates/service.yaml
+++ b/bitnami/phpmyadmin/templates/service.yaml
@@ -1,23 +1,56 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "phpmyadmin.fullname" . }}
-  labels:
-    app.kubernetes.io/name: {{ include "phpmyadmin.fullname" . }}
-    helm.sh/chart: {{ include "phpmyadmin.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+  name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.service.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.service.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if and .Values.service.clusterIP (eq .Values.service.type "ClusterIP") }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
+  {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
+  {{- end }}
+  {{ if eq .Values.service.type "LoadBalancer" }}
+  loadBalancerSourceRanges: {{ .Values.service.loadBalancerSourceRanges }}
+  {{ end }}
+  {{- if (and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP))) }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   ports:
-    - port: {{ .Values.service.port }}
+    - name: http
+      port: {{ .Values.service.port }}
+      protocol: TCP
       targetPort: http
+      {{- if (and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.http))) }}
+      nodePort: {{ .Values.service.nodePorts.http }}
+      {{- else if eq .Values.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+    - name: https
+      port: {{ .Values.service.httpsPort }}
       protocol: TCP
       name: http
+      targetPort: https
+      {{- if (and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.https))) }}
+      nodePort: {{ .Values.service.nodePorts.https }}
+      {{- else if eq .Values.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
     - port: 9117
       targetPort: metrics
       protocol: TCP
       name: metrics
-  selector:
-    app.kubernetes.io/name: {{ include "phpmyadmin.fullname" . }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/phpmyadmin/templates/service.yaml
+++ b/bitnami/phpmyadmin/templates/service.yaml
@@ -42,15 +42,10 @@ spec:
     - name: https
       port: {{ .Values.service.httpsPort }}
       protocol: TCP
-      name: http
       targetPort: https
       {{- if (and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.https))) }}
       nodePort: {{ .Values.service.nodePorts.https }}
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
-    - port: 9117
-      targetPort: metrics
-      protocol: TCP
-      name: metrics
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/phpmyadmin/templates/servicemonitor.yaml
+++ b/bitnami/phpmyadmin/templates/servicemonitor.yaml
@@ -43,4 +43,5 @@ spec:
       - {{ .Release.Namespace }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: metrics
 {{- end }}

--- a/bitnami/phpmyadmin/templates/tls-secrets.yaml
+++ b/bitnami/phpmyadmin/templates/tls-secrets.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled }}
+{{- if .Values.ingress.secrets }}
+{{- range .Values.ingress.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  namespace: {{ $.Release.Namespace }}
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
+    {{- if $.Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" $.Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if $.Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .certificate | b64enc }}
+  tls.key: {{ .key | b64enc }}
+---
+{{- end }}
+{{- else if and .Values.ingress.tls (not .Values.ingress.certManager) }}
+{{- $ca := genCA "phpmyadmin-ca" 365 }}
+{{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-tls" .Values.ingress.hostname }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $cert.Cert | b64enc | quote }}
+  tls.key: {{ $cert.Key | b64enc | quote }}
+  ca.crt: {{ $ca.Cert | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/bitnami/phpmyadmin/values.yaml
+++ b/bitnami/phpmyadmin/values.yaml
@@ -23,21 +23,386 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
-## String to partially override phpmyadmin.fullname template (will maintain the release name)
+## String to partially override common.names.fullname template (will maintain the release name)
 ##
 # nameOverride:
 
-## String to fully override phpmyadmin.fullname template
+## String to fully override common.names.fullname template
 ##
 # fullnameOverride:
 
-## User of the application
-## ref: https://github.com/bitnami/bitnami-docker-phpmyadmin#environment-variables
+## Add labels to all the deployed resources
+##
+commonLabels: {}
+
+## Add annotations to all the deployed resources
+##
+commonAnnotations: {}
+
+## Kubernetes Cluster Domain
+##
+clusterDomain: cluster.local
+
+## Extra objects to deploy (value evaluated as a template)
+##
+extraDeploy: []
+
+## Command and args for running the container (set to default if not set). Use array form
+##
+command: []
+args: []
+
+## An array to add extra env vars to configure phpMyAdmin
+## For example:
+# extraEnvVars:
+# - name: PHP_UPLOAD_MAX_FILESIZE
+#   value: "80M"
+extraEnvVars: {}
+
+## Name of a ConfigMap containing extra env vars
+##
+extraEnvVarsCM:
+
+## Secret with extra environment variables
+##
+extraEnvVarsSecret:
+
+## phpMyAdmin container ports to open
+##
+containerPorts:
+  http: 8080
+  https: 8443
+
+## Strategy to use to update Pods
+##
+updateStrategy:
+  ## StrategyType
+  ## Can be set to RollingUpdate or OnDelete
+  ##
+  type: RollingUpdate
+
+## phpMyAdmin pods' Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+##
+podSecurityContext:
+  enabled: true
+  fsGroup: 1001
+
+## phpMyAdmin containers' Security Context (only main container)
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+##
+containerSecurityContext:
+  enabled: true
+  runAsUser: 1001
+
+## phpMyAdmin containers' resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources
+##
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits: {}
+  #  cpu: 100m
+  #  memory: 128Mi
+  requests: {}
+  #  cpu: 100m
+  #  memory: 128Mi
+
+## phpMyAdmin containers' liveness and readiness probes. Evaluated as a template.
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+##
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  timeoutSeconds: 30
+  periodSeconds: 10
+  successThreshold: 1
+  failureThreshold: 6
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  timeoutSeconds: 30
+  periodSeconds: 10
+  successThreshold: 1
+  failureThreshold: 6
+  httpGet:
+    path: /
+    port: http
+
+## Custom Liveness probes for phpMyAdmin
+##
+customLivenessProbe: {}
+
+## Custom Rediness probes phpMyAdmin
+##
+customReadinessProbe: {}
+
+## Pod extra labels
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+##
+podLabels: {}
+
+## Annotations for server pods.
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+
+## Pod affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+## Allowed values: soft, hard
+##
+podAffinityPreset: ""
+
+## Pod anti-affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+## Allowed values: soft, hard
+##
+podAntiAffinityPreset: soft
+
+## Node affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+## Allowed values: soft, hard
+##
+nodeAffinityPreset:
+  ## Node affinity type
+  ## Allowed values: soft, hard
+  type: ""
+  ## Node label key to match
+  ## E.g.
+  ## key: "kubernetes.io/e2e-az-name"
+  ##
+  key: ""
+  ## Node label values to match
+  ## E.g.
+  ## values:
+  ##   - e2e-az1
+  ##   - e2e-az2
+  ##
+  values: []
+
+## Affinity for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
+##
+affinity: {}
+
+## Node labels for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+
+## Tolerations for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+
+## Extra volumes to add to the deployment
+##
+extraVolumes: []
+
+## Extra volume mounts to add to the container
+##
+extraVolumeMounts: []
+
+## Add init containers to the Magento pods.
+## Example:
+## initContainers:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+initContainers: {}
+
+## Add sidecars to the Magento pods.
+## Example:
+## sidecars:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+sidecars: {}
+
+## Service configuratiom
 ##
 service:
+  ## Service type.
+  ##
   type: ClusterIP
+  ## HTTP Port
+  ##
   port: 80
+  ## HTTPS Port
+  ##
+  httpsPort: 443
+  ## Specify the nodePort values for the LoadBalancer and NodePort service types.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+  ##
+  nodePorts:
+    http: ""
+    https: ""
+  ## Service clusterIP.
+  ##
+  # clusterIP: None
+  ## loadBalancerIP for the phpMyAdmin Service (optional, cloud specific)
+  ## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
+  ##
+  # loadBalancerIP:
+  ## Load Balancer sources
+  ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  ## Example:
+  ## loadBalancerSourceRanges:
+  ##   - 10.10.10.0/24
+  ##
+  loadBalancerSourceRanges: []
+  ## Enable client source IP preservation
+  ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+  ##
+  externalTrafficPolicy: Cluster
+  ## Provide any additional annotations which may be required (evaluated as a template).
+  ##
+  annotations: {}
 
+## Ingress configuratiom
+##
+ingress:
+  ## Set to true to enable ingress record generation
+  ##
+  enabled: false
+
+  ## Set this to true in order to add the corresponding annotations for cert-manager
+  ##
+  certManager: false
+
+  ## When the ingress is enabled, a host pointing to this will be created
+  ##
+  hostname: phpmyadmin.local
+
+  ## Ingress annotations done as key:value pairs
+  ## For a full list of possible ingress annotations, please see
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ##
+  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+  ##
+  annotations: {}
+
+  ## Enable TLS configuration for the hostname defined at ingress.hostname parameter
+  ## TLS certificates will be retrieved from a TLS secret with name: {{- printf "%s-tls" .Values.ingress.hostname }}
+  ## You can use the ingress.secrets parameter to create this TLS secret, relay on cert-manager to create it, or
+  ## let the chart create self-signed certificates for you
+  ##
+  tls: false
+
+  ## The list of additional hostnames to be covered with this ingress record.
+  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+  ## Example:
+  ## extraHosts:
+  ##   - name: phpmyadmin.local
+  ##     path: /
+  ##
+  extraHosts: []
+
+  ## The tls configuration for additional hostnames to be covered with this ingress record.
+  ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## Example:
+  ## extraTls:
+  ## - hosts:
+  ##     - phpmyadmin.local
+  ##   secretName: phpmyadmin.local-tls
+  ##
+  extraTls: []
+
+  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or -----BEGIN RSA PRIVATE KEY-----
+  ## name should line up with a secretName set further up
+  ##
+  ## If it is not set and you're using cert-manager, this is unneeded, as it will create the secret for you
+  ## If it is not set and you're NOT using cert-manager either, self-signed certificates will be created
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  ##
+  ## Example
+  ## secrets:
+  ##   - name: phpmyadmin.local-tls
+  ##     key: ""
+  ##     certificate: ""
+  ##
+  secrets: []
+
+## Prometheus Exporter / Metrics
+##
+metrics:
+  enabled: false
+  image:
+    registry: docker.io
+    repository: bitnami/apache-exporter
+    tag: 0.8.0-debian-10-r234
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+
+  ## Metrics exporter resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+
+  ## Metrics exporter pod Annotation and Labels
+  ##
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9117"
+
+  ## Prometheus Service Monitor
+  ## ref: https://github.com/coreos/prometheus-operator
+  ##      https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+  ##
+  serviceMonitor:
+    ## If the operator is installed in your cluster, set to true to create a Service Monitor Entry
+    ##
+    enabled: false
+    ## Specify the namespace in which the serviceMonitor resource will be created
+    # namespace: ""
+    ## The name of the label on the target service to use as the job name in prometheus
+    # jobLabel:
+    ## Specify the interval at which metrics should be scraped
+    ##
+    interval: 30s
+    ## Specify the timeout after which the scrape is ended
+    # scrapeTimeout: 30s
+    ## Relabeling (before scrape)
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+    ##
+    # relabellings:
+    ## Specify honorLabels parameter to add the scrape endpoint
+    ##
+    ## Metric relabeling
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+    ##
+    # metricRelabelings:
+    ## Specify honorLabels parameter to add the scrape endpoint
+    ##
+    honorLabels: false
+    ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+    ##
+    additionalLabels: {}
+
+## Database configuration
+##
 db:
   ## If you do not want the user to be able to specify an arbitrary MySQL server
   ## at login time, set this to false
@@ -82,190 +447,9 @@ db:
     ##
     verify: true
 
-ingress:
-  ## Set this to true to enable ingress record generation
-  ##
-  enabled: false
-
-  ## Set this to true in order to add the corresponding annotations for cert-manager
-  ##
-  certManager: false
-
-  ## Set this to true in order to add the corresponding annotations to redirect traffic to /
-  ##
-  rewriteTarget: true
-
-  ## Additional Ingress annotations done as key:value pairs
-  ## Example:
-  ## annotations:
-  ##   kubernetes.io/ingress.class: nginx
-  ##   kubernetes.io/tls-acme: "true"
-  ##
-  # annotations
-
-  ## The list of hostnames to be covered with this ingress record.
-  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
-  ##
-  hosts:
-    - name: phpmyadmin.local
-      path: /
-
-      ## Set this to true in order to enable TLS on the ingress record
-      tls: false
-
-      ## Optionally specify the TLS hosts for the ingress record
-      ## Useful when the Ingress controller supports www-redirection
-      ## If not specified, the above host name will be used
-      # tlsHosts:
-      # - www.phpmyadmin.local
-      # - phpmyadmin.local
-
-      ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
-      tlsSecret: phpmyadmin.local-tls
-
-## An array to add extra env vars to configure phpMyAdmin
-## For example:
-# extraEnvVars:
-# - name: PHP_UPLOAD_MAX_FILESIZE
-#   value: "80M"
-extraEnvVars: {}
-
-## Name of a ConfigMap containing extra env vars
 ##
-extraEnvVarsCM:
-
-## Secret with extra environment variables
+## MariaDB chart configuration
 ##
-extraEnvVarsSecret:
-
-## phpMyAdmin pods' Security Context
-## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+## https://github.com/bitnami/charts/blob/master/bitnami/mariadb/values.yaml
 ##
-podSecurityContext:
-  fsGroup: 1001
-
-## phpMyAdmin containers' Security Context (only main container)
-## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
-##
-containerSecurityContext:
-  runAsUser: 1001
-
-## PhpMyAdmin containers' liveness and readiness probes. Evaluated as a template.
-## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
-##
-livenessProbe:
-  initialDelaySeconds: 30
-  timeoutSeconds: 30
-  periodSeconds: 10
-  successThreshold: 1
-  failureThreshold: 6
-  httpGet:
-    path: /
-    port: http
-readinessProbe:
-  initialDelaySeconds: 30
-  timeoutSeconds: 30
-  periodSeconds: 10
-  successThreshold: 1
-  failureThreshold: 6
-  httpGet:
-    path: /
-    port: http
-
-## PhpMyAdmin containers' resource requests and limits
-## ref: http://kubernetes.io/docs/user-guide/compute-resources
-##
-resources:
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  limits: {}
-  #  cpu: 100m
-  #  memory: 128Mi
-  requests: {}
-  #  cpu: 100m
-  #  memory: 128Mi
-
-## Node labels for pod assignment
-## Ref: https://kubernetes.io/docs/user-guide/node-selection/
-##
-nodeSelector: {}
-
-## Tolerations for pod assignment
-## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-##
-tolerations: []
-
-## Affinity for pod assignment
-## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-##
-affinity: {}
-
-## Pod labels
-podLabels: {}
-
-## Pod annotations
-podAnnotations: {}
-
-## Prometheus Exporter / Metrics
-##
-metrics:
-  enabled: false
-  image:
-    registry: docker.io
-    repository: bitnami/apache-exporter
-    tag: 0.8.0-debian-10-r234
-    pullPolicy: IfNotPresent
-    ## Optionally specify an array of imagePullSecrets.
-    ## Secrets must be manually created in the namespace.
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ##
-    # pullSecrets:
-    #   - myRegistryKeySecretName
-  ## Metrics exporter pod Annotation and Labels
-  ##
-  podAnnotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9117"
-  ## Metrics exporter resource requests and limits
-  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-  ##
-  resources: {}
-
-  ## Prometheus Service Monitor
-  ## ref: https://github.com/coreos/prometheus-operator
-  ##      https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
-  ##
-  serviceMonitor:
-    ## If the operator is installed in your cluster, set to true to create a Service Monitor Entry
-    ##
-    enabled: false
-    ## Specify the namespace in which the serviceMonitor resource will be created
-    # namespace: ""
-    ## The name of the label on the target service to use as the job name in prometheus
-    # jobLabel:
-    ## Specify the interval at which metrics should be scraped
-    ##
-    interval: 30s
-    ## Specify the timeout after which the scrape is ended
-    # scrapeTimeout: 30s
-    ## Relabeling (before scrape)
-    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
-    ##
-    # relabellings:
-    ## Specify honorLabels parameter to add the scrape endpoint
-    ##
-    ## Metric relabeling
-    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
-    ##
-    # metricRelabelings:
-    ## Specify honorLabels parameter to add the scrape endpoint
-    ##
-    honorLabels: false
-    ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with
-    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
-    ##
-    additionalLabels: {}
-
 mariadb: {}

--- a/bitnami/phpmyadmin/values.yaml
+++ b/bitnami/phpmyadmin/values.yaml
@@ -360,11 +360,21 @@ metrics:
   ##
   resources: {}
 
-  ## Metrics exporter pod Annotation and Labels
+  ## Prometheus Exporter service configuration
   ##
-  podAnnotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9117"
+  service:
+    type: ClusterIP
+    port: 9117
+    ## Annotations for Prometheus Exporter pods. Evaluated as a template.
+    ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+    ##
+    ##
+    ## Use serviceLoadBalancerIP to request a specific static IP,
+    ## otherwise leave blank
+    # loadBalancerIP:
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "{{ .Values.metrics.service.port }}"
 
   ## Prometheus Service Monitor
   ## ref: https://github.com/coreos/prometheus-operator


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR adapts the charts below so it uses the common presets added on `bitnami/common` at https://github.com/bitnami/charts/pull/3713.

- bitnami/mxnet
- bitnami/node-exporter
- bitnami/phpmyadmin

It also refactors phpMyAdmin based on best practices since it had a lot of technical debt. These changes implied a major version in this case.

**Benefits**

- Balanced UX for both advanced Kubernetes admins and less experienced.
- Opinionated presets but users can still define their own affinity
- 100% customizable
- No backwards incompatibility

**Possible drawbacks**

- Complexity

**Checklist**

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files