### PR TITLE
[bitnami/testlink] fix externaldb-secrets.yaml db password key name

### DIFF
--- a/bitnami/testlink/Chart.yaml
+++ b/bitnami/testlink/Chart.yaml
@@ -28,4 +28,4 @@ name: testlink
 sources:
   - https://github.com/bitnami/bitnami-docker-testlink
   - http://www.testlink.org/
-version: 9.0.3
+version: 9.0.4

--- a/bitnami/testlink/templates/externaldb-secrets.yaml
+++ b/bitnami/testlink/templates/externaldb-secrets.yaml
@@ -6,5 +6,5 @@ metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 type: Opaque
 data:
-  db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
+  mariadb-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
**Description of the change**

change externaldb-secrets.yaml db-password key to mariadb-password.

**Benefits**

![image](https://user-images.githubusercontent.com/23514869/102170106-9477db00-3ece-11eb-8d99-b17bb845f84c.png)

fix Error: couldn't find key mariadb-password in Secret default/testlink-externaldb.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/testlink]`)

