### PR TITLE
fix: add annotations to volumeClaimTemplates for MySQL

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -25,4 +25,4 @@ name: mysql
 sources:
   - https://github.com/bitnami/bitnami-docker-mysql
   - https://mysql.com
-version: 8.2.0
+version: 8.2.1

--- a/bitnami/mysql/templates/primary/statefulset.yaml
+++ b/bitnami/mysql/templates/primary/statefulset.yaml
@@ -312,6 +312,10 @@ spec:
         name: data
         labels: {{ include "common.labels.matchLabels" . | nindent 10 }}
           app.kubernetes.io/component: primary
+      {{- if .Values.primary.persistence.annotations }}
+        annotations:
+          {{- toYaml .Values.primary.persistence.annotations | nindent 10 }}
+      {{- end }}
       spec:
         accessModes:
           {{- range .Values.primary.persistence.accessModes }}

--- a/bitnami/mysql/templates/secondary/statefulset.yaml
+++ b/bitnami/mysql/templates/secondary/statefulset.yaml
@@ -281,6 +281,10 @@ spec:
         name: data
         labels: {{ include "common.labels.matchLabels" . | nindent 10 }}
           app.kubernetes.io/component: secondary
+      {{- if .Values.secondary.persistence.annotations }}
+        annotations:
+          {{- toYaml .Values.secondary.persistence.annotations | nindent 10 }}
+      {{- end }}
       spec:
         accessModes:
           {{- range .Values.secondary.persistence.accessModes }}


### PR DESCRIPTION
Currently, the chart doesn't add `annotations` from values to the statefulset `volumeClaimTemplates` so I made the changes needed for them to be added.