### PR TITLE
[bitnami/wordpress] Fix issue with wildcard ingress hosts

### DIFF
--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -31,4 +31,4 @@ name: wordpress
 sources:
   - https://github.com/bitnami/bitnami-docker-wordpress
   - http://www.wordpress.com/
-version: 10.1.5
+version: 10.1.6

--- a/bitnami/wordpress/templates/ingress.yaml
+++ b/bitnami/wordpress/templates/ingress.yaml
@@ -32,7 +32,7 @@ spec:
               servicePort: http
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
-    - host: "{{ .name }}"
+    - host: {{ .name | quote }}
       http:
         paths:
           - path: {{ default "/" .path }}

--- a/bitnami/wordpress/templates/ingress.yaml
+++ b/bitnami/wordpress/templates/ingress.yaml
@@ -32,7 +32,7 @@ spec:
               servicePort: http
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
-    - host: {{ .name }}
+    - host: "{{ .name }}"
       http:
         paths:
           - path: {{ default "/" .path }}


### PR DESCRIPTION
**Description of the change**
Quote the calls to the `ingress.extraHosts` hostnames so that it can successfully render non-alphanumeric characters. This is required in order to use wildcard domains (`*.example.org`) as hosts.

```
Error: YAML parse error on wordpress/templates/ingress.yaml: error converting YAML to JSON: yaml: line 20: did not find expected alphabetic or numeric character
```

**Applicable issues**

  - fixes #4839

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)


