### PR TITLE
[bitnami/redis] Fix Redis sentinel synchronization and user creation permission error

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -19,4 +19,4 @@ name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 12.3.1
+version: 12.3.2

--- a/bitnami/redis/templates/configmap-scripts.yaml
+++ b/bitnami/redis/templates/configmap-scripts.yaml
@@ -24,25 +24,14 @@ data:
     }
 
     HEADLESS_SERVICE="{{ template "redis.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+    REDIS_SERVICE="{{ template "redis.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
 
     export REDIS_REPLICATION_MODE="slave"
     if [[ -z "$(getent ahosts "$HEADLESS_SERVICE" | grep -v "^$(hostname -i) ")" ]]; then
-      if [[ ! -f /data/redisboot.lock ]]; then
-        export REDIS_REPLICATION_MODE="master"
-      else
-        if is_boolean_yes "$REDIS_TLS_ENABLED"; then
-          sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $HEADLESS_SERVICE -p {{ .Values.sentinel.port }} --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} info"
-        else
-          sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $HEADLESS_SERVICE -p {{ .Values.sentinel.port }} info"
-        fi
-        if [[ ! ($($sentinel_info_command)) ]]; then
-           export REDIS_REPLICATION_MODE="master"
-           rm /data/redisboot.lock
-        fi
-      fi
+      export REDIS_REPLICATION_MODE="master"
     fi
 
-    {{- if (eq (.Values.securityContext.runAsUser | int) 0) }}
+    {{- if and .Values.securityContext.runAsUser (eq (.Values.securityContext.runAsUser | int) 0) }}
     useradd redis
     chown -R redis {{ .Values.slave.persistence.path }}
     {{- end }}
@@ -68,9 +57,9 @@ data:
       fi
 
       if is_boolean_yes "$REDIS_TLS_ENABLED"; then
-        sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $HEADLESS_SERVICE -p {{ .Values.sentinel.port }} --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
+        sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $REDIS_SERVICE -p {{ .Values.sentinel.port }} --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
       else
-        sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $HEADLESS_SERVICE -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
+        sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $REDIS_SERVICE -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
       fi
       REDIS_SENTINEL_INFO=($($sentinel_info_command))
       REDIS_MASTER_HOST=${REDIS_SENTINEL_INFO[0]}
@@ -136,7 +125,6 @@ data:
     {{- end }}
     {{- end }}
 
-    touch /data/redisboot.lock
     {{- if .Values.slave.command }}
     exec {{ .Values.slave.command }} "${ARGS[@]}"
     {{- else }}
@@ -194,6 +182,7 @@ data:
     }
 
     HEADLESS_SERVICE="{{ template "redis.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+    REDIS_SERVICE="{{ template "redis.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
 
     if [[ -n $REDIS_PASSWORD_FILE ]]; then
       password_aux=`cat ${REDIS_PASSWORD_FILE}`
@@ -215,19 +204,7 @@ data:
 
     export REDIS_REPLICATION_MODE="slave"
     if [[ -z "$(getent ahosts "$HEADLESS_SERVICE" | grep -v "^$(hostname -i) ")" ]]; then
-      if [[ ! -f /data/sentinelboot.lock ]]; then
-        export REDIS_REPLICATION_MODE="master"
-      else
-        if is_boolean_yes "$REDIS_SENTINEL_TLS_ENABLED"; then
-          sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $HEADLESS_SERVICE -p {{ .Values.sentinel.port }} --tls --cert ${REDIS_SENTINEL_TLS_CERT_FILE} --key ${REDIS_SENTINEL_TLS_KEY_FILE} --cacert ${REDIS_SENTINEL_TLS_CA_FILE} info"
-        else
-          sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $HEADLESS_SERVICE -p {{ .Values.sentinel.port }} info"
-        fi
-        if [[ ! ($($sentinel_info_command)) ]]; then
-           export REDIS_REPLICATION_MODE="master"
-           rm /data/sentinelboot.lock
-        fi
-      fi
+      export REDIS_REPLICATION_MODE="master"
     fi
 
     if [[ "$REDIS_REPLICATION_MODE" == "master" ]]; then
@@ -235,9 +212,9 @@ data:
       REDIS_MASTER_PORT_NUMBER="{{ .Values.redisPort }}"
     else
       if is_boolean_yes "$REDIS_SENTINEL_TLS_ENABLED"; then
-        sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $HEADLESS_SERVICE -p {{ .Values.sentinel.port }} --tls --cert ${REDIS_SENTINEL_TLS_CERT_FILE} --key ${REDIS_SENTINEL_TLS_KEY_FILE} --cacert ${REDIS_SENTINEL_TLS_CA_FILE} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
+        sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $REDIS_SERVICE -p {{ .Values.sentinel.port }} --tls --cert ${REDIS_SENTINEL_TLS_CERT_FILE} --key ${REDIS_SENTINEL_TLS_KEY_FILE} --cacert ${REDIS_SENTINEL_TLS_CA_FILE} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
       else
-        sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $HEADLESS_SERVICE -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
+        sentinel_info_command="redis-cli {{- if .Values.usePassword }} -a $REDIS_PASSWORD {{- end }} -h $REDIS_SERVICE -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
       fi
       REDIS_SENTINEL_INFO=($($sentinel_info_command))
       REDIS_MASTER_HOST=${REDIS_SENTINEL_INFO[0]}
