### PR TITLE
[bitnami/harbor] Define external psql endpoint via secret, set sslmode

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-harbor-registry
   - https://github.com/bitnami/bitnami-docker-harbor-registryctl
   - https://goharbor.io/
-version: 9.1.1
+version: 9.1.2

--- a/bitnami/harbor/README.md
+++ b/bitnami/harbor/README.md
@@ -712,7 +712,7 @@ The following tables list the configurable parameters of the Harbor chart and th
 | `externalDatabase.notarySignerDatabase` | External database name for notary signer                                                                  | `nil`                            |
 | `externalDatabase.notarySignerUsername` | External database username for notary signer                                                                  | `nil`                            |
 | `externalDatabase.notarySignerPassword`        | External database password for notary signer                                                                          | `nil`                            |
-| `externalDatabase.sslmode`              | External database ssl mode                                                                                | `nil`                            |
+| `externalDatabase.sslmode`              | External database ssl mode                                                                                | `disable`                        |
 
 ### Redis Parameters
 

--- a/bitnami/harbor/templates/clair/clair-dpl.yaml
+++ b/bitnami/harbor/templates/clair/clair-dpl.yaml
@@ -202,7 +202,10 @@ spec:
             - name: SCANNER_STORE_REDIS_URL
               value: {{ include "harbor.redisForClairAdapter" . }}
             - name: SCANNER_CLAIR_DATABASE_URL
-              value: {{ include "harbor.database.clair" . }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "harbor.clair" . }}
+                  key: database
             {{- if .Values.internalTLS.enabled }}
             - name: INTERNAL_TLS_ENABLED
               value: "true"

--- a/bitnami/harbor/templates/notary/notary-secret-envvars.yaml
+++ b/bitnami/harbor/templates/notary/notary-secret-envvars.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.notary.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "harbor.notary-server" . }}-envvars
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+    app.kubernetes.io/component: notary
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  server_db_url: {{ include "harbor.database.notaryServer" . }}
+  signer_db_url: {{ include "harbor.database.notarySigner" . }}
+{{- end }}

--- a/bitnami/harbor/templates/notary/notary-server.yaml
+++ b/bitnami/harbor/templates/notary/notary-server.yaml
@@ -85,7 +85,10 @@ spec:
             - name: MIGRATIONS_PATH
               value: migrations/server/postgresql
             - name: DB_URL
-              value: {{ include "harbor.database.notaryServer" . }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "harbor.notary-server" . }}-envvars
+                  key: server_db_url
             {{- if .Values.notary.server.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.notary.server.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/bitnami/harbor/templates/notary/notary-signer.yaml
+++ b/bitnami/harbor/templates/notary/notary-signer.yaml
@@ -84,7 +84,10 @@ spec:
             - name: MIGRATIONS_PATH
               value: migrations/signer/postgresql
             - name: DB_URL
-              value: {{ include "harbor.database.notarySigner" . | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "harbor.notary-server" . }}-envvars
+                  key: signer_db_url
             - name: NOTARY_SIGNER_DEFAULTALIAS
               value: defaultalias
             {{- if .Values.notary.signer.extraEnvVars }}

--- a/bitnami/harbor/values-production.yaml
+++ b/bitnami/harbor/values-production.yaml
@@ -2703,7 +2703,7 @@ externalDatabase:
   port: 5432
   ## External database ssl mode
   ##
-  sslmode:
+  sslmode: disable
   ## External database name for core
   ##
   coreDatabase:

--- a/bitnami/harbor/values.yaml
+++ b/bitnami/harbor/values.yaml
@@ -2702,7 +2702,7 @@ externalDatabase:
   port: 5432
   ## External database ssl mode
   ##
-  sslmode:
+  sslmode: disable
   ## External database name for core
   ##
   coreDatabase:


### PR DESCRIPTION
**Description of the change**
- Allow Postgres endpoints to be defined via environment `secretKeyRef`
- Disable SSL by default (no longer `nil`) for external database connections

**Benefits**
This change allows you to define the Postgres endpoint as a secret
value, rather than providing passwords in raw values files. A new secret
template is created for notary to introduce relevant environment
variables for the notary service.

Additionally, the default configuration for `externalDatabase.sslmode`
was configured as `nil`. This change explicitly sets `disable` for both
`values.yaml` and `values-production.yaml`.

Chart version received a patch version bump. This _could_ potentially
be seen as a minor version bump, depending on the interpretation of
semantic versioning.

Co-authored-by: Robert Van Voorhees <rvanvoorhees@vmware.com>

**Possible drawbacks**
nil.

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
