### PR TITLE
[bitnami/mongodb-sharded] fix for ConfigMaps

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb-sharded
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb-sharded
   - https://mongodb.org
-version: 3.2.0
+version: 3.2.1

--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb-sharded
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb-sharded
   - https://mongodb.org
-version: 3.2.1
+version: 3.2.2

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-configmap.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-configmap.yaml
@@ -7,5 +7,5 @@ metadata:
     app.kubernetes.io/component: configsvr
 data:
   mongodb.conf: |-
-    {{- include "common.tplvalues.render" (dict "value" .Values.configsvr.config "context" $) | indent 4 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.configsvr.config "context" $) | nindent 4 }}
 {{- end }}

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
@@ -320,7 +320,7 @@ spec:
         {{- if .Values.common.initScriptsSecret }}
         - name: custom-init-scripts-secret
           secret:
-            name: {{ include "mongodb-sharded.initScriptsSecret" . }}
+            secretName: {{ include "mongodb-sharded.initScriptsSecret" . }}
             defaultMode: 0755
         {{- end }}
         {{- if .Values.common.extraVolumes }}

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-configmap.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-configmap.yaml
@@ -7,5 +7,5 @@ metadata:
     app.kubernetes.io/component: mongos
 data:
   mongodb.conf: |-
-    {{- include "common.tplvalues.render" (dict "value" .Values.mongos.config "context" $) | indent 4 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.mongos.config "context" $) | nindent 4 }}
 {{- end }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-configmap.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-configmap.yaml
@@ -7,5 +7,5 @@ metadata:
     app.kubernetes.io/component: shardsvr-arbiter
 data:
   mongodb.conf: |-
-    {{- include "common.tplvalues.render" (dict "value" .Values.shardsvr.arbiter.config "context" $) | indent 4 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.shardsvr.arbiter.config "context" $) | nindent 4 }}
 {{- end }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
@@ -300,7 +300,7 @@ spec:
         {{- if $.Values.common.initScriptsSecret }}
         - name: custom-init-scripts-secret
           secret:
-            name: {{ include "mongodb-sharded.initScriptsSecret" $ }}
+            secretName: {{ include "mongodb-sharded.initScriptsSecret" $ }}
             defaultMode: 0755
         {{- end }}
       {{- if $.Values.common.extraVolumes }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-configmap.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-configmap.yaml
@@ -7,5 +7,5 @@ metadata:
     app.kubernetes.io/component: shardsvr
 data:
   mongodb.conf: |-
-    {{- include "common.tplvalues.render" (dict "value" .Values.shardsvr.dataNode.config "context" $) | indent 4 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.shardsvr.dataNode.config "context" $) | nindent 4 }}
 {{- end }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -320,7 +320,7 @@ spec:
         {{- if $.Values.common.initScriptsSecret }}
         - name: custom-init-scripts-secret
           secret:
-            name: {{ include "mongodb-sharded.initScriptsSecret" $ }}
+            secretName: {{ include "mongodb-sharded.initScriptsSecret" $ }}
             defaultMode: 0755
         {{- end }}
         {{- if or $.Values.shardsvr.dataNode.config $.Values.shardsvr.dataNode.configCM }}


### PR DESCRIPTION

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #4523 (fix for ConfigMap)

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
