### PR TITLE
[bitnami/nats] Invalid list when using Values.extraFlags #4712

### DIFF
--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -24,4 +24,4 @@ name: nats
 sources:
   - https://github.com/bitnami/bitnami-docker-nats
   - https://nats.io/
-version: 6.0.2
+version: 6.0.3

--- a/bitnami/nats/templates/deployment.yaml
+++ b/bitnami/nats/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
             # for the implementation inside Dockerfile:
             # - https://github.com/bitnami/bitnami-docker-nats#configuration
             {{- range $key, $value := .Values.extraFlags }}
-            --{{ $key }}{{ if $value }}={{ $value }}{{ end }}
+            - --{{ $key }}{{ if $value }}={{ $value }}{{ end }}
             {{- end }}
             {{- end }}
           {{- if .Values.extraEnvVars }}

--- a/bitnami/nats/templates/statefulset.yaml
+++ b/bitnami/nats/templates/statefulset.yaml
@@ -78,7 +78,7 @@ spec:
             # for the implementation inside Dockerfile:
             # - https://github.com/bitnami/bitnami-docker-nats#configuration
             {{- range $key, $value := .Values.extraFlags }}
-            --{{ $key }}{{ if $value }}={{ $value }}{{ end }}
+            - --{{ $key }}{{ if $value }}={{ $value }}{{ end }}
             {{- end }}
             {{- end }}
           {{- if .Values.extraEnvVars }}


### PR DESCRIPTION
See Issue #4712 

Added hyphen `-` to fix the list when using .Values.extraFlags
This fixes a bug


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
