### PR TITLE
[bitnami/keycloak] Update ingress rules

### DIFF
--- a/bitnami/keycloak/Chart.lock
+++ b/bitnami/keycloak/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.2.3
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.2.0
-digest: sha256:803b61eb1ef4a0fb7c588d8024ec07f02dac1ae22e8b53699eb9808c2b121531
-generated: "2021-01-02T03:40:34.155887203Z"
+  version: 10.2.1
+digest: sha256:54af38b83d1a057e4858666f7ddf4ed348971eb8178e289c09fc384c51505127
+generated: "2021-01-05T13:37:28.649354+01:00"

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 1.1.7
+version: 1.2.0

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -59,14 +59,15 @@ The following tables lists the configurable parameters of the Keycloak chart and
 
 ### Common parameters
 
-| Parameter           | Description                                       | Default                        |
-|---------------------|---------------------------------------------------|--------------------------------|
-| `nameOverride`      | String to partially override keycloak.fullname    | `nil`                          |
-| `fullnameOverride`  | String to fully override keycloak.fullname        | `nil`                          |
-| `commonLabels`      | Labels to add to all deployed objects             | `{}`                           |
-| `commonAnnotations` | Annotations to add to all deployed objects        | `{}`                           |
-| `clusterDomain`     | Default Kubernetes cluster domain                 | `cluster.local`                |
-| `extraDeploy`       | Array of extra objects to deploy with the release | `[]` (evaluated as a template) |
+| Parameter           | Description                                                          | Default                        |
+|---------------------|----------------------------------------------------------------------|--------------------------------|
+| `nameOverride`      | String to partially override keycloak.fullname                       | `nil`                          |
+| `fullnameOverride`  | String to fully override keycloak.fullname                           | `nil`                          |
+| `commonLabels`      | Labels to add to all deployed objects                                | `{}`                           |
+| `commonAnnotations` | Annotations to add to all deployed objects                           | `{}`                           |
+| `clusterDomain`     | Default Kubernetes cluster domain                                    | `cluster.local`                |
+| `extraDeploy`       | Array of extra objects to deploy with the release                    | `[]` (evaluated as a template) |
+| `kubeVersion`       | Force target Kubernetes version (using Helm capabilities if not set) | `nil`                          |
 
 ### Keycloak parameters
 
@@ -154,6 +155,9 @@ The following tables lists the configurable parameters of the Keycloak chart and
 | `service.loadBalancerSourceRanges` | Address that are allowed when service is LoadBalancer                             | `[]`                           |
 | `service.annotations`              | Annotations for Keycloak service                                                  | `{}` (evaluated as a template) |
 | `ingress.enabled`                  | Enable ingress controller resource                                                | `false`                        |
+| `ingress.apiVersion`               | Force Ingress API version (automatically detected if not set)                     | ``                             |
+| `ingress.path`                     | Ingress path                                                                      | `/`                            |
+| `ingress.pathType`                 | Ingress path type                                                                 | `ImplementationSpecific`       |
 | `ingress.certManager`              | Add annotations for cert-manager                                                  | `false`                        |
 | `ingress.hostname`                 | Default host for the ingress resource                                             | `keycloak.local`               |
 | `ingress.tls`                      | Enable TLS configuration for the hostname defined at `ingress.hostname` parameter | `false`                        |

--- a/bitnami/keycloak/templates/ingress.yaml
+++ b/bitnami/keycloak/templates/ingress.yaml
@@ -27,19 +27,21 @@ spec:
     - host: {{ .Values.ingress.hostname }}
       http:
         paths:
-          - path: /
-            backend:
-              serviceName: {{ template "keycloak.fullname" . }}
-              servicePort: http
+          - path: {{ .Values.ingress.path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.ingress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
     - host: {{ .name }}
       http:
         paths:
           - path: {{ default "/" .path }}
-            backend:
-              serviceName: {{ template "keycloak.fullname" $ }}
-              servicePort: http
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
+            pathType: {{ default "ImplementationSpecific" .pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
   {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
   tls:

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -8,6 +8,10 @@
 #     - myRegistryKeySecretName
 #   storageClass: myStorageClass
 
+## Force target Kubernetes version (using Helm capabilites if not set)
+##
+kubeVersion:
+
 ## String to partially override aspnet-core.fullname template (will maintain the release name)
 ##
 # nameOverride:
@@ -421,6 +425,18 @@ ingress:
   ## When the ingress is enabled, a host pointing to this will be created
   ##
   hostname: keycloak.local
+
+  ## Override API Version (automatically detected if not set)
+  ##
+  apiVersion:
+
+  ## Ingress Path
+  ##
+  path: /
+
+  ## Ingress Path type
+  ##
+  pathType: ImplementationSpecific
 
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see


### PR DESCRIPTION
**Description of the change**
This PR updates the common library with the changes from https://github.com/bitnami/charts/pull/4859. 

- Depending on the Kubernetes version it will generate the proper Ingress object
- It allows forcing a Kubernetes version so it is compatible with GitOps approaches

**Benefits**
Chart compatible with all Kubernetes versions

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

