### PR TITLE
copy eventrouter chart from helm/stable to bitnami

### DIFF
--- a/bitnami/eventrouter/.helmignore
+++ b/bitnami/eventrouter/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/bitnami/eventrouter/Chart.yaml
+++ b/bitnami/eventrouter/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+description: DEPRECATED A Helm chart for eventruter (https://github.com/heptiolabs/eventrouter)
+name: eventrouter
+version: 0.3.2
+appVersion: 0.3
+home: https://github.com/heptiolabs/eventrouter
+sources:
+- https://github.com/heptiolabs/eventrouter
+keywords:
+- eventrouter
+deprecated: true

--- a/bitnami/eventrouter/Chart.yaml
+++ b/bitnami/eventrouter/Chart.yaml
@@ -1,3 +1,5 @@
+annotations:
+  category: Infrastructure
 apiVersion: v1
 description: DEPRECATED A Helm chart for eventruter (https://github.com/heptiolabs/eventrouter)
 name: eventrouter

--- a/bitnami/eventrouter/Chart.yaml
+++ b/bitnami/eventrouter/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 description: DEPRECATED A Helm chart for eventruter (https://github.com/heptiolabs/eventrouter)
 name: eventrouter
 version: 0.3.2
-appVersion: 0.3
+appVersion: 0.3.0
 home: https://github.com/heptiolabs/eventrouter
 sources:
 - https://github.com/heptiolabs/eventrouter

--- a/bitnami/eventrouter/README.md
+++ b/bitnami/eventrouter/README.md
@@ -1,0 +1,45 @@
+# ⚠️ Repo Archive Notice
+
+As of Nov 13, 2020, charts in this repo will no longer be updated.
+For more information, see the Helm Charts [Deprecation and Archive Notice](https://github.com/helm/charts#%EF%B8%8F-deprecation-and-archive-notice), and [Update](https://helm.sh/blog/charts-repo-deprecation/).
+
+# eventrouter
+
+[eventrouter](https://github.com/heptiolabs/eventrouter) simple introspective kubernetes service that forwards events to a specified sink.
+
+## DEPRECATION NOTICE
+
+This chart is deprecated and no longer supported.
+
+## Installation
+
+```console
+$ helm install stable/eventrouter --name my-release
+NAME: k8s-eventrouter
+LAST DEPLOYED: Fri Feb 28 14:57:53 2020
+NAMESPACE: default
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+eventrouter has been installed!
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the eventrouter chart and their default values.
+
+|        Parameter        |                                                         Description                                                         |              Default               |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| `image.repository`      | Container image name                                                                                                        | `gcr.io/heptio-images/eventrouter` |
+| `image.tag`             | Container image tag                                                                                                         | `v0.3`                             |
+| `rbac.create`           | If `true`, create and use RBAC resources                                                                                    | `true`                             |
+| `serviceAccount.name`   | Service account to be used. If not set and serviceAccount.create is `true`, a name is generated using the fullname template | ``                                 |
+| `serviceAccount.create` | If true, create a new service account                                                                                       | `true`                             |
+| `tolerations`           | List of node taints to tolerate                                                                                             | `[]`                               |
+| `nodeSelector`          | Node labels for pod assignment                                                                                              | `{}`                               |
+| `sink`                  | Sink to send the events to                                                                                                  | `glog`                             |
+| `podAnnotations`        | Annotations for pod metadata                                                                                                | `{}`                               |
+| `containerPorts`        | List of ports for the container                                                                                             | `[]`                               |
+| `securityContext`       | Security context for the pod                                                                                                | `{}`                               |
+| `enablePrometheus`      | Enable prometheus                                                                                                           | `true                              |

--- a/bitnami/eventrouter/templates/NOTES.txt
+++ b/bitnami/eventrouter/templates/NOTES.txt
@@ -1,0 +1,1 @@
+eventrouter has been installed!

--- a/bitnami/eventrouter/templates/_helpers.tpl
+++ b/bitnami/eventrouter/templates/_helpers.tpl
@@ -1,0 +1,54 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "eventrouter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "eventrouter.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "eventrouter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Generate basic labels */}}
+{{- define "eventrouter.labels" }}
+app: {{ template "eventrouter.name" . }}
+heritage: {{.Release.Service }}
+release: {{.Release.Name }}
+chart: {{ template "eventrouter.chart" . }}
+{{- if .Values.podLabels}}
+{{ toYaml .Values.podLabels }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "eventrouter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "eventrouter.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/bitnami/eventrouter/templates/clusterrole.yaml
+++ b/bitnami/eventrouter/templates/clusterrole.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels: {{ include "eventrouter.labels" . | indent 4 }}
+  name: {{ template "eventrouter.fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+{{- end -}}

--- a/bitnami/eventrouter/templates/clusterrole.yaml
+++ b/bitnami/eventrouter/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels: {{ include "eventrouter.labels" . | indent 4 }}

--- a/bitnami/eventrouter/templates/clusterrolebinding.yaml
+++ b/bitnami/eventrouter/templates/clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels: {{ include "eventrouter.labels" . | indent 4 }}
+  name: {{ template "eventrouter.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "eventrouter.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "eventrouter.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/bitnami/eventrouter/templates/clusterrolebinding.yaml
+++ b/bitnami/eventrouter/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels: {{ include "eventrouter.labels" . | indent 4 }}

--- a/bitnami/eventrouter/templates/configmap.yaml
+++ b/bitnami/eventrouter/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "eventrouter.fullname" . }}
+  labels: {{ include "eventrouter.labels" . | indent 4 }}
+  namespace: {{ .Release.Namespace }}
+data:
+  config.json: |-
+    {
+      "sink": "{{ .Values.sink }}",
+      "enable-prometheus": "{{ .Values.enablePrometheus }}"
+    }

--- a/bitnami/eventrouter/templates/deployment.yaml
+++ b/bitnami/eventrouter/templates/deployment.yaml
@@ -1,0 +1,56 @@
+{{- if semverCompare "^1.9-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: apps/v1
+{{- else }}
+apiVersion: apps/v1beta1
+{{- end }}
+kind: Deployment
+metadata:
+  labels: {{ include "eventrouter.labels" . | indent 4 }}
+  name: {{ template "eventrouter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "eventrouter.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "eventrouter.name" . }}
+        release: {{ .Release.Name }}
+    {{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+    {{- end }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        volumeMounts:
+          - name: config-volume
+            mountPath: /etc/eventrouter
+    {{- if .Values.containerPorts }}
+        ports:
+{{ toYaml .Values.containerPorts | indent 10 }}
+    {{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+    {{- end }}
+    {{- if .Values.securityContext }}
+      securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
+    {{- end }}
+      serviceAccountName: {{ template "eventrouter.serviceAccountName" . }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ template "eventrouter.fullname" . }}

--- a/bitnami/eventrouter/templates/serviceaccount.yaml
+++ b/bitnami/eventrouter/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels: {{ include "eventrouter.labels" . | indent 4 }}
+  name: {{ template "eventrouter.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/bitnami/eventrouter/values.yaml
+++ b/bitnami/eventrouter/values.yaml
@@ -1,0 +1,39 @@
+# Default values for eventrouter.
+
+image:
+  repository: gcr.io/heptio-images/eventrouter
+  tag: v0.3
+  pullPolicy: IfNotPresent
+resources: {}
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+tolerations: []
+
+nodeSelector: {}
+
+sink: glog
+
+podAnnotations: {}
+
+containerPorts: []
+
+securityContext: {}
+  # runAsUser: 1000
+
+enablePrometheus: true


### PR DESCRIPTION
**Description of the change**
Copied the current eventrouter from https://github.com/helm/charts/tree/master/stable/eventrouter

**Benefits**
Eventrouter helm chart has a home again

**Possible drawbacks**
- Not sure how I can keep the old versions of the eventrouter helm chart. Sorry, I'm new to github collaboration

**Applicable issues**
- Fixes #4696

**Additional information**
Any feedback is welcome