### PR TITLE
[bitnami/spring-cloud-dataflow] Support extraVolume and extraVolumeMounts

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -38,4 +38,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-spring-cloud-dataflow
   - https://github.com/bitnami/bitnami-docker-spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 2.0.2
+version: 2.1.0

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -139,7 +139,8 @@ The following tables lists the configurable parameters of the Spring Cloud Data 
 | `server.autoscaling.targetMemory`            | Target Memory utilization percentage                                                                   | `nil`                                                   |
 | `server.jdwp.enabled`                        | Enable Java Debug Wire Protocol (JDWP)                                                                 | `false`                                                 |
 | `server.jdwp.port`                           | JDWP TCP port                                                                                          | `5005`                                                  |
-
+| `server.extraVolumes`                        | Extra Volumes to be set on the Dataflow Server Pod                                                     | `nil`                                                   |
+| `server.extraVolumeMounts`                   | Extra VolumeMounts to be set on the Dataflow Container                                                 | `nil`                                                   |
 ### Dataflow Skipper parameters
 
 | Parameter                                    | Description                                                                                            | Default                                                 |
@@ -191,6 +192,8 @@ The following tables lists the configurable parameters of the Spring Cloud Data 
 | `skipper.autoscaling.targetMemory`           | Target Memory utilization percentage                                                                   | `nil`                                                   |
 | `skipper.jdwp.enabled`                       | Enable Java Debug Wire Protocol (JDWP)                                                                 | `false`                                                 |
 | `skipper.jdwp.port`                          | JDWP TCP port                                                                                          | `5005`                                                  |
+| `skipper.extraVolumes`                       | Extra Volumes to be set on the Skipper Pod                                                             | `nil`                                                   |
+| `skipper.extraVolumeMounts`                  | Extra VolumeMounts to be set on the Skipper Container                                                  | `nil`                                                   |
 | `externalSkipper.host`                       | Host of a external Skipper Server                                                                      | `localhost`                                             |
 | `externalSkipper.port`                       | External Skipper Server port number                                                                    | `7577`                                                  |
 

--- a/bitnami/spring-cloud-dataflow/templates/server/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/deployment.yaml
@@ -188,6 +188,9 @@ spec:
             - name: config
               mountPath: /opt/bitnami/spring-cloud-dataflow/conf
               readOnly: true
+            {{- if .Values.server.extraVolumeMounts }}
+            {{- toYaml .Values.server.extraVolumeMounts | nindent 12 }}
+            {{- end }}
         {{- if .Values.server.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.server.sidecars "context" $) | nindent 8 }}
         {{- end }}
@@ -206,4 +209,7 @@ spec:
           configMap:
             name: {{ include "scdf.fullname" . }}-scripts
             defaultMode: 0755
+        {{- end }}
+        {{- if .Values.server.extraVolumes }}
+          {{- toYaml .Values.server.extraVolumes | nindent 8 }}
         {{- end }}

--- a/bitnami/spring-cloud-dataflow/templates/skipper/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/deployment.yaml
@@ -161,6 +161,9 @@ spec:
               mountPath: /etc/secrets/rabbitmq
               readOnly: true
             {{- end }}
+            {{- if .Values.server.extraVolumeMounts }}
+            {{- toYaml .Values.server.extraVolumeMounts | nindent 12 }}
+            {{- end }}
         {{- if .Values.skipper.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.skipper.sidecars "context" $) | nindent 8 }}
         {{- end }}
@@ -184,5 +187,8 @@ spec:
           configMap:
             name: {{ include "scdf.fullname" . }}-scripts
             defaultMode: 0755
+        {{- end }}
+        {{- if .Values.server.extraVolumes }}
+          {{- toYaml .Values.server.extraVolumes | nindent 8 }}
         {{- end }}
 {{- end }}

--- a/bitnami/spring-cloud-dataflow/values-production.yaml
+++ b/bitnami/spring-cloud-dataflow/values-production.yaml
@@ -334,15 +334,14 @@ server:
     port: 5005
 
   ## Extra volumes to mount
-  ## Example Use Case: mount systemd journal volume
-  # extraVolumes:
-  #   - name: systemd
-  #       hostPath:
-  #         path: /run/log/journal/
+  ##
+  #extraVolumes:
+  #  - name: sample
+  #    emptyDir: {}
   #
-  # extraVolumeMounts:
-  #   - name: systemd
-  #     mountPath: /run/log/journal/
+  #extraVolumeMounts:
+  #  - name: sample
+  #    mountPath: /temp/sample
 
 ##
 ## Spring Cloud Skipper parameters.
@@ -580,15 +579,14 @@ skipper:
     port: 5005
 
   ## Extra volumes to mount
-  ## Example Use Case: mount systemd journal volume
-  # extraVolumes:
-  #   - name: systemd
-  #       hostPath:
-  #         path: /run/log/journal/
+  ##
+  #extraVolumes:
+  #  - name: sample
+  #    emptyDir: {}
   #
-  # extraVolumeMounts:
-  #   - name: systemd
-  #     mountPath: /run/log/journal/
+  #extraVolumeMounts:
+  #  - name: sample
+  #    mountPath: /temp/sample
 
 ##
 ## External Skipper Configuration

--- a/bitnami/spring-cloud-dataflow/values-production.yaml
+++ b/bitnami/spring-cloud-dataflow/values-production.yaml
@@ -335,13 +335,13 @@ server:
 
   ## Extra volumes to mount
   ##
