### PR TITLE
[bitnami/node] fix(ingress): passing wrong scope in range

### DIFF
--- a/bitnami/node/Chart.yaml
+++ b/bitnami/node/Chart.yaml
@@ -28,4 +28,4 @@ name: node
 sources:
   - https://github.com/bitnami/bitnami-docker-node
   - http://nodejs.org/
-version: 14.0.0
+version: 14.0.1

--- a/bitnami/node/ci/values-with-ingress-and-persistence.yaml
+++ b/bitnami/node/ci/values-with-ingress-and-persistence.yaml
@@ -1,5 +1,5 @@
-# Test values file for generating all of the yaml and check that
-# the rendering is correct
+## Test values file for generating all of the yaml and check that
+## the rendering is correct
 
 ingress:
   enabled: true

--- a/bitnami/node/templates/deployment.yaml
+++ b/bitnami/node/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
       {{- if .Values.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 12 }}
+      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       initContainers:
         {{- if .Values.getAppFromExternalRepository }}

--- a/bitnami/node/templates/ingress.yaml
+++ b/bitnami/node/templates/ingress.yaml
@@ -1,12 +1,12 @@
 {{- if .Values.ingress.enabled }}
 {{- range .Values.ingress.hosts }}
-apiVersion: {{ template "common.capabilities.ingress.apiVersion" . }}
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" $ }}
 kind: Ingress
 metadata:
-  name: {{ template "common.names.fullname" $ }}
+  name: {{ include "common.names.fullname" $ }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
-    {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- if $.Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" $.Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   annotations:
     {{- if .certManager }}
@@ -15,8 +15,8 @@ metadata:
     {{- range $key, $value := .annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
-    {{- if .Values.commonAnnotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- if $.Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
 spec:
   rules:
@@ -25,7 +25,7 @@ spec:
         paths:
           - path: {{ default "/" .path }}
             backend:
-              serviceName: {{ template "common.names.fullname" $ }}
+              serviceName: {{ include "common.names.fullname" $ }}
               servicePort: 80
   {{- if .tls }}
   tls:

--- a/bitnami/node/values.yaml
+++ b/bitnami/node/values.yaml
@@ -113,7 +113,7 @@ applicationPort: 3000
 ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
 ## Allowed values: soft, hard
 ##
-podAffinityPreset: ""
+podAffinityPreset: ''
 
 ## Pod anti-affinity preset
 ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
@@ -128,12 +128,12 @@ podAntiAffinityPreset: soft
 nodeAffinityPreset:
   ## Node affinity type
   ## Allowed values: soft, hard
-  type: ""
+  type: ''
   ## Node label key to match
   ## E.g.
   ## key: "kubernetes.io/e2e-az-name"
   ##
-  key: ""
+  key: ''
   ## Node label values to match
   ## E.g.
   ## values:
@@ -183,7 +183,7 @@ extraDeploy: []
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
 livenessProbe:
   enabled: true
-  path: "/"
+  path: '/'
   initialDelaySeconds: 60
   periodSeconds: 10
   timeoutSeconds: 5
@@ -191,7 +191,7 @@ livenessProbe:
   successThreshold: 1
 readinessProbe:
   enabled: true
-  path: "/"
+  path: '/'
   initialDelaySeconds: 10
   periodSeconds: 5
   timeoutSeconds: 3
@@ -328,7 +328,7 @@ service:
   ## Control where client requests go, to the same pod or round-robin
   ## Values: ClientIP or None
   ## ref: https://kubernetes.io/docs/user-guide/services/
-  sessionAffinity: "None"
+  sessionAffinity: 'None'
 
   ## Specify the nodePort value for the LoadBalancer and NodePort service types.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
@@ -411,7 +411,7 @@ mongodb:
     ## MongoDB root password
     ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#setting-the-root-password-on-first-run
     ##
-    rootPassword: ""
+    rootPassword: ''
 
     ## MongoDB custom user and database
     ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#creating-a-user-and-database-on-first-run


### PR DESCRIPTION
**Description of the change**

- fix(ingress): passing wrong scope in range
- fix(values): indent properly
- fix(deployment): fix security context indentation 

**Benefits**

We can properly deploy the chart using ingress.

**Possible drawbacks**

N/A

**Applicable issues**

  - fixes #4516

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files