### PR TITLE
[bitnami/ghost] enabled replicacount value for ghost deployment

### DIFF
--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -33,4 +33,4 @@ name: ghost
 sources:
   - https://github.com/bitnami/bitnami-docker-ghost
   - http://www.ghost.org/
-version: 11.1.9
+version: 11.2.0

--- a/bitnami/ghost/templates/deployment.yaml
+++ b/bitnami/ghost/templates/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}

--- a/bitnami/ghost/values.yaml
+++ b/bitnami/ghost/values.yaml
@@ -27,6 +27,9 @@ image:
   # pullSecrets:
   #   - myRegistryKeySecretName
 
+## Number of ghost replicas to deploy
+replicaCount: 1
+
 ## Command and args for running the Ghost container (set to default if not set). Use array form
 ##
 command: []


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - 
- I have tested the code locally

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

I have enabled `replicaCount` as a value in `values.yaml` and have updated the `templates/deployment.yaml` to use the value specified in the `values.yaml` file.

**Benefits**

Users can now specify how many replicas they want for the ghost deployment using either `--set replicaCount=` or by overriding the `values.yaml` file. This also makes the Chart inline with the documentation.


**Applicable issues**

- [ghost] replicaCount value is not used, unable to set replicaCount for deployment #4872

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
