### PR TITLE
[bitnami/owncloud] New major version

### DIFF
--- a/bitnami/owncloud/Chart.lock
+++ b/bitnami/owncloud/Chart.lock
@@ -1,6 +1,9 @@
 dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.1.2
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 9.0.1
-digest: sha256:6a5735e0b7e5868bbf3eec9d9d031eb20a5928dd38894899c5bccf2e8f7c5a61
-generated: "2020-11-18T12:07:23.518660856Z"
+  version: 9.1.2
+digest: sha256:89ed471ff3cf35e48152a7318b71c56140c437bc9f80fcdc164b95e5738c3a7e
+generated: "2020-12-11T14:00:31.729585+01:00"

--- a/bitnami/owncloud/Chart.yaml
+++ b/bitnami/owncloud/Chart.yaml
@@ -3,9 +3,16 @@ annotations:
 apiVersion: v2
 appVersion: 10.5.0
 dependencies:
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.bitnami.com/bitnami
+    tags:
+      - owncloud-database
     version: 9.x.x
 description: A file sharing server that puts the control and security of your own data back into your hands.
 engine: gotpl
@@ -24,4 +31,4 @@ name: owncloud
 sources:
   - https://github.com/bitnami/bitnami-docker-owncloud
   - https://owncloud.org/
-version: 9.0.0
+version: 10.0.0

--- a/bitnami/owncloud/README.md
+++ b/bitnami/owncloud/README.md
@@ -48,70 +48,127 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Parameters
 
-The following table lists the configurable parameters of the ownCloud chart and their default values.
+The following table lists the configurable parameters of the ownCloud chart and their default values per section/component:
 
