### PR TITLE
[bitnami/postgresql] Clarify sharedBuffers example in postgresql README

### DIFF
--- a/bitnami/postgresql/README.md
+++ b/bitnami/postgresql/README.md
@@ -353,7 +353,7 @@ This helm chart also supports to customize the whole configuration file.
 
 Add your custom file to "files/postgresql.conf" in your working directory. This file will be mounted as configMap to the containers and it will be used for configuring the PostgreSQL server.
 
-Alternatively, you can specify PostgreSQL configuration parameters using the `postgresqlConfiguration` parameter as a dict, using camelCase, e.g. {"sharedBuffers": "500MB"}.
+Alternatively, you can add additional PostgreSQL configuration parameters using the `postgresqlExtendedConf` parameter as a dict, using camelCase, e.g. {"sharedBuffers": "500MB"}. Alternatively, to replace the entire default configuration use `postgresqlConfiguration`.
 
 In addition to these options, you can also set an external ConfigMap with all the configuration files. This is done by setting the `configurationConfigMap` parameter. Note that this will override the two previous options.
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Clarify the postgresql chart README as discussed in #4877. Changes the `sharedBuffers` configuration example to use `postgresqlExtendedConf` which "extends" the configuration file instead of the current example of `postgresqlConfiguration` which **replaces** the configuration.

**Benefits**

The current description was confusing to me as following the example exactly produces a pod/service that is not usable in the same way the default configuration. If this resulted in small differences I'd say maybe it was OK, but currently this results in a postgresql server that can't be connected to outside localhost.

**Possible drawbacks**

Since the change mentions both configuration options I don't see any downsides.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - related to #4877 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
