### PR TITLE
[bitnami/spark] Reorder service and metrics to follow the standard guidelines

### DIFF
--- a/bitnami/spark/values-production.yaml
+++ b/bitnami/spark/values-production.yaml
@@ -259,69 +259,6 @@ worker:
     ## Max number of workers when using autoscaling
     replicasMax: 10
 
-## Metrics configuration
-##
-metrics:
-  enabled: enabled
-
-  ## Prometheus metrics service parameters
-  ##
-  service:
-    ## Metrics port
-    ##
-    port: 9117
-    ## Annotations for the Prometheus metics service
-    ##
-    annotations:
-      prometheus.io/scrape: "true"
-      prometheus.io/port: "{{ .Values.metrics.service.port }}"
-
-  ## Prometheus Service Monitor
-  ## ref: https://github.com/coreos/prometheus-operator
-  ##      https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
-  ##
-  podMonitor:
-    ## If the operator is installed in your cluster, set to true to create a Service Monitor Entry
-    ##
-    enabled: false
-    ## Specify the namespace in which the podMonitor resource will be created
-    # namespace: ""
-    ## Specify the interval at which metrics should be scraped
-    ##
-    # interval: 30s
-    ## Specify the timeout after which the scrape is ended
-    # scrapeTimeout: 10s
-
-  masterAnnotations:
-    prometheus.io/scrape: 'true'
-    prometheus.io/port: "{{ .Values.master.webPort }}"
-
-  workerAnnotations:
-    prometheus.io/scrape: 'true'
-    prometheus.io/port: "{{ .Values.worker.webPort }}"
-
-  ## Custom PrometheusRule to be defined
-  ## The value is evaluated as a template, so, for example, the value can depend on .Release or .Chart
-  ## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions
-  ##
-  prometheusRule:
-    enabled: false
-    additionalLabels: {}
-    namespace: ''
-    ## These are just examples rules, please adapt them to your needs.
-    ## Make sure to constraint the rules to the current postgresql service.
-    ## rules:
-    ##   - alert: HugeReplicationLag
-    ##     expr: pg_replication_lag{service="{{ template "postgresql.fullname" . }}-metrics"} / 3600 > 1
-    ##     for: 1m
-    ##     labels:
-    ##       severity: critical
-    ##     annotations:
-    ##       description: replication for {{ template "postgresql.fullname" . }} PostgreSQL is lagging by {{ "{{ $value }}" }} hour(s).
-    ##       summary: PostgreSQL replication is lagging by {{ "{{ $value }}" }} hour(s).
-    ##
-    rules: []
-
 ## Security configuration
 ##
 security:
@@ -409,3 +346,66 @@ ingress:
     - hosts:
         - spark.domain.com
       secretName: spark.local-tls
+
+## Metrics configuration
+##
+metrics:
+  enabled: enabled
+
+  ## Prometheus metrics service parameters
+  ##
+  service:
+    ## Metrics port
+    ##
+    port: 9117
+    ## Annotations for the Prometheus metics service
+    ##
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "{{ .Values.metrics.service.port }}"
+
+  ## Prometheus Service Monitor
+  ## ref: https://github.com/coreos/prometheus-operator
+  ##      https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+  ##
+  podMonitor:
+    ## If the operator is installed in your cluster, set to true to create a Service Monitor Entry
+    ##
+    enabled: false
+    ## Specify the namespace in which the podMonitor resource will be created
+    # namespace: ""
+    ## Specify the interval at which metrics should be scraped
+    ##
+    # interval: 30s
+    ## Specify the timeout after which the scrape is ended
+    # scrapeTimeout: 10s
+
+  masterAnnotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: "{{ .Values.master.webPort }}"
+
+  workerAnnotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: "{{ .Values.worker.webPort }}"
+
+  ## Custom PrometheusRule to be defined
+  ## The value is evaluated as a template, so, for example, the value can depend on .Release or .Chart
+  ## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions
+  ##
+  prometheusRule:
+    enabled: false
+    additionalLabels: {}
+    namespace: ''
+    ## These are just examples rules, please adapt them to your needs.
+    ## Make sure to constraint the rules to the current postgresql service.
+    ## rules:
+    ##   - alert: HugeReplicationLag
+    ##     expr: pg_replication_lag{service="{{ template "postgresql.fullname" . }}-metrics"} / 3600 > 1
+    ##     for: 1m
+    ##     labels:
+    ##       severity: critical
+    ##     annotations:
+    ##       description: replication for {{ template "postgresql.fullname" . }} PostgreSQL is lagging by {{ "{{ $value }}" }} hour(s).
+    ##       summary: PostgreSQL replication is lagging by {{ "{{ $value }}" }} hour(s).
+    ##
+    rules: []