@@ -295,7 +272,6 @@ data:
     ARGS+=("--tls-dh-params-file" "${REDIS_SENTINEL_TLS_DH_PARAMS_FILE}")
     {{- end }}
     {{- end }}
-    touch /data/sentinelboot.lock
     exec redis-server /opt/bitnami/redis-sentinel/etc/sentinel.conf --sentinel {{- if .Values.tls.enabled }} "${ARGS[@]}" {{- end }}
 {{- else }}
   start-master.sh: |

--- a/bitnami/redis/templates/configmap-scripts.yaml
+++ b/bitnami/redis/templates/configmap-scripts.yaml
@@ -276,7 +276,7 @@ data:
 {{- else }}
   start-master.sh: |
     #!/bin/bash
-    {{- if (eq (.Values.securityContext.runAsUser | int) 0) }}
+    {{- if and .Values.securityContext.runAsUser (eq (.Values.securityContext.runAsUser | int) 0) }}
     useradd redis
     chown -R redis {{ .Values.master.persistence.path }}
     {{- end }}
@@ -327,7 +327,7 @@ data:
   {{- if .Values.cluster.enabled }}
   start-slave.sh: |
     #!/bin/bash
-    {{- if (eq (.Values.securityContext.runAsUser | int) 0) }}
+    {{- if and .Values.securityContext.runAsUser (eq (.Values.securityContext.runAsUser | int) 0) }}
     useradd redis
     chown -R redis {{ .Values.slave.persistence.path }}
     {{- end }}

--- a/bitnami/redis/templates/headless-svc.yaml
+++ b/bitnami/redis/templates/headless-svc.yaml
@@ -11,7 +11,9 @@ metadata:
 spec:
   type: ClusterIP
   clusterIP: None
+  {{- if .Values.sentinel.enabled }}
   publishNotReadyAddresses: true
+  {{- end }}
   ports:
     - name: redis
       port: {{ .Values.redisPort }}

--- a/bitnami/redis/templates/headless-svc.yaml
+++ b/bitnami/redis/templates/headless-svc.yaml
@@ -11,6 +11,7 @@ metadata:
 spec:
   type: ClusterIP
   clusterIP: None
+  publishNotReadyAddresses: true
   ports:
     - name: redis
       port: {{ .Values.redisPort }}

--- a/bitnami/redis/values-production.yaml
+++ b/bitnami/redis/values-production.yaml
@@ -18,7 +18,7 @@ image:
   ## Bitnami Redis image tag
   ## ref: https://github.com/bitnami/bitnami-docker-redis#supported-tags-and-respective-dockerfile-links
   ##
-  tag: 6.0.9-debian-10-r38
+  tag: 6.0.9-debian-10-r66
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -60,7 +60,7 @@ sentinel:
     ## Bitnami Redis image tag
     ## ref: https://github.com/bitnami/bitnami-docker-redis-sentinel#supported-tags-and-respective-dockerfile-links
     ##
-    tag: 6.0.9-debian-10-r38
+    tag: 6.0.9-debian-10-r66
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -650,7 +650,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/redis-exporter
-    tag: 1.13.1-debian-10-r32
+    tag: 1.15.0-debian-10-r8
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -18,7 +18,7 @@ image:
   ## Bitnami Redis image tag
   ## ref: https://github.com/bitnami/bitnami-docker-redis#supported-tags-and-respective-dockerfile-links
   ##
-  tag: 6.0.9-debian-10-r38
+  tag: 6.0.9-debian-10-r66
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -60,7 +60,7 @@ sentinel:
     ## Bitnami Redis image tag
     ## ref: https://github.com/bitnami/bitnami-docker-redis-sentinel#supported-tags-and-respective-dockerfile-links
     ##
-    tag: 6.0.9-debian-10-r38
+    tag: 6.0.9-debian-10-r66
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -651,7 +651,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/redis-exporter
-    tag: 1.13.1-debian-10-r32
+    tag: 1.15.0-debian-10-r8
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Edited `redis-headless` service to contain `publishNotReadyAddresses: true` to make redis nodes discoverable without being ready due to [kubernetes implementation](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-hostname-and-subdomain-fields). This change caused a bug with the current startup scripts when `redis-headless` service redirects the sentinel connections to the same pod which isn't initialized yet. The `redis` service is used for sentinel/redis connections which only contains the fully initialized and ready pods as the workaround. Removed the `boot.lock` files due to these changes making the need for `boot.lock` files(redisboot.lock, sentinelboot.lock) obsolete. 

Also fixed the issue where not having a `runAsUser` under the `securityContext` definition in our `values.yaml` causes a permission error due to `nil` casting to 0 which adds the code to create a user named `redis` when `runAsUser` is set to root(0). Since we don't actually have our user set as root the commands face a permission error.

**Benefits**

Redis is now booting up, restarting, scaling up/down properly with synchronization successfully. This fix also prevents a potential data loss if a separate master without a slave is resolved by the `redis` service, failure/deletion of this node causes the data to be deleted when it synchronizes with an available master upon startup.

**Possible drawbacks**

I am unsure of the performance effects of using the `redis` service for sentinel/replication communication which also serves the clients.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #4819

**Additional information**

Please let me know if there are any bugs/improvements I've missed.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