-| Parameter                            | Description                                                                                           | Default                                                      |
-|--------------------------------------|-------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `global.imageRegistry`               | Global Docker image registry                                                                          | `nil`                                                        |
-| `global.imagePullSecrets`            | Global Docker registry secret names as an array                                                       | `[]` (does not add image pull secrets to deployed pods)      |
-| `global.storageClass`                | Global storage class for dynamic provisioning                                                         | `nil`                                                        |
-| `image.registry`                     | ownCloud image registry                                                                               | `docker.io`                                                  |
-| `image.repository`                   | ownCloud Image name                                                                                   | `bitnami/owncloud`                                           |
-| `image.tag`                          | ownCloud Image tag                                                                                    | `{TAG_NAME}`                                                 |
-| `image.pullPolicy`                   | Image pull policy                                                                                     | `IfNotPresent`                                               |
-| `image.pullSecrets`                  | Specify docker-registry secret names as an array                                                      | `[]` (does not add image pull secrets to deployed pods)      |
-| `nameOverride`                       | String to partially override owncloud.fullname template with a string (will prepend the release name) | `nil`                                                        |
-| `fullnameOverride`                   | String to fully override owncloud.fullname template with a string                                     | `nil`                                                        |
-| `ingress.enabled`                    | Enable ingress controller resource                                                                    | `false`                                                      |
-| `ingress.hosts.certManager`          | Add annotations for cert-manager                                                                      | `false`                                                      |
-| `ingress.annotations`                | Annotations for this host's ingress record                                                            | `[]`                                                         |
-| `ingress.hosts[0].name`              | Hostname to your ownCloud installation                                                                | `owncloud.local`                                             |
-| `ingress.hosts[0].path`              | Path within the url structure                                                                         | `/`                                                          |
-| `ingress.hosts[0].tls`               | Utilize TLS backend in ingress                                                                        | `false`                                                      |
-| `ingress.hosts[0].tlsSecret`         | TLS Secret (certificates)                                                                             | `owncloud.local-tls-secret`                                  |
-| `ingress.secrets[0].name`            | TLS Secret Name                                                                                       | `nil`                                                        |
-| `ingress.secrets[0].certificate`     | TLS Secret Certificate                                                                                | `nil`                                                        |
-| `ingress.secrets[0].key`             | TLS Secret Key                                                                                        | `nil`                                                        |
-| `networkPolicyApiVersion`            | The kubernetes network API version                                                                    | `extensions/v1beta1`                                         |
-| `owncloudHost`                       | ownCloud host to create application URLs                                                              | `nil`                                                        |
-| `owncloudLoadBalancerIP`             | `loadBalancerIP` for the owncloud Service                                                             | `nil`                                                        |
-| `owncloudUsername`                   | User of the application                                                                               | `user`                                                       |
-| `owncloudPassword`                   | Application password                                                                                  | Randomly generated                                           |
-| `owncloudEmail`                      | Admin email                                                                                           | `user@example.com`                                           |
-| `externalDatabase.host`              | Host of the external database                                                                         | `nil`                                                        |
-| `allowEmptyPassword`                 | Allow DB blank passwords                                                                              | `yes`                                                        |
-| `serviceType`                        | Kubernetes Service type                                                                               | `LoadBalancer`                                               |
-| `persistence.enabled`                | Enable persistence using PVC                                                                          | `true`                                                       |
-| `persistence.owncloud.storageClass`  | PVC Storage Class for ownCloud volume                                                                 | `nil` (uses alpha storage class annotation)                  |
-| `persistence.owncloud.existingClaim` | An Existing PVC name for ownCloud volume                                                              | `nil` (uses alpha storage class annotation)                  |
-| `persistence.owncloud.accessMode`    | PVC Access Mode for ownCloud volume                                                                   | `ReadWriteOnce`                                              |
-| `persistence.owncloud.size`          | PVC Storage Request for ownCloud volume                                                               | `8Gi`                                                        |
-| `updateStrategy.type`                | Owncloud deployment strategy                                                                          | `RollingUpdate`                                              |
-| `resources`                          | CPU/Memory resource requests/limits                                                                   | Memory: `512Mi`, CPU: `300m`                                 |
-| `podAnnotations`                     | Pod annotations                                                                                       | `{}`                                                         |
-| `affinity`                           | Map of node/pod affinities                                                                            | `{}`                                                         |
-| `extraEnvVars`                       | Pass extra environment variables to the image                                                         | `[]`                                                         |
-| `metrics.enabled`                    | Start a side-car prometheus exporter                                                                  | `false`                                                      |
-| `metrics.image.registry`             | Apache exporter image registry                                                                        | `docker.io`                                                  |
-| `metrics.image.repository`           | Apache exporter image name                                                                            | `bitnami/apache-exporter`                                    |
-| `metrics.image.tag`                  | Apache exporter image tag                                                                             | `{TAG_NAME}`                                                 |
-| `metrics.image.pullPolicy`           | Image pull policy                                                                                     | `IfNotPresent`                                               |
-| `metrics.image.pullSecrets`          | Specify docker-registry secret names as an array                                                      | `[]` (does not add image pull secrets to deployed pods)      |
-| `metrics.podAnnotations`             | Additional annotations for Metrics exporter pod                                                       | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
-| `metrics.resources`                  | Exporter resource requests/limit                                                                      | {}                                                           |
-| `certificates.customCertificate.certificateSecret`| Secret containing the certificate and key to add                                         | `""`                                                         |
-| `certificates.customCertificate.chainSecret.name` | Name of the secret containing the certificate chain                                      | `""`                                                         |
-| `certificates.customCertificate.chainSecret.key`  | Key of the certificate chain file inside the secret                                      | `""`                                                         |
-| `certificates.customCertificate.certificateLocation`| Location in the container to store the certificate                                     | `/etc/ssl/certs/ssl-cert-snakeoil.pem`                       |
-| `certificates.customCertificate.keyLocation`| Location in the container to store the private key                                             | `/etc/ssl/private/ssl-cert-snakeoil.key`                     |
-| `certificates.customCertificate.chainLocation`| Location in the container to store the certificate chain                                     | `/etc/ssl/certs/chain.pem`                                   |
-| `certificates.customCAs`             | Defines a list of secrets to import into the container trust store                                    | `[]`                                                         |
-| `certificates.image.registry`        | Container sidecar registry                                                                            | `docker.io`                                                  |
-| `certificates.image.repository`      | Container sidecar image                                                                               | `bitnami/minideb`                                            |
-| `certificates.image.tag`             | Container sidecar image tag                                                                           | `buster`                                                     |
-| `certificates.image.pullPolicy`      | Container sidecar image pull policy                                                                   | `IfNotPresent`                                               |
-| `certificates.image.pullSecrets`     | Container sidecar image pull secrets                                                                  | `image.pullSecrets`                                          |
-| `certificates.extraEnvVars`          | Container sidecar extra environment variables (eg proxy)                                              | `[]`                                                         |
+### Global parameters
+
+| Parameter                               | Description                                                | Default                                                 |
+|-----------------------------------------|------------------------------------------------------------|---------------------------------------------------------|
+| `global.imageRegistry`                  | Global Docker image registry                               | `nil`                                                   |
+| `global.imagePullSecrets`               | Global Docker registry secret names as an array            | `[]` (does not add image pull secrets to deployed pods) |
+| `global.storageClass`                   | Global storage class for dynamic provisioning              | `nil`                                                   |
+
+### Common parameters
+
+| Parameter                               | Description                                                | Default                                                 |
+|-----------------------------------------|------------------------------------------------------------|---------------------------------------------------------|
+| `nameOverride`                          | String to partially override common.names.fullname         | `nil`                                                   |
+| `fullnameOverride`                      | String to fully override common.names.fullname             | `nil`                                                   |
+| `commonLabels`                          | Labels to add to all deployed objects                      | `{}`                                                    |
+| `commonAnnotations`                     | Annotations to add to all deployed objects                 | `{}`                                                    |
+| `clusterDomain`                         | Default Kubernetes cluster domain                          | `cluster.local`                                         |
+| `extraDeploy`                           | Array of extra objects to deploy with the release          | `[]` (evaluated as a template)                          |
+
+### ownCloud parameters
+
+| Parameter                               | Description                                                                              | Default                                                 |
+|-----------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `image.registry`                        | owncloud image registry                                                                  | `docker.io`                                             |
+| `image.repository`                      | ownCloud image name                                                                      | `bitnami/owncloud`                                      |
+| `image.tag`                             | ownCloud image tag                                                                       | `{TAG_NAME}`                                            |
+| `image.pullPolicy`                      | Image pull policy                                                                        | `IfNotPresent`                                          |
+| `image.pullSecrets`                     | Specify docker-registry secret names as an array                                         | `[]` (does not add image pull secrets to deployed pods) |
+| `owncloudUsername`                      | User of the application                                                                  | `user`                                                  |
+| `owncloudPassword`                      | Application password                                                                     | `bitnami`                                               |
+| `owncloudEmail`                         | Admin email                                                                              | `user@example.com`                                      |
+| `owncloudHost`                          | ownCloud host to create application URLs                                                 | `nil`                                                   |
+| `smtpHost`                              | SMTP host                                                                                | `nil`                                                   |
+| `smtpPort`                              | SMTP port                                                                                | `nil`                                                   |
+| `smtpUser`                              | SMTP user                                                                                | `nil`                                                   |
+| `smtpPassword`                          | SMTP password                                                                            | `nil`                                                   |
+| `smtpProtocol`                          | SMTP protocol [`ssl`, `tls`]                                                             | `nil`                                                   |
+| `command`                               | Override default container command (useful when using custom images)                     | `nil`                                                   |
+| `args`                                  | Override default container args (useful when using custom images)                        | `nil`                                                   |
+| `extraEnvVars`                          | Extra environment variables to be set on ownCloud container                              | `{}`                                                    |
+| `extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars                                     | `nil`                                                   |
+| `extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars                                        | `nil`                                                   |
+
+### ownCloud deployment parameters
+
+| Parameter                               | Description                                                                              | Default                                                 |
+|-----------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `containerPorts.http`                   | HTTP port to expose at container level                                                   | `8080`                                                  |
+| `containerPorts.https`                  | HTTPS port to expose at container level                                                  | `8443`                                                  |
+| `podSecurityContext`                    | ownCloud pods' Security Context                                                          | Check `values.yaml` file                                |
+| `containerSecurityContext`              | ownCloud containers' Security Context                                                    | Check `values.yaml` file                                |
+| `resources.limits`                      | The resources limits for the ownCloud container                                          | `{}`                                                    |
+| `resources.requests`                    | The requested resources for the ownCloud container                                       | `{"memory": "512Mi", "cpu": "300m"}`                    |
+| `leavinessProbe`                        | Leaviness probe configuration for ownCloud                                               | Check `values.yaml` file                                |
+| `readinessProbe`                        | Readiness probe configuration for ownCloud                                               | Check `values.yaml` file                                |
+| `customLivenessProbe`                   | Override default liveness probe                                                          | `nil`                                                   |
+| `customReadinessProbe`                  | Override default readiness probe                                                         | `nil`                                                   |
+| `updateStrategy`                        | Strategy to use to update Pods                                                           | Check `values.yaml` file                                |
+| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`      | `""`                                                    |
+| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `soft`                                                  |
+| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`| `""`                                                    |
+| `nodeAffinityPreset.key`                | Node label key to match. Ignored if `affinity` is set.                                   | `""`                                                    |
+| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                | `[]`                                                    |
+| `affinity`                              | Affinity for pod assignment                                                              | `{}` (evaluated as a template)                          |
+| `nodeSelector`                          | Node labels for pod assignment                                                           | `{}` (evaluated as a template)                          |
+| `tolerations`                           | Tolerations for pod assignment                                                           | `[]` (evaluated as a template)                          |
+| `podLabels`                             | Extra labels for ownCloud pods                                                           | `{}` (evaluated as a template)                          |
+| `podAnnotations`                        | Annotations for ownCloud pods                                                            | `{}` (evaluated as a template)                          |
+| `extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for ownCloud container(s)       | `[]`                                                    |
+| `extraVolumes`                          | Optionally specify extra list of additional volumes for ownCloud pods                    | `[]`                                                    |
+| `initContainers`                        | Add additional init containers to the ownCloud pods                                      | `{}` (evaluated as a template)                          |
+| `sidecars`                              | Add additional sidecar containers to the ownCloud pods                                   | `{}` (evaluated as a template)                          |
+| `persistence.enabled`                   | Enable persistence using PVC                                                             | `true`                                                  |
+| `persistence.storageClass`              | PVC Storage Class for ownCloud volume                                                    | `nil` (uses alpha storage class annotation)             |
+| `persistence.existingClaim`             | An Existing PVC name for ownCloud volume                                                 | `nil` (uses alpha storage class annotation)             |
+| `persistence.accessMode`                | PVC Access Mode for ownCloud volume                                                      | `ReadWriteOnce`                                         |
+| `persistence.size`                      | PVC Storage Request for ownCloud volume                                                  | `8Gi`                                                   |
+
+### ownCloud Certificates parameters
+
+| Parameter                                           | Description                                                                  | Default                                                 |
+|-----------------------------------------------------|------------------------------------------------------------------------------|---------------------------------------------------------|
+| `certificates.image.registry`                       | Container sidecar registry                                                   | `docker.io`                                             |
+| `certificates.image.repository`                     | Container sidecar image                                                      | `bitnami/minideb`                                       |
+| `certificates.image.tag`                            | Container sidecar image tag                                                  | `buster`                                                |
+| `certificates.image.pullPolicy`                     | Container sidecar image pull policy                                          | `Always`                                                |
+| `certificates.image.pullSecrets`                    | Container sidecar image pull secrets                                         | `image.pullSecrets`                                     |
+| `certificates.customCertificate.certificateSecret`  | Secret containing the certificate and key to add                             | `""`                                                    |
+| `certificates.customCertificate.chainSecret.name`   | Name of the secret containing the certificate chain                          | `""`                                                    |
+| `certificates.customCertificate.chainSecret.key`    | Key of the certificate chain file inside the secret                          | `""`                                                    |
+| `certificates.customCertificate.certificateLocation`| Location in the container to store the certificate                           | `/etc/ssl/certs/ssl-cert-snakeoil.pem`                  |
+| `certificates.customCertificate.keyLocation`        | Location in the container to store the private key                           | `/etc/ssl/private/ssl-cert-snakeoil.key`                |
+| `certificates.customCertificate.chainLocation`      | Location in the container to store the certificate chain                     | `/etc/ssl/certs/chain.pem`                              |
+| `certificates.customCAs`                            | Defines a list of secrets to import into the container trust store           | `[]`                                                    |
+| `certificates.extraEnvVars`                         | Container sidecar extra environment variables (eg proxy)                     | `[]`                                                    |
+
+### Exposure parameters
+
+| Parameter                               | Description                                                                              | Default                                                 |
+|-----------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `service.type`                          | Kubernetes Service type                                                                  | `LoadBalancer`                                          |
+| `service.loadBalancerIP`                | Kubernetes LoadBalancerIP to request                                                     | `nil`                                                   |
+| `service.port`                          | Service HTTP port                                                                        | `80`                                                    |
+| `service.httpsPort`                     | Service HTTPS port                                                                       | `""`                                                    |
+| `service.externalTrafficPolicy`         | Enable client source IP preservation                                                     | `Cluster`                                               |
+| `service.nodePorts.http`                | Kubernetes http node port                                                                | `""`                                                    |
+| `service.nodePorts.https`               | Kubernetes https node port                                                               | `""`                                                    |
+| `ingress.enabled`                       | Enable ingress controller resource                                                       | `false`                                                 |
+| `ingress.certManager`                   | Add annotations for cert-manager                                                         | `false`                                                 |
+| `ingress.hostname`                      | Default host for the ingress resource                                                    | `owncloud.local`                                        |
+| `ingress.tls`                           | Enable TLS configuration for the hostname defined at `ingress.hostname` parameter        | `false`                                                 |
+| `ingress.annotations`                   | Ingress annotations                                                                      | `{}` (evaluated as a template)                          |
+| `ingress.extraHosts[0].name`            | Additional hostnames to be covered                                                       | `nil`                                                   |
+| `ingress.extraHosts[0].path`            | Additional hostnames to be covered                                                       | `nil`                                                   |
+| `ingress.extraTls[0].hosts[0]`          | TLS configuration for additional hostnames to be covered                                 | `nil`                                                   |
+| `ingress.extraTls[0].secretName`        | TLS configuration for additional hostnames to be covered                                 | `nil`                                                   |
+| `ingress.secrets[0].name`               | TLS Secret Name                                                                          | `nil`                                                   |
+| `ingress.secrets[0].certificate`        | TLS Secret Certificate                                                                   | `nil`                                                   |
+| `ingress.secrets[0].key`                | TLS Secret Key                                                                           | `nil`                                                   |
 
 ### Database parameters
 
@@ -136,13 +193,27 @@ The following table lists the configurable parameters of the ownCloud chart and 
 | `externalDatabase.port`                    | Port of the existing database                         | `3306`                                         |
 | `externalDatabase.existingSecret`          | Name of the database existing Secret Object           | `nil`                                          |
 
+### Metrics parameters
+
+| Parameter                               | Description                                                | Default                                                      |
+|-----------------------------------------|------------------------------------------------------------|--------------------------------------------------------------|
+| `metrics.enabled`                       | Start a side-car prometheus exporter                       | `false`                                                      |
+| `metrics.image.registry`                | Apache exporter image registry                             | `docker.io`                                                  |
+| `metrics.image.repository`              | Apache exporter image name                                 | `bitnami/apache-exporter`                                    |
+| `metrics.image.tag`                     | Apache exporter image tag                                  | `{TAG_NAME}`                                                 |
+| `metrics.image.pullPolicy`              | Image pull policy                                          | `IfNotPresent`                                               |
+| `metrics.image.pullSecrets`             | Specify docker-registry secret names as an array           | `[]` (does not add image pull secrets to deployed pods)      |
+| `metrics.service.port`                  | Service Metrics port                                       | `9117`                                                       |
+| `metrics.service.annotations`           | Annotations for enabling prometheus scraping               | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
+| `metrics.resources`                     | Exporter resource requests/limit                           | `{}`                                                         |
+
 The above parameters map to the env variables defined in [bitnami/owncloud](http://github.com/bitnami/bitnami-docker-owncloud). For more information please refer to the [bitnami/owncloud](http://github.com/bitnami/bitnami-docker-owncloud) image documentation.
 
 > **Note**:
 >
 > For ownCloud to function correctly, you should specify the `owncloudHost` parameter to specify the FQDN (recommended) or the public IP address of the ownCloud service.
 >
-> Optionally, you can specify the `owncloudLoadBalancerIP` parameter to assign a reserved IP address to the ownCloud service of the chart. However please note that this feature is only available on a few cloud providers (f.e. GKE).
+> Optionally, you can specify the `service.loadBalancerIP` parameter to assign a reserved IP address to the ownCloud service of the chart. However please note that this feature is only available on a few cloud providers (f.e. GKE).
 >
 > To reserve a public IP address on GKE:
 >
@@ -150,13 +221,13 @@ The above parameters map to the env variables defined in [bitnami/owncloud](http
 > $ gcloud compute addresses create owncloud-public-ip
 > ```
 >
