### PR TITLE
[bitnami/common] Fix node affinity templates

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -20,4 +20,4 @@ sources:
   - https://github.com/bitnami/charts
   - http://www.bitnami.com/
 type: library
-version: 1.1.1
+version: 1.1.2

--- a/bitnami/common/templates/_affinities.tpl
+++ b/bitnami/common/templates/_affinities.tpl
@@ -8,12 +8,12 @@ Return a soft nodeAffinity definition
 preferredDuringSchedulingIgnoredDuringExecution:
   - preference:
       matchExpressions:
-        key: {{ .key }}
-        operator: In
-        values:
-          {{- range .values }}
-          - {{ . }}
-          {{- end }}
+        - key: {{ .key }}
+          operator: In
+          values:
+            {{- range .values }}
+            - {{ . }}
+            {{- end }}
     weight: 1
 {{- end -}}
 
@@ -25,12 +25,12 @@ Return a hard nodeAffinity definition
 requiredDuringSchedulingIgnoredDuringExecution:
   nodeSelectorTerms:
     - matchExpressions:
-        key: {{ .key }}
-        operator: In
-        values:
-          {{- range .values }}
-          - {{ . }}
-          {{- end }}
+        - key: {{ .key }}
+          operator: In
+          values:
+            {{- range .values }}
+            - {{ . }}
+            {{- end }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR fixes the node affinity templates by ensuring the "matchExpress" object contains an array of objects, instead of an object.

```console
$ k explain sts.spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution.preference.matchExpressions
KIND:     StatefulSet
VERSION:  apps/v1

RESOURCE: matchExpressions <[]Object>

DESCRIPTION:
     A list of node selector requirements by node's labels.

     A node selector requirement is a selector that contains values, a key, and
     an operator that relates the key and values.

FIELDS:
   key	<string> -required-
     The label key that the selector applies to.

   operator	<string> -required-
     Represents a key's relationship to a set of values. Valid operators are In,
     NotIn, Exists, DoesNotExist. Gt, and Lt.

   values	<[]string>
     An array of string values. If the operator is In or NotIn, the values array
     must be non-empty. If the operator is Exists or DoesNotExist, the values
     array must be empty. If the operator is Gt or Lt, the values array must
     have a single element, which will be interpreted as an integer. This array
     is replaced during a strategic merge patch.
```

**Benefits**

Users can set NodeAffinity with presets.

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/4681

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
