### PR TITLE
[bitnami/dokuwiki] Fix multiple ingress hosts

### DIFF
--- a/bitnami/dokuwiki/Chart.yaml
+++ b/bitnami/dokuwiki/Chart.yaml
@@ -24,4 +24,4 @@ name: dokuwiki
 sources:
   - https://github.com/bitnami/bitnami-docker-dokuwiki
   - http://www.dokuwiki.org/
-version: 10.0.2
+version: 10.0.3

--- a/bitnami/dokuwiki/templates/ingress.yaml
+++ b/bitnami/dokuwiki/templates/ingress.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.ingress.enabled }}
-{{- range .Values.ingress.hosts  }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -23,6 +22,11 @@ metadata:
     {{- end }}
 spec:
   rules:
+  {{- $tls := false }}
+  {{- range .Values.ingress.hosts  }}
+  {{- if .tls }}
+    {{- $tls = true }}
+  {{- end }}
   - host: {{ .name }}
     http:
       paths:
@@ -30,12 +34,15 @@ spec:
           backend:
             serviceName: {{ template "dokuwiki.fullname" $ }}
             servicePort: 80
-{{- if .tls }}
+  {{- end }}
+  {{- if $tls }}
   tls:
+  {{- range .Values.ingress.hosts  }}
+  {{- if .tls }}
   - hosts:
     - {{ .name }}
     secretName: {{ .tlsSecret }}
-{{- end }}
----
-{{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Previously, when attempting to use multiple ingress hosts, only the last ingress was created.
This was because the template was appending a resource template with the same name,
causing only the last one to be enabled.

Iteration has been moved inside the resource template to fix this issue and support
multiple ingress hosts.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Fixes #4618

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

None. This is a backwards compatible bugfix.

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #4618

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
