### PR TITLE
[bitnami/mongodb-sharded] Add missing extraEnvs to statefulsets

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb-sharded
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb-sharded
   - https://mongodb.org
-version: 3.1.0
+version: 3.1.1

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
@@ -4,35 +4,35 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ printf "%s-shard%d-arbiter" (include "common.names.fullname" $ ) $i }}
-  labels: {{- include "common.labels.standard" $ | nindent 4 }}
+  name: {{ printf "%s-shard%d-arbiter" (include "mongodb-sharded.fullname" $ ) $i }}
+  labels: {{- include "mongodb-sharded.labels" $ | nindent 4 }}
     app.kubernetes.io/component: shardsvr-arbiter
 spec:
   selector:
-    matchLabels: {{- include "common.labels.matchLabels" $ | nindent 6 }}
+    matchLabels: {{- include "mongodb-sharded.matchLabels" $ | nindent 6 }}
       app.kubernetes.io/component: shardsvr-arbiter
   podManagementPolicy: {{ $.Values.shardsvr.arbiter.podManagementPolicy }}
   updateStrategy: {{- toYaml $.Values.shardsvr.arbiter.updateStrategy | nindent 4 }}
-  serviceName: {{ include "common.names.fullname" $ }}-headless
+  serviceName: {{ include "mongodb-sharded.fullname" $ }}-headless
   replicas: {{ $.Values.shardsvr.arbiter.replicas }}
   template:
     metadata:
-      labels: {{- include "common.labels.standard" $ | nindent 8 }}
+      labels: {{- include "mongodb-sharded.labels" $ | nindent 8 }}
         app.kubernetes.io/component: shardsvr-arbiter
         {{- if $.Values.shardsvr.arbiter.podLabels }}
-          {{- include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.arbiter.podLabels "context" $ ) | nindent 8 }}
+          {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.arbiter.podLabels "context" $ ) | nindent 8 }}
         {{- end }}
         shard: {{ $i | quote }}
       {{- if or $.Values.common.podAnnotations $.Values.shardsvr.arbiter.podAnnotations $.Values.metrics.enabled }}
       annotations:
         {{- if $.Values.common.podAnnotations }}
-           {{- include "common.tplvalues.render" ( dict "value" $.Values.common.podAnnotations "context" $ ) | nindent 8 }}
+           {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.common.podAnnotations "context" $ ) | nindent 8 }}
         {{- end }}
         {{- if $.Values.shardsvr.arbiter.podAnnotations }}
-          {{- include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.arbiter.podAnnotations "context" $ ) | nindent 8 }}
+          {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.arbiter.podAnnotations "context" $ ) | nindent 8 }}
         {{- end }}
         {{- if $.Values.metrics.enabled }}
-           {{- include "common.tplvalues.render" ( dict "value" $.Values.metrics.podAnnotations "context" $ ) | nindent 8 }}
+           {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.metrics.podAnnotations "context" $ ) | nindent 8 }}
         {{- end }}
       {{- end }}
     spec:
@@ -40,20 +40,9 @@ spec:
       {{- if $.Values.common.schedulerName }}
       schedulerName: {{ $.Values.common.schedulerName | quote }}
       {{- end }}
-      {{- if $.Values.shardsvr.arbiter.affinity }}
-      affinity: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.arbiter.affinity "context" $) | nindent 8 }}
-      {{- else }}
-      affinity:
-        podAffinity: {{- include "common.affinities.pods" (dict "type" $.Values.shardsvr.arbiter.podAffinityPreset "component" "shardsvr-arbiter" "context" $) | nindent 10 }}
-        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" $.Values.shardsvr.arbiter.podAntiAffinityPreset "component" "shardsvr-arbiter" "context" $) | nindent 10 }}
-        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" $.Values.shardsvr.arbiter.nodeAffinityPreset.type "key" $.Values.shardsvr.arbiter.nodeAffinityPreset.key "values" $.Values.shardsvr.arbiter.nodeAffinityPreset.values) | nindent 10 }}
-      {{- end }}
-      {{- if $.Values.shardsvr.arbiter.nodeSelector }}
-      nodeSelector: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.arbiter.nodeSelector "context" $) | nindent 8 }}
-      {{- end }}
-      {{- if $.Values.shardsvr.arbiter.tolerations }}
-      tolerations: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.arbiter.tolerations "context" $) | nindent 8 }}
-      {{- end }}
+      nodeSelector: {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.arbiter.nodeSelector "context" $ ) | nindent 8 }}
+      affinity: {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.arbiter.affinity "context" (set $ "arbiterLoopId" $i) ) | nindent 8 }}
+      tolerations: {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.arbiter.tolerations "context" $ ) | nindent 8 }}
       {{- if $.Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ $.Values.securityContext.fsGroup }}
@@ -62,10 +51,10 @@ spec:
       {{- if or (ge (len $.Values.shardsvr.arbiter.initContainers) 1) (ge (len $.Values.common.initContainers) 1) }}
       initContainers:
         {{- with $.Values.shardsvr.arbiter.initContainers }}
-        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8}}
+        {{- include "mongodb-sharded.tplValue" ( dict "value" . "context" $ ) | nindent 8}}
         {{- end }}
         {{- with $.Values.common.initContainers }}
-        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8}}
+        {{- include "mongodb-sharded.tplValue" ( dict "value" . "context" $ ) | nindent 8}}
         {{- end }}
       {{- end }}
       containers:
@@ -104,12 +93,12 @@ spec:
             - name: MONGODB_REPLICA_SET_MODE
               value: "arbiter"
             - name: MONGODB_INITIAL_PRIMARY_HOST
-              value: {{ printf "%s-shard%d-data-0.%s-headless.%s.svc.%s" (include "common.names.fullname" $ ) $i (include "common.names.fullname" $ ) $.Release.Namespace $.Values.clusterDomain }}
+              value: {{ printf "%s-shard%d-data-0.%s-headless.%s.svc.%s" (include "mongodb-sharded.fullname" $ ) $i (include "mongodb-sharded.fullname" $ ) $.Release.Namespace $.Values.clusterDomain }}
             - name: MONGODB_REPLICA_SET_NAME
-              value: {{ printf "%s-shard-%d" ( include "common.names.fullname" $ ) $i }}
+              value: {{ printf "%s-shard-%d" ( include "mongodb-sharded.fullname" $ ) $i }}
             {{- if $.Values.common.useHostnames }}
             - name: MONGODB_ADVERTISED_HOSTNAME
-              value: "$(MONGODB_POD_NAME).{{ include "common.names.fullname" $ }}-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}"
+              value: "$(MONGODB_POD_NAME).{{ include "mongodb-sharded.fullname" $ }}-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}"
             {{- end }}
             - name: MONGODB_ENABLE_IPV6
             {{- if $.Values.common.mongodbEnableIPv6 }}
@@ -144,23 +133,29 @@ spec:
             - name: MONGODB_EXTRA_FLAGS
               value: {{ $.Values.shardsvr.arbiter.mongodbExtraFlags | join " " | quote }}
             {{- end }}
+            {{- if .Values.common.extraEnvVars }}
+              {{- include "common.tplvalues.render" ( dict "value" $.Values.common.extraEnvVars "context" $ ) | nindent 12 }}
+            {{- end }}
+            {{- if .Values.shardsvr.arbiter.extraEnvVars }}
+              {{- include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.arbiter.extraEnvVars "context" $ ) | nindent 12 }}
+            {{- end }}
           {{- if or $.Values.common.extraEnvVarsCM $.Values.common.extraEnvVarsSecret $.Values.shardsvr.arbiter.extraEnvVarsCM $.Values.shardsvr.arbiter.extraEnvVarsSecret }}
           envFrom:
             {{- if $.Values.common.extraEnvVarsCM }}
             - configMapRef:
-                name: {{ include "common.tplvalues.render" ( dict "value" $.Values.common.extraEnvVarsCM "context" $ ) }}
+                name: {{ include "mongodb-sharded.tplValue" ( dict "value" $.Values.common.extraEnvVarsCM "context" $ ) }}
             {{- end }}
             {{- if $.Values.common.extraEnvVarsSecret }}
             - secretRef:
-                name: {{ include "common.tplvalues.render" ( dict "value" $.Values.common.extraEnvVarsSecret "context" $ ) }}
+                name: {{ include "mongodb-sharded.tplValue" ( dict "value" $.Values.common.extraEnvVarsSecret "context" $ ) }}
             {{- end }}
             {{- if $.Values.shardsvr.arbiter.extraEnvVarsCM }}
             - configMapRef:
-                name: {{ include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.arbiter.extraEnvVarsCM "context" $ ) }}
+                name: {{ include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.arbiter.extraEnvVarsCM "context" $ ) }}
             {{- end }}
             {{- if $.Values.shardsvr.arbiter.extraEnvVarsSecret }}
             - configMapRef:
-                name: {{ include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.arbiter.extraEnvVarsSecret "context" $ ) }}
+                name: {{ include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.arbiter.extraEnvVarsSecret "context" $ ) }}
             {{- end }}
           {{- end }}
           {{- if $.Values.livenessProbe.enabled }}
@@ -201,10 +196,10 @@ spec:
               mountPath: /docker-entrypoint-initdb.d/secret
             {{- end }}
             {{- if $.Values.common.extraVolumeMounts }}
-              {{- include "common.tplvalues.render" ( dict "value" $.Values.common.extraVolumeMounts "context" $ ) | nindent 12 }}
+              {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.common.extraVolumeMounts "context" $ ) | nindent 12 }}
             {{- end }}
             {{- if $.Values.shardsvr.arbiter.extraVolumeMounts }}
-              {{- include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.arbiter.extraVolumeMounts "context" $ ) | nindent 12 }}
+              {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.arbiter.extraVolumeMounts "context" $ ) | nindent 12 }}
             {{- end }}
           resources: {{- toYaml $.Values.shardsvr.arbiter.resources | nindent 12 }}
         {{- if $.Values.metrics.enabled }}
@@ -269,10 +264,10 @@ spec:
           resources: {{ toYaml $.Values.metrics.resources | nindent 12 }}
         {{- end }}
         {{- with $.Values.shardsvr.arbiter.sidecars }}
-        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8}}
+        {{- include "mongodb-sharded.tplValue" ( dict "value" . "context" $ ) | nindent 8}}
         {{- end }}
         {{- with $.Values.common.sidecars }}
-        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8}}
+        {{- include "mongodb-sharded.tplValue" ( dict "value" . "context" $ ) | nindent 8}}
         {{- end }}
       volumes:
         {{- if or $.Values.shardsvr.arbiter.config $.Values.shardsvr.arbiter.configCM }}
@@ -298,10 +293,10 @@ spec:
             defaultMode: 0755
         {{- end }}
       {{- if $.Values.common.extraVolumes }}
