### PR TITLE
[bitnami/etcd] Add publishNotReadyAddresses: true to headless service

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -25,4 +25,4 @@ name: etcd
 sources:
   - https://github.com/bitnami/bitnami-docker-etcd
   - https://coreos.com/etcd/
-version: 5.3.1
+version: 5.3.2

--- a/bitnami/etcd/templates/svc-headless.yaml
+++ b/bitnami/etcd/templates/svc-headless.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   type: ClusterIP
   clusterIP: None
+  publishNotReadyAddresses: true
   ports:
     {{- if .Values.auth.client.clientPortNameOverride }}
     {{- if .Values.auth.client.secureTransport }}


### PR DESCRIPTION
**Description of the change**

Add `publishNotReadyAddresses: true` to etcd headless service

**Benefits**

Headless service has `service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"` annotation set, but it is deprecated in favor of `publishNotReadyAddresses: true`.

**Possible drawbacks**

**Applicable issues**

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
