### PR TITLE
[bitnami/metallb] fix: take speaker tolertation value into account

### DIFF
--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: metallb
 description: The Metal LB for Kubernetes
-version: 2.0.1
+version: 2.0.2
 appVersion: 0.9.5
 home: https://github.com/bitnami/charts/tree/master/bitnami/metallb
 icon: https://bitnami.com/assets/stacks/metallb-speaker/img/metallb-speaker-stack-220x234.png

--- a/bitnami/metallb/templates/speaker/daemonset.yaml
+++ b/bitnami/metallb/templates/speaker/daemonset.yaml
@@ -26,9 +26,9 @@ spec:
       {{- end }}
     spec: 
       {{- include "common.images.pullSecrets" (dict "images" (list .Values.speaker.image .Values.controller.image) "global" .Values.global) | nindent 6 }}
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
+      {{- if .Values.speaker.tolerations}}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.speaker.tolerations "context" $) | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "metallb.speakerServiceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.speaker.daemonset.terminationGracePeriodSeconds }}
       hostNetwork: true

--- a/bitnami/metallb/templates/speaker/daemonset.yaml
+++ b/bitnami/metallb/templates/speaker/daemonset.yaml
@@ -26,9 +26,9 @@ spec:
       {{- end }}
     spec: 
       {{- include "common.images.pullSecrets" (dict "images" (list .Values.speaker.image .Values.controller.image) "global" .Values.global) | nindent 6 }}
-      {{- if .Values.speaker.tolerations}}
-      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.speaker.tolerations "context" $) | nindent 8 }}
-      {{- end }}
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       serviceAccountName: {{ include "metallb.speakerServiceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.speaker.daemonset.terminationGracePeriodSeconds }}
       hostNetwork: true
@@ -116,5 +116,5 @@ spec:
       affinity: {{- include "metallb.tplValue" (dict "value" .Values.speaker.affinity "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.speaker.tolerations}}
-      tolerations: {{- include "metallb.tplValue" (dict "value" .Values.speaker.tolerations "context" $) | nindent 8 }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.speaker.tolerations "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/metallb/values.yaml
+++ b/bitnami/metallb/values.yaml
@@ -316,7 +316,9 @@ speaker:
   ## Tolerations for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
-  tolerations: []
+  tolerations:
+  - key: node-role.kubernetes.io/master
+    effect: NoSchedule
 
   ## Affinity for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity

--- a/bitnami/metallb/values.yaml
+++ b/bitnami/metallb/values.yaml
@@ -316,9 +316,7 @@ speaker:
   ## Tolerations for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
-  tolerations:
-  - key: node-role.kubernetes.io/master
-    effect: NoSchedule
+  tolerations: []
 
   ## Affinity for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

The metallb chart contains a `speaker.tolerations` key inside the values.yaml file, but throws an error when you define it.
Seeing as the controller one did work, I went and mimic the tolerations template block from there, don't know enough about the bitnami helm charts to say for sure why the original block wasn't working.

The original block was failing  the CI pipeline.

**Benefits**

Users will be able to define the tolerations for speakers. As the default might not work for all k8s clusters.

**Applicable issues**

  - fixes #4841 

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
