### PR TITLE
Fix probe error messages

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb-sharded
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb-sharded
   - https://mongodb.org
-version: 3.2.7
+version: 3.2.8

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
@@ -193,16 +193,10 @@ spec:
           readinessProbe:
             exec:
               command:
-                - sh
-                - -ec
-                - |-
-                  #!/bin/sh
-                  {{- if $.Values.usePasswordFile }}
-                  export MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD="$(cat "${MONGODB_ROOT_PASSWORD_FILE}")"
-                  {{- else }}
-                  export MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD="$(echo "${MONGODB_ROOT_PASSWORD}")"
-                  {{- end }}
-                  mongo -u root -p "$(echo "${MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD}")" --eval "db.adminCommand('ping')" || mongo --eval "db.adminCommand('ping')"
+                - mongo
+                - --disableImplicitSessions
+                - --eval
+                - "db.adminCommand('ping')"
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-dep-sts.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-dep-sts.yaml
@@ -172,16 +172,10 @@ spec:
           livenessProbe:
             exec:
               command:
-                - sh
-                - -ec
-                - |-
-                  #!/bin/sh
-                  {{- if $.Values.usePasswordFile }}
-                  export MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD="$(cat "${MONGODB_ROOT_PASSWORD_FILE}")"
-                  {{- else }}
-                  export MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD="$(echo "${MONGODB_ROOT_PASSWORD}")"
-                  {{- end }}
-                  mongo -u root -p "$(echo "${MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD}")" --eval "db.adminCommand('ping')" || mongo --eval "db.adminCommand('ping')"
+                - mongo
+                - --disableImplicitSessions
+                - --eval
+                - "db.adminCommand('ping')"
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -192,16 +186,10 @@ spec:
           readinessProbe:
             exec:
               command:
-                - sh
-                - -ec
-                - |-
-                  #!/bin/sh
-                  {{- if $.Values.usePasswordFile }}
-                  export MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD="$(cat "${MONGODB_ROOT_PASSWORD_FILE}")"
-                  {{- else }}
-                  export MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD="$(echo "${MONGODB_ROOT_PASSWORD}")"
-                  {{- end }}
-                  mongo -u root -p "$(echo "${MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD}")" --eval "db.adminCommand('ping')" || mongo --eval "db.adminCommand('ping')"
+                - mongo
+                - --disableImplicitSessions
+                - --eval
+                - "db.adminCommand('ping')"
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -198,16 +198,10 @@ spec:
           readinessProbe:
             exec:
               command:
-                - sh
-                - -ec
-                - |-
-                  #!/bin/sh
-                  {{- if $.Values.usePasswordFile }}
-                  export MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD="$(cat "${MONGODB_ROOT_PASSWORD_FILE}")"
-                  {{- else }}
-                  export MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD="$(echo "${MONGODB_ROOT_PASSWORD}")"
-                  {{- end }}
-                  mongo -u root -p "$(echo "${MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD}")" --eval "db.adminCommand('ping')" || mongo --eval "db.adminCommand('ping')"
+                - mongo
+                - --disableImplicitSessions
+                - --eval
+                - "db.adminCommand('ping')"
             initialDelaySeconds: {{ $.Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ $.Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ $.Values.readinessProbe.timeoutSeconds }}

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 10.3.5
+version: 10.3.6

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -292,6 +292,7 @@ spec:
             exec:
               command:
                 - mongo
+                - --disableImplicitSessions
               {{- if .Values.tls.enabled }}
                 - --tls
                 - --tlsCertificateKeyFile=/certs/mongodb.pem
@@ -312,6 +313,7 @@ spec:
             exec:
               command:
                 - mongo
+                - --disableImplicitSessions
               {{- if .Values.tls.enabled }}
                 - --tls
                 - --tlsCertificateKeyFile=/certs/mongodb.pem

--- a/bitnami/mongodb/templates/standalone/dep-sts.yaml
+++ b/bitnami/mongodb/templates/standalone/dep-sts.yaml
@@ -233,6 +233,7 @@ spec:
             exec:
               command:
                 - mongo
+                - --disableImplicitSessions
               {{- if .Values.tls.enabled }}
                 - --tls
                 - --tlsCertificateKeyFile=/certs/mongodb.pem
@@ -253,6 +254,7 @@ spec:
             exec:
               command:
                 - mongo
+                - --disableImplicitSessions
               {{- if .Values.tls.enabled }}
                 - --tls
                 - --tlsCertificateKeyFile=/certs/mongodb.pem


### PR DESCRIPTION
**Description of the change**

Default liveness and readiness probes are based on the command `mongo --eval "db.adminCommand('ping')"` which fills the logs with this error message : 
````
ACCESS   [conn165] Unauthorized: not authorized on admin to execute command { endSessions: [ { id: UUID("5e039c6f-fc79-48e1-9f99-73fb8c5b5c25") } ], $db: "admin" }
````

This change adds an additional `--disableImplicitSessions` which removes this annoying error message.

**Benefits**

No more error message that may be difficult to understand and fills the logs for no reason

**Possible drawbacks**

-

**Applicable issues**

-

**Additional information**

- EDIT : I just noticed that there is a typo in the commit messages (bitnami->bitname). If necessary, I can post another PR.