### PR TITLE
[bitnami/redis] Fix Sentinel Redis with TLS

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -19,4 +19,4 @@ name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 12.2.2
+version: 12.2.3

--- a/bitnami/redis/templates/configmap-scripts.yaml
+++ b/bitnami/redis/templates/configmap-scripts.yaml
@@ -80,6 +80,12 @@ data:
       # Immediately attempt to connect to the reported master. If it doesn't exist the connection attempt will either hang
       # or fail with "port unreachable" and give no data. The liveness check will then timeout waiting for the redis
       # container to be ready and restart the it. By then the new master will likely have been elected
+      if is_boolean_yes "$REDIS_TLS_ENABLED"; then
+        sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $REDIS_MASTER_HOST -p {{ .Values.sentinel.port }} --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
+      else
+        sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $REDIS_MASTER_HOST -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
+      fi
+
       if [[ ! ($($sentinel_info_command)) ]]; then
         # master doesn't actually exist, this probably means the remaining pods haven't elected a new one yet
         # and are reporting the old one still. Once this happens the container will get stuck and never see the new
@@ -240,6 +246,12 @@ data:
       # Immediately attempt to connect to the reported master. If it doesn't exist the connection attempt will either hang
       # or fail with "port unreachable" and give no data. The liveness check will then timeout waiting for the sentinel
       # container to be ready and restart the it. By then the new master will likely have been elected
+      if is_boolean_yes "$REDIS_SENTINEL_TLS_ENABLED"; then
+        sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $REDIS_MASTER_HOST -p {{ .Values.sentinel.port }} --tls --cert ${REDIS_SENTINEL_TLS_CERT_FILE} --key ${REDIS_SENTINEL_TLS_KEY_FILE} --cacert ${REDIS_SENTINEL_TLS_CA_FILE} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
+      else
+        sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $REDIS_MASTER_HOST -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
+      fi
+
       if [[ ! ($($sentinel_info_command)) ]]; then
         # master doesn't actually exist, this probably means the remaining pods haven't elected a new one yet
         # and are reporting the old one still. Once this happens the container will get stuck and never see the new

--- a/bitnami/redis/templates/configmap-scripts.yaml
+++ b/bitnami/redis/templates/configmap-scripts.yaml
@@ -80,8 +80,6 @@ data:
       # Immediately attempt to connect to the reported master. If it doesn't exist the connection attempt will either hang
       # or fail with "port unreachable" and give no data. The liveness check will then timeout waiting for the redis
       # container to be ready and restart the it. By then the new master will likely have been elected
-      sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $REDIS_MASTER_HOST -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
-
       if [[ ! ($($sentinel_info_command)) ]]; then
         # master doesn't actually exist, this probably means the remaining pods haven't elected a new one yet
         # and are reporting the old one still. Once this happens the container will get stuck and never see the new
@@ -242,8 +240,6 @@ data:
       # Immediately attempt to connect to the reported master. If it doesn't exist the connection attempt will either hang
       # or fail with "port unreachable" and give no data. The liveness check will then timeout waiting for the sentinel
       # container to be ready and restart the it. By then the new master will likely have been elected
-      sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $REDIS_MASTER_HOST -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
-
       if [[ ! ($($sentinel_info_command)) ]]; then
         # master doesn't actually exist, this probably means the remaining pods haven't elected a new one yet
         # and are reporting the old one still. Once this happens the container will get stuck and never see the new


### PR DESCRIPTION
**Description of the change**

Fix the startup of the pods when `sentinel.enabled=true` and `tls.enabled=true`. Removed a duplicate variable that breaks on TLS enabled.
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

It actually makes the chart work with TLS.
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
