### PR TITLE
[bitnami/nginx-ingress-controller] Use correct port for ingress-nginx healthchecks

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -26,4 +26,4 @@ name: nginx-ingress-controller
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx-ingress-controller
   - https://github.com/kubernetes/ingress-nginx
-version: 7.0.3
+version: 7.0.4

--- a/bitnami/nginx-ingress-controller/values-production.yaml
+++ b/bitnami/nginx-ingress-controller/values-production.yaml
@@ -240,7 +240,7 @@ livenessProbe:
   enabled: true
   httpGet:
     path: /healthz
-    port: http
+    port: 10254
     scheme: HTTP
   failureThreshold: 3
   initialDelaySeconds: 10
@@ -251,7 +251,7 @@ readinessProbe:
   enabled: true
   httpGet:
     path: /healthz
-    port: http
+    port: 10254
     scheme: HTTP
   failureThreshold: 3
   initialDelaySeconds: 10

--- a/bitnami/nginx-ingress-controller/values-production.yaml
+++ b/bitnami/nginx-ingress-controller/values-production.yaml
@@ -240,7 +240,7 @@ livenessProbe:
   enabled: true
   httpGet:
     path: /healthz
-    port: 10254
+    port: "{{ .Values.containerPorts.metrics }}"
     scheme: HTTP
   failureThreshold: 3
   initialDelaySeconds: 10
@@ -251,7 +251,7 @@ readinessProbe:
   enabled: true
   httpGet:
     path: /healthz
-    port: 10254
+    port: "{{ .Values.containerPorts.metrics }}"
     scheme: HTTP
   failureThreshold: 3
   initialDelaySeconds: 10

--- a/bitnami/nginx-ingress-controller/values.yaml
+++ b/bitnami/nginx-ingress-controller/values.yaml
@@ -240,7 +240,7 @@ livenessProbe:
   enabled: true
   httpGet:
     path: /healthz
-    port: http
+    port: 10254
     scheme: HTTP
   failureThreshold: 3
   initialDelaySeconds: 10
@@ -251,7 +251,7 @@ readinessProbe:
   enabled: true
   httpGet:
     path: /healthz
-    port: http
+    port: 10254
     scheme: HTTP
   failureThreshold: 3
   initialDelaySeconds: 10

--- a/bitnami/nginx-ingress-controller/values.yaml
+++ b/bitnami/nginx-ingress-controller/values.yaml
@@ -240,7 +240,7 @@ livenessProbe:
   enabled: true
   httpGet:
     path: /healthz
-    port: 10254
+    port: "{{ .Values.containerPorts.metrics }}"
     scheme: HTTP
   failureThreshold: 3
   initialDelaySeconds: 10
@@ -251,7 +251,7 @@ readinessProbe:
   enabled: true
   httpGet:
     path: /healthz
-    port: 10254
+    port: "{{ .Values.containerPorts.metrics }}"
     scheme: HTTP
   failureThreshold: 3
   initialDelaySeconds: 10


### PR DESCRIPTION
**Description of the change**

`ingress-nginx` uses port `10254` to serve the `/healthz` location.
Starting from version `7.0.0` the `bitnami/nginx-ingress-controller` chart specifies a different port for `ingress-nginx`'s liveness and readiness checks in `values.yaml` and `values-production.yaml`. This prevents the `ingress-nginx` pods from passing the checks if the user doesn't change the default setting.

This PR sets the `livenessProbe.httpGet.port` and `readinessProbe.httpGet.port` settings to match the port used by `ingress-nginx`.

**Benefits**

`ingress-nginx` pods pass liveness and readiness checks after installing the `bitnami/nginx-ingress-controller` chart.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files