### PR TITLE
[bitnami/influxdb] Fix affinity template function call

### DIFF
--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -24,4 +24,4 @@ name: influxdb
 sources:
   - https://github.com/bitnami/bitnami-docker-influxdb
   - https://www.influxdata.com/products/influxdb-overview/
-version: 1.1.0
+version: 1.1.1

--- a/bitnami/influxdb/templates/_helpers.tpl
+++ b/bitnami/influxdb/templates/_helpers.tpl
@@ -359,19 +359,6 @@ influxdb: replicaCount
 {{- end -}}
 
 {{/*
-Renders a value that contains template.
-Usage:
-{{ include "influxdb.tplValue" ( dict "value" .Values.path.to.the.Value "context" $) }}
-*/}}
-{{- define "influxdb.tplValue" -}}
-    {{- if typeIs "string" .value }}
-        {{- tpl .value .context }}
-    {{- else }}
-        {{- tpl (.value | toYaml) .context }}
-    {{- end }}
-{{- end -}}
-
-{{/*
 Return the appropriate apiVersion for ingress.
 */}}
 {{- define "ingress.apiVersion" -}}

--- a/bitnami/influxdb/templates/influxdb/deployment-standalone.yaml
+++ b/bitnami/influxdb/templates/influxdb/deployment-standalone.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       {{- include "influxdb.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.influxdb.affinity }}
-      affinity: {{- include "fluentd.tplValue" (dict "value" .Values.influxdb.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "influxdb.tplValue" (dict "value" .Values.influxdb.affinity "context" $) | nindent 8 }}
       {{- else }}
       affinity:
         podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.influxdb.podAffinityPreset "component" "influxdb" "context" $) | nindent 10 }}

--- a/bitnami/influxdb/templates/influxdb/deployment-standalone.yaml
+++ b/bitnami/influxdb/templates/influxdb/deployment-standalone.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       {{- include "influxdb.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.influxdb.affinity }}
-      affinity: {{- include "influxdb.tplValue" (dict "value" .Values.influxdb.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.influxdb.affinity "context" $) | nindent 8 }}
       {{- else }}
       affinity:
         podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.influxdb.podAffinityPreset "component" "influxdb" "context" $) | nindent 10 }}
@@ -33,10 +33,10 @@ spec:
         nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.influxdb.nodeAffinityPreset.type "key" .Values.influxdb.nodeAffinityPreset.key "values" .Values.influxdb.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
       {{- if .Values.influxdb.nodeSelector }}
-      nodeSelector: {{- include "influxdb.tplValue" (dict "value" .Values.influxdb.nodeSelector "context" $) | nindent 8 }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.influxdb.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.influxdb.tolerations }}
-      tolerations: {{- include "influxdb.tplValue" (dict "value" .Values.influxdb.tolerations "context" $) | nindent 8 }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.influxdb.tolerations "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.influxdb.securityContext.enabled }}
       securityContext:

--- a/bitnami/influxdb/templates/influxdb/service-metrics.yaml
+++ b/bitnami/influxdb/templates/influxdb/service-metrics.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "influxdb.labels" . | nindent 4 }}
     app.kubernetes.io/component: influxdb
   {{- if .Values.metrics.service.annotations }}
-  annotations: {{- include "influxdb.tplValue" ( dict "value" .Values.metrics.service.annotations "context" $) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.service.annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.metrics.service.type }}

--- a/bitnami/influxdb/templates/influxdb/service.yaml
+++ b/bitnami/influxdb/templates/influxdb/service.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "influxdb.labels" . | nindent 4 }}
     app.kubernetes.io/component: influxdb
   {{- if .Values.influxdb.service.annotations }}
-  annotations: {{- include "influxdb.tplValue" ( dict "value" .Values.influxdb.service.annotations "context" $) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.influxdb.service.annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.influxdb.service.type }}