-> The reserved IP address can be associated to the ownCloud service by specifying it as the value of the `owncloudLoadBalancerIP` parameter while installing the chart.
+> The reserved IP address can be associated to the ownCloud service by specifying it as the value of the `service.loadBalancerIP` parameter while installing the chart.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
 $ helm install my-release \
-  --set owncloudUsername=admin,owncloudPassword=password,mariadb.mariadbRootPassword=secretpassword \
+  --set owncloudUsername=admin,owncloudPassword=password,mariadb.auth.rootPassword=secretpassword \
     bitnami/owncloud
 ```
 
@@ -198,15 +269,73 @@ certificates:
 ```
 
 > Tip! You can create a secret containing your CA certificates using the following command:
+
 ```bash
 kubectl create secret generic my-ca-1 --from-file my-ca-1.crt
 ```
+
+### Adding extra environment variables
+
+In case you want to add extra environment variables (useful for advanced operations like custom init scripts), you can use the `extraEnvVars` property.
+
+```yaml
+extraEnvVars:
+  - name: LOG_LEVEL
+    value: DEBUG
+```
+
+Alternatively, you can use a ConfigMap or a Secret with the environment variables. To do so, use the `extraEnvVarsCM` or the `extraEnvVarsSecret` values.
+
+### Sidecars and Init Containers
+
+If you have a need for additional containers to run within the same pod as the ownCloud app (e.g. an additional metrics or logging exporter), you can do so via the `sidecars` config parameter. Simply define your container according to the Kubernetes container spec.
+
+```yaml
+sidecars:
+  - name: your-image-name
+    image: your-image
+    imagePullPolicy: Always
+    ports:
+      - name: portname
+       containerPort: 1234
+```
+
+Similarly, you can add extra init containers using the `initContainers` parameter.
+
+```yaml
+initContainers:
+  - name: your-image-name
+    image: your-image
+    imagePullPolicy: Always
+    ports:
+      - name: portname
+        containerPort: 1234
+```
+
+### Setting Pod's affinity
+
+This chart allows you to set your custom affinity using the `affinity` paremeter. Find more infomation about Pod's affinity in the [kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity).
+
+As an alternative, you can use of the preset configurations for pod affinity, pod anti-affinity, and node affinity available at the [bitnami/common](https://github.com/bitnami/charts/tree/master/bitnami/common#affinities) chart. To do so, set the `podAffinityPreset`, `podAntiAffinityPreset`, or `nodeAffinityPreset` parameters.
 
 ## Troubleshooting
 
 Find more information about how to deal with common errors related to Bitnami’s Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
 
 ## Upgrading
+
+### To 10.0.0
+
+The [Bitnami ownCloud](https://github.com/bitnami/bitnami-docker-owncloud) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Apache daemon was started as the `daemon` user. From now on, both the container and the Apache daemon run as user `1001`. You can revert this behavior by setting the parameters `containerSecurityContext.runAsUser` to `root`.
+
+This version also introduces `bitnami/common`, a [library chart](https://helm.sh/docs/topics/library_charts/#helm) as a dependency. More documentation about this new utility could be found [here](https://github.com/bitnami/charts/tree/master/bitnami/common#bitnami-common-library-chart). Please, make sure that you have updated the chart dependencies before executing any upgrade.
+
+Consequences:
+
+- The HTTP/HTTPS ports exposed by the container are now `8080/8443` instead of `80/443`.
+- Backwards compatibility is not guaranteed.
+
+To upgrade to `8.0.0`, backup ownCloud data and the previous MariaDB databases, install a new ownCloud chart and import the backups and data, ensuring the `1001` user has the appropriate permissions on the migrated volume.
 
 ### To 9.0.0
 

--- a/bitnami/owncloud/README.md
+++ b/bitnami/owncloud/README.md
@@ -78,6 +78,7 @@ The following table lists the configurable parameters of the ownCloud chart and 
 | `image.tag`                             | ownCloud image tag                                                                       | `{TAG_NAME}`                                            |
 | `image.pullPolicy`                      | Image pull policy                                                                        | `IfNotPresent`                                          |
 | `image.pullSecrets`                     | Specify docker-registry secret names as an array                                         | `[]` (does not add image pull secrets to deployed pods) |
+| `image.debug`                           | Specify if debug logs should be enabled                                                  | `false`                                                 |
 | `owncloudUsername`                      | User of the application                                                                  | `user`                                                  |
 | `owncloudPassword`                      | Application password                                                                     | `bitnami`                                               |
 | `owncloudEmail`                         | Admin email                                                                              | `user@example.com`                                      |

--- a/bitnami/owncloud/ci/values-with-host-and-ingress.yaml
+++ b/bitnami/owncloud/ci/values-with-host-and-ingress.yaml
@@ -1,5 +1,12 @@
+owncloudHost: owncloud.local
 service:
   type: ClusterIP
+ingress:
+  enabled: true
+  tls: true
+  hostname: owncloud.local
+metrics:
+  enabled: true
 # Avoids issues with yamllint
 livenessProbe:
   httpGet:
@@ -7,3 +14,4 @@ livenessProbe:
 readinessProbe:
   httpGet:
     httpHeaders: []
+

--- a/bitnami/owncloud/templates/NOTES.txt
+++ b/bitnami/owncloud/templates/NOTES.txt
@@ -12,53 +12,94 @@ host. To configure ownCloud with the URL of your service:
 
   {{- if contains "NodePort" .Values.service.type }}
 
-  export APP_PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "owncloud.fullname" . }} -o jsonpath="{.spec.ports[0].nodePort}")
+  export APP_PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} -o jsonpath="{.spec.ports[0].nodePort}")
   export APP_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
 
   {{- else if contains "LoadBalancer" .Values.service.type }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "owncloud.fullname" . }}'
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "common.names.fullname" . }}'
 
-  export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "owncloud.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
-  export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "owncloud.fullname" . }} -o jsonpath="{.data.owncloud-password}" | base64 --decode)
+  export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
   {{- end }}
+
+2. Get ownCloud and database credentials:
+
+  export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} -o jsonpath="{.data.owncloud-password}" | base64 --decode)
   export MARIADB_ROOT_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "owncloud.mariadb.fullname" . }} -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)
   export MARIADB_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "owncloud.mariadb.fullname" . }} -o jsonpath="{.data.mariadb-password}" | base64 --decode)
 
-2. Complete your ownCloud deployment by running:
+3. Complete your ownCloud deployment by running:
 
 {{- if .Values.mariadb.enabled }}
 
   helm upgrade {{ .Release.Name }} bitnami/{{ .Chart.Name }} \
-    --set owncloudHost=$APP_HOST,owncloudPassword=$APP_PASSWORD,mariadb.auth.rootPassword=$MARIADB_ROOT_PASSWORD,mariadb.auth.password=$MARIADB_PASSWORD{{- if .Values.global }}{{- if .Values.global.imagePullSecrets }},global.imagePullSecrets={{ .Values.global.imagePullSecrets }}{{- end }}{{- end }}
+    --set owncloudHost=$APP_HOST,owncloudPassword=$APP_PASSWORD,service.type={{ .Values.service.type }},mariadb.auth.rootPassword=$MARIADB_ROOT_PASSWORD,mariadb.auth.password=$MARIADB_PASSWORD{{- if .Values.global }}{{- if .Values.global.imagePullSecrets }},global.imagePullSecrets={{ .Values.global.imagePullSecrets }}{{- end }}{{- end }}
 {{- else }}
 
   ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
-
   helm upgrade {{ .Release.Name }} bitnami/{{ .Chart.Name }} \
     --set owncloudPassword=$APP_PASSWORD,owncloudHost=$APP_HOST,service.type={{ .Values.service.type }},mariadb.enabled=false{{- if not (empty .Values.externalDatabase.host) }},externalDatabase.host={{ .Values.externalDatabase.host }}{{- end }}{{- if not (empty .Values.externalDatabase.user) }},externalDatabase.user={{ .Values.externalDatabase.user }}{{- end }}{{- if not (empty .Values.externalDatabase.password) }},externalDatabase.password={{ .Values.externalDatabase.password }}{{- end }}{{- if not (empty .Values.externalDatabase.database) }},externalDatabase.database={{ .Values.externalDatabase.database }}{{- end }}{{- if .Values.global }}{{- if .Values.global.imagePullSecrets }},global.imagePullSecrets={{ .Values.global.imagePullSecrets }}{{- end }}{{- end }}
+
 {{- end }}
-
 {{- else -}}
-1. Get the ownCloud URL by running:
+{{- if .Values.ingress.enabled }}
 
-{{- if eq .Values.service.type "ClusterIP" }}
+1. Get the ownCloud URL and associate its hostname to your cluster external IP:
 