-        {{- include "common.tplvalues.render" ( dict "value" $.Values.common.extraVolumes "context" $ ) | nindent 8 }}
+        {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.common.extraVolumes "context" $ ) | nindent 8 }}
       {{- end }}
       {{- if $.Values.shardsvr.arbiter.extraVolumes }}
-        {{- include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.arbiter.extraVolumes "context" $ ) | nindent 8 }}
+        {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.arbiter.extraVolumes "context" $ ) | nindent 8 }}
       {{- end }}
 {{- if lt $i (sub $replicas 1) }}
 ---

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
@@ -1,4 +1,4 @@
-{{- if and $.Values.shards $.Values.shardsvr.arbiter.replicas }}
+{{- if and .Values.shards .Values.shardsvr.arbiter.replicas }}
 {{- $replicas := $.Values.shards | int }}
 {{- range $i, $e := until $replicas }}
 apiVersion: apps/v1
@@ -144,10 +144,10 @@ spec:
             - name: MONGODB_EXTRA_FLAGS
               value: {{ $.Values.shardsvr.arbiter.mongodbExtraFlags | join " " | quote }}
             {{- end }}
-            {{- if .Values.common.extraEnvVars }}
+            {{- if $.Values.common.extraEnvVars }}
               {{- include "common.tplvalues.render" ( dict "value" $.Values.common.extraEnvVars "context" $ ) | nindent 12 }}
             {{- end }}
-            {{- if .Values.shardsvr.arbiter.extraEnvVars }}
+            {{- if $.Values.shardsvr.arbiter.extraEnvVars }}
               {{- include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.arbiter.extraEnvVars "context" $ ) | nindent 12 }}
             {{- end }}
           {{- if or $.Values.common.extraEnvVarsCM $.Values.common.extraEnvVarsSecret $.Values.shardsvr.arbiter.extraEnvVarsCM $.Values.shardsvr.arbiter.extraEnvVarsSecret }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
@@ -4,35 +4,35 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ printf "%s-shard%d-arbiter" (include "mongodb-sharded.fullname" $ ) $i }}
-  labels: {{- include "mongodb-sharded.labels" $ | nindent 4 }}
+  name: {{ printf "%s-shard%d-arbiter" (include "common.names.fullname" $ ) $i }}
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: shardsvr-arbiter
 spec:
   selector:
-    matchLabels: {{- include "mongodb-sharded.matchLabels" $ | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" $ | nindent 6 }}
       app.kubernetes.io/component: shardsvr-arbiter
   podManagementPolicy: {{ $.Values.shardsvr.arbiter.podManagementPolicy }}
   updateStrategy: {{- toYaml $.Values.shardsvr.arbiter.updateStrategy | nindent 4 }}
-  serviceName: {{ include "mongodb-sharded.fullname" $ }}-headless
+  serviceName: {{ include "common.names.fullname" $ }}-headless
   replicas: {{ $.Values.shardsvr.arbiter.replicas }}
   template:
     metadata:
-      labels: {{- include "mongodb-sharded.labels" $ | nindent 8 }}
+      labels: {{- include "common.labels.standard" $ | nindent 8 }}
         app.kubernetes.io/component: shardsvr-arbiter
         {{- if $.Values.shardsvr.arbiter.podLabels }}
-          {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.arbiter.podLabels "context" $ ) | nindent 8 }}
+          {{- include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.arbiter.podLabels "context" $ ) | nindent 8 }}
         {{- end }}
         shard: {{ $i | quote }}
       {{- if or $.Values.common.podAnnotations $.Values.shardsvr.arbiter.podAnnotations $.Values.metrics.enabled }}
       annotations:
         {{- if $.Values.common.podAnnotations }}
-           {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.common.podAnnotations "context" $ ) | nindent 8 }}
+           {{- include "common.tplvalues.render" ( dict "value" $.Values.common.podAnnotations "context" $ ) | nindent 8 }}
         {{- end }}
         {{- if $.Values.shardsvr.arbiter.podAnnotations }}
-          {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.arbiter.podAnnotations "context" $ ) | nindent 8 }}
+          {{- include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.arbiter.podAnnotations "context" $ ) | nindent 8 }}
         {{- end }}
         {{- if $.Values.metrics.enabled }}
-           {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.metrics.podAnnotations "context" $ ) | nindent 8 }}
+           {{- include "common.tplvalues.render" ( dict "value" $.Values.metrics.podAnnotations "context" $ ) | nindent 8 }}
         {{- end }}
       {{- end }}
     spec:
@@ -40,9 +40,20 @@ spec:
       {{- if $.Values.common.schedulerName }}
       schedulerName: {{ $.Values.common.schedulerName | quote }}
       {{- end }}
-      nodeSelector: {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.arbiter.nodeSelector "context" $ ) | nindent 8 }}
-      affinity: {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.arbiter.affinity "context" (set $ "arbiterLoopId" $i) ) | nindent 8 }}
-      tolerations: {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.arbiter.tolerations "context" $ ) | nindent 8 }}
+      {{- if $.Values.shardsvr.arbiter.affinity }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.arbiter.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" $.Values.shardsvr.arbiter.podAffinityPreset "component" "shardsvr-arbiter" "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" $.Values.shardsvr.arbiter.podAntiAffinityPreset "component" "shardsvr-arbiter" "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" $.Values.shardsvr.arbiter.nodeAffinityPreset.type "key" $.Values.shardsvr.arbiter.nodeAffinityPreset.key "values" $.Values.shardsvr.arbiter.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      {{- if $.Values.shardsvr.arbiter.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.arbiter.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if $.Values.shardsvr.arbiter.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.arbiter.tolerations "context" $) | nindent 8 }}
+      {{- end }}
       {{- if $.Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ $.Values.securityContext.fsGroup }}
@@ -51,10 +62,10 @@ spec:
       {{- if or (ge (len $.Values.shardsvr.arbiter.initContainers) 1) (ge (len $.Values.common.initContainers) 1) }}
       initContainers:
         {{- with $.Values.shardsvr.arbiter.initContainers }}
-        {{- include "mongodb-sharded.tplValue" ( dict "value" . "context" $ ) | nindent 8}}
+        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8}}
         {{- end }}
         {{- with $.Values.common.initContainers }}
