### PR TITLE
[bitnami/nginx-ingress-controller] Fix probes port

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -26,4 +26,4 @@ name: nginx-ingress-controller
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx-ingress-controller
   - https://github.com/kubernetes/ingress-nginx
-version: 7.0.4
+version: 7.0.5

--- a/bitnami/nginx-ingress-controller/values-production.yaml
+++ b/bitnami/nginx-ingress-controller/values-production.yaml
@@ -240,7 +240,7 @@ livenessProbe:
   enabled: true
   httpGet:
     path: /healthz
-    port: "{{ .Values.containerPorts.metrics }}"
+    port: 10254
     scheme: HTTP
   failureThreshold: 3
   initialDelaySeconds: 10
@@ -251,7 +251,7 @@ readinessProbe:
   enabled: true
   httpGet:
     path: /healthz
-    port: "{{ .Values.containerPorts.metrics }}"
+    port: 10254
     scheme: HTTP
   failureThreshold: 3
   initialDelaySeconds: 10

--- a/bitnami/nginx-ingress-controller/values.yaml
+++ b/bitnami/nginx-ingress-controller/values.yaml
@@ -240,7 +240,7 @@ livenessProbe:
   enabled: true
   httpGet:
     path: /healthz
-    port: "{{ .Values.containerPorts.metrics }}"
+    port: 10254
     scheme: HTTP
   failureThreshold: 3
   initialDelaySeconds: 10
@@ -251,7 +251,7 @@ readinessProbe:
   enabled: true
   httpGet:
     path: /healthz
-    port: "{{ .Values.containerPorts.metrics }}"
+    port: 10254
     scheme: HTTP
   failureThreshold: 3
   initialDelaySeconds: 10


### PR DESCRIPTION
**Description of the change**

Changes introduced in PR #4739 are not working in the CI/CD because of the following error:
```
Error: Deployment.apps "nginx-ingress-controller-kz7yrdhin0" is invalid: [spec.template.spec.containers[0].livenessProbe.httpGet.port: Invalid value: "10254": must contain at least one letter or number (a-z, 0-9), spec.template.spec.containers[0].readinessProbe.httpGet.port: Invalid value: "10254": must contain at least one letter or number (a-z, 0-9)]
```

**Applicable issues**

  - fixes #4739

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files