### PR TITLE
[bitnami/thanos] Reorder HPA to prevent GitOps Diff

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -23,4 +23,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 3.2.1
+version: 3.2.2

--- a/bitnami/thanos/templates/query-frontend/hpa.yaml
+++ b/bitnami/thanos/templates/query-frontend/hpa.yaml
@@ -13,16 +13,16 @@ spec:
   minReplicas: {{ .Values.queryFrontend.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.queryFrontend.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.queryFrontend.autoscaling.targetCPU }}
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: {{ .Values.queryFrontend.autoscaling.targetCPU }}
-    {{- end }}
     {{- if .Values.queryFrontend.autoscaling.targetMemory }}
     - type: Resource
       resource:
         name: memory
         targetAverageUtilization: {{ .Values.queryFrontend.autoscaling.targetMemory  }}
+    {{- end }}
+    {{- if .Values.queryFrontend.autoscaling.targetCPU }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.queryFrontend.autoscaling.targetCPU }}
     {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/query/hpa.yaml
+++ b/bitnami/thanos/templates/query/hpa.yaml
@@ -14,16 +14,16 @@ spec:
   minReplicas: {{ $query.autoscaling.minReplicas }}
   maxReplicas: {{ $query.autoscaling.maxReplicas }}
   metrics:
-    {{- if $query.autoscaling.targetCPU }}
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: {{ $query.autoscaling.targetCPU }}
-    {{- end }}
     {{- if $query.autoscaling.targetMemory }}
     - type: Resource
       resource:
         name: memory
         targetAverageUtilization: {{ $query.autoscaling.targetMemory  }}
+    {{- end }}
+    {{- if $query.autoscaling.targetCPU }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ $query.autoscaling.targetCPU }}
     {{- end }}
 {{- end }}    

--- a/bitnami/thanos/templates/storegateway/hpa.yaml
+++ b/bitnami/thanos/templates/storegateway/hpa.yaml
@@ -13,16 +13,16 @@ spec:
   minReplicas: {{ .Values.storegateway.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.storegateway.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.storegateway.autoscaling.targetCPU }}
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: {{ .Values.storegateway.autoscaling.targetCPU }}
-    {{- end }}
     {{- if .Values.storegateway.autoscaling.targetMemory }}
     - type: Resource
       resource:
         name: memory
         targetAverageUtilization: {{ .Values.storegateway.autoscaling.targetMemory  }}
+    {{- end }}
+    {{- if .Values.storegateway.autoscaling.targetCPU }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.storegateway.autoscaling.targetCPU }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Since kubernetes automatically re-order HPA manifests to have memory before CPU, when using GitOps engines like ArgoCD we always get OutOfSync objects.
<!-- Describe the scope of your change - i.e. what the change does. -->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
