### PR TITLE
[bitnami/*] Fix Parse & Phabricator

### DIFF
--- a/bitnami/parse/Chart.yaml
+++ b/bitnami/parse/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-parse
   - https://github.com/bitnami/bitnami-docker-parse-dashboard
   - https://parse.com/
-version: 13.2.0
+version: 13.2.1

--- a/bitnami/parse/templates/_helpers.tpl
+++ b/bitnami/parse/templates/_helpers.tpl
@@ -36,12 +36,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- if .Values.fullnameOverride -}}
 {{- printf "%s-mongodb" .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
 {{- printf "%s-mongodb" .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s-mongodb" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/phabricator/Chart.yaml
+++ b/bitnami/phabricator/Chart.yaml
@@ -32,4 +32,4 @@ name: phabricator
 sources:
   - https://github.com/bitnami/bitnami-docker-phabricator
   - https://www.phacility.com/phabricator/
-version: 10.2.0
+version: 10.2.1

--- a/bitnami/phabricator/templates/_helpers.tpl
+++ b/bitnami/phabricator/templates/_helpers.tpl
@@ -50,12 +50,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- if .Values.fullnameOverride -}}
 {{- printf "%s-mariadb" .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
 {{- printf "%s-mariadb" .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s-mariadb" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

At https://github.com/bitnami/charts/pull/4701 two macros were wrongly updated, and as a consequence, the installation of these charts are failing with errors like the ones below:

```
Error: secret "XXXX-phabric-phabricator-mariadb" not found
```

**Benefits**

The chart cant be installed with any release name.

**Possible drawbacks**

None

**Applicable issues**

None

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
