### PR TITLE
[bitnami/nginx-ingress-controller] Do not set replicas in deployment when HPA is enabled

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -20,4 +20,4 @@ name: nginx-ingress-controller
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx-ingress-controller
   - https://github.com/kubernetes/ingress-nginx
-version: 6.0.0
+version: 6.0.1

--- a/bitnami/nginx-ingress-controller/templates/controller-deployment.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-deployment.yaml
@@ -16,7 +16,9 @@ spec:
   selector:
     matchLabels: {{- include "nginx-ingress.matchLabels" . | nindent 6 }}
       component: {{ .Values.name }}
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   minReadySeconds: {{ .Values.minReadySeconds }}


### PR DESCRIPTION
**Description of the change**

Do not set replicas in deployment when HPA is enabled.

**Benefits**

Replica count won't be affected by an `helm upgrade` while HPA is active.

**Possible drawbacks**

None.

**Applicable issues**

None.

**Additional information**

None.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
