### PR TITLE
[bitnami/kube-prometheus] Add chart global labels to exporters manifests

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-prometheus
   - https://github.com/bitnami/bitnami-docker-alertmanager
   - https://github.com/prometheus-operator/kube-prometheus
-version: 3.1.1
+version: 3.1.2

--- a/bitnami/kube-prometheus/templates/exporters/core-dns/service.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/core-dns/service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-coredns
   namespace: {{ .Values.coreDns.namespace }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "kube-prometheus.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ template "kube-prometheus.fullname" . }}-coredns
 spec:
   clusterIP: None

--- a/bitnami/kube-prometheus/templates/exporters/core-dns/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/core-dns/servicemonitor.yaml
@@ -4,7 +4,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-coredns
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "kube-prometheus.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ template "kube-prometheus.fullname" . }}-coredns
 spec:
   jobLabel: k8s-app

--- a/bitnami/kube-prometheus/templates/exporters/kube-apiserver/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-apiserver/servicemonitor.yaml
@@ -4,7 +4,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-apiserver
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "kube-prometheus.labels" . | nindent 4 }}
     app.kubernetes.io/component: apiserver
 spec:
   jobLabel: component

--- a/bitnami/kube-prometheus/templates/exporters/kube-controller-manager/endpoints.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-controller-manager/endpoints.yaml
@@ -4,7 +4,7 @@ kind: Endpoints
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-kube-controller-manager
   namespace: {{ .Values.kubeControllerManager.namespace }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "kube-prometheus.labels" . | nindent 4 }}
     app.kubernetes.io/component: kube-controller-manager
 subsets:
   - addresses:

--- a/bitnami/kube-prometheus/templates/exporters/kube-controller-manager/service.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-controller-manager/service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-kube-controller-manager
   namespace: {{ .Values.kubeControllerManager.namespace }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "kube-prometheus.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ template "kube-prometheus.fullname" . }}-kube-controller-manager
 spec:
   clusterIP: None

--- a/bitnami/kube-prometheus/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -4,7 +4,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-kube-controller-manager
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "kube-prometheus.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ template "kube-prometheus.fullname" . }}-kube-controller-manager
 spec:
   jobLabel: component

--- a/bitnami/kube-prometheus/templates/exporters/kube-proxy/endpoints.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-proxy/endpoints.yaml
@@ -4,7 +4,7 @@ kind: Endpoints
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-kube-proxy
   namespace: {{ .Values.kubeProxy.namespace }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "kube-prometheus.labels" . | nindent 4 }}
     app.kubernetes.io/component: kube-proxy
 subsets:
   - addresses:

--- a/bitnami/kube-prometheus/templates/exporters/kube-proxy/service.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-proxy/service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-kube-proxy
   namespace: {{ .Values.kubeProxy.namespace }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "kube-prometheus.labels" . | nindent 4 }}
     app.kubernetes.io/component: kube-proxy
 spec:
   clusterIP: None

--- a/bitnami/kube-prometheus/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -4,7 +4,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-kube-proxy
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "kube-prometheus.labels" . | nindent 4 }}
     app.kubernetes.io/component: kube-proxy
 spec:
   jobLabel: k8s-app

--- a/bitnami/kube-prometheus/templates/exporters/kube-scheduler/endpoints.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-scheduler/endpoints.yaml
@@ -4,7 +4,7 @@ kind: Endpoints
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-kube-scheduler
   namespace: {{ .Values.kubeScheduler.namespace }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "kube-prometheus.labels" . | nindent 4 }}
     app.kubernetes.io/component: kube-scheduler
 subsets:
   - addresses:

--- a/bitnami/kube-prometheus/templates/exporters/kube-scheduler/service.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-scheduler/service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-kube-scheduler
   namespace: {{ .Values.kubeScheduler.namespace }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "kube-prometheus.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ template "kube-prometheus.fullname" . }}-kube-scheduler
 spec:
   clusterIP: None

--- a/bitnami/kube-prometheus/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -4,7 +4,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-kube-scheduler
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "kube-prometheus.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ template "kube-prometheus.fullname" . }}-kube-scheduler
 spec:
   jobLabel: component

--- a/bitnami/kube-prometheus/templates/exporters/kubelet/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kubelet/servicemonitor.yaml
@@ -4,7 +4,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-kubelet
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  labels: {{- include "kube-prometheus.labels" . | nindent 4 }}
     app.kubernetes.io/component: kubelet
 spec:
   jobLabel: k8s-app


### PR DESCRIPTION
**Description of the change**

For all exporters manifests (in templates/exporters), replacing labels inclusion.
From: include "common.labels.standard"
To: include "kube-prometheus.labels"

kube-prometheus.labels is using common.labels.standard with global.labels injected.

**Benefits**

Use global labels defined in values.yaml
K8s resources will refer to global labels.
Can be used for serviceMonitor selectors.

**Possible drawbacks**

Global labels will be apply to all exporters manifests.

**Applicable issues**

None

**Additional information**

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