-        {{- include "mongodb-sharded.tplValue" ( dict "value" . "context" $ ) | nindent 8}}
+        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8}}
         {{- end }}
       {{- end }}
       containers:
@@ -93,12 +104,12 @@ spec:
             - name: MONGODB_REPLICA_SET_MODE
               value: "arbiter"
             - name: MONGODB_INITIAL_PRIMARY_HOST
-              value: {{ printf "%s-shard%d-data-0.%s-headless.%s.svc.%s" (include "mongodb-sharded.fullname" $ ) $i (include "mongodb-sharded.fullname" $ ) $.Release.Namespace $.Values.clusterDomain }}
+              value: {{ printf "%s-shard%d-data-0.%s-headless.%s.svc.%s" (include "common.names.fullname" $ ) $i (include "common.names.fullname" $ ) $.Release.Namespace $.Values.clusterDomain }}
             - name: MONGODB_REPLICA_SET_NAME
-              value: {{ printf "%s-shard-%d" ( include "mongodb-sharded.fullname" $ ) $i }}
+              value: {{ printf "%s-shard-%d" ( include "common.names.fullname" $ ) $i }}
             {{- if $.Values.common.useHostnames }}
             - name: MONGODB_ADVERTISED_HOSTNAME
-              value: "$(MONGODB_POD_NAME).{{ include "mongodb-sharded.fullname" $ }}-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}"
+              value: "$(MONGODB_POD_NAME).{{ include "common.names.fullname" $ }}-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}"
             {{- end }}
             - name: MONGODB_ENABLE_IPV6
             {{- if $.Values.common.mongodbEnableIPv6 }}
@@ -143,19 +154,19 @@ spec:
           envFrom:
             {{- if $.Values.common.extraEnvVarsCM }}
             - configMapRef:
-                name: {{ include "mongodb-sharded.tplValue" ( dict "value" $.Values.common.extraEnvVarsCM "context" $ ) }}
+                name: {{ include "common.tplvalues.render" ( dict "value" $.Values.common.extraEnvVarsCM "context" $ ) }}
             {{- end }}
             {{- if $.Values.common.extraEnvVarsSecret }}
             - secretRef:
-                name: {{ include "mongodb-sharded.tplValue" ( dict "value" $.Values.common.extraEnvVarsSecret "context" $ ) }}
+                name: {{ include "common.tplvalues.render" ( dict "value" $.Values.common.extraEnvVarsSecret "context" $ ) }}
             {{- end }}
             {{- if $.Values.shardsvr.arbiter.extraEnvVarsCM }}
             - configMapRef:
-                name: {{ include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.arbiter.extraEnvVarsCM "context" $ ) }}
+                name: {{ include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.arbiter.extraEnvVarsCM "context" $ ) }}
             {{- end }}
             {{- if $.Values.shardsvr.arbiter.extraEnvVarsSecret }}
             - configMapRef:
-                name: {{ include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.arbiter.extraEnvVarsSecret "context" $ ) }}
+                name: {{ include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.arbiter.extraEnvVarsSecret "context" $ ) }}
             {{- end }}
           {{- end }}
           {{- if $.Values.livenessProbe.enabled }}
@@ -196,10 +207,10 @@ spec:
               mountPath: /docker-entrypoint-initdb.d/secret
             {{- end }}
             {{- if $.Values.common.extraVolumeMounts }}
-              {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.common.extraVolumeMounts "context" $ ) | nindent 12 }}
+              {{- include "common.tplvalues.render" ( dict "value" $.Values.common.extraVolumeMounts "context" $ ) | nindent 12 }}
             {{- end }}
             {{- if $.Values.shardsvr.arbiter.extraVolumeMounts }}
-              {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.arbiter.extraVolumeMounts "context" $ ) | nindent 12 }}
+              {{- include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.arbiter.extraVolumeMounts "context" $ ) | nindent 12 }}
             {{- end }}
           resources: {{- toYaml $.Values.shardsvr.arbiter.resources | nindent 12 }}
         {{- if $.Values.metrics.enabled }}
@@ -264,10 +275,10 @@ spec:
           resources: {{ toYaml $.Values.metrics.resources | nindent 12 }}
         {{- end }}
         {{- with $.Values.shardsvr.arbiter.sidecars }}
-        {{- include "mongodb-sharded.tplValue" ( dict "value" . "context" $ ) | nindent 8}}
+        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8}}
         {{- end }}
         {{- with $.Values.common.sidecars }}
-        {{- include "mongodb-sharded.tplValue" ( dict "value" . "context" $ ) | nindent 8}}
+        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8}}
         {{- end }}
       volumes:
         {{- if or $.Values.shardsvr.arbiter.config $.Values.shardsvr.arbiter.configCM }}
@@ -293,10 +304,10 @@ spec:
             defaultMode: 0755
         {{- end }}
       {{- if $.Values.common.extraVolumes }}