-  echo "ownCloud URL: echo http://127.0.0.1:8080/"
-  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "owncloud.fullname" . }} 8080:{{ .Values.service.port }}
+   export CLUSTER_IP=$(minikube ip) # On Minikube. Use: `kubectl cluster-info` on others K8s clusters
+   echo "ownCloud URL: http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.hostname }}"
+   echo "ownCloud Admin URL: http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.hostname }}/oc-admin"
+   echo "$CLUSTER_IP  {{ .Values.ingress.hostname }}" | sudo tee -a /etc/hosts
 
 {{- else }}
 
-{{- $port:=.Values.service.port | toString }}
-  echo "ownCloud URL: http://$APP_HOST{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}/"
+1. Get the ownCloud URL by running:
 
+{{- if contains "NodePort" .Values.service.type }}
+
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "common.names.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo "ownCloud URL: http://$NODE_IP:$NODE_PORT/"
+  echo "ownCloud Admin URL: http://$NODE_IP:$NODE_PORT/oc-admin"
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ include "common.names.fullname" . }}'
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "common.names.fullname" . }} --include "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+
+  {{- $port:=.Values.service.port | toString }}
+  echo "ownCloud URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}/"
+  echo "ownCloud Admin URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}/oc-admin"
+
+{{- else if contains "ClusterIP"  .Values.service.type }}
+
+  echo "ownCloud URL: http://127.0.0.1:8080/"
+  echo "ownCloud Admin URL: http://127.0.0.1:8080/oc-admin"
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "common.names.fullname" . }} 8080:{{ .Values.service.port }}
+
+{{- end }}
+{{- end }}
 {{- end }}
 
 2. Get your ownCloud login credentials by running:
 
   echo User:     {{ .Values.owncloudUsername }}
-  echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "owncloud.fullname" . }} -o jsonpath="{.data.owncloud-password}" | base64 --decode)
+  echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "common.names.fullname" . }} -o jsonpath="{.data.owncloud-password}" | base64 --decode)
+
+{{- if .Values.metrics.enabled }}
+
+You can access Apache Prometheus metrics following the steps below:
+
+1. Get the Apache Prometheus metrics URL by running:
+
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ printf "%s-metrics" (include "common.names.fullname" .) }} {{ .Values.metrics.service.port }}:{{ .Values.metrics.service.port }} &
+    echo "Apache Prometheus metrics URL: http://127.0.0.1:{{ .Values.metrics.service.port }}/metrics"
+
+2. Open a browser and access Apache Prometheus metrics using the obtained URL.
+
 {{- end }}
 
 {{- else -}}
@@ -70,32 +111,23 @@ host. To configure ownCloud with the URL of your service:
 This deployment will be incomplete until you configure ownCloud with a resolvable database
 host. To configure ownCloud to use and external database host:
 
-
 1. Complete your ownCloud deployment by running:
-
-{{- if contains "NodePort" .Values.service.type }}
-  export APP_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-{{- else if contains "LoadBalancer" .Values.service.type }}
-
-  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "owncloud.fullname" . }}'
-
-  export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "owncloud.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
-{{- else }}
-
-  export APP_HOST=127.0.0.1
-{{- end }}
-  export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "owncloud.fullname" . }} -o jsonpath="{.data.owncloud-password}" | base64 --decode)
 
   ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
 
-  helm upgrade {{ .Release.Name }} bitnami/{{ .Chart.Name }} \
-    --set owncloudPassword=$APP_PASSWORD,owncloudHost=$APP_HOST,service.type={{ .Values.service.type }},mariadb.enabled=false{{- if not (empty .Values.externalDatabase.user) }},externalDatabase.user={{ .Values.externalDatabase.user }}{{- end }}{{- if not (empty .Values.externalDatabase.password) }},externalDatabase.password={{ .Values.externalDatabase.password }}{{- end }}{{- if not (empty .Values.externalDatabase.database) }},externalDatabase.database={{ .Values.externalDatabase.database }}{{- end }},externalDatabase.host=YOUR_EXTERNAL_DATABASE_HOST{{- if .Values.global }}{{- if .Values.global.imagePullSecrets }},global.imagePullSecrets={{ .Values.global.imagePullSecrets }}{{- end }}{{- end }}
-{{- end }}
-
-{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
-
-WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
-+info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
+  helm upgrade {{ .Release.Name }} --set service.type={{ .Values.service.type }},mariadb.enabled=false,externalDatabase.host=YOUR_EXTERNAL_DATABASE_HOST bitnami/owncloud
 
 {{- end }}
+
+{{- include "owncloud.checkRollingTags" . }}
+{{- $passwordValidationErrors := list -}}
+{{- $secretName := include "common.names.fullname" . -}}
+{{- $requiredOwncloudPassword := dict "valueKey" "owncloudPassword" "secret" $secretName "field" "owncloud-password" "context" $ -}}
+{{- $requiredOwncloudPasswordError := include "common.validations.values.single.empty" $requiredOwncloudPassword -}}
+{{- $passwordValidationErrors = append $passwordValidationErrors $requiredOwncloudPasswordError -}}
+{{- if .Values.mariadb.enabled }}
+    {{- $mariadbSecretName := include "owncloud.databaseSecretName" . -}}
+    {{- $mariadbPasswordValidationErrors := include "common.validations.values.mariadb.passwords" (dict "secret" $mariadbSecretName "subchart" true "context" $) -}}
+    {{- $passwordValidationErrors = append $passwordValidationErrors $mariadbPasswordValidationErrors -}}
+{{- end }}
+{{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordValidationErrors "context" $) -}}

--- a/bitnami/owncloud/templates/NOTES.txt
+++ b/bitnami/owncloud/templates/NOTES.txt
@@ -121,9 +121,7 @@ host. To configure ownCloud to use and external database host:
 {{- $requiredOwncloudPassword := dict "valueKey" "owncloudPassword" "secret" $secretName "field" "owncloud-password" "context" $ -}}
 {{- $requiredOwncloudPasswordError := include "common.validations.values.single.empty" $requiredOwncloudPassword -}}
 {{- $passwordValidationErrors = append $passwordValidationErrors $requiredOwncloudPasswordError -}}
-{{- if .Values.mariadb.enabled }}
-    {{- $mariadbSecretName := include "owncloud.databaseSecretName" . -}}
-    {{- $mariadbPasswordValidationErrors := include "common.validations.values.mariadb.passwords" (dict "secret" $mariadbSecretName "subchart" true "context" $) -}}
-    {{- $passwordValidationErrors = append $passwordValidationErrors $mariadbPasswordValidationErrors -}}
-{{- end }}
+{{- $mariadbSecretName := include "owncloud.databaseSecretName" . -}}
+{{- $mariadbPasswordValidationErrors := include "common.validations.values.mariadb.passwords" (dict "secret" $mariadbSecretName "subchart" true "context" $) -}}
+{{- $passwordValidationErrors = append $passwordValidationErrors $mariadbPasswordValidationErrors -}}
 {{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordValidationErrors "context" $) -}}

--- a/bitnami/owncloud/templates/NOTES.txt
+++ b/bitnami/owncloud/templates/NOTES.txt
@@ -49,7 +49,6 @@ host. To configure ownCloud with the URL of your service:
 
    export CLUSTER_IP=$(minikube ip) # On Minikube. Use: `kubectl cluster-info` on others K8s clusters
    echo "ownCloud URL: http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.hostname }}"
-   echo "ownCloud Admin URL: http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.hostname }}/oc-admin"
    echo "$CLUSTER_IP  {{ .Values.ingress.hostname }}" | sudo tee -a /etc/hosts
 
 {{- else }}
@@ -61,26 +60,22 @@ host. To configure ownCloud with the URL of your service:
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "common.names.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo "ownCloud URL: http://$NODE_IP:$NODE_PORT/"
-  echo "ownCloud Admin URL: http://$NODE_IP:$NODE_PORT/oc-admin"
 
 {{- else if contains "LoadBalancer" .Values.service.type }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
         Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ include "common.names.fullname" . }}'
 
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "common.names.fullname" . }} --include "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "common.names.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
 
   {{- $port:=.Values.service.port | toString }}
   echo "ownCloud URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}/"
-  echo "ownCloud Admin URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}/oc-admin"
 
 {{- else if contains "ClusterIP"  .Values.service.type }}
 
   echo "ownCloud URL: http://127.0.0.1:8080/"
-  echo "ownCloud Admin URL: http://127.0.0.1:8080/oc-admin"
   kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "common.names.fullname" . }} 8080:{{ .Values.service.port }}
 
-{{- end }}
 {{- end }}
 {{- end }}
 
@@ -100,6 +95,7 @@ You can access Apache Prometheus metrics following the steps below:
 
 2. Open a browser and access Apache Prometheus metrics using the obtained URL.
 
+{{- end }}
 {{- end }}
 
 {{- else -}}

--- a/bitnami/owncloud/templates/_certificates.tpl
+++ b/bitnami/owncloud/templates/_certificates.tpl
@@ -4,55 +4,32 @@
 Return the proper image name used for setting up Certificates
 */}}
 {{- define "certificates.image" -}}
