### PR TITLE
[bitnami/osclass] Fix Osclass issue related to mariadb secret name

### DIFF
--- a/bitnami/osclass/Chart.lock
+++ b/bitnami/osclass/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.3
+  version: 1.1.4
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
   version: 9.1.4
-digest: sha256:0fea73dda5a799b991bb2a69005b09c5e327b437ebd4eb523e0535d1f7f56868
-generated: "2020-12-20T01:13:40.616407096Z"
+digest: sha256:cfb8534f4ea6d000c32363a495cca208ca7b21dd72ba8e1403acb7a410851d90
+generated: "2020-12-25T11:48:12.655272425Z"

--- a/bitnami/osclass/Chart.yaml
+++ b/bitnami/osclass/Chart.yaml
@@ -31,4 +31,4 @@ name: osclass
 sources:
   - https://github.com/bitnami/bitnami-docker-osclass
   - https://osclass.org/
-version: 9.0.1
+version: 9.0.2

--- a/bitnami/osclass/templates/_helpers.tpl
+++ b/bitnami/osclass/templates/_helpers.tpl
@@ -50,12 +50,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- if .Values.fullnameOverride -}}
 {{- printf "%s-mariadb" .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
 {{- printf "%s-mariadb" .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s-mariadb" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/osclass/values.yaml
+++ b/bitnami/osclass/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/osclass
-  tag: 3.9.0-debian-10-r163
+  tag: 3.9.0-debian-10-r165
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -423,7 +423,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.8.0-debian-10-r245
+    tag: 0.8.0-debian-10-r250
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**

Similar to #4730, two macros were wrongly updated, and as a consequence, the installation of these charts are failing with errors like the ones below:

```
Events:
  Type     Reason     Age                   From                   Message
  ----     ------     ----                  ----                   -------
  Warning  Failed     7m48s (x12 over 10m)  kubelet, 10.240.0.109  Error: secret "oscl-tkvt4-osclass-mariadb" not found
```

**Benefits**

The chart can be installed with any release name.

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)