### PR TITLE
[bitnami/jasperreports] Add common subchart as dependency

### DIFF
--- a/bitnami/jasperreports/Chart.lock
+++ b/bitnami/jasperreports/Chart.lock
@@ -1,6 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 9.0.1
-digest: sha256:6a5735e0b7e5868bbf3eec9d9d031eb20a5928dd38894899c5bccf2e8f7c5a61
-generated: "2020-11-20T09:52:39.625467948Z"
+  version: 9.1.2
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.1.1
+digest: sha256:906007a3aa36816f5766558b685a5d6985c8672778afca5a190b88326c66912a
+generated: "2020-12-10T14:28:57.749378324+01:00"

--- a/bitnami/jasperreports/Chart.yaml
+++ b/bitnami/jasperreports/Chart.yaml
@@ -7,6 +7,11 @@ dependencies:
     name: mariadb
     repository: https://charts.bitnami.com/bitnami
     version: 9.x.x
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
 description: The JasperReports server can be used as a stand-alone or embedded reporting and BI server that offers web-based reporting, analytic tools and visualization, and a dashboard feature for compiling multiple custom views
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/jasperreports
@@ -25,4 +30,4 @@ name: jasperreports
 sources:
   - https://github.com/bitnami/bitnami-docker-jasperreports
   - http://community.jaspersoft.com/project/jasperreports-server
-version: 9.1.0
+version: 9.1.1


### PR DESCRIPTION
**Description of the change**

Add common subchart (library) for bitnami/jasperreports

**Applicable issues**

  - fixes #4673

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)