### PR TITLE
[bitnami/chart/redis] adds logic to restart the redis and sentinel containers of a returning node while sentinel is performing a failover

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -19,4 +19,4 @@ name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 12.1.1
+version: 12.1.2

--- a/bitnami/redis/templates/configmap-scripts.yaml
+++ b/bitnami/redis/templates/configmap-scripts.yaml
@@ -75,6 +75,11 @@ data:
       REDIS_SENTINEL_INFO=($($sentinel_info_command))
       REDIS_MASTER_HOST=${REDIS_SENTINEL_INFO[0]}
       REDIS_MASTER_PORT_NUMBER=${REDIS_SENTINEL_INFO[1]}
+
+			sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $REDIS_MASTER_HOST -p {{ .Values.sentinel.port  }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet  }}"
+			if [[ ! ($($sentinel_info_command))  ]]; then
+				exit 1
+			fi
     fi
 
     if [[ ! -f /opt/bitnami/redis/etc/redis.conf ]];then
@@ -225,6 +230,11 @@ data:
       REDIS_SENTINEL_INFO=($($sentinel_info_command))
       REDIS_MASTER_HOST=${REDIS_SENTINEL_INFO[0]}
       REDIS_MASTER_PORT_NUMBER=${REDIS_SENTINEL_INFO[1]}
+
+			sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $REDIS_MASTER_HOST -p {{ .Values.sentinel.port  }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet  }}"
+			if [[ ! ($($sentinel_info_command))  ]]; then
+				exit 1
+			fi
     fi
     sentinel_conf_set "sentinel monitor" "{{ .Values.sentinel.masterSet }} "$REDIS_MASTER_HOST" "$REDIS_MASTER_PORT_NUMBER" {{ .Values.sentinel.quorum }}"
 

--- a/bitnami/redis/templates/configmap-scripts.yaml
+++ b/bitnami/redis/templates/configmap-scripts.yaml
@@ -76,10 +76,11 @@ data:
       REDIS_MASTER_HOST=${REDIS_SENTINEL_INFO[0]}
       REDIS_MASTER_PORT_NUMBER=${REDIS_SENTINEL_INFO[1]}
 
-			sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $REDIS_MASTER_HOST -p {{ .Values.sentinel.port  }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet  }}"
-			if [[ ! ($($sentinel_info_command))  ]]; then
-				exit 1
-			fi
+      sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $REDIS_MASTER_HOST -p {{ .Values.sentinel.port  }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet  }}"
+
+      if [[ ! ($($sentinel_info_command))  ]]; then
+        exit 1
+      fi
     fi
 
     if [[ ! -f /opt/bitnami/redis/etc/redis.conf ]];then
@@ -231,10 +232,11 @@ data:
       REDIS_MASTER_HOST=${REDIS_SENTINEL_INFO[0]}
       REDIS_MASTER_PORT_NUMBER=${REDIS_SENTINEL_INFO[1]}
 
-			sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $REDIS_MASTER_HOST -p {{ .Values.sentinel.port  }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet  }}"
-			if [[ ! ($($sentinel_info_command))  ]]; then
-				exit 1
-			fi
+      sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $REDIS_MASTER_HOST -p {{ .Values.sentinel.port  }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet  }}"
+
+      if [[ ! ($($sentinel_info_command))  ]]; then
+        exit 1
+      fi
     fi
     sentinel_conf_set "sentinel monitor" "{{ .Values.sentinel.masterSet }} "$REDIS_MASTER_HOST" "$REDIS_MASTER_PORT_NUMBER" {{ .Values.sentinel.quorum }}"
 


### PR DESCRIPTION
Updates: https://github.com/bitnami/charts/pull/4478
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
With the current version of charts/redis i'm observing after the master goes down and restarts faster than sentinel can failover
the restarted master will get stuck looking at it's previous master IP and not participate in the failover taking place. This change continually reboots the redis and sentinel containers until the failover has taken place so it can rejoin the cluster.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
Improved robustness of the Sentinel Solution
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
We are still observing some configuration issues and cluster instability with the `failoverTimeout` and `downAfterMilliseconds` defaults. Investigation will continue and be returned to the contributors. 
<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #3700

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
