### PR TITLE
[bitnami/spring-cloud-dataflow] feat: move composedtak env var to the next version

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.lock
+++ b/bitnami/spring-cloud-dataflow/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 9.0.1
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
-  version: 8.2.0
+  version: 8.3.0
 - name: kafka
   repository: https://charts.bitnami.com/bitnami
-  version: 12.2.1
-digest: sha256:219ce762abc0fb5d120a0e7474c577e14582f895709e29e8b5283af6a6491a8c
-generated: "2020-11-30T03:38:02.628364209Z"
+  version: 12.2.3
+digest: sha256:e59b7acacffd1c15ff41dca2bc5b463a416bc4f4d23adc49b6ea495f87c8d93c
+generated: "2020-12-04T09:35:55.919705082Z"

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: DeveloperTools
 apiVersion: v2
-appVersion: 2.6.4
+appVersion: 2.7.0
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: DeveloperTools
 apiVersion: v2
-appVersion: 2.6.4
+appVersion: 2.7.0
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -38,4 +38,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-spring-cloud-dataflow
   - https://github.com/bitnami/bitnami-docker-spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 2.1.0
+version: 2.2.0

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: DeveloperTools
 apiVersion: v2
-appVersion: 2.7.0
+appVersion: 2.6.4
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -300,7 +300,7 @@ Alternatively, a YAML file that specifies the values for the parameters can be p
 helm install my-release -f values.yaml bitnami/spring-cloud-dataflow
 ```
 
-> **Tip**: You can use the default [values.yaml](values.yaml)
+> **Tip**: You can use the default [values.yaml](https://github.com/bitnami/charts/blob/master/bitnami/spring-cloud-dataflow/values.yaml)
 
 ## Configuration and installation details
 

--- a/bitnami/spring-cloud-dataflow/templates/server/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/deployment.yaml
@@ -126,7 +126,7 @@ spec:
             - name: JAVA_TOOL_OPTIONS
               value: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address={{ .Values.server.jdwp.port }}"
             {{- end }}
-            - name: SPRING_CLOUD_DATAFLOW_TASK_COMPOSED_TASK_RUNNER_URI
+            - name: SPRING_CLOUD_DATAFLOW_TASK_COMPOSEDTASKRUNNER_URI
               value: 'docker://{{ include "common.images.image" (dict "imageRoot" .Values.server.composedTaskRunner.image) }}'
             {{- range $key, $value := .Values.server.extraEnvVars }}
             - name: {{ $value.name }}

--- a/bitnami/spring-cloud-dataflow/values-production.yaml
+++ b/bitnami/spring-cloud-dataflow/values-production.yaml
@@ -51,7 +51,7 @@ server:
     image:
       registry: docker.io
       repository: bitnami/spring-cloud-dataflow-composed-task-runner
-      tag: 2.7.0-debian-10-r0
+      tag: 2.7.0-debian-10-r3
 
   ## Spring Cloud Dataflow Server configuration parameters
   ##
@@ -358,7 +358,7 @@ skipper:
   image:
     registry: docker.io
     repository: bitnami/spring-cloud-skipper
-    tag: 2.6.0-debian-10-r4
+    tag: 2.6.0-debian-10-r7
     ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##
@@ -644,7 +644,7 @@ waitForBackends:
   image:
     registry: docker.io
     repository: bitnami/kubectl
-    tag: 1.18.12-debian-10-r14
+    tag: 1.18.12-debian-10-r17
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -704,7 +704,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/prometheus-rsocket-proxy
-    tag: 1.2.1-debian-10-r89
+    tag: 1.3.0-debian-10-r1
     ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##

--- a/bitnami/spring-cloud-dataflow/values-production.yaml
+++ b/bitnami/spring-cloud-dataflow/values-production.yaml
@@ -30,7 +30,7 @@ server:
   image:
     registry: docker.io
     repository: bitnami/spring-cloud-dataflow
-    tag: 2.6.4-debian-10-r0
+    tag: 2.7.0-debian-10-r0
     ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##
@@ -51,7 +51,7 @@ server:
     image:
       registry: docker.io
       repository: bitnami/spring-cloud-dataflow-composed-task-runner
-      tag: 2.6.3-debian-10-r50
+      tag: 2.7.0-debian-10-r0
 
   ## Spring Cloud Dataflow Server configuration parameters
   ##
@@ -790,7 +790,6 @@ mariadb:
 ## All of these values are ignored when mariadb.enabled is set to true
 ##
 externalDatabase:
-
   ## Database server host and port
   ##
   host: localhost
@@ -808,7 +807,7 @@ externalDatabase:
     ## This provides a mechanism to define a fully customized JDBC URL for the data flow server rather than having it
     ## derived from the common, individual attributes. This property, when defined, has precedence over the
     ## individual attributes (scheme, host, port, database)
-    url: ""
+    url: ''
     database: dataflow
     user: dataflow
   ## Skipper and database
@@ -818,7 +817,7 @@ externalDatabase:
     ## This provides a mechanism to define a fully customized JDBC URL for skipper rather than having it
     ## derived from the common, individual attributes. This property, when defined, has precedence over the
     ## individual attributes (scheme, host, port, database)
-    url: ""
+    url: ''
     database: skipper
     user: skipper
   ## Hibernate Dialect

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -51,7 +51,7 @@ server:
     image:
       registry: docker.io
       repository: bitnami/spring-cloud-dataflow-composed-task-runner
-      tag: 2.7.0-debian-10-r0
+      tag: 2.7.0-debian-10-r3
 
   ## Spring Cloud Dataflow Server configuration parameters
   ##
@@ -358,7 +358,7 @@ skipper:
   image:
     registry: docker.io
     repository: bitnami/spring-cloud-skipper
-    tag: 2.6.0-debian-10-r4
+    tag: 2.6.0-debian-10-r7
     ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##
@@ -644,7 +644,7 @@ waitForBackends:
   image:
     registry: docker.io
     repository: bitnami/kubectl
-    tag: 1.18.12-debian-10-r14
+    tag: 1.18.12-debian-10-r17
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -704,7 +704,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/prometheus-rsocket-proxy
-    tag: 1.2.1-debian-10-r89
+    tag: 1.3.0-debian-10-r1
     ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -30,7 +30,7 @@ server:
   image:
     registry: docker.io
     repository: bitnami/spring-cloud-dataflow
-    tag: 2.6.4-debian-10-r0
+    tag: 2.7.0-debian-10-r0
     ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##
@@ -51,7 +51,7 @@ server:
     image:
       registry: docker.io
       repository: bitnami/spring-cloud-dataflow-composed-task-runner
-      tag: 2.6.3-debian-10-r50
+      tag: 2.7.0-debian-10-r0
 
   ## Spring Cloud Dataflow Server configuration parameters
   ##


### PR DESCRIPTION
Signed-off-by: darteaga <darteaga@vmware.com>

**Description of the change**

Update composed task runner uri environment variable.

**Benefits**

Update chart to support 2.7.0 version changes.

**Possible drawbacks**

N/A

**Applicable issues**

  - related #4570

**Additional information**

Do not merge until the new version of the container is released.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