-  #extraVolumes:
-  #  - name: sample
-  #    emptyDir: {}
+  # extraVolumes:
+  #   - name: sample
+  #     emptyDir: {}
   #
-  #extraVolumeMounts:
-  #  - name: sample
-  #    mountPath: /temp/sample
+  # extraVolumeMounts:
+  #   - name: sample
+  #     mountPath: /temp/sample
 
 ##
 ## Spring Cloud Skipper parameters.
@@ -580,13 +580,13 @@ skipper:
 
   ## Extra volumes to mount
   ##
-  #extraVolumes:
-  #  - name: sample
-  #    emptyDir: {}
+  # extraVolumes:
+  #   - name: sample
+  #     emptyDir: {}
   #
-  #extraVolumeMounts:
-  #  - name: sample
-  #    mountPath: /temp/sample
+  # extraVolumeMounts:
+  #   - name: sample
+  #     mountPath: /temp/sample
 
 ##
 ## External Skipper Configuration

--- a/bitnami/spring-cloud-dataflow/values-production.yaml
+++ b/bitnami/spring-cloud-dataflow/values-production.yaml
@@ -333,6 +333,17 @@ server:
     ##
     port: 5005
 
+  ## Extra volumes to mount
+  ## Example Use Case: mount systemd journal volume
+  # extraVolumes:
+  #   - name: systemd
+  #       hostPath:
+  #         path: /run/log/journal/
+  #
+  # extraVolumeMounts:
+  #   - name: systemd
+  #     mountPath: /run/log/journal/
+
 ##
 ## Spring Cloud Skipper parameters.
 ##
@@ -567,6 +578,17 @@ skipper:
     ## Specify port for remote debugging.
     ##
     port: 5005
+
+  ## Extra volumes to mount
+  ## Example Use Case: mount systemd journal volume
+  # extraVolumes:
+  #   - name: systemd
+  #       hostPath:
+  #         path: /run/log/journal/
+  #
+  # extraVolumeMounts:
+  #   - name: systemd
+  #     mountPath: /run/log/journal/
 
 ##
 ## External Skipper Configuration

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -333,14 +333,15 @@ server:
     ##
     port: 5005
 
-  # Extra volumes to mount
-  extraVolumes:
-    - name: sample
-      emptyDir: {}
-
-  extraVolumeMounts:
-    - name: sample
-      mountPath: /temp/sample
+  ## Extra volumes to mount
+  ##
+  #extraVolumes:
+  #  - name: sample
+  #    emptyDir: {}
+  #
+  #extraVolumeMounts:
+  #  - name: sample
+  #    mountPath: /temp/sample
 
 ##
 ## Spring Cloud Skipper parameters.
@@ -577,14 +578,14 @@ skipper:
     ##
     port: 5005
 
-  # Extra volumes to mount
-  extraVolumes:
-    - name: sample
-      emptyDir: {}
-
-  extraVolumeMounts:
-    - name: sample
-      mountPath: /temp/sample
+  ## Extra volumes to mount
+  #extraVolumes:
+  #  - name: sample
+  #    emptyDir: {}
+  #
+  #extraVolumeMounts:
+  #  - name: sample
+  #    mountPath: /temp/sample
 
 ##
 ## External Skipper Configuration

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -335,13 +335,13 @@ server:
 
   ## Extra volumes to mount
   ##
-  #extraVolumes:
-  #  - name: sample
-  #    emptyDir: {}
+  # extraVolumes:
+  #   - name: sample
+  #     emptyDir: {}
   #
-  #extraVolumeMounts:
-  #  - name: sample
-  #    mountPath: /temp/sample
+  # extraVolumeMounts:
+  #   - name: sample
+  #     mountPath: /temp/sample
 
 ##
 ## Spring Cloud Skipper parameters.
@@ -579,13 +579,13 @@ skipper:
     port: 5005
 
   ## Extra volumes to mount
-  #extraVolumes:
-  #  - name: sample
-  #    emptyDir: {}
+  # extraVolumes:
+  #   - name: sample
+  #     emptyDir: {}
   #
-  #extraVolumeMounts:
-  #  - name: sample
-  #    mountPath: /temp/sample
+  # extraVolumeMounts:
+  #   - name: sample
+  #     mountPath: /temp/sample
 
 ##
 ## External Skipper Configuration

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -333,6 +333,15 @@ server:
     ##
     port: 5005
 
+  # Extra volumes to mount
+  extraVolumes:
+    - name: sample
+      emptyDir: {}
+
+  extraVolumeMounts:
+    - name: sample
+      mountPath: /temp/sample
+
 ##
 ## Spring Cloud Skipper parameters.
 ##
@@ -567,6 +576,15 @@ skipper:
     ## Specify port for remote debugging.
     ##
     port: 5005
+
+  # Extra volumes to mount
+  extraVolumes:
+    - name: sample
+      emptyDir: {}
+
+  extraVolumeMounts:
+    - name: sample
+      mountPath: /temp/sample
 
 ##
 ## External Skipper Configuration


### PR DESCRIPTION
**Description of the change**

Added optional Volume and VolumeMount for the Dataflow Server and Skipper Pod/Container to be added via values extraVolumes and extraVolumeMounts.

**Benefits**

Volumes are configurable while installation (upgrade)

**Applicable issues**

  - fixes #4534 

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