--- a/bitnami/spark/values.yaml
+++ b/bitnami/spark/values.yaml
@@ -259,69 +259,6 @@ worker:
     ## Max number of workers when using autoscaling
     replicasMax: 5
 
-## Metrics configuration
-##
-metrics:
-  enabled: false
-
-  ## Prometheus metrics service parameters
-  ##
-  service:
-    ## Metrics port
-    ##
-    port: 9117
-    ## Annotations for the Prometheus metics service
-    ##
-    annotations:
-      prometheus.io/scrape: "true"
-      prometheus.io/port: "{{ .Values.metrics.service.port }}"
-
-  ## Prometheus Service Monitor
-  ## ref: https://github.com/coreos/prometheus-operator
-  ##      https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
-  ##
-  podMonitor:
-    ## If the operator is installed in your cluster, set to true to create a Service Monitor Entry
-    ##
-    enabled: false
-    ## Specify the namespace in which the podMonitor resource will be created
-    # namespace: ""
-    ## Specify the interval at which metrics should be scraped
-    ##
-    # interval: 30s
-    ## Specify the timeout after which the scrape is ended
-    # scrapeTimeout: 10s
-
-  masterAnnotations:
-    prometheus.io/scrape: 'true'
-    prometheus.io/port: "{{ .Values.master.webPort }}"
-
-  workerAnnotations:
-    prometheus.io/scrape: 'true'
-    prometheus.io/port: "{{ .Values.worker.webPort }}"
-
-  ## Custom PrometheusRule to be defined
-  ## The value is evaluated as a template, so, for example, the value can depend on .Release or .Chart
-  ## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions
-  ##
-  prometheusRule:
-    enabled: false
-    additionalLabels: {}
-    namespace: ''
-    ## These are just examples rules, please adapt them to your needs.
-    ## Make sure to constraint the rules to the current postgresql service.
-    ## rules:
-    ##   - alert: HugeReplicationLag
-    ##     expr: pg_replication_lag{service="{{ template "postgresql.fullname" . }}-metrics"} / 3600 > 1
-    ##     for: 1m
-    ##     labels:
-    ##       severity: critical
-    ##     annotations:
-    ##       description: replication for {{ template "postgresql.fullname" . }} PostgreSQL is lagging by {{ "{{ $value }}" }} hour(s).
-    ##       summary: PostgreSQL replication is lagging by {{ "{{ $value }}" }} hour(s).
-    ##
-    rules: []
-
 ## Security configuration
 ##
 security:
@@ -409,3 +346,66 @@ ingress:
     - hosts:
         - spark.domain.com
       secretName: spark.local-tls
+
+## Metrics configuration
+##
+metrics:
+  enabled: false
+
+  ## Prometheus metrics service parameters
+  ##
+  service:
+    ## Metrics port
+    ##
+    port: 9117
+    ## Annotations for the Prometheus metics service
+    ##
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "{{ .Values.metrics.service.port }}"
+
+  ## Prometheus Service Monitor
+  ## ref: https://github.com/coreos/prometheus-operator
+  ##      https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+  ##
+  podMonitor:
+    ## If the operator is installed in your cluster, set to true to create a Service Monitor Entry
+    ##
+    enabled: false
+    ## Specify the namespace in which the podMonitor resource will be created
+    # namespace: ""
+    ## Specify the interval at which metrics should be scraped
+    ##
+    # interval: 30s
+    ## Specify the timeout after which the scrape is ended
+    # scrapeTimeout: 10s
+
+  masterAnnotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: "{{ .Values.master.webPort }}"
+
+  workerAnnotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: "{{ .Values.worker.webPort }}"
+
+  ## Custom PrometheusRule to be defined
+  ## The value is evaluated as a template, so, for example, the value can depend on .Release or .Chart
+  ## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions
+  ##
+  prometheusRule:
+    enabled: false
+    additionalLabels: {}
+    namespace: ''
+    ## These are just examples rules, please adapt them to your needs.
+    ## Make sure to constraint the rules to the current postgresql service.
+    ## rules:
+    ##   - alert: HugeReplicationLag
+    ##     expr: pg_replication_lag{service="{{ template "postgresql.fullname" . }}-metrics"} / 3600 > 1
+    ##     for: 1m
+    ##     labels:
+    ##       severity: critical
+    ##     annotations:
+    ##       description: replication for {{ template "postgresql.fullname" . }} PostgreSQL is lagging by {{ "{{ $value }}" }} hour(s).
+    ##       summary: PostgreSQL replication is lagging by {{ "{{ $value }}" }} hour(s).
+    ##
+    rules: []


### PR DESCRIPTION
**Description of the change**

Reorder the metrics section to follow the standard guidelines

**Applicable issues**

  - Introduced as part of #4605


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ n/a] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ n/a] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
