### PR TITLE
[bitnami/kafka] Use autoDiscovery values for NodePort external access

### DIFF
--- a/bitnami/kafka/templates/scripts-configmap.yaml
+++ b/bitnami/kafka/templates/scripts-configmap.yaml
@@ -84,7 +84,9 @@ data:
     {{- end }}
     export EXTERNAL_ACCESS_PORT={{ .Values.externalAccess.service.port }}
     {{- else if eq .Values.externalAccess.service.type "NodePort" }}
-    {{- if .Values.externalAccess.service.domain }}
+    {{- if .Values.externalAccess.autoDiscovery.enabled }}
+    export EXTERNAL_ACCESS_IP="$(<${SHARED_FILE})"
+    {{- else if .Values.externalAccess.service.domain }}
     export EXTERNAL_ACCESS_IP={{ .Values.externalAccess.service.domain }}
     {{- else }}
     export EXTERNAL_ACCESS_IP=$(curl -s https://ipinfo.io/ip)


### PR DESCRIPTION
**Description of the change**

If externalAccess is enabled and the service is NodePort the `EXTERNAL_ACCESS_IP` value is not used when writing the `setup.sh` script.

**Benefits**

Use the autoDiscovery feature when using NodePort for the external access service

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

None

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)