### PR TITLE
[bitnami/kafka] Register targetPod in global context

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 12.4.2
+version: 12.4.3

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -551,7 +551,7 @@ Following the aforementioned steps will also allow to connect the brokers from t
 
 #### Name resolution with External-DNS
 
-You can use the following values to generate External-DNS annotations which automatically creating DNS records for each ReplicaSet pod:
+You can use the following values to generate External-DNS annotations which automatically creates DNS records for each ReplicaSet pod:
 
 ```yaml
 externalAccess:

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -549,6 +549,16 @@ The pod will try to get the external ip of the node using `curl -s https://ipinf
 
 Following the aforementioned steps will also allow to connect the brokers from the outside using the cluster's default service (when `service.type` is `LoadBalancer` or `NodePort`). Use the property `service.externalPort` to specify the port used for external connections.
 
+#### Name resolution with External-DNS
+
+You can use the following values to generate External-DNS annotations which automatically creating DNS records for each ReplicaSet pod:
+
+```yaml
+externalAccess:
+  service:
+    annotations:
+      external-dns.alpha.kubernetes.io/hostname: "{{ .targetPod }}.example.com"
+```
 ### Sidecars
 
 If you have a need for additional containers to run within the same pod as Kafka (e.g. an additional metrics or logging exporter), you can do so via the `sidecars` config parameter. Simply define your container according to the Kubernetes container spec.

--- a/bitnami/kafka/templates/svc-external-access.yaml
+++ b/bitnami/kafka/templates/svc-external-access.yaml
@@ -5,6 +5,7 @@
 
 {{- range $i, $e := until $replicaCount }}
 {{- $targetPod := printf "%s-%d" (printf "%s" $fullName) $i }}
+{{- $_ := set $ "targetPod" $targetPod }}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
To allow accessing the current targetPod in the annotations. Same as https://github.com/bitnami/charts/pull/4642.

**Description of the change**

We register a new variable with the current index of pod for annotations

**Benefits**

Service annotations can now retrieve the targetPod for example for a DNS

`external-dns.alpha.kubernetes.io/hostname: '{{ .targetPod }}.example.com'`

**Possible drawbacks**


**Applicable issues**


**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