--- a/bitnami/influxdb/templates/influxdb/statefulset-high-availability.yaml
+++ b/bitnami/influxdb/templates/influxdb/statefulset-high-availability.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       {{- include "influxdb.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.influxdb.affinity }}
-      affinity: {{- include "fluentd.tplValue" (dict "value" .Values.influxdb.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "influxdb.tplValue" (dict "value" .Values.influxdb.affinity "context" $) | nindent 8 }}
       {{- else }}
       affinity:
         podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.influxdb.podAffinityPreset "component" "influxdb" "context" $) | nindent 10 }}

--- a/bitnami/influxdb/templates/influxdb/statefulset-high-availability.yaml
+++ b/bitnami/influxdb/templates/influxdb/statefulset-high-availability.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       {{- include "influxdb.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.influxdb.affinity }}
-      affinity: {{- include "influxdb.tplValue" (dict "value" .Values.influxdb.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.influxdb.affinity "context" $) | nindent 8 }}
       {{- else }}
       affinity:
         podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.influxdb.podAffinityPreset "component" "influxdb" "context" $) | nindent 10 }}
@@ -35,10 +35,10 @@ spec:
         nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.influxdb.nodeAffinityPreset.type "key" .Values.influxdb.nodeAffinityPreset.key "values" .Values.influxdb.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
       {{- if .Values.influxdb.nodeSelector }}
-      nodeSelector: {{- include "influxdb.tplValue" (dict "value" .Values.influxdb.nodeSelector "context" $) | nindent 8 }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.influxdb.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.influxdb.tolerations }}
-      tolerations: {{- include "influxdb.tplValue" (dict "value" .Values.influxdb.tolerations "context" $) | nindent 8 }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.influxdb.tolerations "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.influxdb.securityContext.enabled }}
       securityContext:

--- a/bitnami/influxdb/templates/relay/deployment.yaml
+++ b/bitnami/influxdb/templates/relay/deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       {{- include "influxdb.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.relay.affinity }}
-      affinity: {{- include "fluentd.tplValue" (dict "value" .Values.relay.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "influxdb.tplValue" (dict "value" .Values.relay.affinity "context" $) | nindent 8 }}
       {{- else }}
       affinity:
         podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.relay.podAffinityPreset "component" "relay" "context" $) | nindent 10 }}

--- a/bitnami/influxdb/templates/relay/deployment.yaml
+++ b/bitnami/influxdb/templates/relay/deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       {{- include "influxdb.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.relay.affinity }}
-      affinity: {{- include "influxdb.tplValue" (dict "value" .Values.relay.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.relay.affinity "context" $) | nindent 8 }}
       {{- else }}
       affinity:
         podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.relay.podAffinityPreset "component" "relay" "context" $) | nindent 10 }}
@@ -33,10 +33,10 @@ spec:
         nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.relay.nodeAffinityPreset.type "key" .Values.relay.nodeAffinityPreset.key "values" .Values.relay.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
       {{- if .Values.relay.nodeSelector }}
-      nodeSelector: {{- include "influxdb.tplValue" (dict "value" .Values.relay.nodeSelector "context" $) | nindent 8 }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.relay.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.relay.tolerations }}
-      tolerations: {{- include "influxdb.tplValue" (dict "value" .Values.relay.tolerations "context" $) | nindent 8 }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.relay.tolerations "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.relay.securityContext.enabled }}
       securityContext:

--- a/bitnami/influxdb/templates/relay/service.yaml
+++ b/bitnami/influxdb/templates/relay/service.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "influxdb.labels" . | nindent 4 }}
     app.kubernetes.io/component: relay
   {{- if .Values.relay.service.annotations }}
-  annotations: {{- include "influxdb.tplValue" ( dict "value" .Values.relay.service.annotations "context" $) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.relay.service.annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.relay.service.type }}


### PR DESCRIPTION
Signed-off-by: Andrey Voronkov <voronkovaa@gmail.com>

**Description of the change**

Bugfix. Chart install fails on actually setting affinity templates

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
