### PR TITLE
[bitnami/metallb] update tplValue references

### DIFF
--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: metallb
 description: The Metal LB for Kubernetes
-version: 2.0.2
+version: 2.0.3
 appVersion: 0.9.5
 home: https://github.com/bitnami/charts/tree/master/bitnami/metallb
 icon: https://bitnami.com/assets/stacks/metallb-speaker/img/metallb-speaker-stack-220x234.png

--- a/bitnami/metallb/templates/speaker/daemonset.yaml
+++ b/bitnami/metallb/templates/speaker/daemonset.yaml
@@ -64,12 +64,12 @@ spec:
               name: {{ include "metallb.speaker.secretName" . }}
               key: {{ include "metallb.speaker.secretKey" . }}
         {{- if .Values.speaker.extraEnvVars }}
-        {{- include "metallb.tplValue" ( dict "value" .Values.speaker.extraEnvVars "context" $ ) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.speaker.extraEnvVars "context" $ ) | nindent 8 }}
         {{- end }}
         {{- if .Values.extraEnvVarsSecret }}
         envFrom:
         - secretRef:
-            name: {{ include "metallb.tplValue" ( dict "value" .Values.speaker.extraEnvVarsSecret "context" $ ) }}
+            name: {{ include "common.tplvalues.render" ( dict "value" .Values.speaker.extraEnvVarsSecret "context" $ ) }}
         {{- end }}
         ports:
         - name: metrics
@@ -109,11 +109,11 @@ spec:
             add: {{- toYaml .Values.speaker.securityContext.capabilities.add | nindent 12 }}
       {{- end }}
       nodeSelector:
-      {{- if .Values.speaker.nodeSelector }} {{- include "metallb.tplValue" (dict "value" .Values.speaker.nodeSelector "context" $) | nindent 8 }}
+      {{- if .Values.speaker.nodeSelector }} {{- include "common.tplvalues.render" (dict "value" .Values.speaker.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
         "kubernetes.io/os": linux
       {{- if .Values.speaker.affinity }}
-      affinity: {{- include "metallb.tplValue" (dict "value" .Values.speaker.affinity "context" $) | nindent 8 }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.speaker.affinity "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.speaker.tolerations}}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.speaker.tolerations "context" $) | nindent 8 }}


### PR DESCRIPTION
**Description of the change**

During the migration to the common library (#3889) the `metallb.tplValue` template has been removed from the [bitnami/metallb] chart, but not all references were updated. This PR aims to fix the issue within the [bitnami/metallb] chart by replacing the outdated references with the `common.tplvalues.render` template (which seems to be the common replacement of the removed tempate).

**Benefits**

Users of the chart will be able to define the following configuration values without breaking the chart:

- speaker.extraEnvVarsSecret
- speaker.extraEnvVars
- speaker.nodeSelector
- speaker.affinity

**Possible drawbacks**

N/A

**Applicable issues**

  - fixes #4885 

**Additional information**

The same issue seems to be present in the following charts as well:

- ejbca in charts/bitnami/ejbca/templates/ingress.yaml
- kafka in charts/bitnami/kafka/templates/log4j-configmap.yaml
- mongodb-shared in charts/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml

**Checklist**

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
