### PR TITLE
[bitnami/mongodb-sharded] fix for #4536

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb-sharded
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb-sharded
   - https://mongodb.org
-version: 3.2.5
+version: 3.2.6

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
@@ -193,9 +193,16 @@ spec:
           readinessProbe:
             exec:
               command:
-                - mongo
-                - --eval
-                - "db.adminCommand('ping')"
+                - sh
+                - -ec
+                - |-
+                  #!/bin/sh
+                  {{- if $.Values.usePasswordFile }}
+                  export MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD="$(cat "${MONGODB_ROOT_PASSWORD_FILE}")"
+                  {{- else }}
+                  export MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD="$(echo "${MONGODB_ROOT_PASSWORD}")"
+                  {{- end }}
+                  mongo -u root -p "$(echo "${MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD}")" --eval "db.adminCommand('ping')" || mongo --eval "db.adminCommand('ping')"
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-dep-sts.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-dep-sts.yaml
@@ -172,9 +172,16 @@ spec:
           livenessProbe:
             exec:
               command:
-                - mongo
-                - --eval
-                - "db.adminCommand('ping')"
+                - sh
+                - -ec
+                - |-
+                  #!/bin/sh
+                  {{- if $.Values.usePasswordFile }}
+                  export MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD="$(cat "${MONGODB_ROOT_PASSWORD_FILE}")"
+                  {{- else }}
+                  export MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD="$(echo "${MONGODB_ROOT_PASSWORD}")"
+                  {{- end }}
+                  mongo -u root -p "$(echo "${MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD}")" --eval "db.adminCommand('ping')" || mongo --eval "db.adminCommand('ping')"
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -185,9 +192,16 @@ spec:
           readinessProbe:
             exec:
               command:
-                - mongo
-                - --eval
-                - "db.adminCommand('ping')"
+                - sh
+                - -ec
+                - |-
+                  #!/bin/sh
+                  {{- if $.Values.usePasswordFile }}
+                  export MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD="$(cat "${MONGODB_ROOT_PASSWORD_FILE}")"
+                  {{- else }}
+                  export MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD="$(echo "${MONGODB_ROOT_PASSWORD}")"
+                  {{- end }}
+                  mongo -u root -p "$(echo "${MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD}")" --eval "db.adminCommand('ping')" || mongo --eval "db.adminCommand('ping')"
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -198,9 +198,16 @@ spec:
           readinessProbe:
             exec:
               command:
-                - mongo
-                - --eval
-                - "db.adminCommand('ping')"
+                - sh
+                - -ec
+                - |-
+                  #!/bin/sh
+                  {{- if $.Values.usePasswordFile }}
+                  export MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD="$(cat "${MONGODB_ROOT_PASSWORD_FILE}")"
+                  {{- else }}
+                  export MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD="$(echo "${MONGODB_ROOT_PASSWORD}")"
+                  {{- end }}
+                  mongo -u root -p "$(echo "${MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD}")" --eval "db.adminCommand('ping')" || mongo --eval "db.adminCommand('ping')"
             initialDelaySeconds: {{ $.Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ $.Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ $.Values.readinessProbe.timeoutSeconds }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #4536

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
