### PR TITLE
[bitnami/metallb] Fix metallb service type from None to ClusterIP

### DIFF
--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: metallb
 description: The Metal LB for Kubernetes
-version: 2.0.0
+version: 2.0.1
 appVersion: 0.9.5
 home: https://github.com/bitnami/charts/tree/master/bitnami/metallb
 icon: https://bitnami.com/assets/stacks/metallb-speaker/img/metallb-speaker-stack-220x234.png

--- a/bitnami/metallb/templates/controller/service.yaml
+++ b/bitnami/metallb/templates/controller/service.yaml
@@ -12,7 +12,8 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  type: None
+  type: ClusterIP
+  clusterIP: "None"
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: controller
   ports:

--- a/bitnami/metallb/templates/speaker/service.yaml
+++ b/bitnami/metallb/templates/speaker/service.yaml
@@ -12,7 +12,8 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  type: None
+  type: ClusterIP
+  clusterIP: "None"
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: speaker
   ports:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Change the service type from None (invalid) to ClusterIP (valid)

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

This fixes the chart when serviceMonitor is enabled

None is not a valid service type when trying to apply this chart we get
```Error: Service "metallb-controller-metrics" is invalid: spec.type: Unsupported value: "None": supported values: "ClusterIP", "ExternalName", "LoadBalancer", "NodePort"```
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

N/A
<!-- Describe any known limitations with your change -->

**Applicable issues**

N/A
<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.