### PR TITLE
[bitnami/common] Adding networking apiVersion support for versions 1.19+

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -20,4 +20,4 @@ sources:
   - https://github.com/bitnami/charts
   - http://www.bitnami.com/
 type: library
-version: 1.1.2
+version: 1.1.3

--- a/bitnami/common/templates/_capabilities.tpl
+++ b/bitnami/common/templates/_capabilities.tpl
@@ -27,7 +27,9 @@ Return the appropriate apiVersion for ingress.
 {{- define "common.capabilities.ingress.apiVersion" -}}
 {{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "extensions/v1beta1" -}}
-{{- else -}}
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
**Description of the change**
Adding networking apiVersion support in `_capabilities.tpl` for versions 1.19+

**Benefits**

 Removes deprecation warning for ingress on cluster with k8s version 1.19 or higher

**Possible drawbacks**

none to my knowledge


**Applicable issues**

  - fixes #4775

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). 
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

**Be gentle**

This is my first helm template merge request! Sorry if i messed something up! 