-        {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.common.extraVolumes "context" $ ) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" $.Values.common.extraVolumes "context" $ ) | nindent 8 }}
       {{- end }}
       {{- if $.Values.shardsvr.arbiter.extraVolumes }}
-        {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.arbiter.extraVolumes "context" $ ) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.arbiter.extraVolumes "context" $ ) | nindent 8 }}
       {{- end }}
 {{- if lt $i (sub $replicas 1) }}
 ---

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -154,10 +154,10 @@ spec:
             - name: MONGODB_EXTRA_FLAGS
               value: {{ $.Values.shardsvr.dataNode.mongodbExtraFlags | join " " | quote }}
             {{- end }}
-            {{- if .Values.common.extraEnvVars }}
+            {{- if $.Values.common.extraEnvVars }}
               {{- include "common.tplvalues.render" ( dict "value" $.Values.common.extraEnvVars "context" $ ) | nindent 12 }}
             {{- end }}
-            {{- if .Values.shardsvr.dataNode.extraEnvVars }}
+            {{- if $.Values.shardsvr.dataNode.extraEnvVars }}
               {{- include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.dataNode.extraEnvVars "context" $ ) | nindent 12 }}
             {{- end }}
           {{- if or $.Values.common.extraEnvVarsCM $.Values.common.extraEnvVarsSecret $.Values.shardsvr.dataNode.extraEnvVarsCM $.Values.shardsvr.dataNode.extraEnvVarsSecret }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -4,55 +4,44 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ printf "%s-shard%d-data" (include "common.names.fullname" $ ) $i }}
-  labels: {{- include "common.labels.standard" $ | nindent 4 }}
+  name: {{ printf "%s-shard%d-data" (include "mongodb-sharded.fullname" $ ) $i }}
+  labels: {{- include "mongodb-sharded.labels" $ | nindent 4 }}
     app.kubernetes.io/component: shardsvr
 spec:
   selector:
-    matchLabels: {{- include "common.labels.matchLabels" $ | nindent 6 }}
+    matchLabels: {{- include "mongodb-sharded.matchLabels" $ | nindent 6 }}
       app.kubernetes.io/component: shardsvr
   podManagementPolicy: {{ $.Values.shardsvr.dataNode.podManagementPolicy }}
   updateStrategy: {{- toYaml $.Values.shardsvr.dataNode.updateStrategy | nindent 4 }}
-  serviceName: {{ include "common.names.fullname" $ }}-headless
+  serviceName: {{ include "mongodb-sharded.fullname" $ }}-headless
   replicas: {{ $.Values.shardsvr.dataNode.replicas }}
   template:
     metadata:
-      labels: {{- include "common.labels.standard" $ | nindent 8 }}
+      labels: {{- include "mongodb-sharded.labels" $ | nindent 8 }}
         app.kubernetes.io/component: shardsvr
         {{- if $.Values.shardsvr.dataNode.podLabels }}
-          {{- include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.dataNode.podLabels "context" $ ) | nindent 8 }}
+          {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.dataNode.podLabels "context" $ ) | nindent 8 }}
         {{- end }}
         shard: {{ $i | quote }}
       {{- if or $.Values.common.podAnnotations $.Values.shardsvr.dataNode.podAnnotations $.Values.metrics.enabled }}
       annotations:
         {{- if $.Values.common.podAnnotations }}
-           {{- include "common.tplvalues.render" ( dict "value" $.Values.common.podAnnotations "context" $ ) | nindent 8 }}
+           {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.common.podAnnotations "context" $ ) | nindent 8 }}
         {{- end }}
         {{- if $.Values.shardsvr.dataNode.podAnnotations }}
-          {{- include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.dataNode.podAnnotations "context" $ ) | nindent 8 }}
+          {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.dataNode.podAnnotations "context" $ ) | nindent 8 }}
         {{- end }}
         {{- if $.Values.metrics.enabled }}
-           {{- include "common.tplvalues.render" ( dict "value" $.Values.metrics.podAnnotations "context" $ ) | nindent 8 }}
+           {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.metrics.podAnnotations "context" $ ) | nindent 8 }}
         {{- end }}
       {{- end }}
     spec:
       {{- if $.Values.common.schedulerName }}
       schedulerName: {{ $.Values.common.schedulerName | quote }}
       {{- end }}
-      {{- if $.Values.shardsvr.dataNode.affinity }}
-      affinity: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.dataNode.affinity "context" $) | nindent 8 }}
-      {{- else }}
-      affinity:
-        podAffinity: {{- include "common.affinities.pods" (dict "type" $.Values.shardsvr.dataNode.podAffinityPreset "component" "shardsvr" "context" $) | nindent 10 }}
-        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" $.Values.shardsvr.dataNode.podAntiAffinityPreset "component" "shardsvr" "context" $) | nindent 10 }}
-        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" $.Values.shardsvr.dataNode.nodeAffinityPreset.type "key" $.Values.shardsvr.dataNode.nodeAffinityPreset.key "values" $.Values.shardsvr.dataNode.nodeAffinityPreset.values) | nindent 10 }}
-      {{- end }}
-      {{- if $.Values.shardsvr.dataNode.nodeSelector }}
-      nodeSelector: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.dataNode.nodeSelector "context" $) | nindent 8 }}
-      {{- end }}
-      {{- if $.Values.shardsvr.dataNode.tolerations }}
-      tolerations: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.dataNode.tolerations "context" $) | nindent 8 }}
-      {{- end }}
+      nodeSelector: {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.dataNode.nodeSelector "context" $ ) | nindent 8 }}
+      affinity: {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.dataNode.affinity "context" (set $ "dataNodeLoopId" $i) ) | nindent 8 }}
+      tolerations: {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.dataNode.tolerations "context" $ ) | nindent 8 }}
       serviceAccountName: {{ include "mongodb-sharded.serviceAccountName" (dict "value" $.Values.shardsvr.dataNode.serviceAccount "context" $) }}
       {{- if $.Values.securityContext.enabled }}
       securityContext:
@@ -73,10 +62,10 @@ spec:
               mountPath: {{ $.Values.shardsvr.persistence.mountPath }}
         {{- end }}
         {{- with $.Values.shardsvr.dataNode.initContainers }}
-        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8}}
+        {{- include "mongodb-sharded.tplValue" ( dict "value" . "context" $ ) | nindent 8}}
         {{- end }}
         {{- with $.Values.common.initContainers }}
-        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8}}
+        {{- include "mongodb-sharded.tplValue" ( dict "value" . "context" $ ) | nindent 8}}
         {{- end }}
       containers:
         - name: mongodb
@@ -112,14 +101,14 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: MONGODB_MONGOS_HOST
-              value: {{ include "common.names.fullname" $ }}
+              value: {{ include "mongodb-sharded.fullname" $ }}
             - name: MONGODB_INITIAL_PRIMARY_HOST
-              value: {{ printf "%s-shard%d-data-0.%s-headless.%s.svc.%s" (include "common.names.fullname" $ ) $i (include "common.names.fullname" $ ) $.Release.Namespace $.Values.clusterDomain }}
+              value: {{ printf "%s-shard%d-data-0.%s-headless.%s.svc.%s" (include "mongodb-sharded.fullname" $ ) $i (include "mongodb-sharded.fullname" $ ) $.Release.Namespace $.Values.clusterDomain }}
             - name: MONGODB_REPLICA_SET_NAME
-              value: {{ printf "%s-shard-%d" ( include "common.names.fullname" $ ) $i }}
+              value: {{ printf "%s-shard-%d" ( include "mongodb-sharded.fullname" $ ) $i }}
               {{- if $.Values.common.useHostnames }}
             - name: MONGODB_ADVERTISED_HOSTNAME
-              value: "$(MONGODB_POD_NAME).{{ include "common.names.fullname" $ }}-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}"
+              value: "$(MONGODB_POD_NAME).{{ include "mongodb-sharded.fullname" $ }}-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}"
               {{- end }}
             {{- if $.Values.usePasswordFile }}
             - name: MONGODB_ROOT_PASSWORD_FILE
@@ -154,6 +143,31 @@ spec:
             - name: MONGODB_EXTRA_FLAGS
               value: {{ $.Values.shardsvr.dataNode.mongodbExtraFlags | join " " | quote }}
             {{- end }}
+            {{- if .Values.common.extraEnvVars }}
+              {{- include "common.tplvalues.render" ( dict "value" $.Values.common.extraEnvVars "context" $ ) | nindent 12 }}
+            {{- end }}
+            {{- if .Values.shardsvr.dataNode.extraEnvVars }}
+              {{- include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.dataNode.extraEnvVars "context" $ ) | nindent 12 }}
+            {{- end }}
+          {{- if or $.Values.common.extraEnvVarsCM $.Values.common.extraEnvVarsSecret $.Values.shardsvr.dataNode.extraEnvVarsCM $.Values.shardsvr.dataNode.extraEnvVarsSecret }}
+          envFrom:
+            {{- if $.Values.common.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "mongodb-sharded.tplValue" ( dict "value" $.Values.common.extraEnvVarsCM "context" $ ) }}
+            {{- end }}
+            {{- if $.Values.common.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "mongodb-sharded.tplValue" ( dict "value" $.Values.common.extraEnvVarsSecret "context" $ ) }}
+            {{- end }}
+            {{- if $.Values.shardsvr.dataNode.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.dataNode.extraEnvVarsCM "context" $ ) }}
+            {{- end }}
+            {{- if $.Values.shardsvr.dataNode.extraEnvVarsSecret }}
+            - configMapRef:
+                name: {{ include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.dataNode.extraEnvVarsSecret "context" $ ) }}
+            {{- end }}
+          {{- end }}
           command:
             - /bin/bash
             - /entrypoint/replicaset-entrypoint.sh
@@ -204,10 +218,10 @@ spec:
               mountPath: /docker-entrypoint-initdb.d/secret
             {{- end }}
             {{- if $.Values.common.extraVolumeMounts }}
-              {{- include "common.tplvalues.render" ( dict "value" $.Values.common.extraVolumeMounts "context" $ ) | nindent 12 }}
+              {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.common.extraVolumeMounts "context" $ ) | nindent 12 }}
             {{- end }}
             {{- if $.Values.shardsvr.dataNode.extraVolumeMounts }}
-              {{- include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.dataNode.extraVolumeMounts "context" $ ) | nindent 12 }}
+              {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.dataNode.extraVolumeMounts "context" $ ) | nindent 12 }}
             {{- end }}
           resources: {{- toYaml $.Values.shardsvr.dataNode.resources | nindent 12 }}
         {{- if $.Values.metrics.enabled }}
@@ -272,15 +286,15 @@ spec:
           resources: {{ toYaml $.Values.metrics.resources | nindent 12 }}
         {{- end }}
         {{- with $.Values.shardsvr.dataNode.sidecars }}
