### PR TITLE
[bitnami/kong] Ingress Controller version

### DIFF
--- a/bitnami/kong/Chart.lock
+++ b/bitnami/kong/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.1.3
+  version: 10.2.0
 - name: cassandra
   repository: https://charts.bitnami.com/bitnami
-  version: 7.0.1
+  version: 7.1.1
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.1.2
-digest: sha256:c94ed7648507b369c2f1aa99f2a6c51ebd9e81346a9c8a2f987cddc86a7c7ec7
-generated: "2020-12-11T12:21:12.205186+01:00"
+digest: sha256:51a30c6b78b4ad79416242168dcbabf45b1e58463db2ef1c854c0115d9a9c19d
+generated: "2020-12-15T16:50:19.843177157Z"

--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -34,4 +34,4 @@ name: kong
 sources:
   - https://github.com/bitnami/bitnami-docker-kong
   - https://konghq.com/
-version: 3.0.8
+version: 3.1.0

--- a/bitnami/kong/README.md
+++ b/bitnami/kong/README.md
@@ -290,6 +290,7 @@ This chart includes a `values-production.yaml` file where you can find some para
 - metrics.enabled: false
 + metrics.enabled: true
 ```
+
 ### Database backend
 
 The Bitnami Kong chart allows setting two database backends: PostgreSQL or Cassandra. For each option, there are two extra possibilities: deploy a sub-chart with the database installation or use an existing one. The list below details the different options (replace the placeholders specified between _UNDERSCORES_):
@@ -427,6 +428,10 @@ $ helm upgrade my-release bitnami/kong \
 ```
 
 > Note: you need to substitute the placeholders _[POSTGRESQL_PASSWORD]_ with the values obtained from instructions in the installation notes.
+
+### To 3.1.0
+
+Kong Ingress Controller version was bumped to new major version, `1.x.x`. The associated CRDs were updated accordingly.
 
 ### To 3.0.0
 

--- a/bitnami/kong/values-production.yaml
+++ b/bitnami/kong/values-production.yaml
@@ -154,7 +154,7 @@ ingressController:
   image:
     registry: docker.io
     repository: bitnami/kong-ingress-controller
-    tag: 0.10.0-debian-10-r81
+    tag: 1.1.0-debian-10-r5
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/kong/values-production.yaml
+++ b/bitnami/kong/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/kong
-  tag: 2.2.1-debian-10-r9
+  tag: 2.2.1-debian-10-r10
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/kong/values.yaml
+++ b/bitnami/kong/values.yaml
@@ -154,7 +154,7 @@ ingressController:
   image:
     registry: docker.io
     repository: bitnami/kong-ingress-controller
-    tag: 0.10.0-debian-10-r81
+    tag: 1.1.0-debian-10-r5
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/kong/values.yaml
+++ b/bitnami/kong/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/kong
-  tag: 2.2.1-debian-10-r9
+  tag: 2.2.1-debian-10-r10
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR bumps Kong Ingress Controller version to new major version, `1.x.x`. The associated CRDs were updated accordingly in a previous PR, see https://github.com/bitnami/charts/pull/4729

**Benefits**

Use latest Kong Ingress Controller features

**Possible drawbacks**

None

**Applicable issues**

None

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files