### PR TITLE
[bitnami/mongodb] increase chart version for mongo to bring all changes to 11.3.0 online

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 10.3.0
+version: 10.3.1


### PR DESCRIPTION

**Description of the change**

Just increasing the version number of the mongodb chart to get all changes online in the chart repository.

**Benefits**

Two different pull requests (#4690, #4715) have both changed the chart's version to 10.3.0. Unfortunately, this results in only the changes of #4690 to be deployed to the helm repository, the others are ignored. Since there does not seem to be another pull request for mongodb which seems to be merged soon, I opened this pull request just to ensure that also the changes of #4715 will get uploaded to the repository.

**Possible drawbacks**

Nothing known.

**Applicable issues**

  * #4690
  * #4715

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
