### PR TITLE
[bitnami/mongodb] Add custom CA support 

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 10.2.0
+version: 10.3.0

--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -171,6 +171,8 @@ The following tables lists the configurable parameters of the MongoDB chart and 
 | `extraEnvVarsSecret`                      | Name of existing Secret containing extra env vars (in case of sensitive data)                              | `nil`                                                   |
 | `tls.enabled`                             | Enable MongoDB TLS support between nodes in the cluster as well as between mongo clients and nodes         | `false`                                                 |
 | `tls.existingSecret`                      | Existing secret with TLS certificates (keys: `mongodb-ca-cert`, `mongodb-ca-key`, `client-pem`)            | `nil`                                                   |
+| `tls.caCert`                             | Custom CA certificated (base64 encoded)         | `nil`                                                 |
+| `tls.caKey`                             | CA certificate private key (base64 encoded)      | `nil`                                                 |
 | `tls.image.registry`                      | Init container TLS certs setup image registry (nginx)                                                      | `docker.io`                                             |
 | `tls.image.repository`                    | Init contianer TLS certs setup image name (nginx)                                                          | `bitnami/nginx`                                         |
 | `tls.image.tag`                           | Init container TLS certs setup image tag (nginx)                                                           | `{TAG_NAME}`                                            |
@@ -552,6 +554,10 @@ To enable full TLS encryption set tls.enabled to true
 The secrets-ca.yaml utilizes the helm "pre-install" hook to ensure that the certs will only be generated on chart install. The genCA function will create a new self-signed x509 certificate authority, the genSignedCert function creates an object with a pair of items in it — the Cert and Key which we base64 encode and use in a yaml like object. With the genSignedCert function, we pass the CN, an empty IP list (the nil part), the validity and the CA created previously.
 To hold the signed certificate created above, we can use a kubernetes Secret object and the initContainer sets up the rest.
 Using Helm’s hook annotations ensures that the certs will only be generated on chart install. This will prevent overriding the certs anytime we upgrade the chart’s released instance.
+
+### Using your own CA
+
+To use your own CA set `tls.caCert` and `tls.caKey` with appropriate base64 encoded data. The secrets-ca.yaml will utilize this data to create secret. Please Note:- Currently only RSA private keys are supported.
 
 ### Accessing the cluster
 

--- a/bitnami/mongodb/templates/secrets-ca.yaml
+++ b/bitnami/mongodb/templates/secrets-ca.yaml
@@ -1,8 +1,5 @@
 {{- if and .Values.tls.enabled (not .Values.tls.existingSecret) -}}
 {{- $cn := printf "%s.%s.svc.cluster.local" ( include "mongodb.fullname" . ) .Release.Namespace }}
-{{- $ca := genCA "myMongo-ca" 3650 -}}
-{{- $cert := genSignedCert $cn nil nil 3650 $ca -}}
-{{- $pem := printf "%s%s" $cert.Cert $cert.Key -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -15,7 +12,19 @@ metadata:
     app.kubernetes.io/component: mongodb
 type: Opaque
 data:
+  {{ if and .Values.tls.caCert .Values.tls.caKey }}
+  {{- $ca := buildCustomCert .Values.tls.caCert .Values.tls.caKey -}}
+  {{- $cert := genSignedCert $cn nil nil 3650 $ca -}}
+  {{- $pem := printf "%s%s" $cert.Cert $cert.Key -}}
   mongodb-ca-cert: {{ b64enc $ca.Cert }}
   mongodb-ca-key: {{ b64enc $ca.Key }}
   client-pem: {{ b64enc $pem }}
+  {{- else -}}
+  {{- $ca:= genCA "myMongo-ca" 3650 -}}
+  {{- $cert := genSignedCert $cn nil nil 3650 $ca -}}
+  {{- $pem := printf "%s%s" $cert.Cert $cert.Key -}}
+  mongodb-ca-cert: {{ b64enc $ca.Cert }}
+  mongodb-ca-key: {{ b64enc $ca.Key }}
+  client-pem: {{ b64enc $pem }}
+  {{- end -}}
 {{- end -}}

--- a/bitnami/mongodb/values-production.yaml
+++ b/bitnami/mongodb/values-production.yaml
@@ -98,6 +98,9 @@ tls:
   ##
   # existingSecret: name-of-existing-secret
 
+  ## Add Custom CA certificate
+  # caCert: base64 encoded ca certificate
+  # caKey: base64 encoded private key
   ##
   ## Bitnami Nginx image
   ##

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -98,6 +98,9 @@ tls:
   ##
   # existingSecret: name-of-existing-secret
 
+  ## Add Custom CA certificate
+  # caCert: base64 encoded ca certificate
+  # caKey: base64 encoded private key
   ##
   ## Bitnami Nginx image
   ##


### PR DESCRIPTION
Description of the change

Added a `tls.caCert` and `tls.caKey` to customise the `ca-clients`

Benefits

Allows to use own CA 

Possible drawbacks

Backwards compatibile, so no obvious issues beyond the minor increase in complexity

Applicable issues

fixes https://github.com/bitnami/charts/issues/4387

Additional information

NA

Checklist

 Chart version bumped in Chart.yaml according to semver.
 Variables are documented in the README.md
 Title of the PR starts with chart name (e.g. [bitnami/chart])
 If the chart contains a values-production.yaml apart from values.yaml, ensure that you implement the changes in both files