### PR TITLE
[bitnami/influxdb] Fix typo in files inclusion

### DIFF
--- a/bitnami/influxdb/Chart.lock
+++ b/bitnami/influxdb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.0.1
-digest: sha256:e66388f254b9de6470bca6d8c1c565d1c16a5569beef68a7bc99e486e73ccbdb
-generated: "2020-11-24T12:53:20.51555+01:00"
+  version: 1.1.1
+digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
+generated: "2020-12-05T11:59:31.722671416+03:00"

--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -24,4 +24,4 @@ name: influxdb
 sources:
   - https://github.com/bitnami/bitnami-docker-influxdb
   - https://www.influxdata.com/products/influxdb-overview/
-version: 1.1.1
+version: 1.1.2

--- a/bitnami/influxdb/templates/influxdb/configmap-initdb-scripts.yaml
+++ b/bitnami/influxdb/templates/influxdb/configmap-initdb-scripts.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "influxdb.fullname" . }}-initdb-scripts
-  labels: 
+  labels:
     {{- include "influxdb.labels" . | nindent 4 }}
     app.kubernetes.io/component: influxdb
 data:

--- a/bitnami/influxdb/templates/influxdb/configmap.yaml
+++ b/bitnami/influxdb/templates/influxdb/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "influxdb.fullname" . }}
-  labels: 
+  labels:
     {{- include "influxdb.labels" . | nindent 4 }}
     app.kubernetes.io/component: influxdb
 data:

--- a/bitnami/influxdb/templates/influxdb/pvc-backup.yaml
+++ b/bitnami/influxdb/templates/influxdb/pvc-backup.yaml
@@ -3,7 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ include "influxdb.fullname" . }}-backups
-  labels: 
+  labels:
     {{- include "influxdb.labels" . | nindent 4 }}
 spec:
   accessModes:

--- a/bitnami/influxdb/templates/influxdb/pvc.yaml
+++ b/bitnami/influxdb/templates/influxdb/pvc.yaml
@@ -3,7 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ include "influxdb.fullname" . }}
-  labels: 
+  labels:
     {{- include "influxdb.labels" . | nindent 4 }}
 spec:
   accessModes:

--- a/bitnami/influxdb/templates/influxdb/secrets.yaml
+++ b/bitnami/influxdb/templates/influxdb/secrets.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "influxdb.fullname" . }}
-  labels: 
+  labels:
     {{- include "influxdb.labels" . | nindent 4 }}
 type: Opaque
 data:

--- a/bitnami/influxdb/templates/influxdb/service-headless.yaml
+++ b/bitnami/influxdb/templates/influxdb/service-headless.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "influxdb.fullname" . }}-headless
-  labels: 
+  labels:
     {{- include "influxdb.labels" . | nindent 4 }}
     app.kubernetes.io/component: influxdb
 spec:
@@ -18,7 +18,7 @@ spec:
       targetPort: rpc
       protocol: TCP
       name: rpc
-  selector: 
+  selector:
     {{- include "influxdb.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: influxdb
 {{- end }}

--- a/bitnami/influxdb/templates/influxdb/service-metrics.yaml
+++ b/bitnami/influxdb/templates/influxdb/service-metrics.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "influxdb.fullname" . }}-metrics
-  labels: 
+  labels:
     {{- include "influxdb.labels" . | nindent 4 }}
     app.kubernetes.io/component: influxdb
   {{- if .Values.metrics.service.annotations }}
@@ -33,7 +33,7 @@ spec:
       {{- else if eq .Values.metrics.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
-  selector: 
+  selector:
     {{- include "influxdb.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: influxdb
 {{- end }}

--- a/bitnami/influxdb/templates/influxdb/service.yaml
+++ b/bitnami/influxdb/templates/influxdb/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "influxdb.fullname" . }}
-  labels: 
+  labels:
     {{- include "influxdb.labels" . | nindent 4 }}
     app.kubernetes.io/component: influxdb
   {{- if .Values.influxdb.service.annotations }}
@@ -41,6 +41,6 @@ spec:
       {{- else if eq .Values.influxdb.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
-  selector: 
+  selector:
     {{- include "influxdb.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: influxdb

--- a/bitnami/influxdb/templates/influxdb/servicemonitor.yaml
+++ b/bitnami/influxdb/templates/influxdb/servicemonitor.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- if .Values.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.metrics.serviceMonitor.namespace }}
   {{- end }}
-  labels: 
+  labels:
     {{- include "influxdb.labels" . | nindent 4 }}
     app.kubernetes.io/component: influxdb
     {{- range $key, $value := .Values.metrics.serviceMonitor.selector }}

--- a/bitnami/influxdb/templates/influxdb/statefulset-high-availability.yaml
+++ b/bitnami/influxdb/templates/influxdb/statefulset-high-availability.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "influxdb.fullname" . }}
-  labels: 
+  labels:
     {{- include "influxdb.labels" . | nindent 4 }}
     app.kubernetes.io/component: influxdb
 spec:
@@ -16,12 +16,12 @@ spec:
     rollingUpdate: null
     {{- end }}
   selector:
-    matchLabels: 
+    matchLabels:
       {{- include "influxdb.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: influxdb
   template:
     metadata:
-      labels: 
+      labels:
         {{ include "influxdb.labels" . | nindent 8 }}
         app.kubernetes.io/component: influxdb
     spec:

--- a/bitnami/influxdb/templates/relay/configmap.yaml
+++ b/bitnami/influxdb/templates/relay/configmap.yaml
@@ -3,12 +3,12 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "influxdb.fullname" . }}-relay
-  labels: 
+  labels:
     {{- include "influxdb.labels" . | nindent 4 }}
     app.kubernetes.io/component: relay
 data:
 {{- if (.Files.Glob "files/conf/relay.toml") }}
-{{ (.Files.Glob "iles/conf/relay.toml").AsConfig | indent 2 }}
+{{ (.Files.Glob "files/conf/relay.toml").AsConfig | indent 2 }}
 {{- else if .Values.relay.configuration }}
   relay.toml: |-
 {{ tpl .Values.relay.configuration . | indent 4 }}

--- a/bitnami/influxdb/templates/relay/deployment.yaml
+++ b/bitnami/influxdb/templates/relay/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "influxdb.fullname" . }}-relay
-  labels: 
+  labels:
     {{- include "influxdb.labels" . | nindent 4 }}
     app.kubernetes.io/component: relay
 spec:
@@ -14,12 +14,12 @@ spec:
     rollingUpdate: null
     {{- end }}
   selector:
-    matchLabels: 
+    matchLabels:
       {{- include "influxdb.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: relay
   template:
     metadata:
-      labels: 
+      labels:
         {{- include "influxdb.labels" . | nindent 8 }}
         app.kubernetes.io/component: relay
     spec:

--- a/bitnami/influxdb/templates/relay/service.yaml
+++ b/bitnami/influxdb/templates/relay/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "influxdb.fullname" . }}-relay
-  labels: 
+  labels:
     {{- include "influxdb.labels" . | nindent 4 }}
     app.kubernetes.io/component: relay
   {{- if .Values.relay.service.annotations }}
@@ -33,7 +33,7 @@ spec:
       {{- else if eq .Values.relay.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
-  selector: 
+  selector:
     {{- include "influxdb.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: relay
   {{- end }}


### PR DESCRIPTION
* Remove extra spaces after labels:
* Fix path for file inclusion

Signed-off-by: Andrey Voronkov <voronkovaa@gmail.com>

**Description of the change**
Bugfix & cosmetics


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
