### PR TITLE
[bitnami/*] Add notice regarding parameters immutability after chart installation

### DIFF
--- a/bitnami/airflow/README.md
+++ b/bitnami/airflow/README.md
@@ -355,6 +355,8 @@ $ helm install my-release \
 
 The above command sets the credentials to access the Airflow web UI.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/consul/README.md
+++ b/bitnami/consul/README.md
@@ -216,6 +216,8 @@ $ helm install my-release --set domain=consul-domain,gossipKey=secretkey bitnami
 
 The above command sets the HashiCorp Consul domain to `consul-domain` and sets the gossip key to `secretkey`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/discourse/README.md
+++ b/bitnami/discourse/README.md
@@ -239,6 +239,8 @@ $ helm install my-release \
 
 The above command sets the Discourse administrator account username and password to `admin` and `password` respectively. Additionally, it sets the Postgresql `bn_discourse` user password to `secretpassword`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/dokuwiki/README.md
+++ b/bitnami/dokuwiki/README.md
@@ -211,6 +211,8 @@ $ helm install my-release \
 
 The above command sets the DokuWiki administrator account username and password to `admin` and `password` respectively.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/drupal/README.md
+++ b/bitnami/drupal/README.md
@@ -238,6 +238,8 @@ $ helm install my-release \
 
 The above command sets the Drupal administrator account username and password to `admin` and `password` respectively. Additionally, it sets the MariaDB `root` user password to `secretpassword`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/ejbca/README.md
+++ b/bitnami/ejbca/README.md
@@ -198,6 +198,8 @@ $ helm install my-release \
 
 The above command sets the EJBCA administrator account username and password to `admin` and `password` respectively. Additionally, it sets the MariaDB `bn_ejbca` user password to `secretpassword`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/etcd/README.md
+++ b/bitnami/etcd/README.md
@@ -176,6 +176,8 @@ $ helm install my-release \
 
 The above command sets the etcd `root` account password to `secretpassword`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/ghost/README.md
+++ b/bitnami/ghost/README.md
@@ -236,6 +236,8 @@ $ helm install my-release \
 
 The above command sets the Ghost administrator account username and password to `admin` and `password` respectively. Additionally, it sets the MariaDB `root` user password to `secretpassword`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/grafana/README.md
+++ b/bitnami/grafana/README.md
@@ -306,6 +306,8 @@ $ helm install my-release \
 
 The above command sets the Grafana admin user to `admin-user`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/harbor/README.md
+++ b/bitnami/harbor/README.md
@@ -753,6 +753,8 @@ $ helm install my-release \
 
 The above command sets the Harbor administrator account password to `password`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/influxdb/README.md
+++ b/bitnami/influxdb/README.md
@@ -275,6 +275,8 @@ $ helm install my-release \
 
 The above command sets the InfluxDB<sup>TM</sup> admin user to `admin-user`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/jasperreports/README.md
+++ b/bitnami/jasperreports/README.md
@@ -192,6 +192,8 @@ $ helm install my-release \
 
 The above command sets the JasperReports administrator account username and password to `admin` and `password` respectively. Additionally, it sets the MariaDB `root` user password to `secretpassword`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/jenkins/README.md
+++ b/bitnami/jenkins/README.md
@@ -201,6 +201,8 @@ $ helm install my-release \
 
 The above command sets the Jenkins administrator account username and password to `admin` and `password` respectively.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/joomla/README.md
+++ b/bitnami/joomla/README.md
@@ -203,6 +203,8 @@ $ helm install my-release \
 
 The above command sets the Joomla! administrator account username and password to `admin` and `password` respectively. Additionally, it sets the MariaDB `root` user password to `secretpassword`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -245,6 +245,8 @@ helm install my-release --set auth.adminPassword=secretpassword bitnami/keycloak
 
 The above command sets the Keycloak administrator password to `secretpassword`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash

--- a/bitnami/kibana/README.md
+++ b/bitnami/kibana/README.md
@@ -164,6 +164,8 @@ $ helm install my-release \
 
 The above command sets the Kibana admin user to `admin-user`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/magento/README.md
+++ b/bitnami/magento/README.md
@@ -282,6 +282,8 @@ $ helm install my-release \
 
 The above command sets the Magento administrator account username and password to `admin` and `password` respectively. Additionally, it sets the MariaDB `root` user password to `secretpassword`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/mariadb-galera/README.md
+++ b/bitnami/mariadb-galera/README.md
@@ -207,6 +207,8 @@ $ helm install my-release \
 
 The above command sets the MariaDB `root` account password to `secretpassword`. Additionally it creates a database named `my_database`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash

--- a/bitnami/mariadb/README.md
+++ b/bitnami/mariadb/README.md
@@ -264,6 +264,8 @@ $ helm install my-release \
 
 The above command sets the MariaDB `root` account password to `secretpassword`. Additionally it creates a database named `my_database`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash

--- a/bitnami/mediawiki/README.md
+++ b/bitnami/mediawiki/README.md
@@ -210,6 +210,8 @@ $ helm install my-release \
 
 The above command sets the MediaWiki administrator account username and password to `admin` and `password` respectively. Additionally, it sets the MariaDB `root` user password to `secretpassword`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/memcached/README.md
+++ b/bitnami/memcached/README.md
@@ -74,7 +74,6 @@ The following tables lists the configurable parameters of the Memcached chart an
 | `service.annotations`                    | Additional annotations for Memcached service                                              | `{}`                                                         |
 | `resources.requests`                     | CPU/Memory resource requests                                                              | `{memory: "256Mi", cpu: "250m"}`                             |
 | `resources.limits`                       | CPU/Memory resource limits                                                                | `{}`                                                         |
-| `portName`                               | Name of the main port exposed by memcached                                                | `memcache`                                                   |
 | `persistence.enabled`                    | Enable persistence using PVC (Requires architecture: "high-availability")                 | `true`                                                       |
 | `persistence.storageClass`               | PVC Storage Class for Memcached volume                                                    | `nil` (uses alpha storage class annotation)                  |
 | `persistence.accessMode`                 | PVC Access Mode for Memcached volume                                                      | `ReadWriteOnce`                                              |
@@ -101,7 +100,6 @@ The following tables lists the configurable parameters of the Memcached chart an
 | `metrics.image.pullSecrets`              | Specify docker-registry secret names as an array                                          | `[]` (does not add image pull secrets to deployed pods)      |
 | `metrics.podAnnotations`                 | Additional annotations for Metrics exporter                                               | `{prometheus.io/scrape: "true", prometheus.io/port: "9150"}` |
 | `metrics.resources`                      | Exporter resource requests/limit                                                          | `{}`                                                         |
-| `metrics.portName`                       | Memcached exporter port name                                                              | `metrics`                                                    |
 | `metrics.service.type`                   | Kubernetes service type for Prometheus metrics                                            | `ClusterIP`                                                  |
 | `metrics.service.port`                   | Prometheus metrics service port                                                           | `9150`                                                       |
 | `metrics.service.annotations`            | Prometheus exporter svc annotations                                                       | `{prometheus.io/scrape: "true", prometheus.io/port: "9150"}` |
@@ -115,6 +113,8 @@ $ helm install my-release --set memcachedUsername=user,memcachedPassword=passwor
 ```
 
 The above command sets the Memcached admin account username and password to `user` and `password` respectively.
+
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 

--- a/bitnami/memcached/README.md
+++ b/bitnami/memcached/README.md
@@ -74,6 +74,7 @@ The following tables lists the configurable parameters of the Memcached chart an
 | `service.annotations`                    | Additional annotations for Memcached service                                              | `{}`                                                         |
 | `resources.requests`                     | CPU/Memory resource requests                                                              | `{memory: "256Mi", cpu: "250m"}`                             |
 | `resources.limits`                       | CPU/Memory resource limits                                                                | `{}`                                                         |
+| `portName`                               | Name of the main port exposed by memcached                                                | `memcache`                                                   |
 | `persistence.enabled`                    | Enable persistence using PVC (Requires architecture: "high-availability")                 | `true`                                                       |
 | `persistence.storageClass`               | PVC Storage Class for Memcached volume                                                    | `nil` (uses alpha storage class annotation)                  |
 | `persistence.accessMode`                 | PVC Access Mode for Memcached volume                                                      | `ReadWriteOnce`                                              |
@@ -100,6 +101,7 @@ The following tables lists the configurable parameters of the Memcached chart an
 | `metrics.image.pullSecrets`              | Specify docker-registry secret names as an array                                          | `[]` (does not add image pull secrets to deployed pods)      |
 | `metrics.podAnnotations`                 | Additional annotations for Metrics exporter                                               | `{prometheus.io/scrape: "true", prometheus.io/port: "9150"}` |
 | `metrics.resources`                      | Exporter resource requests/limit                                                          | `{}`                                                         |
+| `metrics.portName`                       | Memcached exporter port name                                                              | `metrics`                                                    |
 | `metrics.service.type`                   | Kubernetes service type for Prometheus metrics                                            | `ClusterIP`                                                  |
 | `metrics.service.port`                   | Prometheus metrics service port                                                           | `9150`                                                       |
 | `metrics.service.annotations`            | Prometheus exporter svc annotations                                                       | `{prometheus.io/scrape: "true", prometheus.io/port: "9150"}` |

--- a/bitnami/minio/README.md
+++ b/bitnami/minio/README.md
@@ -167,6 +167,8 @@ $ helm install my-release \
 
 The above command sets the MinIO&reg; Server access key and secret key to `minio-access-key` and `minio-secret-key`, respectively.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -222,7 +222,7 @@ The following tables lists the configurable parameters of the MongoDB&reg; chart
 | Parameter                                         | Description                                                                                       | Default                        |
 |---------------------------------------------------|---------------------------------------------------------------------------------------------------|--------------------------------|
 | `service.type`                                    | Kubernetes Service type                                                                           | `ClusterIP`                    |
-| `service.nameOverride`                            | MongoDB&reg; service name                                                                         | `{mongodb.fullname}-headless`  | 
+| `service.nameOverride`                            | MongoDB&reg; service name                                                                         | `{mongodb.fullname}-headless`  |
 | `service.port`                                    | MongoDB&reg; service port                                                                         | `27017`                        |
 | `service.portName`                                | MongoDB&reg; service port name                                                                    | `mongodb`                      |
 | `service.nodePort`                                | Port to bind to for NodePort and LoadBalancer service types                                       | `""`                           |
@@ -368,6 +368,8 @@ $ helm install my-release \
 ```
 
 The above command sets the MongoDB&reg; `root` account password to `secretpassword`. Additionally, it creates a standard database user named `my-user`, with the password `my-password`, who has access to a database named `my-database`.
+
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 

--- a/bitnami/moodle/README.md
+++ b/bitnami/moodle/README.md
@@ -238,6 +238,8 @@ $ helm install my-release \
 
 The above command sets the Moodle<sup>TM</sup> administrator account username and password to `admin` and `password` respectively. Additionally, it sets the MariaDB `root` user password to `secretpassword`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -262,6 +262,8 @@ $ helm install my-release \
 
 The above command sets the MySQL `root` account password to `secretpassword`. Additionally it creates a database named `app_database`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash

--- a/bitnami/nats/README.md
+++ b/bitnami/nats/README.md
@@ -215,6 +215,8 @@ $ helm install my-release \
 
 The above command enables NATS client authentication with `my-user` as user and `T0pS3cr3t` as password credentials.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash

--- a/bitnami/odoo/README.md
+++ b/bitnami/odoo/README.md
@@ -187,6 +187,8 @@ $ helm install my-release \
 
 The above command sets the Odoo administrator account password to `password` and the PostgreSQL `postgres` user password to `secretpassword`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/opencart/README.md
+++ b/bitnami/opencart/README.md
@@ -253,6 +253,8 @@ $ helm install my-release \
 
 The above command sets the OpenCart administrator account username and password to `admin` and `password` respectively. Additionally, it sets the MariaDB `root` user password to `secretpassword`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/orangehrm/README.md
+++ b/bitnami/orangehrm/README.md
@@ -246,6 +246,8 @@ $ helm install my-release \
 
 The above command sets the OrangeHRM administrator account username and password to `admin` and `password` respectively. Additionally, it sets the MariaDB `root` user password to `secretpassword`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/osclass/README.md
+++ b/bitnami/osclass/README.md
@@ -221,6 +221,8 @@ $ helm install my-release \
 
 The above command sets the Osclass administrator account username and password to `admin` and `password` respectively. Additionally, it sets the MariaDB `root` user password to `secretpassword`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/owncloud/README.md
+++ b/bitnami/owncloud/README.md
@@ -261,6 +261,8 @@ $ helm install my-release \
 
 The above command sets the ownCloud administrator account username and password to `admin` and `password` respectively. Additionally, it sets the MariaDB `root` user password to `secretpassword`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/parse/README.md
+++ b/bitnami/parse/README.md
@@ -216,6 +216,8 @@ $ helm install my-release \
 
 The above command sets the Parse administrator account username and password to `admin` and `password` respectively.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/phabricator/README.md
+++ b/bitnami/phabricator/README.md
@@ -243,6 +243,8 @@ $ helm install my-release \
 
 The above command sets the Phabricator administrator account username and password to `admin` and `password` respectively. Additionally, it sets the MariaDB `root` user password to `secretpassword`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/phpbb/README.md
+++ b/bitnami/phpbb/README.md
@@ -211,6 +211,8 @@ $ helm install my-release \
 
 The above command sets the phpBB administrator account username and password to `admin` and `password` respectively. Additionally, it sets the MariaDB `root` user password to `secretpassword`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -301,6 +301,8 @@ $ helm install my-release \
 
 The above command sets the password for user `postgres` to `password`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/postgresql/README.md
+++ b/bitnami/postgresql/README.md
@@ -287,6 +287,8 @@ $ helm install my-release \
 
 The above command sets the PostgreSQL `postgres` account password to `secretpassword`. Additionally it creates a database named `my-database`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/prestashop/README.md
+++ b/bitnami/prestashop/README.md
@@ -260,6 +260,8 @@ $ helm install my-release \
 
 The above command sets the PrestaShop administrator account username and password to `admin` and `password` respectively. Additionally, it sets the MariaDB `root` user password to `secretpassword`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/rabbitmq/README.md
+++ b/bitnami/rabbitmq/README.md
@@ -269,6 +269,8 @@ $ helm install my-release \
 
 The above command sets the RabbitMQ admin username and password to `admin` and `secretpassword` respectively. Additionally the secure erlang cookie is set to `secretcookie`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash

--- a/bitnami/redis-cluster/README.md
+++ b/bitnami/redis-cluster/README.md
@@ -311,6 +311,8 @@ $ helm install my-release \
 
 The above command sets the Redis<sup>TM</sup> server password to `secretpassword`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -312,6 +312,8 @@ $ helm install my-release \
 
 The above command sets the Redis<sup>TM</sup> server password to `secretpassword`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash

--- a/bitnami/redmine/README.md
+++ b/bitnami/redmine/README.md
@@ -310,6 +310,8 @@ $ helm install my-release \
 
 The above command sets the Redmine administrator account username and password to `admin` and `password` respectively. Additionally, it sets the MariaDB `root` user password to `secretpassword`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```bash

--- a/bitnami/suitecrm/README.md
+++ b/bitnami/suitecrm/README.md
@@ -266,6 +266,8 @@ $ helm install my-release \
 
 The above command sets the SuiteCRM administrator account username and password to `admin` and `password` respectively. Additionally, it sets the MariaDB `root` user password to `secretpassword`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/testlink/README.md
+++ b/bitnami/testlink/README.md
@@ -236,6 +236,8 @@ $ helm install my-release \
 
 The above command sets the TestLink administrator account username and password to `admin` and `password` respectively. Additionally, it sets the MariaDB `root` user password to `secretpassword`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/tomcat/README.md
+++ b/bitnami/tomcat/README.md
@@ -174,6 +174,8 @@ $ helm install my-release \
 
 The above command sets the Tomcat management username and password to `manager` and `password` respectively.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/wildfly/README.md
+++ b/bitnami/wildfly/README.md
@@ -177,6 +177,8 @@ $ helm install my-release \
 
 The above command sets the WildFly management username and password to `manager` and `password` respectively.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -268,6 +268,8 @@ helm install my-release \
 
 The above command sets the WordPress administrator account username and password to `admin` and `password` respectively. Additionally, it sets the MariaDB `root` user password to `secretpassword`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -212,6 +212,8 @@ $ helm install my-release \
 
 The above command sets the ZooKeeper user to `newUser`.
 
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```console


### PR DESCRIPTION
**Description of the change**

Hi team,

This PR adds a notice in the chart catalog READMEs to make clear that once a chart is installed, using `helm upgrade --set appnamePassword --set appnameUsername` won't change the username or password, as it is something set at installation time. 

The notice has been included after the block of code with the chart's installation example. Using bitnami/jenkins as an example:

-------------------

```console
$ helm install my-release \
  --set jenkinsUser=admin,jenkinsPassword=password \
    bitnami/jenkins
```
The above command sets the Jenkins administrator account username and password to admin and password respectively.

>    NOTE: once installed, neither username nor password can be changed using Helm CLI. If given the capability, please use the in-app features to do so.

-------------------

**Affected charts**

The notice has been added to the following charts:
- airflow
- consul
- discourse
- dokuwiki
- drupal
- ejbca
- etcd 
- ghost
- grafana 
- harbor
- influxdb
- jasperreports
- jenkins
- joomla
- keycloak
- kibana
- magento
- mariadb
- mariadb-galera
- mediawiki
- memcached
- minio
- mongodb
- moodle
- mysql
- nats
- odoo
- opencart
- orangehrm
- osclass
- owncloud
- parse
- phabricator
- phpbb
- postgresql
- postgresql-ha
- prestashop
- rabbitmq
- redis
- redis-cluster
- redmine
- suitecrm
- testlink
- tomcat
- wildfly
- wordpress
- zookeeper

The notification has been added to those applications with username and password

**Related issues**
- fixes https://github.com/bitnami/charts/issues/4412
