### PR TITLE
[bitnami/*] Update dependencies

### DIFF
--- a/bitnami/airflow/Chart.lock
+++ b/bitnami/airflow/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
+  version: 1.1.2
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 10.1.3
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 12.2.1
-digest: sha256:c404cfbaac544cdc735a15fe5faa2ec8c558666c371b762c211048d9733d976e
-generated: "2020-12-10T19:39:00.430158341Z"
+digest: sha256:3e7dd5fd05ea6fad522bdea76e2ce8c89cd057b6f3156c6773ef8ef14484dca7
+generated: "2020-12-11T12:20:14.151485+01:00"

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -32,4 +32,4 @@ name: airflow
 sources:
   - https://github.com/bitnami/bitnami-docker-airflow
   - https://airflow.apache.org/
-version: 7.0.4
+version: 7.0.5

--- a/bitnami/apache/Chart.lock
+++ b/bitnami/apache/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
-generated: "2020-12-09T14:39:03.659900001Z"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:20:14.894158+01:00"

--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -26,4 +26,4 @@ name: apache
 sources:
   - https://github.com/bitnami/bitnami-docker-apache
   - https://httpd.apache.org
-version: 8.0.2
+version: 8.0.3

--- a/bitnami/aspnet-core/Chart.lock
+++ b/bitnami/aspnet-core/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
-generated: "2020-12-10T15:41:11.72765821Z"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:20:15.050685+01:00"

--- a/bitnami/aspnet-core/Chart.yaml
+++ b/bitnami/aspnet-core/Chart.yaml
@@ -21,4 +21,4 @@ name: aspnet-core
 sources:
   - https://github.com/bitnami/bitnami-docker-aspnet-core
   - https://dotnet.microsoft.com/apps/aspnet
-version: 1.0.1
+version: 1.0.2

--- a/bitnami/cassandra/Chart.lock
+++ b/bitnami/cassandra/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.0.0
-digest: sha256:a2093836b2b6a85d7bf34143d3159b5c413c5e7423bde212de9cb416c985b976
-generated: "2020-11-10T23:08:33.476936043Z"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:20:13.875104+01:00"

--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -23,4 +23,4 @@ name: cassandra
 sources:
   - https://github.com/bitnami/bitnami-docker-cassandra
   - http://cassandra.apache.org
-version: 7.0.1
+version: 7.0.2

--- a/bitnami/consul/Chart.lock
+++ b/bitnami/consul/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
-generated: "2020-12-11T09:51:34.840955935Z"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:20:22.928474+01:00"

--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -19,4 +19,4 @@ name: consul
 sources:
   - https://github.com/bitnami/bitnami-docker-consul
   - https://www.consul.io/
-version: 9.0.4
+version: 9.0.5

--- a/bitnami/contour/Chart.lock
+++ b/bitnami/contour/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
-generated: "2020-12-10T12:40:38.108848876Z"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:20:26.07229+01:00"

--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -26,4 +26,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/bitnami-docker-contour
   - https://projectcontour.io
-version: 3.0.1
+version: 3.0.2

--- a/bitnami/contour/templates/certgen/rbac.yaml
+++ b/bitnami/contour/templates/certgen/rbac.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.rbac.create .Values.contour.enabled (include "contour.contour-certgen.enabled" .) }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "common.names.fullname" .}}-contour-certgen
@@ -18,7 +18,7 @@ rules:
       - create
       - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "common.names.fullname" .}}-contour-certgen

--- a/bitnami/contour/templates/contour/rbac.yaml
+++ b/bitnami/contour/templates/contour/rbac.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.rbac.create .Values.contour.enabled }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname" .}}-contour
@@ -105,7 +105,7 @@ rules:
       - get
       - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "common.names.fullname" .}}-contour

--- a/bitnami/discourse/Chart.lock
+++ b/bitnami/discourse/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
+  version: 1.1.2
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.1.1
+  version: 10.1.3
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 12.1.1
-digest: sha256:2b670b33248702e7cf021b6dcf88f669b90cb5d23283602a831685369a9c957f
-generated: "2020-12-02T00:36:11.59768438Z"
+  version: 12.2.1
+digest: sha256:fd82df504caf4cc291d647f53a85c37d9095323c4f92678f7303d5a4d67a0981
+generated: "2020-12-11T12:20:27.164777+01:00"

--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -32,4 +32,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-discourse
   - https://github.com/spinnaker
   - https://www.discourse.org/
-version: 2.0.2
+version: 2.0.3

--- a/bitnami/dokuwiki/Chart.lock
+++ b/bitnami/dokuwiki/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.0.1
-digest: sha256:8113f0501b7501ad1095541806acefa715b2d689c9f858ecfc13c67825fdd872
-generated: "2020-11-23T23:47:13.532822163Z"
+  version: 1.1.2
+digest: sha256:5a5d1b6e8a55efef1c07768b6bb264c60c98e230792b9a63f85468b95cf58c45
+generated: "2020-12-11T12:20:25.723971+01:00"

--- a/bitnami/dokuwiki/Chart.yaml
+++ b/bitnami/dokuwiki/Chart.yaml
@@ -24,4 +24,4 @@ name: dokuwiki
 sources:
   - https://github.com/bitnami/bitnami-docker-dokuwiki
   - http://www.dokuwiki.org/
-version: 10.0.1
+version: 10.0.2

--- a/bitnami/drupal/Chart.lock
+++ b/bitnami/drupal/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 9.0.1
+  version: 9.1.2
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:2cf593968d4011e82ddaa8edc88f5582d68bc7c7dad021fa366f6bea9931fff2
-generated: "2020-12-08T08:28:24.8124609Z"
+  version: 1.1.2
+digest: sha256:1f9feee2b7e76d92206c4add08806931c512f89eccbf2ce0367ea3d1b095cdda
+generated: "2020-12-11T12:20:30.67884+01:00"

--- a/bitnami/drupal/Chart.yaml
+++ b/bitnami/drupal/Chart.yaml
@@ -31,4 +31,4 @@ name: drupal
 sources:
   - https://github.com/bitnami/bitnami-docker-drupal
   - http://www.drupal.org/
-version: 10.0.6
+version: 10.0.7

--- a/bitnami/ejbca/Chart.lock
+++ b/bitnami/ejbca/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.0.0
+  version: 1.1.2
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 9.0.1
-digest: sha256:fefc5ca7fcd02afaf7cdb1917350200c1b93d8d45ea5d19a73aea0671639cf54
-generated: "2020-11-12T07:16:27.40837395Z"
+  version: 9.1.2
+digest: sha256:2dd4e51eae03fad76176755183ec1b6b173390032d4fe18626a9c1fc32642d60
+generated: "2020-12-11T12:20:34.495212+01:00"

--- a/bitnami/ejbca/Chart.yaml
+++ b/bitnami/ejbca/Chart.yaml
@@ -30,4 +30,4 @@ name: ejbca
 sources:
   - https://github.com/bitnami/bitnami-docker-ejbca
   - https://www.ejbca.org/
-version: 2.0.0
+version: 2.0.1

--- a/bitnami/elasticsearch/Chart.lock
+++ b/bitnami/elasticsearch/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.0.0
+  version: 1.1.2
 - name: kibana
   repository: https://charts.bitnami.com/bitnami
-  version: 6.0.1
-digest: sha256:c615f65b6ad8d323880c78936da085ca8cf0652002fe3975f723fbc99ca89e19
-generated: "2020-11-13T09:00:52.874863454Z"
+  version: 6.2.1
+digest: sha256:73b842510759064c834138d4c05587f95d83340c75ee2d6524bd75ed3591dfff
+generated: "2020-12-11T12:20:35.294367+01:00"

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/bitnami-docker-elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 13.0.2
+version: 13.0.3

--- a/bitnami/elasticsearch/templates/serviceaccount.yaml
+++ b/bitnami/elasticsearch/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   labels: {{- include "elasticsearch.labels" . | nindent 4 }}
     role: curator
 {{- end }}
----
 {{- if .Values.data.serviceAccount.create }}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -15,8 +15,8 @@ metadata:
   labels: {{- include "elasticsearch.labels" . | nindent 4 }}
     role: data
 {{- end }}
----
 {{- if .Values.master.serviceAccount.create }}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -24,8 +24,8 @@ metadata:
   labels: {{- include "elasticsearch.labels" . | nindent 4 }}
     role: master
 {{- end }}
----
 {{- if .Values.coordinating.serviceAccount.create }}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/bitnami/etcd/Chart.lock
+++ b/bitnami/etcd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.0.1
-digest: sha256:e66388f254b9de6470bca6d8c1c565d1c16a5569beef68a7bc99e486e73ccbdb
-generated: "2020-11-24T12:52:51.180468+01:00"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:20:37.294805+01:00"

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -25,4 +25,4 @@ name: etcd
 sources:
   - https://github.com/bitnami/bitnami-docker-etcd
   - https://coreos.com/etcd/
-version: 5.3.0
+version: 5.3.1

--- a/bitnami/external-dns/Chart.lock
+++ b/bitnami/external-dns/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
-generated: "2020-12-07T16:34:44.8134807+02:00"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:20:38.833824+01:00"

--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -24,4 +24,4 @@ sources:
   - https://github.com/kubernetes-sigs/external-dns
   - https://github.com/bitnami/bitnami-docker-external-dns
   - https://github.com/kubernetes-sigs/external-dns
-version: 4.4.1
+version: 4.4.2

--- a/bitnami/fluentd/Chart.lock
+++ b/bitnami/fluentd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
-generated: "2020-12-10T15:21:56.770686823Z"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:20:44.518214+01:00"

--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -25,4 +25,4 @@ name: fluentd
 sources:
   - https://github.com/bitnami/bitnami-docker-fluentd
   - https://www.fluentd.org/
-version: 3.1.1
+version: 3.1.2

--- a/bitnami/ghost/Chart.lock
+++ b/bitnami/ghost/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
+  version: 1.1.2
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
   version: 9.1.2
-digest: sha256:7746fa6e20f2cec7d7f14fa6e359b353e577ccea6bf4a238ce00e810b8a5174f
-generated: "2020-12-10T19:07:49.25608842Z"
+digest: sha256:545231be99c07b545c49621c8a4d2e066fd252b9c3aeed8eefe8d2f72a19ffce
+generated: "2020-12-11T12:20:46.159388+01:00"

--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -33,4 +33,4 @@ name: ghost
 sources:
   - https://github.com/bitnami/bitnami-docker-ghost
   - http://www.ghost.org/
-version: 11.1.6
+version: 11.1.7

--- a/bitnami/grafana/Chart.lock
+++ b/bitnami/grafana/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
-generated: "2020-12-09T12:29:11.384952+01:00"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:20:47.324679+01:00"

--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -24,4 +24,4 @@ name: grafana
 sources:
   - https://github.com/bitnami/bitnami-docker-grafana
   - https://grafana.com/
-version: 4.2.2
+version: 4.2.3

--- a/bitnami/harbor/Chart.lock
+++ b/bitnami/harbor/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.0.0
+  version: 10.1.3
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 12.0.1
+  version: 12.2.1
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.0.0
-digest: sha256:993ed4f9a0d84be467365cfdcb8505420a29c248f287f72a251a2b9eda325370
-generated: "2020-11-18T08:40:01.354827995Z"
+  version: 1.1.2
+digest: sha256:c4b5991d0c7a347d0e118d1127b93bcd2b97c88777c6ae2a2133b58dc4cb1c89
+generated: "2020-12-11T12:20:48.898481+01:00"

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-harbor-registry
   - https://github.com/bitnami/bitnami-docker-harbor-registryctl
   - https://goharbor.io/
-version: 9.1.1
+version: 9.1.2

--- a/bitnami/influxdb/Chart.lock
+++ b/bitnami/influxdb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
-generated: "2020-12-05T11:59:31.722671416+03:00"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:20:53.859771+01:00"

--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -24,4 +24,4 @@ name: influxdb
 sources:
   - https://github.com/bitnami/bitnami-docker-influxdb
   - https://www.influxdata.com/products/influxdb-overview/
-version: 1.1.3
+version: 1.1.4

--- a/bitnami/jasperreports/Chart.lock
+++ b/bitnami/jasperreports/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 9.1.2
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:906007a3aa36816f5766558b685a5d6985c8672778afca5a190b88326c66912a
-generated: "2020-12-10T14:28:57.749378324+01:00"
+  version: 1.1.2
+digest: sha256:1f9feee2b7e76d92206c4add08806931c512f89eccbf2ce0367ea3d1b095cdda
+generated: "2020-12-11T12:20:55.814179+01:00"

--- a/bitnami/jasperreports/Chart.yaml
+++ b/bitnami/jasperreports/Chart.yaml
@@ -30,4 +30,4 @@ name: jasperreports
 sources:
   - https://github.com/bitnami/bitnami-docker-jasperreports
   - http://community.jaspersoft.com/project/jasperreports-server
-version: 9.1.1
+version: 9.1.2

--- a/bitnami/jenkins/Chart.lock
+++ b/bitnami/jenkins/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
-generated: "2020-11-29T19:44:15.634382+01:00"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:20:56.079236+01:00"

--- a/bitnami/jenkins/Chart.yaml
+++ b/bitnami/jenkins/Chart.yaml
@@ -26,4 +26,4 @@ name: jenkins
 sources:
   - https://github.com/bitnami/bitnami-docker-jenkins
   - https://jenkins.io/
-version: 7.0.1
+version: 7.0.2

--- a/bitnami/joomla/Chart.lock
+++ b/bitnami/joomla/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 9.0.1
+  version: 9.1.2
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.0.1
-digest: sha256:7d78cbcd54bade2608462bb162c8487091689ff7f5cb65080a3d580dc6a24912
-generated: "2020-11-19T15:13:48.695523709Z"
+  version: 1.1.2
+digest: sha256:7e1b7cdcc0184a47507d4011856961c1d86b8da01f6d462ca251167bdf519239
+generated: "2020-12-11T12:20:58.518842+01:00"

--- a/bitnami/joomla/Chart.yaml
+++ b/bitnami/joomla/Chart.yaml
@@ -27,4 +27,4 @@ name: joomla
 sources:
   - https://github.com/bitnami/bitnami-docker-joomla
   - http://www.joomla.org/
-version: 9.0.3
+version: 9.0.4

--- a/bitnami/kafka/Chart.lock
+++ b/bitnami/kafka/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
+  version: 1.1.2
 - name: zookeeper
   repository: https://charts.bitnami.com/bitnami
-  version: 6.0.0
-digest: sha256:d53dc1a2f9e9e509b8c15a4c4ecf0dee961ae7c6cb9a617816039ad38dd4f48b
-generated: "2020-12-09T12:15:11.557721022Z"
+  version: 6.0.1
+digest: sha256:5e059dfd8d01ae3efcd29f340bb9ab9c66a5a50d2140c05ab2d34de9bb6471d9
+generated: "2020-12-11T12:21:01.956424+01:00"

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 12.3.0
+version: 12.3.1

--- a/bitnami/keycloak/Chart.lock
+++ b/bitnami/keycloak/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
+  version: 1.1.2
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.1.1
-digest: sha256:249a03d86e619d48d5a4f00396dab9317f264c6871b10e36d03d92db331ad661
-generated: "2020-12-02T11:58:37.584241151Z"
+  version: 10.1.3
+digest: sha256:c2a2ad028a727f97d41f6429fb70d69a39886da92d906665bbb5250397d82ed3
+generated: "2020-12-11T12:21:04.514033+01:00"

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 1.1.1
+version: 1.1.3

--- a/bitnami/kiam/Chart.lock
+++ b/bitnami/kiam/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.0.0
-digest: sha256:a2093836b2b6a85d7bf34143d3159b5c413c5e7423bde212de9cb416c985b976
-generated: "2020-11-16T11:53:31.315224085Z"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:21:04.973187+01:00"

--- a/bitnami/kiam/Chart.yaml
+++ b/bitnami/kiam/Chart.yaml
@@ -23,4 +23,4 @@ name: kiam
 sources:
   - 'https://github.com/bitnami/bitnami-docker-kiam'
   - 'https://github.com/uswitch/kiam'
-version: 0.1.5
+version: 0.1.7

--- a/bitnami/kibana/Chart.lock
+++ b/bitnami/kibana/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
-generated: "2020-12-09T22:58:10.065382638Z"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:21:06.774038+01:00"

--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -25,4 +25,4 @@ name: kibana
 sources:
   - https://github.com/bitnami/bitnami-docker-kibana
   - https://www.elastic.co/products/kibana
-version: 6.2.1
+version: 6.2.2

--- a/bitnami/kong/Chart.lock
+++ b/bitnami/kong/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 7.0.1
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:8688dd2aca635ab548b64fca44be806377cd8f46f5b0ee8359ae33c247aae211
-generated: "2020-12-08T23:00:29.190045719Z"
+  version: 1.1.2
+digest: sha256:c94ed7648507b369c2f1aa99f2a6c51ebd9e81346a9c8a2f987cddc86a7c7ec7
+generated: "2020-12-11T12:21:12.205186+01:00"

--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -34,4 +34,4 @@ name: kong
 sources:
   - https://github.com/bitnami/bitnami-docker-kong
   - https://konghq.com/
-version: 3.0.6
+version: 3.0.7

--- a/bitnami/kong/crds/custom-resource-definitions.yaml
+++ b/bitnami/kong/crds/custom-resource-definitions.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kongconsumers.configuration.konghq.com
@@ -32,7 +32,7 @@ spec:
           items:
             type: string
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kongcredentials.configuration.konghq.com
@@ -67,7 +67,7 @@ spec:
         type:
           type: string
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kongplugins.configuration.konghq.com
@@ -128,7 +128,7 @@ spec:
             - tcp
             - tls
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kongclusterplugins.configuration.konghq.com
@@ -189,7 +189,7 @@ spec:
             - tcp
             - tls
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kongingresses.configuration.konghq.com
@@ -349,7 +349,7 @@ spec:
                     healthy: *healthy
                     unhealthy: *unhealthy
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: tcpingresses.configuration.konghq.com

--- a/bitnami/kong/templates/custom-resource-definitions.yaml
+++ b/bitnami/kong/templates/custom-resource-definitions.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.ingressController.enabled .Values.ingressController.installCRDs }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kongconsumers.configuration.konghq.com
@@ -38,7 +38,7 @@ spec:
           items:
             type: string
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kongcredentials.configuration.konghq.com
@@ -78,7 +78,7 @@ spec:
         type:
           type: string
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kongplugins.configuration.konghq.com
@@ -144,7 +144,7 @@ spec:
             - tcp
             - tls
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kongclusterplugins.configuration.konghq.com
@@ -210,7 +210,7 @@ spec:
             - tcp
             - tls
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kongingresses.configuration.konghq.com
@@ -375,7 +375,7 @@ spec:
                     healthy: *healthy
                     unhealthy: *unhealthy
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: tcpingresses.configuration.konghq.com

--- a/bitnami/kong/templates/ingress-controller-rbac.yaml
+++ b/bitnami/kong/templates/ingress-controller-rbac.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.ingressController.rbac.create .Values.ingressController.enabled }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "common.names.fullname" . }}
@@ -44,7 +44,7 @@ rules:
     verbs:
       - get
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "common.names.fullname" . }}
@@ -66,7 +66,7 @@ subjects:
     name: {{ template "kong.serviceAccount" . }}
     namespace: {{ .Release.Namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
@@ -148,7 +148,7 @@ rules:
       - list
       - watch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "common.names.fullname" . }}

--- a/bitnami/kube-prometheus/Chart.lock
+++ b/bitnami/kube-prometheus/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
+  version: 1.1.2
 - name: node-exporter
   repository: https://charts.bitnami.com/bitnami
-  version: 2.0.0
+  version: 2.1.1
 - name: kube-state-metrics
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.0
-digest: sha256:7229fa41055ab6ca96e88812693ed6bcfdb8434c5644d69f7699293d3e58f0a3
-generated: "2020-12-04T16:28:33.891061998Z"
+  version: 1.1.1
+digest: sha256:c135c24b8a986a1d430b24561aa5faab2417d40afb6bc7290e2c9e174b0be8db
+generated: "2020-12-11T12:21:16.608079+01:00"

--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-prometheus
   - https://github.com/bitnami/bitnami-docker-alertmanager
   - https://github.com/prometheus-operator/kube-prometheus
-version: 3.3.1
+version: 3.3.2

--- a/bitnami/kube-state-metrics/Chart.lock
+++ b/bitnami/kube-state-metrics/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
-generated: "2020-12-10T12:57:18.326141578Z"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:21:14.870406+01:00"

--- a/bitnami/kube-state-metrics/Chart.yaml
+++ b/bitnami/kube-state-metrics/Chart.yaml
@@ -23,4 +23,4 @@ name: kube-state-metrics
 sources:
   - https://github.com/bitnami/bitnami-docker-kube-state-metrics
   - https://github.com/kubernetes/kube-state-metrics
-version: 1.1.1
+version: 1.1.2

--- a/bitnami/kubernetes-event-exporter/Chart.lock
+++ b/bitnami/kubernetes-event-exporter/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.0
-digest: sha256:53383c55a80f2c6d7c546fc466879d53b57b35a3465d46429f7c8d0ccb5b977f
-generated: "2020-11-26T18:01:29.9979309Z"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:21:25.478135+01:00"

--- a/bitnami/kubernetes-event-exporter/Chart.yaml
+++ b/bitnami/kubernetes-event-exporter/Chart.yaml
@@ -24,4 +24,4 @@ name: kubernetes-event-exporter
 sources:
   - https://github.com/bitnami/bitnami-docker-kubernetes-event-exporter
   - https://github.com/opsgenie/kubernetes-event-exporter
-version: 1.0.3
+version: 1.0.4

--- a/bitnami/kubewatch/Chart.lock
+++ b/bitnami/kubewatch/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
-generated: "2020-12-09T16:44:47.136849551Z"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:21:24.054903+01:00"

--- a/bitnami/kubewatch/Chart.yaml
+++ b/bitnami/kubewatch/Chart.yaml
@@ -28,4 +28,4 @@ name: kubewatch
 sources:
   - https://github.com/bitnami/bitnami-docker-kubewatch
   - https://github.com/bitnami-labs/kubewatch
-version: 3.0.1
+version: 3.0.2

--- a/bitnami/logstash/Chart.lock
+++ b/bitnami/logstash/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
-generated: "2020-12-09T22:59:12.229961686Z"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:21:27.260238+01:00"

--- a/bitnami/logstash/Chart.yaml
+++ b/bitnami/logstash/Chart.yaml
@@ -23,4 +23,4 @@ name: logstash
 sources:
   - https://github.com/bitnami/bitnami-docker-logstash
   - https://www.elastic.co/products/logstash
-version: 1.2.1
+version: 1.2.2

--- a/bitnami/magento/Chart.lock
+++ b/bitnami/magento/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.0.1
+  version: 1.1.2
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 9.0.1
+  version: 9.1.2
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
   version: 12.8.2
-digest: sha256:558ae3bfd0c0322a683ca2f2f906e28e2a2267f47d649cf21eb051c377882aba
-generated: "2020-11-25T09:50:46.482351+01:00"
+digest: sha256:48868dfd8be97aa374ba322d705022b6821dc6dc71a01ac397fd74e0ca5f64a1
+generated: "2020-12-11T12:21:27.902167+01:00"

--- a/bitnami/magento/Chart.yaml
+++ b/bitnami/magento/Chart.yaml
@@ -33,4 +33,4 @@ name: magento
 sources:
   - https://github.com/bitnami/bitnami-docker-magento
   - https://magento.com/
-version: 16.0.0
+version: 16.0.1

--- a/bitnami/mariadb-galera/Chart.lock
+++ b/bitnami/mariadb-galera/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.0.1
-digest: sha256:e66388f254b9de6470bca6d8c1c565d1c16a5569beef68a7bc99e486e73ccbdb
-generated: "2020-11-25T11:29:05.260061+01:00"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:21:34.877119+01:00"

--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -28,4 +28,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-mariadb-galera
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 5.3.0
+version: 5.3.1

--- a/bitnami/mariadb/Chart.lock
+++ b/bitnami/mariadb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
-generated: "2020-12-08T16:33:12.126243873Z"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:21:32.262474+01:00"

--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -26,4 +26,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-mariadb
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 9.1.2
+version: 9.1.3

--- a/bitnami/mariadb/values-production.yaml
+++ b/bitnami/mariadb/values-production.yaml
@@ -91,14 +91,16 @@ auth:
   ##
   usePasswordFiles: true
   ## Use custom secret files other than chart provided when usePasswordFiles is set to "true"
-  ##
-  customPasswordFiles:
   ## Example:
   ## customPasswordFiles:
   ##   root: /vault/secrets/mariadb-root
   ##   user: /vault/secrets/mariadb-user
   ##   replicator: /vault/secrets/mariadb-replicator
   ##
+  customPasswordFiles:
+    root: ""
+    user: ""
+    replicator: ""
 
 ## initdb scripts
 ## Specify dictionary of scripts to be run at first boot

--- a/bitnami/mariadb/values.yaml
+++ b/bitnami/mariadb/values.yaml
@@ -87,6 +87,9 @@ auth:
   ## Force users to specify required passwords
   ##
   forcePassword: false
+  ## Mount credentials as files instead of using an environment variable
+  ##
+  usePasswordFiles: false
   ## Use custom secret files other than chart provided when usePasswordFiles is set to "true"
   ## Example:
   ## customPasswordFiles:

--- a/bitnami/mariadb/values.yaml
+++ b/bitnami/mariadb/values.yaml
@@ -87,18 +87,17 @@ auth:
   ## Force users to specify required passwords
   ##
   forcePassword: false
-  ## Mount credentials as files instead of using an environment variable
-  ##
-  usePasswordFiles: false
   ## Use custom secret files other than chart provided when usePasswordFiles is set to "true"
-  ##
-  customPasswordFiles:
   ## Example:
   ## customPasswordFiles:
   ##   root: /vault/secrets/mariadb-root
   ##   user: /vault/secrets/mariadb-user
   ##   replicator: /vault/secrets/mariadb-replicator
   ##
+  customPasswordFiles:
+    root: ""
+    user: ""
+    replicator: ""
 
 ## initdb scripts
 ## Specify dictionary of scripts to be run at first boot

--- a/bitnami/mediawiki/Chart.lock
+++ b/bitnami/mediawiki/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.0.1
+  version: 1.1.2
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 9.0.1
-digest: sha256:b653d41e8f9478c058c43749de2feee098dd0fa6baa6e55324f2dbecbeeca178
-generated: "2020-11-25T13:08:17.001911+01:00"
+  version: 9.1.2
+digest: sha256:be653a736c91e39f6068beda67368374c4397e2b8c05d3628cc04b83af537640
+generated: "2020-12-11T12:21:36.629911+01:00"

--- a/bitnami/mediawiki/Chart.yaml
+++ b/bitnami/mediawiki/Chart.yaml
@@ -32,4 +32,4 @@ name: mediawiki
 sources:
   - https://github.com/bitnami/bitnami-docker-mediawiki
   - http://www.mediawiki.org/
-version: 12.0.0
+version: 12.0.1

--- a/bitnami/memcached/Chart.lock
+++ b/bitnami/memcached/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.0.1
-digest: sha256:e66388f254b9de6470bca6d8c1c565d1c16a5569beef68a7bc99e486e73ccbdb
-generated: "2020-11-25T12:07:14.587843+01:00"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:21:37.364331+01:00"

--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -22,4 +22,4 @@ name: memcached
 sources:
   - https://github.com/bitnami/bitnami-docker-memcached
   - http://memcached.org/
-version: 5.3.2
+version: 5.3.1

--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -22,4 +22,4 @@ name: memcached
 sources:
   - https://github.com/bitnami/bitnami-docker-memcached
   - http://memcached.org/
-version: 5.3.0
+version: 5.3.2

--- a/bitnami/metrics-server/Chart.lock
+++ b/bitnami/metrics-server/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.0.1
-digest: sha256:e66388f254b9de6470bca6d8c1c565d1c16a5569beef68a7bc99e486e73ccbdb
-generated: "2020-11-25T20:03:27.132535+01:00"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:21:39.747476+01:00"

--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -23,4 +23,4 @@ name: metrics-server
 sources:
   - https://github.com/bitnami/bitnami-docker-metrics-server
   - https://github.com/kubernetes-incubator/metrics-server
-version: 5.3.1
+version: 5.3.2

--- a/bitnami/minio/Chart.lock
+++ b/bitnami/minio/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
-generated: "2020-12-04T20:41:02.853122372Z"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:21:43.736549+01:00"

--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -25,4 +25,4 @@ name: minio
 sources:
   - https://github.com/bitnami/bitnami-docker-minio
   - https://min.io
-version: 4.1.2
+version: 4.1.3

--- a/bitnami/mongodb-sharded/Chart.lock
+++ b/bitnami/mongodb-sharded/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.0.1
-digest: sha256:e66388f254b9de6470bca6d8c1c565d1c16a5569beef68a7bc99e486e73ccbdb
-generated: "2020-11-26T10:27:28.274317+01:00"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:21:49.012415+01:00"

--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb-sharded
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb-sharded
   - https://mongodb.org
-version: 3.2.1
+version: 3.2.2

--- a/bitnami/mongodb/Chart.lock
+++ b/bitnami/mongodb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
-generated: "2020-11-26T18:30:32.557890359Z"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:21:45.75672+01:00"

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 10.1.4
+version: 10.1.5

--- a/bitnami/moodle/Chart.lock
+++ b/bitnami/moodle/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 9.0.1
+  version: 9.1.2
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.0.0
-digest: sha256:27ce5c469bf919f37ff334b30b745ea0c60bfcf5d58eca9545e354b2aa27514a
-generated: "2020-11-12T07:14:12.401294492Z"
+  version: 1.1.2
+digest: sha256:7e1b7cdcc0184a47507d4011856961c1d86b8da01f6d462ca251167bdf519239
+generated: "2020-12-11T12:21:49.917299+01:00"

--- a/bitnami/moodle/Chart.yaml
+++ b/bitnami/moodle/Chart.yaml
@@ -25,4 +25,4 @@ name: moodle
 sources:
   - https://github.com/bitnami/bitnami-docker-moodle
   - http://www.moodle.org/
-version: 10.1.0
+version: 10.1.1

--- a/bitnami/mxnet/Chart.lock
+++ b/bitnami/mxnet/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
-generated: "2020-12-09T16:14:39.468185+01:00"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:21:51.225528+01:00"

--- a/bitnami/mxnet/Chart.yaml
+++ b/bitnami/mxnet/Chart.yaml
@@ -24,4 +24,4 @@ name: mxnet
 sources:
   - https://github.com/bitnami/bitnami-docker-mxnet
   - https://mxnet.apache.org/
-version: 2.1.1
+version: 2.1.2

--- a/bitnami/mysql/Chart.lock
+++ b/bitnami/mysql/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
-generated: "2020-12-08T21:03:23.944912698Z"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:21:54.378093+01:00"

--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -25,4 +25,4 @@ name: mysql
 sources:
   - https://github.com/bitnami/bitnami-docker-mysql
   - https://mysql.com
-version: 8.2.1
+version: 8.2.2

--- a/bitnami/mysql/values-production.yaml
+++ b/bitnami/mysql/values-production.yaml
@@ -91,14 +91,16 @@ auth:
   ##
   usePasswordFiles: true
   ## Use custom secret files other than chart provided when usePasswordFiles is set to "true"
-  ##
-  customPasswordFiles:
   ## Example:
   ## customPasswordFiles:
-  ##   root: /vault/secrets/mariadb-root
-  ##   user: /vault/secrets/mariadb-user
-  ##   replicator: /vault/secrets/mariadb-replicator
+  ##   root: /vault/secrets/mysql-root
+  ##   user: /vault/secrets/mysql-user
+  ##   replicator: /vault/secrets/mysql-replicator
   ##
+  customPasswordFiles:
+    root: ""
+    user: ""
+    replicator: ""
 
 ## initdb scripts
 ## Specify dictionary of scripts to be run at first boot

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -91,14 +91,16 @@ auth:
   ##
   usePasswordFiles: false
   ## Use custom secret files other than chart provided when usePasswordFiles is set to "true"
-  ##
-  customPasswordFiles:
   ## Example:
   ## customPasswordFiles:
-  ##   root: /vault/secrets/mariadb-root
-  ##   user: /vault/secrets/mariadb-user
-  ##   replicator: /vault/secrets/mariadb-replicator
+  ##   root: /vault/secrets/mysql-root
+  ##   user: /vault/secrets/mysql-user
+  ##   replicator: /vault/secrets/mysql-replicator
   ##
+  customPasswordFiles:
+    root: ""
+    user: ""
+    replicator: ""
 
 ## initdb scripts
 ## Specify dictionary of scripts to be run at first boot

--- a/bitnami/nats/Chart.lock
+++ b/bitnami/nats/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
-generated: "2020-11-26T19:51:23.764557+01:00"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:21:58.582547+01:00"

--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -24,4 +24,4 @@ name: nats
 sources:
   - https://github.com/bitnami/bitnami-docker-nats
   - https://nats.io/
-version: 6.0.1
+version: 6.0.2

--- a/bitnami/nginx-ingress-controller/Chart.lock
+++ b/bitnami/nginx-ingress-controller/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
-generated: "2020-12-10T12:16:13.704672+01:00"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:21:59.89006+01:00"

--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -26,4 +26,4 @@ name: nginx-ingress-controller
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx-ingress-controller
   - https://github.com/kubernetes/ingress-nginx
-version: 7.0.1
+version: 7.0.2

--- a/bitnami/nginx/Chart.lock
+++ b/bitnami/nginx/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.0.1
-digest: sha256:e66388f254b9de6470bca6d8c1c565d1c16a5569beef68a7bc99e486e73ccbdb
-generated: "2020-11-24T17:01:38.761038074Z"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:21:59.642165+01:00"

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -25,4 +25,4 @@ name: nginx
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx
   - http://www.nginx.org
-version: 8.2.0
+version: 8.2.1

--- a/bitnami/node-exporter/Chart.lock
+++ b/bitnami/node-exporter/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
-generated: "2020-12-09T16:15:07.983788+01:00"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:22:06.639897+01:00"

--- a/bitnami/node-exporter/Chart.yaml
+++ b/bitnami/node-exporter/Chart.yaml
@@ -24,4 +24,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-node-exporter
   - https://github.com/prometheus/node_exporter
   - https://prometheus.io/
-version: 2.1.1
+version: 2.1.2

--- a/bitnami/node/Chart.lock
+++ b/bitnami/node/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
-  version: 10.1.2
+  version: 10.1.4
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:a1fd20148eefe20d50c1db8c0115dbd433ffcfc52d900f1a9d99d042e30ccbee
-generated: "2020-11-26T19:33:30.383090632Z"
+  version: 1.1.2
+digest: sha256:774ffe872a418cc6181b407952757435b99d9d11d2e9d226f47dc3336bfaba2b
+generated: "2020-12-11T12:22:04.305954+01:00"

--- a/bitnami/node/Chart.yaml
+++ b/bitnami/node/Chart.yaml
@@ -28,4 +28,4 @@ name: node
 sources:
   - https://github.com/bitnami/bitnami-docker-node
   - http://nodejs.org/
-version: 14.0.1
+version: 14.0.2

--- a/bitnami/odoo/Chart.lock
+++ b/bitnami/odoo/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 10.1.3
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:5a82abc7f3d615f50c9c67c861209b9b77bb735c53e6e05c1d323c4884fc72e7
-generated: "2020-12-10T04:05:40.017091525Z"
+  version: 1.1.2
+digest: sha256:27ea548c6cd183ba99a4e53e76c502fcc8ac1b366f1dca7e9e4ccb123bc19cbf
+generated: "2020-12-11T12:22:09.101552+01:00"

--- a/bitnami/odoo/Chart.yaml
+++ b/bitnami/odoo/Chart.yaml
@@ -27,4 +27,4 @@ name: odoo
 sources:
   - https://github.com/bitnami/bitnami-docker-odoo
   - https://www.odoo.com/
-version: 17.0.1
+version: 17.0.2

--- a/bitnami/opencart/Chart.lock
+++ b/bitnami/opencart/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 9.0.1
+  version: 9.1.2
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.0.0
-digest: sha256:5da0c5d657ce8c316759a44f887b640ffb807d430036b83ab7f3e416fdf09a19
-generated: "2020-11-12T07:15:43.544610144Z"
+  version: 1.1.2
+digest: sha256:1f9feee2b7e76d92206c4add08806931c512f89eccbf2ce0367ea3d1b095cdda
+generated: "2020-12-11T12:22:10.108404+01:00"

--- a/bitnami/opencart/Chart.yaml
+++ b/bitnami/opencart/Chart.yaml
@@ -29,4 +29,4 @@ name: opencart
 sources:
   - https://github.com/bitnami/bitnami-docker-opencart
   - https://opencart.com/
-version: 9.0.2
+version: 9.0.3

--- a/bitnami/orangehrm/Chart.lock
+++ b/bitnami/orangehrm/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 9.0.1
+  version: 9.1.2
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:2cf593968d4011e82ddaa8edc88f5582d68bc7c7dad021fa366f6bea9931fff2
-generated: "2020-12-02T20:59:02.444187119+01:00"
+  version: 1.1.2
+digest: sha256:1f9feee2b7e76d92206c4add08806931c512f89eccbf2ce0367ea3d1b095cdda
+generated: "2020-12-11T12:22:15.112195+01:00"

--- a/bitnami/orangehrm/Chart.yaml
+++ b/bitnami/orangehrm/Chart.yaml
@@ -31,4 +31,4 @@ name: orangehrm
 sources:
   - https://github.com/bitnami/bitnami-docker-orangehrm
   - https://www.orangehrm.com
-version: 9.0.0
+version: 9.0.2

--- a/bitnami/orangehrm/Chart.yaml
+++ b/bitnami/orangehrm/Chart.yaml
@@ -31,4 +31,4 @@ name: orangehrm
 sources:
   - https://github.com/bitnami/bitnami-docker-orangehrm
   - https://www.orangehrm.com
-version: 9.0.2
+version: 9.0.1

--- a/bitnami/osclass/Chart.lock
+++ b/bitnami/osclass/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 9.0.1
-digest: sha256:6a5735e0b7e5868bbf3eec9d9d031eb20a5928dd38894899c5bccf2e8f7c5a61
-generated: "2020-11-13T10:04:16.639686339Z"
+  version: 9.1.2
+digest: sha256:22a4d46c77dd3ee00ec23268340f4c988c1f680c1bbb79c1f09c813b3de53e24
+generated: "2020-12-11T12:22:13.592722+01:00"

--- a/bitnami/osclass/Chart.yaml
+++ b/bitnami/osclass/Chart.yaml
@@ -24,4 +24,4 @@ name: osclass
 sources:
   - https://github.com/bitnami/bitnami-docker-osclass
   - https://osclass.org/
-version: 8.0.0
+version: 8.0.1

--- a/bitnami/parse/Chart.lock
+++ b/bitnami/parse/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
-  version: 10.1.2
+  version: 10.1.4
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:9eb29620e20671af05d7848d31801ba4ca7ae93435cc61e99ea7bc795aeaf56d
-generated: "2020-11-26T20:40:46.81438+01:00"
+  version: 1.1.2
+digest: sha256:554c05b9fa28947e02f239f85d1eb369701a5737ced03ec12c9284c3d9d39cae
+generated: "2020-12-11T12:22:19.731276+01:00"

--- a/bitnami/parse/Chart.yaml
+++ b/bitnami/parse/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-parse
   - https://github.com/bitnami/bitnami-docker-parse-dashboard
   - https://parse.com/
-version: 13.1.0
+version: 13.1.1

--- a/bitnami/phabricator/Chart.lock
+++ b/bitnami/phabricator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 9.0.1
-digest: sha256:6a5735e0b7e5868bbf3eec9d9d031eb20a5928dd38894899c5bccf2e8f7c5a61
-generated: "2020-11-18T14:19:46.39602979Z"
+  version: 9.1.2
+digest: sha256:22a4d46c77dd3ee00ec23268340f4c988c1f680c1bbb79c1f09c813b3de53e24
+generated: "2020-12-11T12:22:22.704207+01:00"

--- a/bitnami/phabricator/Chart.yaml
+++ b/bitnami/phabricator/Chart.yaml
@@ -32,4 +32,4 @@ name: phabricator
 sources:
   - https://github.com/bitnami/bitnami-docker-phabricator
   - https://www.phacility.com/phabricator/
-version: 10.1.0
+version: 10.1.1

--- a/bitnami/phpbb/Chart.lock
+++ b/bitnami/phpbb/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 9.0.1
+  version: 9.1.2
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.0.1
-digest: sha256:7d78cbcd54bade2608462bb162c8487091689ff7f5cb65080a3d580dc6a24912
-generated: "2020-11-19T15:27:05.051431097Z"
+  version: 1.1.2
+digest: sha256:7e1b7cdcc0184a47507d4011856961c1d86b8da01f6d462ca251167bdf519239
+generated: "2020-12-11T12:22:25.023526+01:00"

--- a/bitnami/phpbb/Chart.yaml
+++ b/bitnami/phpbb/Chart.yaml
@@ -26,4 +26,4 @@ name: phpbb
 sources:
   - https://github.com/bitnami/bitnami-docker-phpbb
   - https://www.phpbb.com/
-version: 9.0.0
+version: 9.0.1

--- a/bitnami/phpmyadmin/Chart.lock
+++ b/bitnami/phpmyadmin/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
+  version: 1.1.2
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
   version: 9.1.2
-digest: sha256:a2e41ea64175a575ec8ab0d6747231eba30ecb9e175564dfce42c6bad6fc77d7
-generated: "2020-12-09T16:14:58.723502+01:00"
+digest: sha256:bc38fb97d1d8c3e52d07d03f14380a91f7685873c3c390a48271d6b8115ca1c0
+generated: "2020-12-11T12:22:28.835951+01:00"

--- a/bitnami/phpmyadmin/Chart.yaml
+++ b/bitnami/phpmyadmin/Chart.yaml
@@ -29,4 +29,4 @@ name: phpmyadmin
 sources:
   - https://github.com/bitnami/bitnami-docker-phpmyadmin
   - https://www.phpmyadmin.net/
-version: 8.0.1
+version: 8.0.2

--- a/bitnami/postgresql-ha/Chart.lock
+++ b/bitnami/postgresql-ha/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:ad6046f2a1622d170c845325153551e3af6aee263e3d4621bfc20348f6394e78
-generated: "2020-12-08T04:08:52.248608117Z"
+  version: 1.1.2
+digest: sha256:5a5d1b6e8a55efef1c07768b6bb264c60c98e230792b9a63f85468b95cf58c45
+generated: "2020-12-11T12:22:30.121136+01:00"

--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -27,4 +27,4 @@ name: postgresql-ha
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 6.2.1
+version: 6.2.2

--- a/bitnami/postgresql/Chart.lock
+++ b/bitnami/postgresql/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:ad6046f2a1622d170c845325153551e3af6aee263e3d4621bfc20348f6394e78
-generated: "2020-12-04T16:16:14.668671686Z"
+  version: 1.1.2
+digest: sha256:5a5d1b6e8a55efef1c07768b6bb264c60c98e230792b9a63f85468b95cf58c45
+generated: "2020-12-11T12:22:28.510708+01:00"

--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -26,4 +26,4 @@ name: postgresql
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 10.1.3
+version: 10.1.4

--- a/bitnami/prestashop/Chart.lock
+++ b/bitnami/prestashop/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 9.1.2
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:906007a3aa36816f5766558b685a5d6985c8672778afca5a190b88326c66912a
-generated: "2020-12-10T14:24:02.199797567Z"
+  version: 1.1.2
+digest: sha256:1f9feee2b7e76d92206c4add08806931c512f89eccbf2ce0367ea3d1b095cdda
+generated: "2020-12-11T12:22:35.967814+01:00"

--- a/bitnami/prestashop/Chart.yaml
+++ b/bitnami/prestashop/Chart.yaml
@@ -29,4 +29,4 @@ name: prestashop
 sources:
   - https://github.com/bitnami/bitnami-docker-prestashop
   - https://prestashop.com/
-version: 12.1.1
+version: 12.1.2

--- a/bitnami/rabbitmq/Chart.lock
+++ b/bitnami/rabbitmq/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
-generated: "2020-12-01T17:48:44.512479386+01:00"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:22:35.996451+01:00"

--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -23,4 +23,4 @@ name: rabbitmq
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq
   - https://www.rabbitmq.com
-version: 8.5.3
+version: 8.5.4

--- a/bitnami/redis-cluster/Chart.lock
+++ b/bitnami/redis-cluster/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:2d81f65661ede4b27144fa09f73db18cab9025d174ae0ba4e1fc3a1a60a7ba8e
-generated: "2020-12-02T18:22:07.44076425Z"
+  version: 1.1.2
+digest: sha256:e96477f37f86a4595dce9057f8d04f903f761f340440986129e53cc55f3d63ee
+generated: "2020-12-11T12:22:38.579386+01:00"

--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -23,4 +23,4 @@ name: redis-cluster
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 4.1.1
+version: 4.1.2

--- a/bitnami/redmine/Chart.lock
+++ b/bitnami/redmine/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.0.1
+  version: 1.1.2
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 9.0.1
+  version: 9.1.2
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.1.0
-digest: sha256:ae9dbe3da482328ed8a2a43188cf839d6c498877964956b295d64e7c4903b936
-generated: "2020-11-23T08:54:08.991433+01:00"
+  version: 10.1.3
+digest: sha256:1aa9a861c05e2be2a49bab8ebd981f8dffc2cc8493b6cba9ed714a8ac6a56445
+generated: "2020-12-11T12:22:40.082425+01:00"

--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -36,4 +36,4 @@ name: redmine
 sources:
   - https://github.com/bitnami/bitnami-docker-redmine
   - http://www.redmine.org/
-version: 15.0.1
+version: 15.0.2

--- a/bitnami/spark/Chart.lock
+++ b/bitnami/spark/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 0.10.0
 digest: sha256:cbe8f782ad7168557b9bb101a4d441d3210e2dda09cd249eb8426d1499ce6afc
-generated: "2020-12-08T16:39:25.492992+01:00"
+generated: "2020-12-11T12:22:43.679084+01:00"

--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -21,4 +21,4 @@ name: spark
 sources:
   - https://github.com/bitnami/bitnami-docker-spark
   - https://spark.apache.org/
-version: 4.2.2
+version: 4.2.3

--- a/bitnami/spring-cloud-dataflow/Chart.lock
+++ b/bitnami/spring-cloud-dataflow/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
+  version: 1.1.2
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 9.0.1
+  version: 9.1.2
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
-  version: 8.3.0
+  version: 8.5.3
 - name: kafka
   repository: https://charts.bitnami.com/bitnami
-  version: 12.2.3
-digest: sha256:e59b7acacffd1c15ff41dca2bc5b463a416bc4f4d23adc49b6ea495f87c8d93c
-generated: "2020-12-04T09:35:55.919705082Z"
+  version: 12.3.0
+digest: sha256:ae5269effe4ce799db8c274606758d77cdb1d1c6c7449adcf70e8aae210e8936
+generated: "2020-12-11T12:22:46.720548+01:00"

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -38,4 +38,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-spring-cloud-dataflow
   - https://github.com/bitnami/bitnami-docker-spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 2.2.0
+version: 2.2.1

--- a/bitnami/suitecrm/Chart.lock
+++ b/bitnami/suitecrm/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 9.1.2
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:906007a3aa36816f5766558b685a5d6985c8672778afca5a190b88326c66912a
-generated: "2020-12-11T11:08:16.328600292Z"
+  version: 1.1.2
+digest: sha256:1f9feee2b7e76d92206c4add08806931c512f89eccbf2ce0367ea3d1b095cdda
+generated: "2020-12-11T12:22:48.402426+01:00"

--- a/bitnami/testlink/Chart.lock
+++ b/bitnami/testlink/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 9.0.0
+  version: 9.1.2
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.0.0
-digest: sha256:15fe4b2dd0a14e80e43e1a9f6dd23e0cbbe47549f709fc4f69f880e953f26184
-generated: "2020-11-11T18:37:17.051375057Z"
+  version: 1.1.2
+digest: sha256:1f9feee2b7e76d92206c4add08806931c512f89eccbf2ce0367ea3d1b095cdda
+generated: "2020-12-11T12:22:49.970011+01:00"

--- a/bitnami/testlink/Chart.yaml
+++ b/bitnami/testlink/Chart.yaml
@@ -28,4 +28,4 @@ name: testlink
 sources:
   - https://github.com/bitnami/bitnami-docker-testlink
   - http://www.testlink.org/
-version: 9.0.1
+version: 9.0.2

--- a/bitnami/thanos/Chart.lock
+++ b/bitnami/thanos/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: minio
   repository: https://charts.bitnami.com/bitnami
-  version: 4.1.1
-digest: sha256:3868245e5c2b8ab1944efc80ffcf28587a81cdf77be9974d79ca77525f6ac300
-generated: "2020-12-08T12:22:13.427185638Z"
+  version: 4.1.2
+digest: sha256:2bf3cd1ffac49d39c0b7a74554b131553d6dc0f8b3bd096be09f75a9ffe2f180
+generated: "2020-12-11T12:22:51.907238+01:00"

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -23,4 +23,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 3.2.3
+version: 3.2.4

--- a/bitnami/wavefront/Chart.lock
+++ b/bitnami/wavefront/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.0.1
+  version: 1.1.2
 - name: kube-state-metrics
   repository: https://charts.bitnami.com/bitnami
-  version: 1.0.0
-digest: sha256:84b6b16e3ae4a54b7fbc3b27df98a2b27482dec2d6c3440af1ce162d35d6e72b
-generated: "2020-11-25T00:41:16.881804027Z"
+  version: 1.1.1
+digest: sha256:8fabda12a6035debb220a2f656ca3ac11391b1262fd4e957ff194e19c3f85522
+generated: "2020-12-11T12:22:58.626095+01:00"

--- a/bitnami/wavefront/Chart.yaml
+++ b/bitnami/wavefront/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-wavefront-proxy
   - https://github.com/wavefrontHQ/wavefront-collector-for-kubernetes
   - https://github.com/wavefrontHQ/wavefront-proxy
-version: 1.0.2
+version: 1.0.3

--- a/bitnami/wordpress/Chart.lock
+++ b/bitnami/wordpress/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 9.1.2
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.1
-digest: sha256:906007a3aa36816f5766558b685a5d6985c8672778afca5a190b88326c66912a
-generated: "2020-12-10T14:55:05.613288218Z"
+  version: 1.1.2
+digest: sha256:1f9feee2b7e76d92206c4add08806931c512f89eccbf2ce0367ea3d1b095cdda
+generated: "2020-12-11T12:22:59.527436+01:00"

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -31,4 +31,4 @@ name: wordpress
 sources:
   - https://github.com/bitnami/bitnami-docker-wordpress
   - http://www.wordpress.com/
-version: 10.0.9
+version: 10.0.10


### PR DESCRIPTION
**Description of the change**

Update dependencies to include latest fix in "common" chart (see https://github.com/bitnami/charts/pull/4692)

**Benefits**

Users can set NodeAffinity with presets.

**Possible drawbacks**

None


**Checklist**

- [x} Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
