### PR TITLE
[bitnami/ghost] use common.ingress.backend to enable 1.20+ usage

### DIFF
--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -33,4 +33,4 @@ name: ghost
 sources:
   - https://github.com/bitnami/bitnami-docker-ghost
   - http://www.ghost.org/
-version: 11.2.1
+version: 11.2.2

--- a/bitnami/ghost/templates/ingress.yaml
+++ b/bitnami/ghost/templates/ingress.yaml
@@ -25,9 +25,8 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            backend:
-              serviceName: "{{ include "common.names.fullname" $ }}"
-              servicePort: http
+            pathType: Prefix
+            backend: {{ include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
   {{- end }}
   tls:
   {{- range .Values.ingress.hosts }}


### PR DESCRIPTION
**Description of the change**

Switches the ghost chart from hardcoded backend to using `common.ingress.backend`.

**Benefits**

Can be used with Kubernetes 1.20+.

**Possible drawbacks**

None.

**Applicable issues**

None.

**Additional information**

None.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files