-        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8}}
+        {{- include "mongodb-sharded.tplValue" ( dict "value" . "context" $ ) | nindent 8}}
         {{- end }}
         {{- with $.Values.common.sidecars }}
-        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8}}
+        {{- include "mongodb-sharded.tplValue" ( dict "value" . "context" $ ) | nindent 8}}
         {{- end }}
       volumes:
         - name: replicaset-entrypoint-configmap
           configMap:
-            name: {{ include "common.names.fullname" $ }}-replicaset-entrypoint
+            name: {{ include "mongodb-sharded.fullname" $ }}-replicaset-entrypoint
         {{- if $.Values.usePasswordFile }}
         - name: secrets
           secret:
@@ -304,10 +318,10 @@ spec:
             name: {{ include "mongodb-sharded.shardsvr.dataNode.configCM" $ }}
         {{- end }}
         {{- if $.Values.common.extraVolumes }}
-          {{- include "common.tplvalues.render" ( dict "value" $.Values.common.extraVolumes "context" $ ) | nindent 8 }}
+          {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.common.extraVolumes "context" $ ) | nindent 8 }}
         {{- end }}
         {{- if $.Values.shardsvr.dataNode.extraVolumes }}
-          {{- include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.dataNode.extraVolumes "context" $ ) | nindent 8 }}
+          {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.dataNode.extraVolumes "context" $ ) | nindent 8 }}
         {{- end }}
   {{- if $.Values.shardsvr.persistence.enabled }}
   volumeClaimTemplates:
@@ -325,7 +339,7 @@ spec:
         resources:
           requests:
             storage: {{ $.Values.shardsvr.persistence.size | quote }}
-        {{- include "common.storage.class" (dict "persistence" $.Values.shardsvr.persistence "global" $.Values.global) | nindent 8 }}
+        {{- include "mongodb-sharded.shardsvr.storageClass" $ | nindent 8}}
   {{- else }}
         - name: datadir
           emptyDir: {}

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -4,44 +4,55 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ printf "%s-shard%d-data" (include "mongodb-sharded.fullname" $ ) $i }}
-  labels: {{- include "mongodb-sharded.labels" $ | nindent 4 }}
+  name: {{ printf "%s-shard%d-data" (include "common.names.fullname" $ ) $i }}
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: shardsvr
 spec:
   selector:
-    matchLabels: {{- include "mongodb-sharded.matchLabels" $ | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" $ | nindent 6 }}
       app.kubernetes.io/component: shardsvr
   podManagementPolicy: {{ $.Values.shardsvr.dataNode.podManagementPolicy }}
   updateStrategy: {{- toYaml $.Values.shardsvr.dataNode.updateStrategy | nindent 4 }}
-  serviceName: {{ include "mongodb-sharded.fullname" $ }}-headless
+  serviceName: {{ include "common.names.fullname" $ }}-headless
   replicas: {{ $.Values.shardsvr.dataNode.replicas }}
   template:
     metadata:
-      labels: {{- include "mongodb-sharded.labels" $ | nindent 8 }}
+      labels: {{- include "common.labels.standard" $ | nindent 8 }}
         app.kubernetes.io/component: shardsvr
         {{- if $.Values.shardsvr.dataNode.podLabels }}
-          {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.dataNode.podLabels "context" $ ) | nindent 8 }}
+          {{- include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.dataNode.podLabels "context" $ ) | nindent 8 }}
         {{- end }}
         shard: {{ $i | quote }}
       {{- if or $.Values.common.podAnnotations $.Values.shardsvr.dataNode.podAnnotations $.Values.metrics.enabled }}
       annotations:
         {{- if $.Values.common.podAnnotations }}
-           {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.common.podAnnotations "context" $ ) | nindent 8 }}
+           {{- include "common.tplvalues.render" ( dict "value" $.Values.common.podAnnotations "context" $ ) | nindent 8 }}
         {{- end }}
         {{- if $.Values.shardsvr.dataNode.podAnnotations }}
-          {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.dataNode.podAnnotations "context" $ ) | nindent 8 }}
+          {{- include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.dataNode.podAnnotations "context" $ ) | nindent 8 }}
         {{- end }}
         {{- if $.Values.metrics.enabled }}
-           {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.metrics.podAnnotations "context" $ ) | nindent 8 }}
+           {{- include "common.tplvalues.render" ( dict "value" $.Values.metrics.podAnnotations "context" $ ) | nindent 8 }}
         {{- end }}
       {{- end }}
     spec:
       {{- if $.Values.common.schedulerName }}
       schedulerName: {{ $.Values.common.schedulerName | quote }}
       {{- end }}
-      nodeSelector: {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.dataNode.nodeSelector "context" $ ) | nindent 8 }}
-      affinity: {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.dataNode.affinity "context" (set $ "dataNodeLoopId" $i) ) | nindent 8 }}
-      tolerations: {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.dataNode.tolerations "context" $ ) | nindent 8 }}
+      {{- if $.Values.shardsvr.dataNode.affinity }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.dataNode.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" $.Values.shardsvr.dataNode.podAffinityPreset "component" "shardsvr" "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" $.Values.shardsvr.dataNode.podAntiAffinityPreset "component" "shardsvr" "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" $.Values.shardsvr.dataNode.nodeAffinityPreset.type "key" $.Values.shardsvr.dataNode.nodeAffinityPreset.key "values" $.Values.shardsvr.dataNode.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      {{- if $.Values.shardsvr.dataNode.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.dataNode.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if $.Values.shardsvr.dataNode.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.dataNode.tolerations "context" $) | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "mongodb-sharded.serviceAccountName" (dict "value" $.Values.shardsvr.dataNode.serviceAccount "context" $) }}
       {{- if $.Values.securityContext.enabled }}
       securityContext:
@@ -62,10 +73,10 @@ spec:
               mountPath: {{ $.Values.shardsvr.persistence.mountPath }}
         {{- end }}
         {{- with $.Values.shardsvr.dataNode.initContainers }}
-        {{- include "mongodb-sharded.tplValue" ( dict "value" . "context" $ ) | nindent 8}}
+        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8}}
         {{- end }}
         {{- with $.Values.common.initContainers }}
