### PR TITLE
[bitnami/nginx-ingress-controller] Add clusterrole rule for ingressclasses

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -26,4 +26,4 @@ name: nginx-ingress-controller
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx-ingress-controller
   - https://github.com/kubernetes/ingress-nginx
-version: 7.0.8
+version: 7.0.9

--- a/bitnami/nginx-ingress-controller/templates/clusterrole.yaml
+++ b/bitnami/nginx-ingress-controller/templates/clusterrole.yaml
@@ -71,4 +71,12 @@ rules:
       - ingresses/status
     verbs:
       - update
+  - apiGroups:
+      - "networking.k8s.io" # k8s 1.14+
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
 {{- end -}}


### PR DESCRIPTION
**Description of the change**
Add a clusterrole rule for ingressclasses.

**Benefits**
Fixes the following error:

```
E1231 09:32:19.028265       1 main.go:124] "Searching IngressClass" err="ingressclasses.networking.k8s.io \"nginx\" is forbidden: User \"system:serviceaccount:default:ingress-controller-nginx-ingress-controller\" cannot get resource \"ingressclasses\" in API group \"networking.k8s.io\" at the cluster scope" class="nginx"
```

**Applicable issues**
  - fixes #4851

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)


