### PR TITLE
[bitnami/kafka] Fix initContainers support

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 12.4.0
+version: 12.4.1

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -85,7 +85,7 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ template "kafka.serviceAccountName" . }}
       {{- end }}
-      {{- if or (and .Values.volumePermissions.enabled .Values.persistence.enabled) (and .Values.externalAccess.enabled .Values.externalAccess.autoDiscovery.enabled) }}
+      {{- if or (and .Values.volumePermissions.enabled .Values.persistence.enabled) (and .Values.externalAccess.enabled .Values.externalAccess.autoDiscovery.enabled) .Values.initContainers }}
       initContainers:
         {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
         - name: volume-permissions


### PR DESCRIPTION
**Description of the change**

Something was missing in https://github.com/bitnami/charts/pull/4658/. With those changes:
```diff
## Extra init containers to add to the deployment
##
-initContainers: []
+initContainers:
+  - name: test
+    image: "bitnami/kafka:2.6.0"
+    command: ["/bin/sh", "-c", "echo hello"]
```
```console
$ helm template kafka . -f values.yaml -s templates/statefulset.yaml
# Source: kafka/templates/statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
...
      initContainers:
        - command:
          - /bin/sh
          - -c
          - echo hello
          image: bitnami/kafka:2.6.0
          name: test
...
```

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #4796

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