-        {{- include "mongodb-sharded.tplValue" ( dict "value" . "context" $ ) | nindent 8}}
+        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8}}
         {{- end }}
       containers:
         - name: mongodb
@@ -101,14 +112,14 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: MONGODB_MONGOS_HOST
-              value: {{ include "mongodb-sharded.fullname" $ }}
+              value: {{ include "common.names.fullname" $ }}
             - name: MONGODB_INITIAL_PRIMARY_HOST
-              value: {{ printf "%s-shard%d-data-0.%s-headless.%s.svc.%s" (include "mongodb-sharded.fullname" $ ) $i (include "mongodb-sharded.fullname" $ ) $.Release.Namespace $.Values.clusterDomain }}
+              value: {{ printf "%s-shard%d-data-0.%s-headless.%s.svc.%s" (include "common.names.fullname" $ ) $i (include "common.names.fullname" $ ) $.Release.Namespace $.Values.clusterDomain }}
             - name: MONGODB_REPLICA_SET_NAME
-              value: {{ printf "%s-shard-%d" ( include "mongodb-sharded.fullname" $ ) $i }}
+              value: {{ printf "%s-shard-%d" ( include "common.names.fullname" $ ) $i }}
               {{- if $.Values.common.useHostnames }}
             - name: MONGODB_ADVERTISED_HOSTNAME
-              value: "$(MONGODB_POD_NAME).{{ include "mongodb-sharded.fullname" $ }}-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}"
+              value: "$(MONGODB_POD_NAME).{{ include "common.names.fullname" $ }}-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}"
               {{- end }}
             {{- if $.Values.usePasswordFile }}
             - name: MONGODB_ROOT_PASSWORD_FILE
@@ -218,10 +229,10 @@ spec:
               mountPath: /docker-entrypoint-initdb.d/secret
             {{- end }}
             {{- if $.Values.common.extraVolumeMounts }}
-              {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.common.extraVolumeMounts "context" $ ) | nindent 12 }}
+              {{- include "common.tplvalues.render" ( dict "value" $.Values.common.extraVolumeMounts "context" $ ) | nindent 12 }}
             {{- end }}
             {{- if $.Values.shardsvr.dataNode.extraVolumeMounts }}
-              {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.dataNode.extraVolumeMounts "context" $ ) | nindent 12 }}
+              {{- include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.dataNode.extraVolumeMounts "context" $ ) | nindent 12 }}
             {{- end }}
           resources: {{- toYaml $.Values.shardsvr.dataNode.resources | nindent 12 }}
         {{- if $.Values.metrics.enabled }}
@@ -286,15 +297,15 @@ spec:
           resources: {{ toYaml $.Values.metrics.resources | nindent 12 }}
         {{- end }}
         {{- with $.Values.shardsvr.dataNode.sidecars }}
-        {{- include "mongodb-sharded.tplValue" ( dict "value" . "context" $ ) | nindent 8}}
+        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8}}
         {{- end }}
         {{- with $.Values.common.sidecars }}
-        {{- include "mongodb-sharded.tplValue" ( dict "value" . "context" $ ) | nindent 8}}
+        {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8}}
         {{- end }}
       volumes:
         - name: replicaset-entrypoint-configmap
           configMap:
-            name: {{ include "mongodb-sharded.fullname" $ }}-replicaset-entrypoint
+            name: {{ include "common.names.fullname" $ }}-replicaset-entrypoint
         {{- if $.Values.usePasswordFile }}
         - name: secrets
           secret:
@@ -318,10 +329,10 @@ spec:
             name: {{ include "mongodb-sharded.shardsvr.dataNode.configCM" $ }}
         {{- end }}
         {{- if $.Values.common.extraVolumes }}
-          {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.common.extraVolumes "context" $ ) | nindent 8 }}
+          {{- include "common.tplvalues.render" ( dict "value" $.Values.common.extraVolumes "context" $ ) | nindent 8 }}
         {{- end }}
         {{- if $.Values.shardsvr.dataNode.extraVolumes }}
-          {{- include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.dataNode.extraVolumes "context" $ ) | nindent 8 }}
+          {{- include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.dataNode.extraVolumes "context" $ ) | nindent 8 }}
         {{- end }}
   {{- if $.Values.shardsvr.persistence.enabled }}
   volumeClaimTemplates:
@@ -339,7 +350,7 @@ spec:
         resources:
           requests:
             storage: {{ $.Values.shardsvr.persistence.size | quote }}
-        {{- include "mongodb-sharded.shardsvr.storageClass" $ | nindent 8}}
+        {{- include "common.storage.class" (dict "persistence" $.Values.shardsvr.persistence "global" $.Values.global) | nindent 8 }}
   {{- else }}
         - name: datadir
           emptyDir: {}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

There are some missing parameters related to `extraEnvs` not included in two of the statefulsets of this chart. Every parameter was already documented and present in `values.yaml`.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #4563

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
