### PR TITLE
[bitnami/minio] Fix a typo on prometheus.io/path annotation

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -25,4 +25,4 @@ name: minio
 sources:
   - https://github.com/bitnami/bitnami-docker-minio
   - https://min.io
-version: 4.1.3
+version: 4.1.4

--- a/bitnami/minio/values-production.yaml
+++ b/bitnami/minio/values-production.yaml
@@ -198,7 +198,7 @@ securityContext:
 ##
 podAnnotations:
   prometheus.io/scrape: "true"
-  prometheus.io/path: "/minio/prometheus/metric"
+  prometheus.io/path: "/minio/prometheus/metrics"
   prometheus.io/port: "9000"
 
 ## Pod affinity preset


### PR DESCRIPTION
**Description of the change**
I fix a typo on the `prometheus.io/path` value according to what is written in [minio documentation](https://docs.minio.io/docs/how-to-monitor-minio-using-prometheus.html). I does not have to change the value in README.md because it was already correct.

**Benefits**
Annotation can be used in Prometheus scraping config to detect MinIO Prometheus endpoint automatically.

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

Thank you very much for your job, it saves me a lot of time to deploy my new architecture on Kubernetes!