### PR TITLE
[bitnami/memcadhed] Memcached persistence is redundant

### DIFF
--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Infrastructure
 apiVersion: v2
-appVersion: 1.6.9
+appVersion: 1.7.0
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami

--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Infrastructure
 apiVersion: v2
-appVersion: 1.7.0
+appVersion: 1.6.9
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -22,4 +22,4 @@ name: memcached
 sources:
   - https://github.com/bitnami/bitnami-docker-memcached
   - http://memcached.org/
-version: 5.3.1
+version: 5.4.0

--- a/bitnami/memcached/values-production.yaml
+++ b/bitnami/memcached/values-production.yaml
@@ -171,7 +171,7 @@ tolerations: []
 ## Persistence - used for dumping and restoring states between recreations
 ## Ref: https://github.com/memcached/memcached/wiki/WarmRestart
 persistence:
-  enabled: true
+  enabled: false
   ## Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -171,7 +171,7 @@ tolerations: []
 ## Persistence - used for dumping and restoring states between recreations
 ## Ref: https://github.com/memcached/memcached/wiki/WarmRestart
 persistence:
-  enabled: true
+  enabled: false
   ## Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
Memcached persistence is redundant due to its designed place all data on RAM