### PR TITLE
[bitnami/etcd] Fix port in endpoints concatenation

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -25,4 +25,4 @@ name: etcd
 sources:
   - https://github.com/bitnami/bitnami-docker-etcd
   - https://coreos.com/etcd/
-version: 5.4.1
+version: 5.4.2

--- a/bitnami/etcd/templates/scripts-configmap.yaml
+++ b/bitnami/etcd/templates/scripts-configmap.yaml
@@ -12,7 +12,7 @@
 {{- $snapshotHistoryLimit := .Values.disasterRecovery.cronjob.snapshotHistoryLimit }}
 {{- $endpoints := list }}
 {{- range $e, $i := until $replicaCount }}
-{{- $endpoints = append $endpoints (printf "%s-%d.%s.%s.svc.%s:%d" $etcdFullname $i $etcdHeadlessServiceName $releaseNamespace $clusterDomain $peerPort) }}
+{{- $endpoints = append $endpoints (printf "%s-%d.%s.%s.svc.%s:%d" $etcdFullname $i $etcdHeadlessServiceName $releaseNamespace $clusterDomain $clientPort) }}
 {{- end }}
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
**Description of the change**

Change back the port from peerPort to clientPort in endpoints concatenation.

**Benefits**

The `etcdctl` command line client interacts with etcd at the client port as a client. 
The `ETCDCTL_ENDPOINTS` environment variable (or `--endpoints` flag of `etcdctl`) must contain the etcd endpoint(s) with the `clientPort`.

**Possible drawbacks**
None

**Applicable issues**
No related issues reported yet

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
