### PR TITLE
[bitnami/common] fix: moving kube version comparison

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: Infrastructure
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 1.1.1
+appVersion: 1.1.4
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://github.com/bitnami/charts/tree/master/bitnami/common
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -20,4 +20,4 @@ sources:
   - https://github.com/bitnami/charts
   - http://www.bitnami.com/
 type: library
-version: 1.1.3
+version: 1.1.4

--- a/bitnami/common/templates/_capabilities.tpl
+++ b/bitnami/common/templates/_capabilities.tpl
@@ -3,7 +3,7 @@
 Return the appropriate apiVersion for deployment.
 */}}
 {{- define "common.capabilities.deployment.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
 {{- print "extensions/v1beta1" -}}
 {{- else -}}
 {{- print "apps/v1" -}}
@@ -14,7 +14,7 @@ Return the appropriate apiVersion for deployment.
 Return the appropriate apiVersion for statefulset.
 */}}
 {{- define "common.capabilities.statefulset.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
 {{- print "apps/v1beta1" -}}
 {{- else -}}
 {{- print "apps/v1" -}}
@@ -25,9 +25,9 @@ Return the appropriate apiVersion for statefulset.
 Return the appropriate apiVersion for ingress.
 */}}
 {{- define "common.capabilities.ingress.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
 {{- print "extensions/v1beta1" -}}
-{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version -}}
 {{- print "networking.k8s.io/v1beta1" -}}
 {{- else -}}
 {{- print "networking.k8s.io/v1" -}}

--- a/githooks/functions/libhelmlint.sh
+++ b/githooks/functions/libhelmlint.sh
@@ -19,7 +19,7 @@ run_helm_lint_chart() {
     printf '\033\033[0;34m- Running helm template in %s \n\033[0m' "$chart_name"
 
     for values_file in "$chart_path"/values.yaml $(< "$ci_values_file_list"); do
-        if [[ ! -f "$values_file" ]];then
+        if [[ ! -f "$values_file" ]] || [[ "$values_file" = */bitnami/common/* ]];then
             continue
         fi
         values_file_display=${values_file#$chart_path/}


### PR DESCRIPTION
Signed-off-by: darteaga <darteaga@vmware.com>

**Description of the change**

- Move `.Capabilities.KubeVersion.GitVersion` to `.Capabilities.KubeVersion.Version` due to the first one have deprecated in helm v3 see https://github.com/helm/helm/blob/master/pkg/chartutil/capabilities.go#L65
- Fix helmlint script to avoid installing `bitnami/common` due to it is not an installable chart

```console
- Running helm template in bitnami/common
Error: library charts are not installable
🚫 helm template --values values.yaml /home/bitnami/projects/charts-bitnami/bitnami/common failed.
```

**Benefits**

We are updated to the latest helm version.

**Possible drawbacks**

N/A

**Applicable issues**

  - related #4784

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files