### PR TITLE
[bitnami/grafana] Change health check path

### DIFF
--- a/bitnami/grafana/Chart.lock
+++ b/bitnami/grafana/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.0.1
-digest: sha256:e66388f254b9de6470bca6d8c1c565d1c16a5569beef68a7bc99e486e73ccbdb
-generated: "2020-11-24T12:53:13.983064+01:00"
+  version: 1.1.1
+digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
+generated: "2020-12-09T12:29:11.384952+01:00"

--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -24,4 +24,4 @@ name: grafana
 sources:
   - https://github.com/bitnami/bitnami-docker-grafana
   - https://grafana.com/
-version: 4.2.0
+version: 4.2.1

--- a/bitnami/grafana/templates/deployment.yaml
+++ b/bitnami/grafana/templates/deployment.yaml
@@ -133,7 +133,7 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /
+              path: /api/health
               port: dashboard
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -144,7 +144,7 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /
+              path: /api/health
               port: dashboard
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}


### PR DESCRIPTION
**Description of the change**

This change changes the readiness and liveness probe of the deployment to the Grafana health route path.

**Benefits**

When deploying the chart with an ingress, the backends remain in an unhealthy state as the / route, which is currently used for the health checks, returns a 302 status (redirects to /login). When changing the readiness and liveness probe to /api/health the ingress health check gets a 200 status when the instance is healthy.

**Possible drawbacks**

None.

**Checklist**

- [x] Chart version bumped in Chart.yaml according to semver.
- [x]  Variables are documented in the README.md
- [x]  Title of the PR starts with chart name (e.g. [bitnami/chart])
- [x]  If the chart contains a values-production.yaml apart from values.yaml, ensure that you implement the changes in both files