### PR TITLE
[bitnami/spring-cloud-dataflow] Update SCDF metrics configuration for…

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -38,4 +38,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-spring-cloud-dataflow
   - https://github.com/bitnami/bitnami-docker-spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 2.3.0
+version: 2.3.1

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -38,4 +38,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-spring-cloud-dataflow
   - https://github.com/bitnami/bitnami-docker-spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 2.3.1
+version: 2.4.0

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -89,6 +89,7 @@ The following tables lists the configurable parameters of the Spring Cloud Data 
 | `server.configuration.accountName`           | The name of the account to configure for the Kubernetes platform                                       | `default`                                               |
 | `server.configuration.trustK8sCerts`         | Trust K8s certificates when querying the Kubernetes API                                                | `false`                                                 |
 | `server.configuration.containerRegistries`   | Container registries configuration                                                                     | `{}` (check `values.yaml` for more information)         |
+| `server.configuration.metricsDashboard`      | Endpoint to the metricsDashboard instance                                                              | `nil`                                                   |
 | `server.existingConfigmap`                   | Name of existing ConfigMap with Dataflow server configuration                                          | `nil`                                                   |
 | `server.extraEnvVars`                        | Extra environment variables to be set on Dataflow server container                                     | `{}`                                                    |
 | `server.extraEnvVarsCM`                      | Name of existing ConfigMap containing extra env vars                                                   | `nil`                                                   |

--- a/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
@@ -64,13 +64,12 @@ data:
           container:
             registry-configurations: {{- include "common.tplvalues.render" (dict "value" .Values.server.configuration.containerRegistries "context" $) | nindent 14 }}
           {{- end }}
-          {{- if .Values.server.configuration.grafanaInfo }}
-          metrics.dashboard:
-            url: {{ .Values.server.configuration.grafanaInfo }}
-          {{- end }}
           {{- if .Values.server.configuration.metricsDashboard }}
           metrics.dashboard:
             url: {{ .Values.server.configuration.metricsDashboard }}
+          {{- else if .Values.server.configuration.grafanaInfo }}
+          metrics.dashboard:
+            url: {{ .Values.server.configuration.grafanaInfo }}
           {{- end }}
       {{- $hibernateDialect := include "scdf.database.hibernate.dialect" .  }}
       {{- if $hibernateDialect }}

--- a/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
@@ -7,6 +7,19 @@ metadata:
     app.kubernetes.io/component: server
 data:
   application.yaml: |-
+    {{- if .Values.metrics.enabled }}
+    {{- $fullname := include "scdf.fullname" . }}
+    {{- $rsocketPort := int .Values.metrics.service.rsocketPort }}     
+    management:
+      metrics:
+         export:
+            prometheus:
+               enabled: true
+               rsocket:
+                  enabled: true
+                  host: {{ $fullname }}-prometheus-proxy
+                  port: {{ $rsocketPort }}
+    {{- end }}     
     spring:
       cloud:
         dataflow:
@@ -51,38 +64,13 @@ data:
           container:
             registry-configurations: {{- include "common.tplvalues.render" (dict "value" .Values.server.configuration.containerRegistries "context" $) | nindent 14 }}
           {{- end }}
-          {{- if .Values.metrics.enabled }}
-          {{- $fullname := include "scdf.fullname" . }}
-          {{- $rsocketPort := int .Values.metrics.service.rsocketPort }}
-          applicationProperties:
-            {{- if .Values.server.configuration.streamingEnabled }}
-            stream:
-              management:
-                metrics:
-                  export:
-                    prometheus:
-                      enabled: true
-                      rsocket:
-                        enabled: true
-                        host: {{ $fullname }}-prometheus-proxy
-                        port: {{ $rsocketPort }}
-            {{- end }}
-            {{- if .Values.server.configuration.batchEnabled }}
-            task:
-              management:
-                metrics:
-                  export:
-                    prometheus:
-                      enabled: true
-                      rsocket:
-                        enabled: true
-                        host: {{ $fullname }}-prometheus-proxy
-                        port: {{ $rsocketPort }}
-            {{- end }}
-          {{- end }}
           {{- if .Values.server.configuration.grafanaInfo }}
-          grafana-info:
+          metrics.dashboard:
             url: {{ .Values.server.configuration.grafanaInfo }}
+          {{- end }}
+          {{- if .Values.server.configuration.metricsDashboard }}
+          metrics.dashboard:
+            url: {{ .Values.server.configuration.metricsDashboard }}
           {{- end }}
       {{- $hibernateDialect := include "scdf.database.hibernate.dialect" .  }}
       {{- if $hibernateDialect }}

--- a/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
@@ -7,6 +7,19 @@ metadata:
     app.kubernetes.io/component: skipper
 data:
   application.yaml: |-
+    {{- if .Values.metrics.enabled }}
+    {{- $fullname := include "scdf.fullname" . }}
+    {{- $rsocketPort := int .Values.metrics.service.rsocketPort }}     
+    management:
+      metrics:
+         export:
+            prometheus:
+               enabled: true
+               rsocket:
+                  enabled: true
+                  host: {{ $fullname }}-prometheus-proxy
+                  port: {{ $rsocketPort }}
+    {{- end }}          
     spring:
       cloud:
         skipper:

--- a/bitnami/spring-cloud-dataflow/values-production.yaml
+++ b/bitnami/spring-cloud-dataflow/values-production.yaml
@@ -76,10 +76,13 @@ server:
     ##     authorization-type: dockeroauth2
     ##
     containerRegistries: {}
-    ## Endpoint to the grafana instance
+    ## Endpoint to the grafana instance (Deprecated: use the metricsDashboard instead)
     ##
     grafanaInfo:
-
+    ## Endpoint to the metricsDashboard instance
+    ##
+    metricsDashboard:
+       
   ## ConfigMap with Spring Cloud Dataflow Server Configuration
   ## NOTE: When it's set the server.configuration.* and deployer.*
   ##  parameters are ignored,

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -76,9 +76,12 @@ server:
     ##     authorization-type: dockeroauth2
     ##
     containerRegistries: {}
-    ## Endpoint to the grafana instance
+    ## Endpoint to the grafana instance (Deprecated: use the metricsDashboard instead)
     ##
     grafanaInfo:
+    ## Endpoint to the metricsDashboard instance
+    ##
+    metricsDashboard:
 
   ## ConfigMap with Spring Cloud Dataflow Server Configuration
   ## NOTE: When it's set the server.configuration.* and deployer.*


### PR DESCRIPTION
… 2.7+

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Adjust the Spring Cloud Data Flow metrics configuration to reflect the latest (2.7.0) breaking changes. 
 - replaces the grafanaInfo.url by metricsDasboard.url property. (Update the README) 
 - Provide metrics configuration for the SCDF and Skipper servers themself. 
 - Remove the per-application and per-task metrics configurations as with 2.7.0 those are automatically configured by replicating the SCDF's own metrics configuration.  

**Benefits**

<!-- What benefits will be realized by the code change? -->
- Resolves a metrics configuration, breaking change. 
- Removes redundant conf.
- Streamline the documentation. 

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
none

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #4751

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ x] Variables are documented in the README.md
- [ x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
