### PR TITLE
[bitnami/metallb] Metallb networkpolicy

### DIFF
--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -23,4 +23,4 @@ sources:
   - https://github.com/metallb/metallb
   - https://github.com/bitnami/bitnami-docker-metallb
   - https://metallb.universe.tf
-version: 1.0.2
+version: 1.1.0

--- a/bitnami/metallb/README.md
+++ b/bitnami/metallb/README.md
@@ -116,6 +116,9 @@ The following tables lists the configurable parameters of the metallb chart and 
 | `prometheus.serviceMonitor.metricRelabelings`         | Specify additional relabeling of metrics.                                                            | `[]`                                                    |
 | `prometheus.serviceMonitor.relabelings`               | Specify general relabeling.                                                                          | `[]`                                                    |
 | `prometheus.serviceMonitor.prometheusRule.enabled`    | Enable prometheus alertmanager basic alerts.                                                         | `true`                                                  |
+| `networkPolicy.enabled`                               | Enable NetworkPolicy                                                                                 | `false`                                                 |
+| `networkPolicy.ingressNSMatchLabels`                  | Allow connections from other namespaces                                                              | `{}`                                                    |
+| `networkPolicy.ingressNSPodMatchLabels`               | For other namespaces match by pod labels and namespace labels                                        | `{}`                                                    |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/metallb/templates/_helpers.tpl
+++ b/bitnami/metallb/templates/_helpers.tpl
@@ -210,3 +210,14 @@ Usage:
         {{- tpl (.value | toYaml) .context }}
     {{- end }}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for networkpolicy.
+*/}}
+{{- define "networkPolicy.apiVersion" -}}
+{{- if semverCompare ">=1.4-0, <1.7-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/bitnami/metallb/templates/networkpolicy.yaml
+++ b/bitnami/metallb/templates/networkpolicy.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.networkPolicy.enabled }}
 kind: NetworkPolicy
-apiVersion: {{ .Values.networkPolicy.apiVersion | default "networking.k8s.io/v1" }}
+apiVersion: {{ template "networkPolicy.apiVersion" . }}
 metadata:
   name: {{ include "metallb.fullname" . }}-controller
   labels:

--- a/bitnami/metallb/templates/networkpolicy.yaml
+++ b/bitnami/metallb/templates/networkpolicy.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ .Values.networkPolicy.apiVersion | default "networking.k8s.io/v1" }}
+metadata:
+  name: {{ include "metallb.fullname" . }}-controller
+  labels:
+    app.kubernetes.io/component: controller
+spec:
+  podSelector:
+    matchLabels: {{- include "metallb.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: controller
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow prometheus scrapes for metrics
+    - ports:
+        - port: {{ .Values.controller.containerPort.metrics }}
+          protocol: TCP
+      {{- if .Values.networkPolicy.ingressNSMatchLabels }}
+      from:
+        - namespaceSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.networkPolicy.ingressNSMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- if .Values.networkPolicy.ingressNSPodMatchLabels }}
+          podSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.networkPolicy.ingressNSPodMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- end }}
+      {{- end }}
+{{- end }}

--- a/bitnami/metallb/values.yaml
+++ b/bitnami/metallb/values.yaml
@@ -53,9 +53,6 @@ networkPolicy:
   ingressNSMatchLabels: {}
   ingressNSPodMatchLabels: {}
 
-  apiVersion:
-
-
 prometheus:
   enabled: false
 

--- a/bitnami/metallb/values.yaml
+++ b/bitnami/metallb/values.yaml
@@ -41,6 +41,21 @@ rbac:
   # create specifies whether to install and use RBAC rules.
   create: true
 
+networkPolicy:
+  ## Specifies whether a NetworkPolicy should be created.
+  ## Prometheus scraping of the controller
+  ##
+  enabled: false
+
+  ## Limit networkpolicy ingress (from)
+  ## Set label for namespace and pods (optional).
+  ##
+  ingressNSMatchLabels: {}
+  ingressNSPodMatchLabels: {}
+
+  apiVersion:
+
+
 prometheus:
   enabled: false
 


### PR DESCRIPTION
**Description of the change**

Add NetworkPolicy for metallb-controller for metrics scraping from Prometheus.

**Benefits**

Maintain the needed NetworkPolicy as part of this charts (together with the ServiceMonitor/PrometheusRule).

**Possible drawbacks**

Not tested towards the metallb-speaker as its normally using HostPorts, or other NetworkPolicy scopes that other might need.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
