### PR TITLE
[bitnami/spring-cloud-dataflow] externalDatabase.existingPasswordKey value

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -38,4 +38,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-spring-cloud-dataflow
   - https://github.com/bitnami/bitnami-docker-spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 2.4.0
+version: 2.4.1

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -265,6 +265,7 @@ The following tables lists the configurable parameters of the Spring Cloud Data 
 | `externalDatabase.port`                      | External database port number                                                                          | `3306`                                                  |
 | `externalDatabase.password`                  | Password for the above username                                                                        | `""`                                                    |
 | `externalDatabase.existingPasswordSecret`    | Existing secret with database password                                                                 | `""`                                                    |
+| `externalDatabase.existingPasswordKey`       | Key of the existing secret with database password                                                      | `datasource-password`                                   |
 | `externalDatabase.dataflow.url`              | JDBC URL for dataflow server. Overrides external scheme, host, port, database, and jdbc parameters.    | `""`                                                    |
 | `externalDatabase.dataflow.username`         | Existing username in the external db to be used by Dataflow server                                     | `dataflow`                                              |
 | `externalDatabase.dataflow.database`         | Name of the existing database to be used by Dataflow server                                            | `dataflow`                                              |

--- a/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
@@ -83,7 +83,7 @@ data:
         driverClassName: {{ include "scdf.database.driver" . }}
         username: {{ include "scdf.database.server.user" . }}
         {{ if .Values.externalDatabase.existingPasswordSecret }}
-        password: ${datasource-password}
+        password: {{ .Values.externalDatabase.existingPasswordKey | default "datasource-password" | printf "${%s}" }}
         {{- else -}}
         password: ${mariadb-password}
         {{- end }}

--- a/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
@@ -81,7 +81,7 @@ data:
         driverClassName: {{ include "scdf.database.driver" . }}
         username: {{ include "scdf.database.skipper.user" . }}
         {{ if .Values.externalDatabase.existingPasswordSecret }}
-        password: ${datasource-password}
+        password: {{ .Values.externalDatabase.existingPasswordKey | default "datasource-password" | printf "${%s}" }}
         {{- else -}}
         password: ${mariadb-password}
         {{- end }}

--- a/bitnami/spring-cloud-dataflow/values-production.yaml
+++ b/bitnami/spring-cloud-dataflow/values-production.yaml
@@ -82,7 +82,7 @@ server:
     ## Endpoint to the metricsDashboard instance
     ##
     metricsDashboard:
-       
+
   ## ConfigMap with Spring Cloud Dataflow Server Configuration
   ## NOTE: When it's set the server.configuration.* and deployer.*
   ##  parameters are ignored,
@@ -871,6 +871,7 @@ externalDatabase:
   # scheme:
   password: ''
   # existingPasswordSecret: name-of-existing-secret
+  # existingPasswordKey: key in existingPasswordSecret, defaults to "datasource-password"
   ## Data Flow user and database
   ##
   dataflow:

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -872,6 +872,7 @@ externalDatabase:
   # scheme:
   password: ''
   # existingPasswordSecret: name-of-existing-secret
+  # existingPasswordKey: key in existingPasswordSecret, defaults to "datasource-password"
   ## Data Flow user and database
   ##
   dataflow:


### PR DESCRIPTION
**Description of the change**

Adding optional `externalDatabase.existingPasswordKey` value, which holds the key of the existing secret.

**Benefits**

Generated by Operators secrets can be used by SCDF without a necessity to copy and transform them. For example, Postgres operator stores the generated for new user password in "password" key of the secret.

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