-{{- $registryName := default .Values.certificates.image.registry .Values.image.registry -}}
-{{- $repositoryName := .Values.certificates.image.repository -}}
-{{- $tag := .Values.certificates.image.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
-{{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-{{- end -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.certificates.image "global" .Values.global) }}
 {{- end -}}
 
 {{- define "certificates.initContainer" -}}
 {{- if .Values.certificates.customCAs }}
 - name: certificates
-  image: {{ template "certificates.image" . }}
-  imagePullPolicy: {{ default .Values.image.pullPolicy .Values.certificates.image.pullPolicy }}
-  {{- if .Values.image.pullSecrets}}
-  imagePullSecrets:
-  {{- range (default .Values.image.pullSecrets .Values.certificates.image.pullSecrets) }}
-    - name: {{ . }}
-  {{- end }}
-  {{- end }}
+  image: {{ include "certificates.image" . }}
+  imagePullPolicy: {{ .Values.certificates.image.pullPolicy }}
   command:
-  {{- if .Values.certificates.customCertificate.certificateSecret }}
-  - sh
-  - -c
-  - if command -v apk >/dev/null; then apk add --no-cache ca-certificates openssl && update-ca-certificates;
-    else apt-get update && apt-get install -y ca-certificates openssl; fi
-  {{- else }}
-  - sh
-  - -c
-  - if command -v apk >/dev/null; then apk add --no-cache ca-certificates openssl && update-ca-certificates;
-    else apt-get update && apt-get install -y ca-certificates openssl; fi
-    && openssl req -new -x509 -days 3650 -nodes -sha256
-       -subj "/CN=$(hostname)" -addext "subjectAltName = DNS:$(hostname)"
-       -out  /etc/ssl/certs/ssl-cert-snakeoil.pem
-       -keyout /etc/ssl/private/ssl-cert-snakeoil.key -extensions v3_req
-  {{- end }}
+    {{- if .Values.certificates.customCertificate.certificateSecret }}
+    - sh
+    - -c
+    - if command -v apk >/dev/null; then apk add --no-cache ca-certificates openssl && update-ca-certificates;
+      else apt-get update && apt-get install -y ca-certificates openssl; fi
+    {{- else }}
+    - sh
+    - -c
+    - if command -v apk >/dev/null; then apk add --no-cache ca-certificates openssl && update-ca-certificates;
+      else apt-get update && apt-get install -y ca-certificates openssl; fi
+      && openssl req -new -x509 -days 3650 -nodes -sha256
+         -subj "/CN=$(hostname)" -addext "subjectAltName = DNS:$(hostname)"
+         -out  /etc/ssl/certs/ssl-cert-snakeoil.pem
+         -keyout /etc/ssl/private/ssl-cert-snakeoil.key -extensions v3_req
+    {{- end }}
   {{- if .Values.certificates.extraEnvVars }}
-  env:
-  {{- tpl (toYaml .Values.certificates.extraEnvVars) $ | nindent 2 }}
+  env: {{- include "common.tplvalues.render" (dict "value" .Values.certificates.extraEnvVars "context" $) | nindent 2 }}
   {{- end }}
   volumeMounts:
     - name: etc-ssl-certs
@@ -97,7 +74,7 @@ Also, we can't use a single if because lazy evaluation is not an option
 {{- end -}}
 {{- end -}}
 
-{{- define "certificates.volumeMount" -}}
+{{- define "certificates.volumeMounts" -}}
 {{- if .Values.certificates.customCAs }}
 - name: etc-ssl-certs
   mountPath: /etc/ssl/certs/

--- a/bitnami/owncloud/templates/_helpers.tpl
+++ b/bitnami/owncloud/templates/_helpers.tpl
@@ -126,5 +126,4 @@ Check if there are rolling tags in the images
 {{- define "owncloud.checkRollingTags" -}}
 {{- include "common.warnings.rollingTag" .Values.image }}
 {{- include "common.warnings.rollingTag" .Values.metrics.image }}
-{{- include "common.warnings.rollingTag" .Values.certificates.image }}
 {{- end -}}

--- a/bitnami/owncloud/templates/_helpers.tpl
+++ b/bitnami/owncloud/templates/_helpers.tpl
@@ -1,35 +1,24 @@
-
 {{/* vim: set filetype=mustache: */}}
+
 {{/*
-Expand the name of the chart.
+Return the proper Owncloud image name
 */}}
-{{- define "owncloud.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- define "owncloud.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
 {{- end -}}
 
 {{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+Return the proper image name (for the metrics image)
 */}}
-{{- define "owncloud.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
+{{- define "owncloud.metrics.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.metrics.image "global" .Values.global) }}
 {{- end -}}
 
 {{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+Return the proper Docker Image Registry Secret Names
 */}}
-{{- define "owncloud.mariadb.fullname" -}}
-{{- printf "%s-%s" .Release.Name "mariadb" | trunc 63 | trimSuffix "-" -}}
+{{- define "owncloud.imagePullSecrets" -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.metrics.image .Values.certificates.image) "global" .Values.global) -}}
 {{- end -}}
 
 {{/*
@@ -54,150 +43,20 @@ If not using ClusterIP, or if a host or LoadBalancerIP is not defined, the value
 {{- end -}}
 
 {{/*
-Create chart name and version as used by the chart label.
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "owncloud.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Return the proper Owncloud image name
-*/}}
-{{- define "owncloud.image" -}}
-{{- $registryName := .Values.image.registry -}}
-{{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
+{{- define "owncloud.mariadb.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- printf "%s-mariadb" .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return the proper image name (for the metrics image)
-*/}}
-{{- define "owncloud.metrics.image" -}}
-{{- $registryName := .Values.metrics.image.registry -}}
-{{- $repositoryName := .Values.metrics.image.repository -}}
-{{- $tag := .Values.metrics.image.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-mariadb" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- printf "%s-%s-mariadb" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
-
-{{/*
-Return the proper Docker Image Registry Secret Names
-*/}}
-{{- define "owncloud.imagePullSecrets" -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
-Also, we can not use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets:
-{{- range .Values.global.imagePullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- else if or .Values.image.pullSecrets .Values.metrics.image.pullSecrets }}
-imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- range .Values.metrics.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end -}}
-{{- else if or .Values.image.pullSecrets .Values.metrics.image.pullSecrets }}
-imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- range .Values.metrics.image.pullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return  the proper Storage Class
-*/}}
-{{- define "owncloud.storageClass" -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
-*/}}
-{{- if .Values.global -}}
-    {{- if .Values.global.storageClass -}}
-        {{- if (eq "-" .Values.global.storageClass) -}}
-            {{- printf "storageClassName: \"\"" -}}
-        {{- else }}
-            {{- printf "storageClassName: %s" .Values.global.storageClass -}}
-        {{- end -}}
-    {{- else -}}
-        {{- if .Values.persistence.owncloud.storageClass -}}
-              {{- if (eq "-" .Values.persistence.owncloud.storageClass) -}}
-                  {{- printf "storageClassName: \"\"" -}}
-              {{- else }}
-                  {{- printf "storageClassName: %s" .Values.persistence.owncloud.storageClass -}}
-              {{- end -}}
-        {{- end -}}
-    {{- end -}}
-{{- else -}}
-    {{- if .Values.persistence.owncloud.storageClass -}}
-        {{- if (eq "-" .Values.persistence.owncloud.storageClass) -}}
-            {{- printf "storageClassName: \"\"" -}}
-        {{- else }}
-            {{- printf "storageClassName: %s" .Values.persistence.owncloud.storageClass -}}
-        {{- end -}}
-    {{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return the appropriate apiVersion for deployment.
-*/}}
-{{- define "owncloud.deployment.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
-{{- print "apps/v1" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Renders a value that contains template.
-Usage:
-{{ include "owncloud.tplValues.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
-*/}}
-{{- define "owncloud.tplValues.render" -}}
-    {{- if typeIs "string" .value }}
-        {{- tpl .value .context }}
-    {{- else }}
-        {{- tpl (.value | toYaml) .context }}
-    {{- end }}
 {{- end -}}
 
 {{/*
@@ -259,4 +118,13 @@ Return the MariaDB Secret Name
 {{- else -}}
     {{- printf "%s-%s" .Release.Name "externaldb" -}}
 {{- end -}}
+{{- end -}}
+
+{{/*
+Check if there are rolling tags in the images
+*/}}
+{{- define "owncloud.checkRollingTags" -}}
+{{- include "common.warnings.rollingTag" .Values.image }}
+{{- include "common.warnings.rollingTag" .Values.metrics.image }}
+{{- include "common.warnings.rollingTag" .Values.certificates.image }}
 {{- end -}}

--- a/bitnami/owncloud/templates/deployment.yaml
+++ b/bitnami/owncloud/templates/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/owncloud/templates/deployment.yaml
+++ b/bitnami/owncloud/templates/deployment.yaml
@@ -66,6 +66,8 @@ spec:
           args: {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 12 }}
           {{- end }}
           env:
+            - name: BITNAMI_DEBUG
+              value: {{ ternary "true" "false" .Values.image.debug | quote }}
             - name: ALLOW_EMPTY_PASSWORD
               value: {{ .Values.allowEmptyPassword | quote }}
             - name: MARIADB_HOST

--- a/bitnami/owncloud/templates/deployment.yaml
+++ b/bitnami/owncloud/templates/deployment.yaml
@@ -1,143 +1,175 @@
 {{- if include "owncloud.host" . -}}
-apiVersion: {{ template "owncloud.deployment.apiVersion" . }}
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
-  name: {{ template "owncloud.fullname" . }}
-  labels:
-    app.kubernetes.io/name: {{ include "owncloud.fullname" . }}
-    helm.sh/chart: {{ include "owncloud.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+  name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   selector:
-    matchLabels:
-      app.kubernetes.io/name: {{ include "owncloud.fullname" . }}
-      app.kubernetes.io/instance: {{ .Release.Name | quote }}
-  replicas: 1
-{{- if .Values.updateStrategy }}
-  strategy: {{ toYaml .Values.updateStrategy | nindent 4 }}
-{{- end }}
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+  strategy: {{- include "common.tplvalues.render" (dict "value" .Values.updateStrategy "context" $ ) | nindent 4 }}
   template:
     metadata:
-      labels:
-        app.kubernetes.io/name: {{ include "owncloud.fullname" . }}
-        helm.sh/chart: {{ include "owncloud.chart" . }}
-        app.kubernetes.io/instance: {{ .Release.Name | quote }}
-{{- if or .Values.podAnnotations .Values.metrics.enabled }}
-      annotations:
-  {{- if .Values.podAnnotations }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
-  {{- end }}
-  {{- if .Values.metrics.podAnnotations }}
-{{ toYaml .Values.metrics.podAnnotations | indent 8 }}
-  {{- end }}
-{{- end }}
-    spec:
-{{- include "owncloud.imagePullSecrets" . | indent 6 }}
-      hostAliases:
-      - ip: "127.0.0.1"
-        hostnames:
-        - "status.localhost"
-      initContainers:
-      {{- include "certificates.initContainer" . | indent 8 }}
-      containers:
-      - name: {{ template "owncloud.fullname" . }}
-        image: {{ template "owncloud.image" . }}
-        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-        env:
-        - name: ALLOW_EMPTY_PASSWORD
-          value: {{ .Values.allowEmptyPassword | quote }}
-        - name: MARIADB_HOST
-          value: {{ include "owncloud.databaseHost" . | quote }}
-        - name: MARIADB_PORT_NUMBER
-          value: {{ include "owncloud.databasePort" . | quote }}
-        - name: OWNCLOUD_DATABASE_NAME
-          value: {{ include "owncloud.databaseName" . | quote }}
-        - name: OWNCLOUD_DATABASE_USER
-          value: {{ include "owncloud.databaseUser" . | quote }}
-        - name: OWNCLOUD_DATABASE_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "owncloud.databaseSecretName" . }}
-              key: mariadb-password
-{{- $port:=.Values.service.port | toString }}
-        - name: OWNCLOUD_HOST
-          value: "{{ include "owncloud.host" . }}{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}"
-        - name: OWNCLOUD_USERNAME
-          value: {{ default "" .Values.owncloudUsername | quote }}
-        - name: OWNCLOUD_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "owncloud.fullname" . }}
-              key: owncloud-password
-        - name: OWNCLOUD_EMAIL
-          value: {{ default "" .Values.owncloudEmail | quote }}
-        {{- if .Values.extraEnvVars }}
-        {{- include "owncloud.tplValues.render" ( dict "value" .Values.extraEnvVars "context" $ ) | nindent 8 }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
-        ports:
-        - name: http
-          containerPort: 80
-        livenessProbe:
-          httpGet:
-            path: /status.php
-            port: http
-            httpHeaders:
-            - name: Host
-              value: {{ include "owncloud.host" . | quote }}
-          initialDelaySeconds: 120
-          timeoutSeconds: 5
-          failureThreshold: 6
-        readinessProbe:
-          httpGet:
-            path: /status.php
-            port: http
-            httpHeaders:
-            - name: Host
-              value: {{ include "owncloud.host" . | quote }}
-          initialDelaySeconds: 30
-          timeoutSeconds: 3
-          periodSeconds: 5
-        resources:
-{{ toYaml .Values.resources | indent 10 }}
-        volumeMounts:
-        {{- include "certificates.volumeMount" . | indent 8 }}
-        - name: owncloud-data
-          mountPath: /bitnami/owncloud
-{{- if .Values.metrics.enabled }}
-      - name: metrics
-        image: {{ template "owncloud.metrics.image" . }}
-        imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
-        command: [ '/bin/apache_exporter', '--scrape_uri', 'http://status.localhost:80/server-status/?auto']
-        ports:
-        - name: metrics
-          containerPort: 9117
-        livenessProbe:
-          httpGet:
-            path: /metrics
-            port: metrics
-          initialDelaySeconds: 15
-          timeoutSeconds: 5
-        readinessProbe:
-          httpGet:
-            path: /metrics
-            port: metrics
-          initialDelaySeconds: 5
-          timeoutSeconds: 1
-        resources:
-  {{ toYaml .Values.metrics.resources | indent 10 }}
-{{- end }}
-      volumes:
-      {{- include "certificates.volumes" . | indent 6 }}
-      - name: owncloud-data
-      {{- if .Values.persistence.enabled }}
-        persistentVolumeClaim:
-          claimName: {{ if .Values.persistence.owncloud.existingClaim }}{{ .Values.persistence.owncloud.existingClaim }}{{- else }}{{ template "owncloud.fullname" . }}-owncloud{{- end }}
+      {{- if .Values.podAnnotations }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- include "owncloud.imagePullSecrets" . | nindent 6 }}
+      hostAliases:
+        - ip: "127.0.0.1"
+          hostnames:
+            - "status.localhost"
+      {{- if .Values.affinity }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- else }}
-        emptyDir: {}
-      {{- end }}
-      {{- with .Values.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAffinityPreset "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAntiAffinityPreset "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" .) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      initContainers:
+        {{- include "certificates.initContainer" . | nindent 8 }}
+        {{- if .Values.initContainers }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+        {{- end }}
+      containers:
+        - name: owncloud
+          image: {{ template "owncloud.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.command "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 12 }}
+          {{- end }}
+          env:
+            - name: ALLOW_EMPTY_PASSWORD
+              value: {{ .Values.allowEmptyPassword | quote }}
+            - name: MARIADB_HOST
+              value: {{ include "owncloud.databaseHost" . | quote }}
+            - name: MARIADB_PORT_NUMBER
+              value: {{ include "owncloud.databasePort" . | quote }}
+            - name: OWNCLOUD_DATABASE_NAME
+              value: {{ include "owncloud.databaseName" . | quote }}
+            - name: OWNCLOUD_DATABASE_USER
+              value: {{ include "owncloud.databaseUser" . | quote }}
+            - name: OWNCLOUD_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "owncloud.databaseSecretName" . }}
+                  key: mariadb-password
+            {{- $port:=.Values.service.port | toString }}
+            - name: OWNCLOUD_HOST
+              value: "{{ include "owncloud.host" . }}{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}"
+            - name: OWNCLOUD_USERNAME
+              value: {{ .Values.owncloudUsername | quote }}
+            - name: OWNCLOUD_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "common.names.fullname" . }}
+                  key: owncloud-password
+            - name: OWNCLOUD_EMAIL
+              value: {{ .Values.owncloudEmail | quote }}
+              {{- if .Values.extraEnvVars }}
+              {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+              {{- end }}
+            {{- if or .Values.extraEnvVarsCM .Values.extraEnvVarsSecret }}
+          envFrom:
+            {{- if .Values.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
+            {{- end }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPorts.http }}
+            {{- if .Values.service.httpsPort }}
+            - name: https
+              containerPort: {{ .Values.containerPorts.https }}
+            {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
+          {{- else if .Values.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 12 }}
+          {{- else if .Values.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.resources }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: owncloud-data
+              mountPath: /bitnami/owncloud
+            {{- include "certificates.volumeMounts" . | nindent 12 }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
+        {{- if .Values.metrics.enabled }}
+        - name: metrics
+          image: {{ template "owncloud.metrics.image" . }}
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
+          command: ['/bin/apache_exporter', '--scrape_uri', 'http://status.localhost:80/server-status/?auto']
+          ports:
+            - name: metrics
+              containerPort: 9117
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 15
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          {{- if .Values.metrics.resources }}
+          resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
+          {{- end }}
+        {{- end }}
+        {{- if .Values.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) | nindent 8 }}
+        {{- end }}
+      volumes:
+        {{- include "certificates.volumes" . | nindent 8 }}
+        - name: owncloud-data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "common.names.fullname" . }}-owncloud{{- end }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}
 {{- end -}}

--- a/bitnami/owncloud/templates/externaldb-secrets.yaml
+++ b/bitnami/owncloud/templates/externaldb-secrets.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-externaldb" (include "common.names.fullname" .) }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/owncloud/templates/externaldb-secrets.yaml
+++ b/bitnami/owncloud/templates/externaldb-secrets.yaml
@@ -1,13 +1,15 @@
-{{- if (not (or .Values.mariadb.enabled .Values.externalDatabase.existingSecret)) }}
+{{- if not (or .Values.mariadb.enabled .Values.externalDatabase.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
-  labels:
-    app.kubernetes.io/name: {{ include "owncloud.fullname" . }}
-    helm.sh/chart: {{ include "owncloud.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+  name: {{ printf "%s-externaldb" (include "common.names.fullname" .) }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   mariadb-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}

--- a/bitnami/owncloud/templates/extra-list.yaml
+++ b/bitnami/owncloud/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/bitnami/owncloud/templates/ingress.yaml
+++ b/bitnami/owncloud/templates/ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/owncloud/templates/ingress.yaml
+++ b/bitnami/owncloud/templates/ingress.yaml
@@ -1,42 +1,53 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: {{ template "owncloud.fullname" . }}
-  labels:
-    app.kubernetes.io/name: {{ include "owncloud.fullname" . }}
-    helm.sh/chart: {{ include "owncloud.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+  name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.ingress.annotations .Values.commonAnnotations .Values.ingress.certManager }}
   annotations:
-    {{- range .Values.ingress.hosts }}
-    {{- if .tls }}
-    ingress.kubernetes.io/secure-backends: "true"
-    {{- end }}
-    {{- end }}
     {{- if .Values.ingress.certManager }}
     kubernetes.io/tls-acme: "true"
     {{- end }}
-    {{- range $key, $value := .Values.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
+    {{- if .Values.ingress.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.annotations "context" $ ) | nindent 4 }}
     {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   rules:
-  {{- range .Values.ingress.hosts }}
-  - host: {{ .name }}
-    http:
-      paths:
-        - path: {{ default "/" .path }}
-          backend:
-            serviceName: {{ template "owncloud.fullname" $ }}
-            servicePort: 80
-  {{- end }}
+    {{- if .Values.ingress.hostname }}
+    - host: {{ .Values.ingress.hostname }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ include "common.names.fullname" . }}
+              servicePort: http
+    {{- end }}
+    {{- range .Values.ingress.extraHosts }}
+    - host: {{ .name }}
+      http:
+        paths:
+          - path: {{ default "/" .path }}
+            backend:
+              serviceName: {{ include "common.names.fullname" $ }}
+              servicePort: http
+    {{- end }}
+  {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
   tls:
-{{- range .Values.ingress.hosts }}
-  - hosts:
-{{- if .tls }}
-    - {{ .name }}
-    secretName: {{ .tlsSecret }}
-{{- end }}
-{{- end }}
+    {{- if .Values.ingress.tls }}
+    - hosts:
+        - {{ .Values.ingress.hostname }}
+      secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
+    {{- end }}
+    {{- if .Values.ingress.extraTls }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.extraTls "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/bitnami/owncloud/templates/metrics-svc.yaml
+++ b/bitnami/owncloud/templates/metrics-svc.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-metrics" (include "common.names.fullname" .) }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.metrics.service.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.metrics.service.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.service.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: metrics
+      port: {{ .Values.metrics.service.port }}
+      protocol: TCP
+      targetPort: metrics
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
+{{- end }}

--- a/bitnami/owncloud/templates/owncloud-pvc.yaml
+++ b/bitnami/owncloud/templates/owncloud-pvc.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ printf "%s-owncloud" (include "common.names.fullname" .) }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/owncloud/templates/owncloud-pvc.yaml
+++ b/bitnami/owncloud/templates/owncloud-pvc.yaml
@@ -2,17 +2,19 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ template "owncloud.fullname" . }}-owncloud
-  labels:
-    app.kubernetes.io/name: {{ include "owncloud.fullname" . }}
-    helm.sh/chart: {{ include "owncloud.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+  name: {{ printf "%s-owncloud" (include "common.names.fullname" .) }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   accessModes:
-    - {{ .Values.persistence.owncloud.accessMode | quote }}
+    - {{ .Values.persistence.accessMode | quote }}
   resources:
     requests:
-      storage: {{ .Values.persistence.owncloud.size | quote }}
-  {{ include "owncloud.storageClass" . }}
+      storage: {{ .Values.persistence.size | quote }}
+  {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 2 }}
 {{- end -}}

--- a/bitnami/owncloud/templates/secrets.yaml
+++ b/bitnami/owncloud/templates/secrets.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/owncloud/templates/secrets.yaml
+++ b/bitnami/owncloud/templates/secrets.yaml
@@ -1,16 +1,21 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "owncloud.fullname" . }}
-  labels:
-    app.kubernetes.io/name: {{ include "owncloud.fullname" . }}
-    helm.sh/chart: {{ include "owncloud.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+  name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
-  {{ if .Values.owncloudPassword }}
+  {{- if .Values.owncloudPassword }}
   owncloud-password: {{ .Values.owncloudPassword | b64enc | quote }}
-  {{ else }}
+  {{- else }}
   owncloud-password: {{ randAlphaNum 10 | b64enc | quote }}
-  {{ end }}
+  {{- end }}
+  {{- if .Values.smtpPassword }}
+  smtp-password: {{ .Values.smtpPassword | b64enc | quote }}
+  {{- end }}

--- a/bitnami/owncloud/templates/svc.yaml
+++ b/bitnami/owncloud/templates/svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/owncloud/templates/svc.yaml
+++ b/bitnami/owncloud/templates/svc.yaml
@@ -1,27 +1,39 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "owncloud.fullname" . }}
-  labels:
-    app.kubernetes.io/name: {{ include "owncloud.fullname" . }}
-    helm.sh/chart: {{ include "owncloud.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+  name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
-  {{- end }}
-  {{- if eq .Values.service.type "LoadBalancer" }}
-  loadBalancerIP: {{ default "" .Values.service.loadBalancerIP }}
   {{- end }}
   ports:
     - name: http
       port: {{ .Values.service.port }}
       targetPort: http
-      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePorts.http)))}}
+      {{- if (and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.http))) }}
       nodePort: {{ .Values.service.nodePorts.http }}
+      {{- else if eq .Values.service.type "ClusterIP" }}
+      nodePort: null
       {{- end }}
-  selector:
-    app.kubernetes.io/name: {{ include "owncloud.fullname" . }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    {{- if .Values.service.httpsPort }}
+    - name: https
+      port: {{ .Values.service.httpsPort }}
+      targetPort: https
+      {{- if (and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.https))) }}
+      nodePort: {{ .Values.service.nodePorts.https }}
+      {{- else if eq .Values.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+    {{- end }}
+  selector: {{ include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/owncloud/templates/tls-secrets.yaml
+++ b/bitnami/owncloud/templates/tls-secrets.yaml
@@ -19,7 +19,8 @@ data:
   tls.key: {{ .key | b64enc }}
 ---
 {{- end }}
-{{- else if and .Values.ingress.tls (not .Values.ingress.certManager) }}
+{{- end }}
+{{- if and .Values.ingress.tls (not .Values.ingress.certManager) }}
 {{- $ca := genCA "owncloud-ca" 365 }}
 {{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
 apiVersion: v1

--- a/bitnami/owncloud/templates/tls-secrets.yaml
+++ b/bitnami/owncloud/templates/tls-secrets.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled }}
+{{- if .Values.ingress.secrets }}
+{{- range .Values.ingress.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  namespace: {{ $.Release.Namespace }}
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
+    {{- if $.Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" $.Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if $.Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .certificate | b64enc }}
+  tls.key: {{ .key | b64enc }}
+---
+{{- end }}
+{{- else if and .Values.ingress.tls (not .Values.ingress.certManager) }}
+{{- $ca := genCA "owncloud-ca" 365 }}
+{{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-tls" .Values.ingress.hostname }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $cert.Cert | b64enc | quote }}
+  tls.key: {{ $cert.Key | b64enc | quote }}
+  ca.crt: {{ $ca.Cert | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/bitnami/owncloud/values.yaml
+++ b/bitnami/owncloud/values.yaml
@@ -23,72 +23,35 @@ image:
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## Example:
+  ## pullSecrets:
+  ##   - myRegistryKeySecretName
   ##
-  # pullSecrets:
-  #   - myRegistryKeySecretName
+  pullSecrets: []
 
-## String to partially override owncloud.fullname template (will maintain the release name)
+## String to partially override common.names.fullname template (will maintain the release name)
 ##
 # nameOverride:
 
-## String to fully override owncloud.fullname template
+## String to fully override common.names.fullname template
 ##
 # fullnameOverride:
 
-## For Kubernetes v1.4, v1.5 and v1.6, use 'extensions/v1beta1'
-## For Kubernetes v1.7, use 'networking.k8s.io/v1'
-networkPolicyApiVersion: extensions/v1beta1
-
-## Configure the ingress resource that allows you to access the
-## ownCloud installation. Set up the URL
-## ref: http://kubernetes.io/docs/user-guide/ingress/
+## Add labels to all the deployed resources
 ##
-ingress:
-  ## Set to true to enable ingress record generation
-  enabled: false
+commonLabels: {}
 
-  ## The list of hostnames to be covered with this ingress record.
-  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
-  hosts:
-  - name: owncloud.local
-
-    ## Set this to true in order to enable TLS on the ingress record
-    ## A side effect of this will be that the backend owncloud service will be connected at port 443
-    tls: false
-
-    ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
-    tlsSecret: owncloud.local-tls
-
-  ## Set this to true in order to add the corresponding annotations for cert-manager
-  certManager: false
-
-  ## Ingress annotations done as key:value pairs
-  ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
-  ##
-  ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
-  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
-  annotations:
-  #  kubernetes.io/ingress.class: nginx
-
-  secrets:
-  ## If you're providing your own certificates, please use this to add the certificates as secrets
-  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
-  ## -----BEGIN RSA PRIVATE KEY-----
-  ##
-  ## name should line up with a tlsSecret set further up
-  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
-  ##
-  ## It is also possible to create and manage the certificates outside of this helm chart
-  ## Please see README.md for more information
-  # - name: owncloud.local-tls
-  #   key:
-  #   certificate:
-
-## ownCloud host to create application URLs
-## ref: https://github.com/bitnami/bitnami-docker-owncloud#configuration
+## Add annotations to all the deployed resources
 ##
-# owncloudHost:
+commonAnnotations: {}
+
+## Kubernetes Cluster Domain
+##
+clusterDomain: cluster.local
+
+## Extra objects to deploy (value evaluated as a template)
+##
+extraDeploy: []
 
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-owncloud#configuration
@@ -106,9 +69,419 @@ owncloudUsername: user
 ##
 owncloudEmail: user@example.com
 
+## ownCloud host to create application URLs
+## ref: https://github.com/bitnami/bitnami-docker-owncloud#configuration
+##
+# owncloudHost:
+
 ## Set to `yes` to allow the container to be started with blank passwords
 ## ref: https://github.com/bitnami/bitnami-docker-owncloud#environment-variables
+##
 allowEmptyPassword: "yes"
+
+## Command and args for running the container (set to default if not set). Use array form
+##
+command: []
+args: []
+
+## An array to add extra env vars
+## Example:
+## extraEnvVars:
+##   - name: FOO
+##     value: "bar"
+##
+extraEnvVars: []
+
+## ConfigMap with extra environment variables
+##
+extraEnvVarsCM:
+
+## Secret with extra environment variables
+##
+extraEnvVarsSecret:
+
+## Strategy to use to update Pods
+##
+updateStrategy:
+  ## StrategyType
+  ## Can be set to RollingUpdate or OnDelete
+  ##
+  type: RollingUpdate
+
+## Owncloud container ports to open
+##
+containerPorts:
+  http: 8080
+  https: 8443
+
+## Owncloud pods' Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+##
+podSecurityContext:
+  enabled: true
+  fsGroup: 1001
+
+## Owncloud containers' SecurityContext
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+##
+containerSecurityContext:
+  enabled: true
+  runAsUser: 1001
+
+## Owncloud resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits: {}
+  #   cpu: 200m
+  #   memory: 256Mi
+  requests:
+    memory: 512Mi
+    cpu: 300m
+
+## Owncloud containers' liveness and readiness probes.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+##
+livenessProbe:
+  enabled: true
+  httpGet:
+    path: /status.php
+    port: http
+    httpHeaders:
+      - name: Host
+        value: "{{ include \"owncloud.host\" . }}"
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+readinessProbe:
+  enabled: true
+  httpGet:
+    path: /status.php
+    port: http
+    httpHeaders:
+      - name: Host
+        value: "{{ include \"owncloud.host\" . }}"
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
+## Custom Liveness probes for Owncloud
+##
+customLivenessProbe: {}
+
+## Custom Rediness probes Owncloud
+##
+customReadinessProbe: {}
+
+## Pod extra labels
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+##
+podLabels: {}
+
+## Annotations for server pods.
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+
+## Pod affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+## Allowed values: soft, hard
+##
+podAffinityPreset: ""
+
+## Pod anti-affinity preset
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+## Allowed values: soft, hard
+##
+podAntiAffinityPreset: soft
+
+## Node affinity preset
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+## Allowed values: soft, hard
+##
+nodeAffinityPreset:
+  ## Node affinity type
+  ## Allowed values: soft, hard
+  type: ""
+  ## Node label key to match
+  ## E.g.
+  ## key: "kubernetes.io/e2e-az-name"
+  ##
+  key: ""
+  ## Node label values to match
+  ## E.g.
+  ## values:
+  ##   - e2e-az1
+  ##   - e2e-az2
+  ##
+  values: []
+
+## Affinity for pod assignment. Evaluated as a template.
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
+##
+affinity: {}
+
+## Node labels for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+
+## Tolerations for pod assignment. Evaluated as a template.
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+
+## Extra volumes to add to the deployment
+##
+extraVolumes: []
+
+## Extra volume mounts to add to the container
+##
+extraVolumeMounts: []
+
+## Add init containers to the Magento pods.
+## Example:
+## initContainers:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+initContainers: {}
+
+## Add sidecars to the Magento pods.
+## Example:
+## sidecars:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+sidecars: {}
+
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  enabled: true
+  ## Owncloud data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+
+  ## A manually managed Persistent Volume and Claim
+  ## Requires persistence.enabled: true
+  ## If defined, PVC must be created manually before volume will be bound
+  # existingClaim:
+
+  accessMode: ReadWriteOnce
+  size: 8Gi
+
+## Kubernetes svc configuration
+## For minikube, set this to NodePort, elsewhere use LoadBalancer
+##
+## Use serviceLoadBalancerIP to request a specific static IP,
+## otherwise leave blank
+##
+service:
+  ## Kubernetes svc type
+  ## For minikube, set this to NodePort, elsewhere use LoadBalancer
+  ##
+  type: LoadBalancer
+  ## Use serviceLoadBalancerIP to request a specific static IP,
+  ## otherwise leave blank
+  ##
+  # loadBalancerIP:
+  # HTTP Port
+  port: 80
+  # HTTPS Port
+  ## Set this to any value (recommended: 443) to enable the https service port
+  # httpsPort: 443
+  ## Use nodePorts to requets some specific ports when usin NodePort
+  ## nodePorts:
+  ##   http: <to set explicitly, choose port between 30000-32767>
+  ##   https: <to set explicitly, choose port between 30000-32767>
+  ##
+  nodePorts:
+    http: ""
+    https: ""
+  ## Enable client source IP preservation
+  ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+  ##
+  externalTrafficPolicy: Cluster
+
+## Ingress configuratiom
+##
+ingress:
+  ## Set to true to enable ingress record generation
+  ##
+  enabled: false
+
+  ## Set this to true in order to add the corresponding annotations for cert-manager
+  ##
+  certManager: false
+
+  ## When the ingress is enabled, a host pointing to this will be created
+  ##
+  hostname: owncloud.local
+
+  ## Ingress annotations done as key:value pairs
+  ## For a full list of possible ingress annotations, please see
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ##
+  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+  ##
+  annotations: {}
+
+  ## Enable TLS configuration for the hostname defined at ingress.hostname parameter
+  ## TLS certificates will be retrieved from a TLS secret with name: {{- printf "%s-tls" .Values.ingress.hostname }}
+  ## You can use the ingress.secrets parameter to create this TLS secret, relay on cert-manager to create it, or
+  ## let the chart create self-signed certificates for you
+  ##
+  tls: false
+
+  ## The list of additional hostnames to be covered with this ingress record.
+  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+  ## Example:
+  ## extraHosts:
+  ##   - name: owncloud.local
+  ##     path: /
+  ##
+  extraHosts: []
+
+  ## The tls configuration for additional hostnames to be covered with this ingress record.
+  ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## Example:
+  ## extraTls:
+  ## - hosts:
+  ##     - owncloud.local
+  ##   secretName: owncloud.local-tls
+  ##
+  extraTls: []
+
+  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or -----BEGIN RSA PRIVATE KEY-----
+  ## name should line up with a secretName set further up
+  ##
+  ## If it is not set and you're using cert-manager, this is unneeded, as it will create the secret for you
+  ## If it is not set and you're NOT using cert-manager either, self-signed certificates will be created
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  ##
+  ## Example
+  ## secrets:
+  ##   - name: owncloud.local-tls
+  ##     key: ""
+  ##     certificate: ""
+  ##
+  secrets: []
+
+## Add custom certificates and certificate authorities to ownCloud container
+##
+certificates:
+  image:
+    registry: docker.io
+    repository: bitnami/minideb
+    tag: buster
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: Always
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+  ## Custom Certificate paramaters
+  ##
+  customCertificate:
+    certificateSecret: ""
+    chainSecret: {}
+    # name: secret-name
+    # key: secret-key
+    certificateLocation: /etc/ssl/certs/ssl-cert-snakeoil.pem
+    keyLocation: /etc/ssl/private/ssl-cert-snakeoil.key
+    chainLocation: /etc/ssl/certs/mychain.pem
+  ## Certificate Authority
+  ## Example:
+  ## customCA:
+  ##   - secret: custom-CA
+  ##   - secret: more-custom-CAs
+  ##
+  customCA: []
+  ## Certificate Authority
+  ## Example:
+  ## customCA:
+  ##   - secret: custom-CA
+  ##   - secret: more-custom-CAs
+  ##
+  ## An array to add extra env vars
+  ## Example:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
+
+## Prometheus Exporter / Metrics
+##
+metrics:
+  enabled: false
+  image:
+    registry: docker.io
+    repository: bitnami/apache-exporter
+    tag: 0.8.0-debian-10-r217
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+
+  ## Metrics exporter resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+
+  ## Prometheus expoter service parameters
+  ##
+  service:
+    ## Metrics port
+    ##
+    port: 9117
+    ## Annotations for the Prometheus exporter service
+    ##
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "{{ .Values.metrics.service.port }}"
 
 ##
 ## External database configuration
@@ -186,131 +559,3 @@ mariadb:
       ## Use an existing PVC
       ##
       existingClaim:
-
-## Kubernetes configuration
-## For minikube, set this to NodePort, elsewhere use LoadBalancer
-##
-service:
-  type: LoadBalancer
-  # HTTP Port
-  port: 80
-  ## loadBalancerIP:
-  ##
-  ## nodePorts:
-  ##   http: <to set explicitly, choose port between 30000-32767>
-  ##   https: <to set explicitly, choose port between 30000-32767>
-  nodePorts:
-    http: ""
-    https: ""
-  ## Enable client source IP preservation
-  ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
-  ##
-  externalTrafficPolicy: Cluster
-
-
-## Enable persistence using Persistent Volume Claims
-## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-##
-persistence:
-  enabled: true
-  owncloud:
-    ## owncloud data Persistent Volume Storage Class
-    ## If defined, storageClassName: <storageClass>
-    ## If set to "-", storageClassName: "", which disables dynamic provisioning
-    ## If undefined (the default) or set to null, no storageClassName spec is
-    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-    ##   GKE, AWS & OpenStack)
-    ##
-    # storageClass: "-"
-
-    ## A manually managed Persistent Volume and Claim
-    ## Requires persistence.enabled: true
-    ## If defined, PVC must be created manually before volume will be bound
-    # existingClaim:
-
-    accessMode: ReadWriteOnce
-    size: 8Gi
-
-## Set up update strategy for the ownCloud installation.
-## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
-## Example:
-# updateStrategy:
-#  type: RollingUpdate
-#  rollingUpdate:
-#    maxSurge: 25%
-#    maxUnavailable: 25%
-updateStrategy:
-  type: RollingUpdate
-
-## Configure resource requests and limits
-## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-##
-resources:
-  requests:
-    memory: 512Mi
-    cpu: 300m
-
-## Pod annotations
-## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-##
-podAnnotations: {}
-
-## Affinity for pod assignment
-## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-##
-affinity: {}
-
-extraEnvVars: []
-
-## Prometheus Exporter / Metrics
-##
-metrics:
-  enabled: false
-  image:
-    registry: docker.io
-    repository: bitnami/apache-exporter
-    tag: 0.8.0-debian-10-r217
-    pullPolicy: IfNotPresent
-    ## Optionally specify an array of imagePullSecrets.
-    ## Secrets must be manually created in the namespace.
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ##
-    # pullSecrets:
-    #   - myRegistryKeySecretName
-     ## Metrics exporter pod Annotation and Labels
-  podAnnotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9117"
-  ## Metrics exporter resource requests and limits
-  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-  ##
-  # resources: {}
-
-# Add custom certificates and certificate authorities to owncloud container
-certificates:
-  customCertificate:
-    certificateSecret: ""
-    chainSecret: {}
-    # name: secret-name
-    # key: secret-key
-    certificateLocation: /etc/ssl/certs/ssl-cert-snakeoil.pem
-    keyLocation: /etc/ssl/private/ssl-cert-snakeoil.key
-    chainLocation: /etc/ssl/certs/mychain.pem
-  customCA: []
-  # - secret: custom-CA
-  # - secret: more-custom-CAs
-  image:
-    registry: docker.io
-    repository: bitnami/minideb
-    tag: buster
-    ## Specify a imagePullPolicy
-    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-    ##
-    pullPolicy: IfNotPresent
-    # pullPolicy:
-    # pullSecrets
-    #   - myRegistryKeySecretName
-  extraEnvVars: []
-  # - name: myvar
-  #   value: myval

--- a/bitnami/owncloud/values.yaml
+++ b/bitnami/owncloud/values.yaml
@@ -28,6 +28,9 @@ image:
   ##   - myRegistryKeySecretName
   ##
   pullSecrets: []
+  ## Set to true if you would like to see extra information on logs
+  ##
+  debug: false
 
 ## String to partially override common.names.fullname template (will maintain the release name)
 ##


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR refactors the whole chart to follow Helm chart best practices, and move the ownCloud image to a "non-root" approach.

This includes several breaking changes, so please review it carefully, putting special emphasis to the "Upgrading" section describing all of them.

**Benefits**

- Standardization.
- Reduces technical debt.

**Possible drawbacks**

It breaks backwards compatibility.

**Applicable issues**

None

**Additional information**

-

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files