### PR TITLE
[bitnami/influxdb] Add trademark in non-readme files and unify format

### DIFF
--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
     tags:
       - bitnami-common
     version: 1.x.x
-description: Grafana is an open source, feature rich metrics dashboard and graph editor for Graphite, Elasticsearch, OpenTSDB, Prometheus and InfluxDB.
+description: Grafana is an open source, feature rich metrics dashboard and graph editor for Graphite, Elasticsearch, OpenTSDB, Prometheus and InfluxDB(TM).
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/grafana
 icon: https://bitnami.com/assets/stacks/grafana/img/grafana-stack-220x234.png
@@ -24,4 +24,4 @@ name: grafana
 sources:
   - https://github.com/bitnami/bitnami-docker-grafana
   - https://grafana.com/
-version: 4.2.4
+version: 4.2.5

--- a/bitnami/grafana/README.md
+++ b/bitnami/grafana/README.md
@@ -1,6 +1,6 @@
 # Grafana
 
-[Grafana](https://grafana.com/) is an open source, feature rich metrics dashboard and graph editor for Graphite, Elasticsearch, OpenTSDB, Prometheus and InfluxDB.
+[Grafana](https://grafana.com/) is an open source, feature rich metrics dashboard and graph editor for Graphite, Elasticsearch, OpenTSDB, Prometheus and InfluxDB<sup>TM</sup>.
 
 ## TL;DR
 

--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
     tags:
       - bitnami-common
     version: 1.x.x
-description: InfluxDB is an open source time-series database designed to handle large write and read loads in real-time.
+description: InfluxDB(TM) is an open source time-series database designed to handle large write and read loads in real-time.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/influxdb
 icon: https://bitnami.com/assets/stacks/influxdb/img/influxdb-stack-220x234.png
@@ -24,4 +24,4 @@ name: influxdb
 sources:
   - https://github.com/bitnami/bitnami-docker-influxdb
   - https://www.influxdata.com/products/influxdb-overview/
-version: 1.1.6
+version: 1.1.7

--- a/bitnami/influxdb/README.md
+++ b/bitnami/influxdb/README.md
@@ -1,6 +1,6 @@
-# InfluxDB(TM)
+# InfluxDB<sup>TM</sup>
 
-[InfluxDB(TM)](https://www.influxdata.com/products/influxdb-overview/) is an open source time-series database designed to handle large write and read loads in real-time.
+[InfluxDB<sup>TM</sup>](https://www.influxdata.com/products/influxdb-overview/) is an open source time-series database designed to handle large write and read loads in real-time.
 
 ## TL;DR
 
@@ -47,105 +47,105 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Parameters
 
-The following tables lists the configurable parameters of the InfluxDB(TM) chart and their default values.
+The following tables lists the configurable parameters of the InfluxDB<sup>TM</sup> chart and their default values.
 
 | Parameter                                         | Description                                                                                                                         | Default                                                 |
 |---------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
 | `global.imageRegistry`                            | Global Docker image registry                                                                                                        | `nil`                                                   |
 | `global.imagePullSecrets`                         | Global Docker registry secret names as an array                                                                                     | `[]` (does not add image pull secrets to deployed pods) |
 | `global.storageClass`                             | Global storage class for dynamic provisioning                                                                                       | `nil`                                                   |
-| `image.registry`                                  | InfluxDB(TM) image registry                                                                                                         | `docker.io`                                             |
-| `image.repository`                                | InfluxDB(TM) image name                                                                                                             | `bitnami/influxdb`                                      |
-| `image.tag`                                       | InfluxDB(TM) image tag                                                                                                              | `{TAG_NAME}`                                            |
-| `image.pullPolicy`                                | InfluxDB(TM) image pull policy                                                                                                      | `IfNotPresent`                                          |
+| `image.registry`                                  | InfluxDB<sup>TM</sup> image registry                                                                                                | `docker.io`                                             |
+| `image.repository`                                | InfluxDB<sup>TM</sup> image name                                                                                                    | `bitnami/influxdb`                                      |
+| `image.tag`                                       | InfluxDB<sup>TM</sup> image tag                                                                                                     | `{TAG_NAME}`                                            |
+| `image.pullPolicy`                                | InfluxDB<sup>TM</sup> image pull policy                                                                                             | `IfNotPresent`                                          |
 | `image.pullSecrets`                               | Specify docker-registry secret names as an array                                                                                    | `[]` (does not add image pull secrets to deployed pods) |
 | `image.debug`                                     | Specify if debug logs should be enabled                                                                                             | `false`                                                 |
 | `nameOverride`                                    | String to partially override influxdb.fullname template with a string (will prepend the release name)                               | `nil`                                                   |
 | `fullnameOverride`                                | String to fully override influxdb.fullname template with a string                                                                   | `nil`                                                   |
 | `clusterDomain`                                   | Default Kubernetes cluster domain                                                                                                   | `cluster.local`                                         |
-| `architecture`                                    | InfluxDB(TM) architecture (`standalone` or `high-availability`)                                                                     | `standalone`                                            |
+| `architecture`                                    | InfluxDB<sup>TM</sup> architecture (`standalone` or `high-availability`)                                                            | `standalone`                                            |
 | `database`                                        | Database to be created on first run                                                                                                 | `my_database`                                           |
 | `authEnabled`                                     | Enable/disable authentication                                                                                                       | `true`                                                  |
-| `adminUser.name`                                  | InfluxDB(TM) admin user name                                                                                                        | `admin`                                                 |
-| `adminUser.pwd`                                   | InfluxDB(TM) admin user's password                                                                                                  | `nil`                                                   |
+| `adminUser.name`                                  | InfluxDB<sup>TM</sup> admin user name                                                                                               | `admin`                                                 |
+| `adminUser.pwd`                                   | InfluxDB<sup>TM</sup> admin user's password                                                                                         | `nil`                                                   |
 | `adminUser.usePasswordFile`                       | Mount admin user's password as file instead of environment variable                                                                 | `false`                                                 |
-| `user.name`                                       | Name for InfluxDB(TM) user with 'admin' privileges on the db specified at `database`                                                | `nil`                                                   |
-| `user.pwd`                                        | InfluxDB(TM) password for `user.name` user                                                                                          | `nil`                                                   |
+| `user.name`                                       | Name for InfluxDB<sup>TM</sup> user with 'admin' privileges on the db specified at `database`                                       | `nil`                                                   |
+| `user.pwd`                                        | InfluxDB<sup>TM</sup> password for `user.name` user                                                                                 | `nil`                                                   |
 | `user.usePasswordFile`                            | Mount `user.name` user's password as file instead of environment variable                                                           | `nil`                                                   |
-| `readUser.name`                                   | Name for InfluxDB(TM) user with 'read' privileges on the db specified at `database`                                                 | `nil`                                                   |
-| `readUser.pwd`                                    | InfluxDB(TM) password for `readUser.name` user                                                                                      | `nil`                                                   |
+| `readUser.name`                                   | Name for InfluxDB<sup>TM</sup> user with 'read' privileges on the db specified at `database`                                        | `nil`                                                   |
+| `readUser.pwd`                                    | InfluxDB<sup>TM</sup> password for `readUser.name` user                                                                             | `nil`                                                   |
 | `readUser.usePasswordFile`                        | Mount `readUser.name` user's password as file instead of environment variable                                                       | `nil`                                                   |
-| `writeUser.name`                                  | Name for InfluxDB(TM) user with 'write' privileges on the db specified at `database`                                                | `nil`                                                   |
-| `writeUser.pwd`                                   | InfluxDB(TM) password for `writeUser.name` user                                                                                     | `nil`                                                   |
+| `writeUser.name`                                  | Name for InfluxDB<sup>TM</sup> user with 'write' privileges on the db specified at `database`                                       | `nil`                                                   |
+| `writeUser.pwd`                                   | InfluxDB<sup>TM</sup> password for `writeUser.name` user                                                                            | `nil`                                                   |
 | `writeUser.usePasswordFile`                       | Mount `writeUser.name` user's password as file instead of environment variable                                                      | `nil`                                                   |
-| `existingSecret`                                  | Name of existing Secret object with InfluxDB(TM) credentials (`adminUser.password`, `user.password`, `readUser.password`, and `writeUser.pwd` will be ignored and picked up from this secret) | `nil`|
+| `existingSecret`                                  | Name of existing Secret object with InfluxDB<sup>TM</sup> credentials (`adminUser.password`, `user.password`, `readUser.password`, and `writeUser.pwd` will be ignored and picked up from this secret) | `nil`|
 | `influxdb.configuration`                          | Specify content for influxdb.conf                                                                                                   | `nil (do not create influxdb.conf)`                     |
-| `influxdb.existingConfiguration`                  | Name of existing ConfigMap object with the InfluxDB(TM) configuration (`influxdb.configuration` will be ignored).                   | `nil`                                                   |
+| `influxdb.existingConfiguration`                  | Name of existing ConfigMap object with the InfluxDB<sup>TM</sup> configuration (`influxdb.configuration` will be ignored).          | `nil`                                                   |
 | `influxdb.initdbScripts`                          | Dictionary of initdb scripts                                                                                                        | `nil`                                                   |
 | `influxdb.initdbScriptsCM`                        | Name of existing ConfigMap object with the initdb scripts (`influxdb.initdbScripts` will be ignored).                               | `nil`                                                   |
 | `influxdb.initdbScriptsSecret`                    | Secret with initdb scripts that contain sensitive information (Note: can be used with `initdbScriptsConfigMap` or `initdbScripts`)  | `nil`                                                   |
-| `influxdb.extraEnvVars`                           | Array containing extra env vars to configure InfluxDB(TM)                                                                           | `nil`                                                   |
-| `influxdb.replicaCount`                           | The number of InfluxDB(TM) replicas to deploy                                                                                       | `1`                                                     |
-| `influxdb.podAffinityPreset`                      | InfluxDB(TM) Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                    | `""`                                                    |
-| `influxdb.podAntiAffinityPreset`                  | InfluxDB(TM) Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                               | `""`                                                    |
-| `influxdb.nodeAffinityPreset.type`                | InfluxDB(TM) Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                              | `""`                                                    |
-| `influxdb.nodeAffinityPreset.key`                 | InfluxDB(TM) Node label key to match Ignored if `affinity` is set.                                                                  | `""`                                                    |
-| `influxdb.nodeAffinityPreset.values`              | InfluxDB(TM) Node label values to match. Ignored if `affinity` is set.                                                              | `[]`                                                    |
-| `influxdb.affinity`                               | InfluxDB(TM) Affinity for pod assignment                                                                                            | `{}` (evaluated as a template)                          |
-| `influxdb.nodeSelector`                           | InfluxDB(TM) Node labels for pod assignment                                                                                         | `{}` (evaluated as a template)                          |
-| `influxdb.tolerations`                            | InfluxDB(TM) Tolerations for pod assignment                                                                                         | `[]` (evaluated as a template)                          |
+| `influxdb.extraEnvVars`                           | Array containing extra env vars to configure InfluxDB<sup>TM</sup>                                                                  | `nil`                                                   |
+| `influxdb.replicaCount`                           | The number of InfluxDB<sup>TM</sup> replicas to deploy                                                                              | `1`                                                     |
+| `influxdb.podAffinityPreset`                      | InfluxDB<sup>TM</sup> Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                           | `""`                                                    |
+| `influxdb.podAntiAffinityPreset`                  | InfluxDB<sup>TM</sup> Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                      | `""`                                                    |
+| `influxdb.nodeAffinityPreset.type`                | InfluxDB<sup>TM</sup> Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                     | `""`                                                    |
+| `influxdb.nodeAffinityPreset.key`                 | InfluxDB<sup>TM</sup> Node label key to match Ignored if `affinity` is set.                                                         | `""`                                                    |
+| `influxdb.nodeAffinityPreset.values`              | InfluxDB<sup>TM</sup> Node label values to match. Ignored if `affinity` is set.                                                     | `[]`                                                    |
+| `influxdb.affinity`                               | InfluxDB<sup>TM</sup> Affinity for pod assignment                                                                                   | `{}` (evaluated as a template)                          |
+| `influxdb.nodeSelector`                           | InfluxDB<sup>TM</sup> Node labels for pod assignment                                                                                | `{}` (evaluated as a template)                          |
+| `influxdb.tolerations`                            | InfluxDB<sup>TM</sup> Tolerations for pod assignment                                                                                | `[]` (evaluated as a template)                          |
 | `infludb.podManagementPolicy`                     | Pod Management Policy [`OrderedReady` or `Parallel`]                                                                                | `OrderedReady`                                          |
-| `influxdb.securityContext.enabled`                | Enable security context for InfluxDB(TM)                                                                                            | `true`                                                  |
-| `influxdb.securityContext.fsGroup`                | Group ID for the InfluxDB(TM) filesystem                                                                                            | `1001`                                                  |
-| `influxdb.securityContext.runAsUser`              | User ID for the InfluxDB(TM) container                                                                                              | `1001`                                                  |
+| `influxdb.securityContext.enabled`                | Enable security context for InfluxDB<sup>TM</sup>                                                                                   | `true`                                                  |
+| `influxdb.securityContext.fsGroup`                | Group ID for the InfluxDB<sup>TM</sup> filesystem                                                                                   | `1001`                                                  |
+| `influxdb.securityContext.runAsUser`              | User ID for the InfluxDB<sup>TM</sup> container                                                                                     | `1001`                                                  |
 | `influxdb.resources`                              | The [resources] to allocate for container                                                                                           | `{}`                                                    |
-| `influxdb.livenessProbe`                          | Liveness probe configuration for InfluxDB(TM)                                                                                       | `Check values.yaml file`                                |
-| `influxdb.readinessProbe`                         | Readiness probe configuration for InfluxDB(TM)                                                                                      | `Check values.yaml file`                                |
-| `influxdb.containerPorts.http`                    | InfluxDB(TM) container HTTP port                                                                                                    | `8086`                                                  |
-| `influxdb.containerPorts.rpc`                     | InfluxDB(TM) container RPC port                                                                                                     | `8088`                                                  |
+| `influxdb.livenessProbe`                          | Liveness probe configuration for InfluxDB<sup>TM</sup>                                                                              | `Check values.yaml file`                                |
+| `influxdb.readinessProbe`                         | Readiness probe configuration for InfluxDB<sup>TM</sup>                                                                             | `Check values.yaml file`                                |
+| `influxdb.containerPorts.http`                    | InfluxDB<sup>TM</sup> container HTTP port                                                                                           | `8086`                                                  |
+| `influxdb.containerPorts.rpc`                     | InfluxDB<sup>TM</sup> container RPC port                                                                                            | `8088`                                                  |
 | `influxdb.service.type`                           | Kubernetes service type (`ClusterIP`, `NodePort` or `LoadBalancer`)                                                                 | `ClusterIP`                                             |
-| `influxdb.service.port`                           | InfluxDB(TM) HTTP port                                                                                                              | `8086`                                                  |
-| `influxdb.service.rpcPort`                        | InfluxDB(TM) RPC port                                                                                                               | `8088`                                                  |
+| `influxdb.service.port`                           | InfluxDB<sup>TM</sup> HTTP port                                                                                                     | `8086`                                                  |
+| `influxdb.service.rpcPort`                        | InfluxDB<sup>TM</sup> RPC port                                                                                                      | `8088`                                                  |
 | `influxdb.service.nodePorts.http`                 | Kubernetes HTTP node port                                                                                                           | `""`                                                    |
 | `influxdb.service.nodePorts.rpc`                  | Kubernetes RPC node port                                                                                                            | `""`                                                    |
-| `influxdb.service.annotations`                    | Annotations for InfluxDB(TM) service                                                                                                | `{}`                                                    |
+| `influxdb.service.annotations`                    | Annotations for InfluxDB<sup>TM</sup> service                                                                                       | `{}`                                                    |
 | `influxdb.service.loadBalancerIP`                 | loadBalancerIP if service type is `LoadBalancer`                                                                                    | `nil`                                                   |
 | `influxdb.service.loadBalancerSourceRanges`       | Address that are allowed when service is LoadBalancer                                                                               | `[]`                                                    |
 | `influxdb.service.clusterIP`                      | Static clusterIP or None for headless services                                                                                      | `nil`                                                   |
-| `relay.image.registry`                            | InfluxDB Relay(TM) image registry                                                                                                   | `docker.io`                                             |
-| `relay.image.repository`                          | InfluxDB Relay(TM) image name                                                                                                       | `bitnami/influxdb-relay`                                |
-| `relay.image.tag`                                 | InfluxDB Relay(TM) image tag                                                                                                        | `{TAG_NAME}`                                            |
-| `relay.image.pullPolicy`                          | InfluxDB Relay(TM) image pull policy                                                                                                | `IfNotPresent`                                          |
+| `relay.image.registry`                            | InfluxDB Relay<sup>TM</sup> image registry                                                                                          | `docker.io`                                             |
+| `relay.image.repository`                          | InfluxDB Relay<sup>TM</sup> image name                                                                                              | `bitnami/influxdb-relay`                                |
+| `relay.image.tag`                                 | InfluxDB Relay<sup>TM</sup> image tag                                                                                               | `{TAG_NAME}`                                            |
+| `relay.image.pullPolicy`                          | InfluxDB Relay<sup>TM</sup> image pull policy                                                                                       | `IfNotPresent`                                          |
 | `relay.image.pullSecrets`                         | Specify docker-registry secret names as an array                                                                                    | `[]` (does not add image pull secrets to deployed pods) |
 | `relay.configuration`                             | Specify content for relay.toml                                                                                                      | `Check values.yaml file`                                |
-| `relay.existingConfiguration`                     | Name of existing ConfigMap object with the InfluxDB Relay(TM) configuration (`relay.configuration` will be ignored)                 | `nil`                                                   |
-| `relay.replicaCount`                              | The number of InfluxDB Relay(TM) replicas to deploy                                                                                 | `1`                                                     |
-| `relay.podAffinityPreset`                         | InfluxDB Relay(TM) Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                              | `""`                                                    |
-| `relay.podAntiAffinityPreset`                     | InfluxDB Relay(TM) Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                         | `""`                                                    |
-| `relay.nodeAffinityPreset.type`                   | InfluxDB Relay(TM) Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                        | `""`                                                    |
-| `relay.nodeAffinityPreset.key`                    | InfluxDB Relay(TM) Node label key to match Ignored if `affinity` is set.                                                            | `""`                                                    |
-| `relay.nodeAffinityPreset.values`                 | InfluxDB Relay(TM) Node label values to match. Ignored if `affinity` is set.                                                        | `[]`                                                    |
-| `relay.affinity`                                  | InfluxDB Relay(TM) Affinity for pod assignment                                                                                      | `{}` (evaluated as a template)                          |
-| `relay.nodeSelector`                              | InfluxDB Relay(TM) Node labels for pod assignment                                                                                   | `{}` (evaluated as a template)                          |
-| `relay.tolerations`                               | InfluxDB Relay(TM) Tolerations for pod assignment                                                                                   | `[]` (evaluated as a template)                          |
-| `relay.securityContext.enabled`                   | Enable security context for InfluxDB Relay(TM)                                                                                      | `true`                                                  |
-| `relay.securityContext.fsGroup`                   | Group ID for the InfluxDB Relay(TM) filesystem                                                                                      | `1001`                                                  |
-| `relay.securityContext.runAsUser`                 | User ID for the InfluxDB Relay(TM) container                                                                                        | `1001`                                                  |
+| `relay.existingConfiguration`                     | Name of existing ConfigMap object with the InfluxDB Relay<sup>TM</sup> configuration (`relay.configuration` will be ignored)        | `nil`                                                   |
+| `relay.replicaCount`                              | The number of InfluxDB Relay<sup>TM</sup> replicas to deploy                                                                        | `1`                                                     |
+| `relay.podAffinityPreset`                         | InfluxDB Relay<sup>TM</sup> Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                     | `""`                                                    |
+| `relay.podAntiAffinityPreset`                     | InfluxDB Relay<sup>TM</sup> Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                | `""`                                                    |
+| `relay.nodeAffinityPreset.type`                   | InfluxDB Relay<sup>TM</sup> Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`               | `""`                                                    |
+| `relay.nodeAffinityPreset.key`                    | InfluxDB Relay<sup>TM</sup> Node label key to match Ignored if `affinity` is set.                                                   | `""`                                                    |
+| `relay.nodeAffinityPreset.values`                 | InfluxDB Relay<sup>TM</sup> Node label values to match. Ignored if `affinity` is set.                                               | `[]`                                                    |
+| `relay.affinity`                                  | InfluxDB Relay<sup>TM</sup> Affinity for pod assignment                                                                             | `{}` (evaluated as a template)                          |
+| `relay.nodeSelector`                              | InfluxDB Relay<sup>TM</sup> Node labels for pod assignment                                                                          | `{}` (evaluated as a template)                          |
+| `relay.tolerations`                               | InfluxDB Relay<sup>TM</sup> Tolerations for pod assignment                                                                          | `[]` (evaluated as a template)                          |
+| `relay.securityContext.enabled`                   | Enable security context for InfluxDB Relay<sup>TM</sup>                                                                             | `true`                                                  |
+| `relay.securityContext.fsGroup`                   | Group ID for the InfluxDB Relay<sup>TM</sup> filesystem                                                                             | `1001`                                                  |
+| `relay.securityContext.runAsUser`                 | User ID for the InfluxDB Relay<sup>TM</sup> container                                                                               | `1001`                                                  |
 | `relay.resources`                                 | The [resources] to allocate for container                                                                                           | `{}`                                                    |
-| `relay.livenessProbe`                             | Liveness probe configuration for InfluxDB Relay(TM)                                                                                 | `Check values.yaml file`                                |
-| `relay.readinessProbe`                            | Readiness probe configuration for InfluxDB Relay(TM)                                                                                | `Check values.yaml file`                                |
-| `relay.containerPorts.http`                       | InfluxDB Relay(TM) container HTTP port                                                                                              | `9096`                                                  |
+| `relay.livenessProbe`                             | Liveness probe configuration for InfluxDB Relay<sup>TM</sup>                                                                        | `Check values.yaml file`                                |
+| `relay.readinessProbe`                            | Readiness probe configuration for InfluxDB Relay<sup>TM</sup>                                                                       | `Check values.yaml file`                                |
+| `relay.containerPorts.http`                       | InfluxDB Relay<sup>TM</sup> container HTTP port                                                                                     | `9096`                                                  |
 | `relay.service.type`                              | Kubernetes service type (`ClusterIP`, `NodePort` or `LoadBalancer`)                                                                 | `ClusterIP`                                             |
-| `relay.service.port`                              | InfluxDB Relay(TM) HTTP port                                                                                                        | `9096`                                                  |
+| `relay.service.port`                              | InfluxDB Relay<sup>TM</sup> HTTP port                                                                                               | `9096`                                                  |
 | `relay.service.nodePort`                          | Kubernetes HTTP node port                                                                                                           | `""`                                                    |
-| `relay.service.annotations`                       | Annotations for InfluxDB Relay(TM) service                                                                                          | `{}`                                                    |
+| `relay.service.annotations`                       | Annotations for InfluxDB Relay<sup>TM</sup> service                                                                                 | `{}`                                                    |
 | `relay.service.loadBalancerIP`                    | loadBalancerIP if service type is `LoadBalancer`                                                                                    | `nil`                                                   |
 | `relay.service.loadBalancerSourceRanges`          | Address that are allowed when service is LoadBalancer                                                                               | `[]`                                                    |
 | `relay.service.clusterIP`                         | Static clusterIP or None for headless services                                                                                      | `nil`                                                   |
 | `ingress.enabled`                                 | Enable ingress controller resource                                                                                                  | `false`                                                 |
 | `ingress.certManager`                             | Add annotations for cert-manager                                                                                                    | `false`                                                 |
 | `ingress.annotations`                             | Ingress annotations                                                                                                                 | `[]`                                                    |
-| `ingress.hosts[0].name`                           | Hostname for InfluxDB(TM) service                                                                                                   | `influxdb.local`                                        |
+| `ingress.hosts[0].name`                           | Hostname for InfluxDB<sup>TM</sup> service                                                                                          | `influxdb.local`                                        |
 | `ingress.hosts[0].path`                           | Path within the url structure                                                                                                       | `/`                                                     |
 | `ingress.tls[0].hosts[0]`                         | TLS hosts                                                                                                                           | `influxdb.local`                                        |
 | `ingress.tls[0].secretName`                       | TLS Secret (certificates)                                                                                                           | `influxdb.local-tls`                                    |
@@ -154,7 +154,7 @@ The following tables lists the configurable parameters of the InfluxDB(TM) chart
 | `ingress.secrets[0].key`                          | TLS Secret Key                                                                                                                      | `nil`                                                   |
 | `metrics.enabled`                                 | Enable the export of Prometheus metrics                                                                                             | `false`                                                 |
 | `metrics.service.type`                            | Kubernetes service type (`ClusterIP`, `NodePort` or `LoadBalancer`)                                                                 | `ClusterIP`                                             |
-| `metrics.service.port`                            | InfluxDB(TM) Prometheus port                                                                                                        | `9122`                                                  |
+| `metrics.service.port`                            | InfluxDB<sup>TM</sup> Prometheus port                                                                                               | `9122`                                                  |
 | `metrics.service.nodePort`                        | Kubernetes HTTP node port                                                                                                           | `""`                                                    |
 | `metrics.service.annotations`                     | Annotations for Prometheus metrics service                                                                                          | `Check values.yaml file`                                |
 | `metrics.service.loadBalancerIP`                  | loadBalancerIP if service type is `LoadBalancer`                                                                                    | `nil`                                                   |
@@ -179,7 +179,7 @@ The following tables lists the configurable parameters of the InfluxDB(TM) chart
 | `volumePermissions.image.pullPolicy`              | Init container volume-permissions image pull policy                                                                                 | `Always`                                                |
 | `volumePermissions.image.pullSecrets`             | Specify docker-registry secret names as an array                                                                                    | `[]` (does not add image pull secrets to deployed pods) |
 | `volumePermissions.securityContext.runAsUser`     | User ID for the init container (when facing issues in OpenShift or uid unknown, try value "auto")                                   | `0`                                                     |
-| `backup.enabled`                                  | enable InfluxDB(TM) backup                                                                                                          | `false`                                                 |
+| `backup.enabled`                                  | enable InfluxDB<sup>TM</sup> backup                                                                                                 | `false`                                                 |
 | `backup.directory`                                | directory where backups are stored in                                                                                               | `"/backups"`                                            |
 | `backup.retentionDays`                            | retention time in days for backups (older backups are deleted)                                                                      | `10`                                                    |
 | `backup.cronjob.schedule`                         | crontab style time schedule for backup execution                                                                                    | `"0 2 * * *"`                                           |
@@ -214,7 +214,7 @@ $ helm install my-release \
   --set adminUser.name=admin-user bitnami/influxdb
 ```
 
-The above command sets the InfluxDB(TM) admin user to `admin-user`.
+The above command sets the InfluxDB<sup>TM</sup> admin user to `admin-user`.
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
@@ -243,7 +243,7 @@ This chart includes a `values-production.yaml` file where you can find some para
 + architecture: high-availability
 ```
 
-- Increase the number of InfluxDB(TM) and InfluxDB Relay(TM) replicas:
+- Increase the number of InfluxDB<sup>TM</sup> and InfluxDB Relay<sup>TM</sup> replicas:
 
 ```diff
 - influxdb.replicaCount: 1
@@ -277,14 +277,14 @@ relay.replicaCount=2
 
 ## Standalone vs High Availability architecture
 
-You can install the InfluxDB(TM) chart with two different architecture setups: "standalone" or "high-availability", you can use the `architecture` parameter:
+You can install the InfluxDB<sup>TM</sup> chart with two different architecture setups: "standalone" or "high-availability", you can use the `architecture` parameter:
 
 ```console
 architecture="standalone"
 architecture="high-availability"
 ```
 
-The standalone architecture installs a deployment with one InfluxDB(TM) server (it cannot be scaled):
+The standalone architecture installs a deployment with one InfluxDB<sup>TM</sup> server (it cannot be scaled):
 
 ```
                ┌──────────────────┐
@@ -308,7 +308,7 @@ The standalone architecture installs a deployment with one InfluxDB(TM) server (
                  └──────────────┘
 ```
 
-The high availability install a statefulset with N InfluxDB(TM) servers and M InfluxDB Relay(TM) instances:
+The high availability install a statefulset with N InfluxDB<sup>TM</sup> servers and M InfluxDB Relay<sup>TM</sup> instances:
 
 ```
                    ┌──────────────────┐
@@ -347,9 +347,9 @@ The high availability install a statefulset with N InfluxDB(TM) servers and M In
       └───────────────────────────────────┘
 ```
 
-### Configure the way how to expose InfluxDB(TM)
+### Configure the way how to expose InfluxDB<sup>TM</sup>
 
-- **Ingress**: The ingress controller must be installed in the Kubernetes cluster. Set `ingress.enabled=true` to expose InfluxDB(TM) through Ingress.
+- **Ingress**: The ingress controller must be installed in the Kubernetes cluster. Set `ingress.enabled=true` to expose InfluxDB<sup>TM</sup> through Ingress.
 - **ClusterIP**: Exposes the service on a cluster-internal IP. Choosing this value makes the service only reachable from within the cluster. Set `influxdb.service.type=ClusterIP` to choose this service type.
 - **NodePort**: Exposes the service on each Node's IP at a static port (the NodePort). You’ll be able to contact the NodePort service, from outside the cluster, by requesting `NodeIP:NodePort`. Set `influxdb.service.type=NodePort` to choose this service type.
 - **LoadBalancer**: Exposes the service externally using a cloud provider's load balancer. Set `influxdb.service.type=LoadBalancer` to choose this service type.
@@ -358,9 +358,9 @@ The high availability install a statefulset with N InfluxDB(TM) servers and M In
 
 This helm chart supports to customize the whole configuration file.
 
-Add your custom configuration file to "files/conf" in your working directory. This file will be mounted as a configMap to the containers and it will be used for configuring InfluxDB(TM).
+Add your custom configuration file to "files/conf" in your working directory. This file will be mounted as a configMap to the containers and it will be used for configuring InfluxDB<sup>TM</sup>.
 
-Alternatively, you can specify the InfluxDB(TM) configuration using the `influxdb.configuration` parameter.
+Alternatively, you can specify the InfluxDB<sup>TM</sup> configuration using the `influxdb.configuration` parameter.
 
 In addition to these options, you can also set an external ConfigMap with all the configuration files. This is done by setting the `influxdb.existingConfiguration` parameter. Note that this will override the two previous options.
 
@@ -376,7 +376,7 @@ extraEnvVars:
 
 ### Initialize a fresh instance
 
-The [Bitnami InfluxDB(TM)](https://github.com/bitnami/bitnami-docker-influxdb) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, they must be located inside the chart folder `files/docker-entrypoint-initdb.d` so they can be consumed as a ConfigMap.
+The [Bitnami InfluxDB<sup>TM</sup>](https://github.com/bitnami/bitnami-docker-influxdb) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, they must be located inside the chart folder `files/docker-entrypoint-initdb.d` so they can be consumed as a ConfigMap.
 
 Alternatively, you can specify custom scripts using the `influxdb.initdbScripts` parameter.
 
@@ -423,7 +423,7 @@ $ helm upgrade my-release bitnami/influxdb \
 
 > Note: you need to substitute the placeholders _[ADMIN_USER_PASSWORD]_, _[USER_PASSWORD]_, _[READ_USER_PASSWORD]_, and _[WRITE_USER_PASSWORD]_ with the values obtained from instructions in the installation notes.
 
-InfluxDB(TM) and InfluxDB Relay(TM) is a trademark owned by InfluxData, which is not affiliated with, and does not endorse, this product.
+InfluxDB<sup>TM</sup> and InfluxDB Relay<sup>TM</sup> is a trademark owned by InfluxData, which is not affiliated with, and does not endorse, this product.
 
 ## Upgrading
 

--- a/bitnami/influxdb/README.md
+++ b/bitnami/influxdb/README.md
@@ -1,6 +1,6 @@
-# InfluxDB (TM)
+# InfluxDB(TM)
 
-[InfluxDB (TM)](https://www.influxdata.com/products/influxdb-overview/) is an open source time-series database designed to handle large write and read loads in real-time.
+[InfluxDB(TM)](https://www.influxdata.com/products/influxdb-overview/) is an open source time-series database designed to handle large write and read loads in real-time.
 
 ## TL;DR
 
@@ -47,105 +47,105 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Parameters
 
-The following tables lists the configurable parameters of the InfluxDB (TM) chart and their default values.
+The following tables lists the configurable parameters of the InfluxDB(TM) chart and their default values.
 
 | Parameter                                         | Description                                                                                                                         | Default                                                 |
 |---------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
 | `global.imageRegistry`                            | Global Docker image registry                                                                                                        | `nil`                                                   |
 | `global.imagePullSecrets`                         | Global Docker registry secret names as an array                                                                                     | `[]` (does not add image pull secrets to deployed pods) |
 | `global.storageClass`                             | Global storage class for dynamic provisioning                                                                                       | `nil`                                                   |
-| `image.registry`                                  | InfluxDB (TM) image registry                                                                                                        | `docker.io`                                             |
-| `image.repository`                                | InfluxDB (TM) image name                                                                                                            | `bitnami/influxdb`                                      |
-| `image.tag`                                       | InfluxDB (TM) image tag                                                                                                             | `{TAG_NAME}`                                            |
-| `image.pullPolicy`                                | InfluxDB (TM) image pull policy                                                                                                     | `IfNotPresent`                                          |
+| `image.registry`                                  | InfluxDB(TM) image registry                                                                                                         | `docker.io`                                             |
+| `image.repository`                                | InfluxDB(TM) image name                                                                                                             | `bitnami/influxdb`                                      |
+| `image.tag`                                       | InfluxDB(TM) image tag                                                                                                              | `{TAG_NAME}`                                            |
+| `image.pullPolicy`                                | InfluxDB(TM) image pull policy                                                                                                      | `IfNotPresent`                                          |
 | `image.pullSecrets`                               | Specify docker-registry secret names as an array                                                                                    | `[]` (does not add image pull secrets to deployed pods) |
 | `image.debug`                                     | Specify if debug logs should be enabled                                                                                             | `false`                                                 |
 | `nameOverride`                                    | String to partially override influxdb.fullname template with a string (will prepend the release name)                               | `nil`                                                   |
 | `fullnameOverride`                                | String to fully override influxdb.fullname template with a string                                                                   | `nil`                                                   |
 | `clusterDomain`                                   | Default Kubernetes cluster domain                                                                                                   | `cluster.local`                                         |
-| `architecture`                                    | InfluxDB (TM) architecture (`standalone` or `high-availability`)                                                                    | `standalone`                                            |
+| `architecture`                                    | InfluxDB(TM) architecture (`standalone` or `high-availability`)                                                                     | `standalone`                                            |
 | `database`                                        | Database to be created on first run                                                                                                 | `my_database`                                           |
 | `authEnabled`                                     | Enable/disable authentication                                                                                                       | `true`                                                  |
-| `adminUser.name`                                  | InfluxDB (TM) admin user name                                                                                                       | `admin`                                                 |
-| `adminUser.pwd`                                   | InfluxDB (TM) admin user's password                                                                                                 | `nil`                                                   |
+| `adminUser.name`                                  | InfluxDB(TM) admin user name                                                                                                        | `admin`                                                 |
+| `adminUser.pwd`                                   | InfluxDB(TM) admin user's password                                                                                                  | `nil`                                                   |
 | `adminUser.usePasswordFile`                       | Mount admin user's password as file instead of environment variable                                                                 | `false`                                                 |
-| `user.name`                                       | Name for InfluxDB (TM) user with 'admin' privileges on the db specified at `database`                                               | `nil`                                                   |
-| `user.pwd`                                        | InfluxDB (TM) password for `user.name` user                                                                                         | `nil`                                                   |
+| `user.name`                                       | Name for InfluxDB(TM) user with 'admin' privileges on the db specified at `database`                                                | `nil`                                                   |
+| `user.pwd`                                        | InfluxDB(TM) password for `user.name` user                                                                                          | `nil`                                                   |
 | `user.usePasswordFile`                            | Mount `user.name` user's password as file instead of environment variable                                                           | `nil`                                                   |
-| `readUser.name`                                   | Name for InfluxDB (TM) user with 'read' privileges on the db specified at `database`                                                | `nil`                                                   |
-| `readUser.pwd`                                    | InfluxDB (TM) password for `readUser.name` user                                                                                     | `nil`                                                   |
+| `readUser.name`                                   | Name for InfluxDB(TM) user with 'read' privileges on the db specified at `database`                                                 | `nil`                                                   |
+| `readUser.pwd`                                    | InfluxDB(TM) password for `readUser.name` user                                                                                      | `nil`                                                   |
 | `readUser.usePasswordFile`                        | Mount `readUser.name` user's password as file instead of environment variable                                                       | `nil`                                                   |
-| `writeUser.name`                                  | Name for InfluxDB (TM) user with 'write' privileges on the db specified at `database`                                               | `nil`                                                   |
-| `writeUser.pwd`                                   | InfluxDB (TM) password for `writeUser.name` user                                                                                    | `nil`                                                   |
+| `writeUser.name`                                  | Name for InfluxDB(TM) user with 'write' privileges on the db specified at `database`                                                | `nil`                                                   |
+| `writeUser.pwd`                                   | InfluxDB(TM) password for `writeUser.name` user                                                                                     | `nil`                                                   |
 | `writeUser.usePasswordFile`                       | Mount `writeUser.name` user's password as file instead of environment variable                                                      | `nil`                                                   |
-| `existingSecret`                                  | Name of existing Secret object with InfluxDB (TM) credentials (`adminUser.password`, `user.password`, `readUser.password`, and `writeUser.pwd` will be ignored and picked up from this secret) | `nil`|
+| `existingSecret`                                  | Name of existing Secret object with InfluxDB(TM) credentials (`adminUser.password`, `user.password`, `readUser.password`, and `writeUser.pwd` will be ignored and picked up from this secret) | `nil`|
 | `influxdb.configuration`                          | Specify content for influxdb.conf                                                                                                   | `nil (do not create influxdb.conf)`                     |
-| `influxdb.existingConfiguration`                  | Name of existing ConfigMap object with the InfluxDB (TM) configuration (`influxdb.configuration` will be ignored).                  | `nil`                                                   |
+| `influxdb.existingConfiguration`                  | Name of existing ConfigMap object with the InfluxDB(TM) configuration (`influxdb.configuration` will be ignored).                   | `nil`                                                   |
 | `influxdb.initdbScripts`                          | Dictionary of initdb scripts                                                                                                        | `nil`                                                   |
 | `influxdb.initdbScriptsCM`                        | Name of existing ConfigMap object with the initdb scripts (`influxdb.initdbScripts` will be ignored).                               | `nil`                                                   |
 | `influxdb.initdbScriptsSecret`                    | Secret with initdb scripts that contain sensitive information (Note: can be used with `initdbScriptsConfigMap` or `initdbScripts`)  | `nil`                                                   |
-| `influxdb.extraEnvVars`                           | Array containing extra env vars to configure InfluxDB (TM)                                                                          | `nil`                                                   |
-| `influxdb.replicaCount`                           | The number of InfluxDB (TM) replicas to deploy                                                                                      | `1`                                                     |
-| `influxdb.podAffinityPreset`                      | InfluxDB Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                        | `""`                                                    |
-| `influxdb.podAntiAffinityPreset`                  | InfluxDB Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                   | `""`                                                    |
-| `influxdb.nodeAffinityPreset.type`                | InfluxDB Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                  | `""`                                                    |
-| `influxdb.nodeAffinityPreset.key`                 | InfluxDB Node label key to match Ignored if `affinity` is set.                                                                      | `""`                                                    |
-| `influxdb.nodeAffinityPreset.values`              | InfluxDB Node label values to match. Ignored if `affinity` is set.                                                                  | `[]`                                                    |
-| `influxdb.affinity`                               | InfluxDB Affinity for pod assignment                                                                                                | `{}` (evaluated as a template)                          |
-| `influxdb.nodeSelector`                           | InfluxDB Node labels for pod assignment                                                                                             | `{}` (evaluated as a template)                          |
-| `influxdb.tolerations`                            | InfluxDB Tolerations for pod assignment                                                                                             | `[]` (evaluated as a template)                          |
+| `influxdb.extraEnvVars`                           | Array containing extra env vars to configure InfluxDB(TM)                                                                           | `nil`                                                   |
+| `influxdb.replicaCount`                           | The number of InfluxDB(TM) replicas to deploy                                                                                       | `1`                                                     |
+| `influxdb.podAffinityPreset`                      | InfluxDB(TM) Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                    | `""`                                                    |
+| `influxdb.podAntiAffinityPreset`                  | InfluxDB(TM) Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                               | `""`                                                    |
+| `influxdb.nodeAffinityPreset.type`                | InfluxDB(TM) Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                              | `""`                                                    |
+| `influxdb.nodeAffinityPreset.key`                 | InfluxDB(TM) Node label key to match Ignored if `affinity` is set.                                                                  | `""`                                                    |
+| `influxdb.nodeAffinityPreset.values`              | InfluxDB(TM) Node label values to match. Ignored if `affinity` is set.                                                              | `[]`                                                    |
+| `influxdb.affinity`                               | InfluxDB(TM) Affinity for pod assignment                                                                                            | `{}` (evaluated as a template)                          |
+| `influxdb.nodeSelector`                           | InfluxDB(TM) Node labels for pod assignment                                                                                         | `{}` (evaluated as a template)                          |
+| `influxdb.tolerations`                            | InfluxDB(TM) Tolerations for pod assignment                                                                                         | `[]` (evaluated as a template)                          |
 | `infludb.podManagementPolicy`                     | Pod Management Policy [`OrderedReady` or `Parallel`]                                                                                | `OrderedReady`                                          |
-| `influxdb.securityContext.enabled`                | Enable security context for InfluxDB (TM)                                                                                           | `true`                                                  |
-| `influxdb.securityContext.fsGroup`                | Group ID for the InfluxDB (TM) filesystem                                                                                           | `1001`                                                  |
-| `influxdb.securityContext.runAsUser`              | User ID for the InfluxDB (TM) container                                                                                             | `1001`                                                  |
+| `influxdb.securityContext.enabled`                | Enable security context for InfluxDB(TM)                                                                                            | `true`                                                  |
+| `influxdb.securityContext.fsGroup`                | Group ID for the InfluxDB(TM) filesystem                                                                                            | `1001`                                                  |
+| `influxdb.securityContext.runAsUser`              | User ID for the InfluxDB(TM) container                                                                                              | `1001`                                                  |
 | `influxdb.resources`                              | The [resources] to allocate for container                                                                                           | `{}`                                                    |
-| `influxdb.livenessProbe`                          | Liveness probe configuration for InfluxDB (TM)                                                                                      | `Check values.yaml file`                                |
-| `influxdb.readinessProbe`                         | Readiness probe configuration for InfluxDB (TM)                                                                                     | `Check values.yaml file`                                |
-| `influxdb.containerPorts.http`                    | InfluxDB (TM) container HTTP port                                                                                                   | `8086`                                                  |
-| `influxdb.containerPorts.rpc`                     | InfluxDB (TM) container RPC port                                                                                                    | `8088`                                                  |
+| `influxdb.livenessProbe`                          | Liveness probe configuration for InfluxDB(TM)                                                                                       | `Check values.yaml file`                                |
+| `influxdb.readinessProbe`                         | Readiness probe configuration for InfluxDB(TM)                                                                                      | `Check values.yaml file`                                |
+| `influxdb.containerPorts.http`                    | InfluxDB(TM) container HTTP port                                                                                                    | `8086`                                                  |
+| `influxdb.containerPorts.rpc`                     | InfluxDB(TM) container RPC port                                                                                                     | `8088`                                                  |
 | `influxdb.service.type`                           | Kubernetes service type (`ClusterIP`, `NodePort` or `LoadBalancer`)                                                                 | `ClusterIP`                                             |
-| `influxdb.service.port`                           | InfluxDB (TM) HTTP port                                                                                                             | `8086`                                                  |
-| `influxdb.service.rpcPort`                        | InfluxDB (TM) RPC port                                                                                                              | `8088`                                                  |
+| `influxdb.service.port`                           | InfluxDB(TM) HTTP port                                                                                                              | `8086`                                                  |
+| `influxdb.service.rpcPort`                        | InfluxDB(TM) RPC port                                                                                                               | `8088`                                                  |
 | `influxdb.service.nodePorts.http`                 | Kubernetes HTTP node port                                                                                                           | `""`                                                    |
 | `influxdb.service.nodePorts.rpc`                  | Kubernetes RPC node port                                                                                                            | `""`                                                    |
-| `influxdb.service.annotations`                    | Annotations for InfluxDB (TM) service                                                                                               | `{}`                                                    |
+| `influxdb.service.annotations`                    | Annotations for InfluxDB(TM) service                                                                                                | `{}`                                                    |
 | `influxdb.service.loadBalancerIP`                 | loadBalancerIP if service type is `LoadBalancer`                                                                                    | `nil`                                                   |
 | `influxdb.service.loadBalancerSourceRanges`       | Address that are allowed when service is LoadBalancer                                                                               | `[]`                                                    |
 | `influxdb.service.clusterIP`                      | Static clusterIP or None for headless services                                                                                      | `nil`                                                   |
-| `relay.image.registry`                            | InfluxDB Relay (TM) image registry                                                                                                  | `docker.io`                                             |
-| `relay.image.repository`                          | InfluxDB Relay (TM) image name                                                                                                      | `bitnami/influxdb-relay`                                |
-| `relay.image.tag`                                 | InfluxDB Relay (TM) image tag                                                                                                       | `{TAG_NAME}`                                            |
-| `relay.image.pullPolicy`                          | InfluxDB Relay (TM) image pull policy                                                                                               | `IfNotPresent`                                          |
+| `relay.image.registry`                            | InfluxDB Relay(TM) image registry                                                                                                   | `docker.io`                                             |
+| `relay.image.repository`                          | InfluxDB Relay(TM) image name                                                                                                       | `bitnami/influxdb-relay`                                |
+| `relay.image.tag`                                 | InfluxDB Relay(TM) image tag                                                                                                        | `{TAG_NAME}`                                            |
+| `relay.image.pullPolicy`                          | InfluxDB Relay(TM) image pull policy                                                                                                | `IfNotPresent`                                          |
 | `relay.image.pullSecrets`                         | Specify docker-registry secret names as an array                                                                                    | `[]` (does not add image pull secrets to deployed pods) |
 | `relay.configuration`                             | Specify content for relay.toml                                                                                                      | `Check values.yaml file`                                |
-| `relay.existingConfiguration`                     | Name of existing ConfigMap object with the InfluxDB Relay (TM) configuration (`relay.configuration` will be ignored)                | `nil`                                                   |
-| `relay.replicaCount`                              | The number of InfluxDB Relay (TM) replicas to deploy                                                                                | `1`                                                     |
-| `relay.podAffinityPreset`                         | InfluxDB Relay Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                  | `""`                                                    |
-| `relay.podAntiAffinityPreset`                     | InfluxDB Relay Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                             | `""`                                                    |
-| `relay.nodeAffinityPreset.type`                   | InfluxDB Relay Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                            | `""`                                                    |
-| `relay.nodeAffinityPreset.key`                    | InfluxDB Relay Node label key to match Ignored if `affinity` is set.                                                                | `""`                                                    |
-| `relay.nodeAffinityPreset.values`                 | InfluxDB Relay Node label values to match. Ignored if `affinity` is set.                                                            | `[]`                                                    |
-| `relay.affinity`                                  | InfluxDB Relay Affinity for pod assignment                                                                                          | `{}` (evaluated as a template)                          |
-| `relay.nodeSelector`                              | InfluxDB Relay Node labels for pod assignment                                                                                       | `{}` (evaluated as a template)                          |
-| `relay.tolerations`                               | InfluxDB Relay Tolerations for pod assignment                                                                                       | `[]` (evaluated as a template)                          |
-| `relay.securityContext.enabled`                   | Enable security context for InfluxDB Relay (TM)                                                                                     | `true`                                                  |
-| `relay.securityContext.fsGroup`                   | Group ID for the InfluxDB Relay (TM) filesystem                                                                                     | `1001`                                                  |
-| `relay.securityContext.runAsUser`                 | User ID for the InfluxDB Relay (TM) container                                                                                       | `1001`                                                  |
+| `relay.existingConfiguration`                     | Name of existing ConfigMap object with the InfluxDB Relay(TM) configuration (`relay.configuration` will be ignored)                 | `nil`                                                   |
+| `relay.replicaCount`                              | The number of InfluxDB Relay(TM) replicas to deploy                                                                                 | `1`                                                     |
+| `relay.podAffinityPreset`                         | InfluxDB Relay(TM) Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                              | `""`                                                    |
+| `relay.podAntiAffinityPreset`                     | InfluxDB Relay(TM) Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                         | `""`                                                    |
+| `relay.nodeAffinityPreset.type`                   | InfluxDB Relay(TM) Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                        | `""`                                                    |
+| `relay.nodeAffinityPreset.key`                    | InfluxDB Relay(TM) Node label key to match Ignored if `affinity` is set.                                                            | `""`                                                    |
+| `relay.nodeAffinityPreset.values`                 | InfluxDB Relay(TM) Node label values to match. Ignored if `affinity` is set.                                                        | `[]`                                                    |
+| `relay.affinity`                                  | InfluxDB Relay(TM) Affinity for pod assignment                                                                                      | `{}` (evaluated as a template)                          |
+| `relay.nodeSelector`                              | InfluxDB Relay(TM) Node labels for pod assignment                                                                                   | `{}` (evaluated as a template)                          |
+| `relay.tolerations`                               | InfluxDB Relay(TM) Tolerations for pod assignment                                                                                   | `[]` (evaluated as a template)                          |
+| `relay.securityContext.enabled`                   | Enable security context for InfluxDB Relay(TM)                                                                                      | `true`                                                  |
+| `relay.securityContext.fsGroup`                   | Group ID for the InfluxDB Relay(TM) filesystem                                                                                      | `1001`                                                  |
+| `relay.securityContext.runAsUser`                 | User ID for the InfluxDB Relay(TM) container                                                                                        | `1001`                                                  |
 | `relay.resources`                                 | The [resources] to allocate for container                                                                                           | `{}`                                                    |
-| `relay.livenessProbe`                             | Liveness probe configuration for InfluxDB Relay (TM)                                                                                | `Check values.yaml file`                                |
-| `relay.readinessProbe`                            | Readiness probe configuration for InfluxDB Relay (TM)                                                                               | `Check values.yaml file`                                |
-| `relay.containerPorts.http`                       | InfluxDB Relay (TM) container HTTP port                                                                                             | `9096`                                                  |
+| `relay.livenessProbe`                             | Liveness probe configuration for InfluxDB Relay(TM)                                                                                 | `Check values.yaml file`                                |
+| `relay.readinessProbe`                            | Readiness probe configuration for InfluxDB Relay(TM)                                                                                | `Check values.yaml file`                                |
+| `relay.containerPorts.http`                       | InfluxDB Relay(TM) container HTTP port                                                                                              | `9096`                                                  |
 | `relay.service.type`                              | Kubernetes service type (`ClusterIP`, `NodePort` or `LoadBalancer`)                                                                 | `ClusterIP`                                             |
-| `relay.service.port`                              | InfluxDB Relay (TM) HTTP port                                                                                                       | `9096`                                                  |
+| `relay.service.port`                              | InfluxDB Relay(TM) HTTP port                                                                                                        | `9096`                                                  |
 | `relay.service.nodePort`                          | Kubernetes HTTP node port                                                                                                           | `""`                                                    |
-| `relay.service.annotations`                       | Annotations for InfluxDB Relay (TM) service                                                                                         | `{}`                                                    |
+| `relay.service.annotations`                       | Annotations for InfluxDB Relay(TM) service                                                                                          | `{}`                                                    |
 | `relay.service.loadBalancerIP`                    | loadBalancerIP if service type is `LoadBalancer`                                                                                    | `nil`                                                   |
 | `relay.service.loadBalancerSourceRanges`          | Address that are allowed when service is LoadBalancer                                                                               | `[]`                                                    |
 | `relay.service.clusterIP`                         | Static clusterIP or None for headless services                                                                                      | `nil`                                                   |
 | `ingress.enabled`                                 | Enable ingress controller resource                                                                                                  | `false`                                                 |
 | `ingress.certManager`                             | Add annotations for cert-manager                                                                                                    | `false`                                                 |
 | `ingress.annotations`                             | Ingress annotations                                                                                                                 | `[]`                                                    |
-| `ingress.hosts[0].name`                           | Hostname for InfluxDB (TM) service                                                                                                  | `influxdb.local`                                        |
+| `ingress.hosts[0].name`                           | Hostname for InfluxDB(TM) service                                                                                                   | `influxdb.local`                                        |
 | `ingress.hosts[0].path`                           | Path within the url structure                                                                                                       | `/`                                                     |
 | `ingress.tls[0].hosts[0]`                         | TLS hosts                                                                                                                           | `influxdb.local`                                        |
 | `ingress.tls[0].secretName`                       | TLS Secret (certificates)                                                                                                           | `influxdb.local-tls`                                    |
@@ -154,7 +154,7 @@ The following tables lists the configurable parameters of the InfluxDB (TM) char
 | `ingress.secrets[0].key`                          | TLS Secret Key                                                                                                                      | `nil`                                                   |
 | `metrics.enabled`                                 | Enable the export of Prometheus metrics                                                                                             | `false`                                                 |
 | `metrics.service.type`                            | Kubernetes service type (`ClusterIP`, `NodePort` or `LoadBalancer`)                                                                 | `ClusterIP`                                             |
-| `metrics.service.port`                            | InfluxDB (TM) Prometheus port                                                                                                       | `9122`                                                  |
+| `metrics.service.port`                            | InfluxDB(TM) Prometheus port                                                                                                        | `9122`                                                  |
 | `metrics.service.nodePort`                        | Kubernetes HTTP node port                                                                                                           | `""`                                                    |
 | `metrics.service.annotations`                     | Annotations for Prometheus metrics service                                                                                          | `Check values.yaml file`                                |
 | `metrics.service.loadBalancerIP`                  | loadBalancerIP if service type is `LoadBalancer`                                                                                    | `nil`                                                   |
@@ -179,14 +179,14 @@ The following tables lists the configurable parameters of the InfluxDB (TM) char
 | `volumePermissions.image.pullPolicy`              | Init container volume-permissions image pull policy                                                                                 | `Always`                                                |
 | `volumePermissions.image.pullSecrets`             | Specify docker-registry secret names as an array                                                                                    | `[]` (does not add image pull secrets to deployed pods) |
 | `volumePermissions.securityContext.runAsUser`     | User ID for the init container (when facing issues in OpenShift or uid unknown, try value "auto")                                   | `0`                                                     |
-| `backup.enabled`                                  | enable InfluxDB (TM) backup                                                                                                         | `false`                                                 |
+| `backup.enabled`                                  | enable InfluxDB(TM) backup                                                                                                          | `false`                                                 |
 | `backup.directory`                                | directory where backups are stored in                                                                                               | `"/backups"`                                            |
 | `backup.retentionDays`                            | retention time in days for backups (older backups are deleted)                                                                      | `10`                                                    |
 | `backup.cronjob.schedule`                         | crontab style time schedule for backup execution                                                                                    | `"0 2 * * *"`                                           |
 | `backup.cronjob.historyLimit`                     | cronjob historylimit                                                                                                                | `1`                                                     |
 | `backup.cronjob.annotations`                      | backup pod annotations                                                                                                              | `{}`                                                    |
 | `backup.uploadProviders.google.enabled`           | enable upload to google storage bucket                                                                                              | `false`                                                 |
-| `backup.uploadProviders.google.secret`            | json secret with serviceaccount data to access Google storage bucket                                                               | `""`                                                    |
+| `backup.uploadProviders.google.secret`            | json secret with serviceaccount data to access Google storage bucket                                                                | `""`                                                    |
 | `backup.uploadProviders.google.secretKey`         | service account secret key name                                                                                                     | `"key.json"`                                            |
 | `backup.uploadProviders.google.existingSecret`    | Name of existing secret object with Google serviceaccount json credentials                                                          | `""`                                                    |
 | `backup.uploadProviders.google.bucketName`        | google storage bucket name name                                                                                                     | `"gs://bucket/influxdb"`                                |
@@ -196,7 +196,7 @@ The following tables lists the configurable parameters of the InfluxDB (TM) char
 | `backup.uploadProviders.google.image.pullPolicy`  | Google Cloud SDK image pull policy                                                                                                  | `IfNotPresent`                                          |
 | `backup.uploadProviders.google.image.pullSecrets` | Specify docker-registry secret names as an array                                                                                    | `[]` (does not add image pull secrets to deployed pods) |
 | `backup.uploadProviders.azure.enabled`            | enable upload to azure storage container                                                                                            | `false`                                                 |
-| `backup.uploadProviders.azure.secret`             | secret with credentials to access Azure storage                                                                                    | `""`                                                    |
+| `backup.uploadProviders.azure.secret`             | secret with credentials to access Azure storage                                                                                     | `""`                                                    |
 | `backup.uploadProviders.azure.secretKey`          | service account secret key name                                                                                                     | `"connection-string"`                                   |
 | `backup.uploadProviders.azure.existingSecret`     | Name of existing secret object                                                                                                      | `""`                                                    |
 | `backup.uploadProviders.azure.containerName`      | destination container                                                                                                               | `"influxdb-container"`                                  |
@@ -214,7 +214,7 @@ $ helm install my-release \
   --set adminUser.name=admin-user bitnami/influxdb
 ```
 
-The above command sets the InfluxDB (TM) admin user to `admin-user`.
+The above command sets the InfluxDB(TM) admin user to `admin-user`.
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
@@ -243,7 +243,7 @@ This chart includes a `values-production.yaml` file where you can find some para
 + architecture: high-availability
 ```
 
-- Increase the number of InfluxDB (TM) and InfluxDB Relay (TM) replicas:
+- Increase the number of InfluxDB(TM) and InfluxDB Relay(TM) replicas:
 
 ```diff
 - influxdb.replicaCount: 1
@@ -277,14 +277,14 @@ relay.replicaCount=2
 
 ## Standalone vs High Availability architecture
 
-You can install the InfluxDB (TM) chart with two different architecture setups: "standalone" or "high-availability", you can use the `architecture` parameter:
+You can install the InfluxDB(TM) chart with two different architecture setups: "standalone" or "high-availability", you can use the `architecture` parameter:
 
 ```console
 architecture="standalone"
 architecture="high-availability"
 ```
 
-The standalone architecture installs a deployment with one InfluxDB (TM) server (it cannot be scaled):
+The standalone architecture installs a deployment with one InfluxDB(TM) server (it cannot be scaled):
 
 ```
                ┌──────────────────┐
@@ -296,60 +296,60 @@ The standalone architecture installs a deployment with one InfluxDB (TM) server 
                         │ /write
                         ▼
                 ┌────────────────┐
-                │    InfluxDB    │
+                │  InfluxDB(TM)  │
                 |      svc       │
                 └───────┬────────┘
                         │
                         ▼
-                  ┌──────────┐
-                  │ InfluxDB │
-                  │  Server  │
-                  │   Pod    │
-                  └──────────┘
+                 ┌──────────────┐
+                 │ InfluxDB(TM) │
+                 │    Server    │
+                 │     Pod      │
+                 └──────────────┘
 ```
 
-The high availability install a statefulset with N InfluxDB (TM) servers and M InfluxDB Relay (TM) instances:
+The high availability install a statefulset with N InfluxDB(TM) servers and M InfluxDB Relay(TM) instances:
 
 ```
-               ┌──────────────────┐
-               │     Ingress      │
-               │    Controller    │
-               └───────┬─┬────────┘
-                       │ │
-                       │ │
-          ┌────────────┘ └─────────────┐
-          │                            │
-          │ /write              /query │
-          ▼                            ▼
-      ┌────────────────┐  ┌────────────────┐
-      │ InfluxDB Relay │  │    InfluxDB    │
-      │      svc       │  │      svc       │
-      └───────┬─┬──────┘  └─────┬─┬────────┘
-      ┌────── │─|───────────────|─│───────┐
-      |       │ |               | │       ▼
-┌─────┴────┐  │ |               | │  ┌──────────┐
-│ InfluxDB │  │ |               | │  │ InfluxDB │
-│  Relay   │◀─┘ |               | └─▶│  Server  │
-│   Pod    │    │               │    │   Pod    │
-└─────┬────┘    │               │    └──────────┘
-      |         │               │           ▲
-      └─────────│───────────────│─────┐     |
-                │               │     |     |
-  ┌──────────── │───────────────│───────────┘
-  |             │               │     |
-  |             │               │     ▼
-┌─┴────────┐    │               │   ┌──────────┐
-│ InfluxDB │    │               │   │ InfluxDB │
-│  Relay   │◀───┘               └──▶│  Server  │
-│   Pod    │                        │   Pod    │
-└─────┬────┘                        └──────────┘
+                   ┌──────────────────┐
+                   │     Ingress      │
+                   │    Controller    │
+                   └───────┬─┬────────┘
+                           │ │
+                           │ │
+              ┌────────────┘ └─────────────┐
+              │                            │
+              │ /write              /query │
+              ▼                            ▼
+      ┌────────────────────┐  ┌────────────────────┐
+      │ InfluxDB Relay(TM) │  │    InfluxDB(TM)    │
+      │          svc       │  │         svc        │
+      └───────────┬─┬──────┘  └─────┬─────┬────────┘
+      ┌────────── │─|───────────────|─────│───────┐
+      |           │ |               |     │       ▼
+┌─────┴────────┐  │ |               |     │  ┌──────────────┐
+│   InfluxDB   │  │ |               |     │  │ InfluxDB(TM) │
+│  Relay(TM)   │◀─┘ |               |     └─▶│    Server    │
+│     Pod      │    │               │        │     Pod      │
+└─────┬────────┘    │               │        └──────────────┘
+      |             │               │           ▲
+      └─────────────│───────────────│───────┐   |
+                    │               │       |   |
+  ┌──────────────── │───────────────│───────────┘
+  |                 │               │       |
+  |                 │               │       ▼
+┌─┴─────────────┐   │               │   ┌──────────────┐
+│    InfluxDB   │   │               │   │ InfluxDB(TM) │
+│   Relay(TM)   │◀──┘               └──▶│  Server      │
+│      Pod      │                       │   Pod        │
+└─────┬─────────┘                       └──────────────┘
       |                                   ▲
       └───────────────────────────────────┘
 ```
 
-### Configure the way how to expose InfluxDB (TM)
+### Configure the way how to expose InfluxDB(TM)
 
-- **Ingress**: The ingress controller must be installed in the Kubernetes cluster. Set `ingress.enabled=true` to expose InfluxDB (TM) through Ingress.
+- **Ingress**: The ingress controller must be installed in the Kubernetes cluster. Set `ingress.enabled=true` to expose InfluxDB(TM) through Ingress.
 - **ClusterIP**: Exposes the service on a cluster-internal IP. Choosing this value makes the service only reachable from within the cluster. Set `influxdb.service.type=ClusterIP` to choose this service type.
 - **NodePort**: Exposes the service on each Node's IP at a static port (the NodePort). You’ll be able to contact the NodePort service, from outside the cluster, by requesting `NodeIP:NodePort`. Set `influxdb.service.type=NodePort` to choose this service type.
 - **LoadBalancer**: Exposes the service externally using a cloud provider's load balancer. Set `influxdb.service.type=LoadBalancer` to choose this service type.
@@ -358,9 +358,9 @@ The high availability install a statefulset with N InfluxDB (TM) servers and M I
 
 This helm chart supports to customize the whole configuration file.
 
-Add your custom configuration file to "files/conf" in your working directory. This file will be mounted as a configMap to the containers and it will be used for configuring InfluxDB (TM).
+Add your custom configuration file to "files/conf" in your working directory. This file will be mounted as a configMap to the containers and it will be used for configuring InfluxDB(TM).
 
-Alternatively, you can specify the InfluxDB (TM) configuration using the `influxdb.configuration` parameter.
+Alternatively, you can specify the InfluxDB(TM) configuration using the `influxdb.configuration` parameter.
 
 In addition to these options, you can also set an external ConfigMap with all the configuration files. This is done by setting the `influxdb.existingConfiguration` parameter. Note that this will override the two previous options.
 
@@ -376,7 +376,7 @@ extraEnvVars:
 
 ### Initialize a fresh instance
 
-The [Bitnami InfluxDB (TM)](https://github.com/bitnami/bitnami-docker-influxdb) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, they must be located inside the chart folder `files/docker-entrypoint-initdb.d` so they can be consumed as a ConfigMap.
+The [Bitnami InfluxDB(TM)](https://github.com/bitnami/bitnami-docker-influxdb) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, they must be located inside the chart folder `files/docker-entrypoint-initdb.d` so they can be consumed as a ConfigMap.
 
 Alternatively, you can specify custom scripts using the `influxdb.initdbScripts` parameter.
 
@@ -423,7 +423,7 @@ $ helm upgrade my-release bitnami/influxdb \
 
 > Note: you need to substitute the placeholders _[ADMIN_USER_PASSWORD]_, _[USER_PASSWORD]_, _[READ_USER_PASSWORD]_, and _[WRITE_USER_PASSWORD]_ with the values obtained from instructions in the installation notes.
 
-InfluxDB (TM) and InfluxDB Relay (TM) is a trademark owned by InfluxData, which is not affiliated with, and does not endorse, this product.
+InfluxDB(TM) and InfluxDB Relay(TM) is a trademark owned by InfluxData, which is not affiliated with, and does not endorse, this product.
 
 ## Upgrading
 

--- a/bitnami/influxdb/README.md
+++ b/bitnami/influxdb/README.md
@@ -2,6 +2,8 @@
 
 [InfluxDB<sup>TM</sup>](https://www.influxdata.com/products/influxdb-overview/) is an open source time-series database designed to handle large write and read loads in real-time.
 
+Disclaimer: The respective trademarks mentioned in the offering are owned by the respective companies. We do not provide a commercial license for any of these products. This listing has an open-source license. InfluxDB<sup>TM</sup> and InfluxDB Relay<sup>TM</sup> are run and maintained by InfluxData, which is a completely separate project from Bitnami.
+
 ## TL;DR
 
 ```console
@@ -422,8 +424,6 @@ $ helm upgrade my-release bitnami/influxdb \
 ```
 
 > Note: you need to substitute the placeholders _[ADMIN_USER_PASSWORD]_, _[USER_PASSWORD]_, _[READ_USER_PASSWORD]_, and _[WRITE_USER_PASSWORD]_ with the values obtained from instructions in the installation notes.
-
-InfluxDB<sup>TM</sup> and InfluxDB Relay<sup>TM</sup> is a trademark owned by InfluxData, which is not affiliated with, and does not endorse, this product.
 
 ## Upgrading
 

--- a/bitnami/influxdb/files/conf/README.md
+++ b/bitnami/influxdb/files/conf/README.md
@@ -1,6 +1,6 @@
-Place your InfluxDB and InfluxDB Relay configuration files here. These will not be used in case the values *existingConfiguration*, *relay.existingConfiguration* are used.
+Place your InfluxDB(TM) and InfluxDB Relay(TM) configuration files here. These will not be used in case the values *existingConfiguration*, *relay.existingConfiguration* are used.
 
 More information can be found in the links below:
 
-- [InfluxDB Configuration File](https://github.com/bitnami/bitnami-docker-influxdb#configuration-file)
-- [InfluxDB Relay Configuration File](https://github.com/bitnami/bitnami-docker-influxdb-relay#configuration)
+- [InfluxDB(TM) Configuration File](https://github.com/bitnami/bitnami-docker-influxdb#configuration-file)
+- [InfluxDB Relay(TM) Configuration File](https://github.com/bitnami/bitnami-docker-influxdb-relay#configuration)

--- a/bitnami/influxdb/files/conf/README.md
+++ b/bitnami/influxdb/files/conf/README.md
@@ -1,6 +1,6 @@
-Place your InfluxDB(TM) and InfluxDB Relay(TM) configuration files here. These will not be used in case the values *existingConfiguration*, *relay.existingConfiguration* are used.
+Place your InfluxDB<sup>TM</sup> and InfluxDB Relay<sup>TM</sup> configuration files here. These will not be used in case the values *existingConfiguration*, *relay.existingConfiguration* are used.
 
 More information can be found in the links below:
 
-- [InfluxDB(TM) Configuration File](https://github.com/bitnami/bitnami-docker-influxdb#configuration-file)
-- [InfluxDB Relay(TM) Configuration File](https://github.com/bitnami/bitnami-docker-influxdb-relay#configuration)
+- [InfluxDB<sup>TM</sup> Configuration File](https://github.com/bitnami/bitnami-docker-influxdb#configuration-file)
+- [InfluxDB Relay<sup>TM</sup> Configuration File](https://github.com/bitnami/bitnami-docker-influxdb-relay#configuration)

--- a/bitnami/influxdb/templates/NOTES.txt
+++ b/bitnami/influxdb/templates/NOTES.txt
@@ -2,16 +2,16 @@
 ** Please be patient while the chart is being deployed **
 
 
-InfluxDB can be accessed through following DNS names from within your cluster:
+InfluxDB(TM) can be accessed through following DNS names from within your cluster:
 
     {{- if eq .Values.architecture "high-availability" }}
-    InfluxDB Relay (write operations): {{ include "influxdb.fullname" . }}-relay.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} (port {{ .Values.relay.service.port }})
-    InfluxDB servers (read operations):  {{ include "influxdb.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} (port {{ .Values.influxdb.service.port }})
+    InfluxDB Relay(TM) (write operations): {{ include "influxdb.fullname" . }}-relay.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} (port {{ .Values.relay.service.port }})
+    InfluxDB(TM) servers (read operations):  {{ include "influxdb.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} (port {{ .Values.influxdb.service.port }})
     {{- else }}
-    InfluxDB: {{ include "influxdb.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} (port {{ .Values.influxdb.service.port }})
+    InfluxDB(TM): {{ include "influxdb.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} (port {{ .Values.influxdb.service.port }})
     {{- end }}
     {{- if .Values.metrics.enabled }}
-    InfluxDB Prometheus Metrics: {{ include "influxdb.fullname" . }}-metrics.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} (port {{ .Values.metrics.service.port }})
+    InfluxDB(TM) Prometheus Metrics: {{ include "influxdb.fullname" . }}-metrics.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} (port {{ .Values.metrics.service.port }})
     {{- end }}
 
 {{- if .Values.authEnabled }}
@@ -63,7 +63,7 @@ To connect to your database run the following commands:
 
 {{- if and (.Values.networkPolicy.enabled) (not .Values.networkPolicy.allowExternal) }}
 
-Note: Since NetworkPolicy is enabled, only pods with label "{{ include "influxdb.fullname" . }}-client=true" will be able to connect to InfluxDB server(s).
+Note: Since NetworkPolicy is enabled, only pods with label "{{ include "influxdb.fullname" . }}-client=true" will be able to connect to InfluxDB(TM) server(s).
 
 {{- end }}
 
@@ -72,7 +72,7 @@ To connect to your database from outside the cluster execute the following comma
 {{- if .Values.ingress.enabled }}
 {{- $ingressHost := first .Values.ingress.hosts }}
 
-  You should be able to access your new InfluxDB server(s) through:
+  You should be able to access your new InfluxDB(TM) server(s) through:
 
     {{- range .Values.ingress.hosts }}
     {{ if .tls }}https{{- else }}http{{ end }}://{{ .name }}

--- a/bitnami/influxdb/templates/_helpers.tpl
+++ b/bitnami/influxdb/templates/_helpers.tpl
@@ -50,7 +50,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{/*
-Return the proper InfluxDB image name
+Return the proper InfluxDB(TM) image name
 */}}
 {{- define "influxdb.image" -}}
 {{- $registryName := .Values.image.registry -}}
@@ -73,7 +73,7 @@ Also, we can't use a single if because lazy evaluation is not an option
 {{- end -}}
 
 {{/*
-Return the proper InfluxDB Relay image name
+Return the proper InfluxDB Relay(TM) image name
 */}}
 {{- define "influxdb.relay.image" -}}
 {{- $registryName := .Values.relay.image.registry -}}
@@ -206,7 +206,7 @@ imagePullSecrets:
 {{- end -}}
 
 {{/*
-Return the InfluxDB credentials secret.
+Return the InfluxDB(TM) credentials secret.
 */}}
 {{- define "influxdb.secretName" -}}
 {{- if .Values.existingSecret -}}
@@ -217,7 +217,7 @@ Return the InfluxDB credentials secret.
 {{- end -}}
 
 {{/*
-Return the InfluxDB configuration configmap.
+Return the InfluxDB(TM) configuration configmap.
 */}}
 {{- define "influxdb.configmapName" -}}
 {{- if .Values.influxdb.existingConfiguration -}}
@@ -228,7 +228,7 @@ Return the InfluxDB configuration configmap.
 {{- end -}}
 
 {{/*
-Return the InfluxDB PVC name.
+Return the InfluxDB(TM) PVC name.
 */}}
 {{- define "influxdb.claimName" -}}
 {{- if .Values.persistence.existingClaim }}
@@ -239,7 +239,7 @@ Return the InfluxDB PVC name.
 {{- end -}}
 
 {{/*
-Return the InfluxDB initialization scripts configmap.
+Return the InfluxDB(TM) initialization scripts configmap.
 */}}
 {{- define "influxdb.initdbScriptsConfigmapName" -}}
 {{- if .Values.influxdb.initdbScriptsCM -}}
@@ -250,14 +250,14 @@ Return the InfluxDB initialization scripts configmap.
 {{- end -}}
 
 {{/*
-Get the InfluxDB initialization scripts secret.
+Get the InfluxDB(TM) initialization scripts secret.
 */}}
 {{- define "influxdb.initdbScriptsSecret" -}}
 {{- printf "%s" (tpl .Values.influxdb.initdbScriptsSecret $) -}}
 {{- end -}}
 
 {{/*
-Return the InfluxDB configuration configmap.
+Return the InfluxDB(TM) configuration configmap.
 */}}
 {{- define "influxdb.relay.configmapName" -}}
 {{- if .Values.relay.existingConfiguration -}}
@@ -268,7 +268,7 @@ Return the InfluxDB configuration configmap.
 {{- end -}}
 
 {{/*
-Return the proper Storage Class for InfluxDB
+Return the proper Storage Class for InfluxDB(TM)
 */}}
 {{- define "influxdb.storageClass" -}}
 {{/*
@@ -338,7 +338,7 @@ Compile all warnings into a single message, and call fail.
 {{- end -}}
 {{- end -}}
 
-{{/* Validate values of InfluxDB - must provide a valid architecture */}}
+{{/* Validate values of InfluxDB(TM) - must provide a valid architecture */}}
 {{- define "influxdb.validateValues.architecture" -}}
 {{- if and (ne .Values.architecture "standalone") (ne .Values.architecture "high-availability") -}}
 influxdb: architecture
@@ -347,7 +347,7 @@ influxdb: architecture
 {{- end -}}
 {{- end -}}
 
-{{/* Validate values of InfluxDB - number of replicas */}}
+{{/* Validate values of InfluxDB(TM) - number of replicas */}}
 {{- define "influxdb.validateValues.replicaCount" -}}
 {{- $replicaCount := int .Values.influxdb.replicaCount }}
 {{- if and (eq .Values.architecture "standalone") (gt $replicaCount 1) -}}

--- a/bitnami/influxdb/values-production.yaml
+++ b/bitnami/influxdb/values-production.yaml
@@ -12,7 +12,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-## Bitnami InfluxDB image
+## Bitnami InfluxDB(TM) image
 ## ref: https://hub.docker.com/r/bitnami/influxdb/tags/
 ##
 image:
@@ -46,7 +46,7 @@ image:
 ##
 clusterDomain: cluster.local
 
-## InfluxDB architecture. Allowed values: standalone or high-availability
+## InfluxDB(TM) architecture. Allowed values: standalone or high-availability
 ##
 architecture: high-availability
 
@@ -60,40 +60,40 @@ database: my_database
 ##
 authEnabled: true
 
-## InfluxDB admin credentials
+## InfluxDB(TM) admin credentials
 ##
 adminUser:
   name: admin
   pwd:
   usePasswordFile: false
-## InfluxDB credentials for user with 'admin' privileges on the db specified at 'database' parameter
+## InfluxDB(TM) credentials for user with 'admin' privileges on the db specified at 'database' parameter
 ##
 user:
   name:
   pwd:
   usePasswordFile: false
-## InfluxDB credentials for user with 'read' privileges on the db specified at 'database' parameter
+## InfluxDB(TM) credentials for user with 'read' privileges on the db specified at 'database' parameter
 ##
 readUser:
   name:
   pwd:
   usePasswordFile: false
-## InfluxDB credentials for user with 'write' privileges on the db specified at 'database' parameter
+## InfluxDB(TM) credentials for user with 'write' privileges on the db specified at 'database' parameter
 ##
 writeUser:
   name:
   pwd:
   usePasswordFile: false
 
-## Secret with InfluxDB credentials
+## Secret with InfluxDB(TM) credentials
 ## NOTE: This will override the users/passwords defined at adminUser, user, readUser and writeUser
 ##
 # existingSecret:
 
-## InfluxDB backend parameters
+## InfluxDB(TM) backend parameters
 ##
 influxdb:
-  ## InfluxDB Configuration
+  ## InfluxDB(TM) Configuration
   ## Specify content for influxdb.conf
   ## Alternatively, you can put your influxdb.conf under the files/conf/ directory
   ##
@@ -104,7 +104,7 @@ influxdb:
   #   dir = "/bitnami/influxdb/meta"
   #   ...
 
-  ## ConfigMap with InfluxDB configuration
+  ## ConfigMap with InfluxDB(TM) configuration
   ## NOTE: This will override influxdb.configuration
   ##
   # existingConfiguration:
@@ -136,7 +136,7 @@ influxdb:
   ##
   # extraEnvVars:
 
-  ## Number of InfluxDB replicas to deploy
+  ## Number of InfluxDB(TM) replicas to deploy
   ##
   replicaCount: 3
 
@@ -199,7 +199,7 @@ influxdb:
   ##
   tolerations: []
 
-  ## K8s Security Context for InfluxDB pods
+  ## K8s Security Context for InfluxDB(TM) pods
   ## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
   securityContext:
@@ -207,7 +207,7 @@ influxdb:
     fsGroup: 1001
     runAsUser: 1001
 
-  ## InfluxDB pods' resource requests and limits
+  ## InfluxDB(TM) pods' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
   resources:
@@ -222,7 +222,7 @@ influxdb:
     #   cpu: 100m
     #   memory: 128Mi
 
-  ## InfluxDB pods' liveness and readiness probes
+  ## InfluxDB(TM) pods' liveness and readiness probes
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   ##
   livenessProbe:
@@ -252,10 +252,10 @@ influxdb:
     ## Service type
     ##
     type: ClusterIP
-    ## InfluxDB HTTP Port
+    ## InfluxDB(TM) HTTP Port
     ##
     port: 8086
-    ## InfluxDB rpc Port
+    ## InfluxDB(TM) rpc Port
     ##
     rpcPort: 8088
     ## Specify the nodePort(s) value for the LoadBalancer and NodePort service types.
@@ -281,10 +281,10 @@ influxdb:
     ##
     annotations: {}
 
-## InfluxDB Relay parameters
+## InfluxDB Relay(TM) parameters
 ##
 relay:
-  ## Bitnami InfluxDB Relay image
+  ## Bitnami InfluxDB Relay(TM) image
   ## ref: https://hub.docker.com/r/bitnami/influxdb-relay/tags/
   ##
   image:
@@ -301,7 +301,7 @@ relay:
     # pullSecrets:
     #   - myRegistryKeySecretName
 
-  ## InfluxDB Relay Configuration
+  ## InfluxDB Relay(TM) Configuration
   ## Specify content for relay.toml
   ## Alternatively, you can put your relay.toml under the files/conf/ directory
   ##
@@ -313,7 +313,7 @@ relay:
     # TCP address to bind to, for HTTP server.
     bind-addr = "0.0.0.0:9096"
 
-    # Array of InfluxDB instances to use as backends for Relay.
+    # Array of InfluxDB(TM) instances to use as backends for Relay.
     output = [
         {{- $influxdbReplicaCount := int .Values.influxdb.replicaCount }}
         {{- $influxdbFullname := include "influxdb.fullname" . }}
@@ -325,12 +325,12 @@ relay:
         {{- end }}
     ]
 
-  ## ConfigMap with InfluxDB Relay configuration
+  ## ConfigMap with InfluxDB Relay(TM) configuration
   ## NOTE: This will override relay.configuration
   ##
   # existingConfiguration:
 
-  ## Number of InfluxDB Relay replicas to deploy
+  ## Number of InfluxDB Relay(TM) replicas to deploy
   ##
   replicaCount: 2
 
@@ -388,7 +388,7 @@ relay:
   ##
   tolerations: []
 
-  ## K8s Security Context for InfluxDB pods
+  ## K8s Security Context for InfluxDB(TM) pods
   ## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
   securityContext:
@@ -396,7 +396,7 @@ relay:
     fsGroup: 1001
     runAsUser: 1001
 
-  ## InfluxDB Relay pods' resource requests and limits
+  ## InfluxDB Relay(TM) pods' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
   resources:
@@ -411,7 +411,7 @@ relay:
     #   cpu: 100m
     #   memory: 128Mi
 
-  ## InfluxDB Relay pods' liveness and readiness probes
+  ## InfluxDB Relay(TM) pods' liveness and readiness probes
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   ##
   livenessProbe:
@@ -440,7 +440,7 @@ relay:
     ## Service type
     ##
     type: ClusterIP
-    ## InfluxDB Relay HTTP port
+    ## InfluxDB Relay(TM) HTTP port
     ##
     port: 9096
     ## Specify the nodePort value for the LoadBalancer and NodePort service types.
@@ -518,7 +518,7 @@ metrics:
     ## Service type
     ##
     type: ClusterIP
-    ## InfluxDB Prometheus port
+    ## InfluxDB(TM) Prometheus port
     ##
     port: 9122
     ## Specify the nodePort value for the LoadBalancer and NodePort service types.
@@ -575,8 +575,8 @@ networkPolicy:
   enabled: true
 
   ## The Policy model to apply. When set to false, only pods with the correct
-  ## client labels will have network access to the ports InfluxDB is listening
-  ## on. When true, InfluxDB will accept connections from any source
+  ## client labels will have network access to the ports InfluxDB(TM) is listening
+  ## on. When true, InfluxDB(TM) will accept connections from any source
   ## (with the correct destination port).
   ##
   allowExternal: false
@@ -640,7 +640,7 @@ volumePermissions:
     runAsUser: 0
 
 
-## InfluxDB backup parameters
+## InfluxDB(TM) backup parameters
 ##
 backup:
   enabled: false
@@ -651,7 +651,7 @@ backup:
   ##
   retentionDays: 10
   ## Cronjob configuration
-  ## This cronjob is used to create InfluxDB backups
+  ## This cronjob is used to create InfluxDB(TM) backups
   ##
   cronjob:
     ## Schedule in Cron format to save snapshots

--- a/bitnami/influxdb/values.yaml
+++ b/bitnami/influxdb/values.yaml
@@ -12,7 +12,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-## Bitnami InfluxDB image
+## Bitnami InfluxDB(TM) image
 ## ref: https://hub.docker.com/r/bitnami/influxdb/tags/
 ##
 image:
@@ -47,7 +47,7 @@ image:
 ##
 clusterDomain: cluster.local
 
-## InfluxDB architecture. Allowed values: standalone or high-availability
+## InfluxDB(TM) architecture. Allowed values: standalone or high-availability
 ##
 architecture: standalone
 
@@ -61,40 +61,40 @@ database: my_database
 ##
 authEnabled: true
 
-## InfluxDB admin credentials
+## InfluxDB(TM) admin credentials
 ##
 adminUser:
   name: admin
   pwd:
   usePasswordFile: false
-## InfluxDB credentials for user with 'admin' privileges on the db specified at 'database' parameter
+## InfluxDB(TM) credentials for user with 'admin' privileges on the db specified at 'database' parameter
 ##
 user:
   name:
   pwd:
   usePasswordFile: false
-## InfluxDB credentials for user with 'read' privileges on the db specified at 'database' parameter
+## InfluxDB(TM) credentials for user with 'read' privileges on the db specified at 'database' parameter
 ##
 readUser:
   name:
   pwd:
   usePasswordFile: false
-## InfluxDB credentials for user with 'write' privileges on the db specified at 'database' parameter
+## InfluxDB(TM) credentials for user with 'write' privileges on the db specified at 'database' parameter
 ##
 writeUser:
   name:
   pwd:
   usePasswordFile: false
 
-## Secret with InfluxDB credentials
+## Secret with InfluxDB(TM) credentials
 ## NOTE: This will override the users/passwords defined at adminUser, user, readUser and writeUser
 ##
 # existingSecret:
 
-## InfluxDB backend parameters
+## InfluxDB(TM) backend parameters
 ##
 influxdb:
-  ## InfluxDB Configuration
+  ## InfluxDB(TM) Configuration
   ## Specify content for influxdb.conf
   ## Alternatively, you can put your influxdb.conf under the files/conf/ directory
   ##
@@ -105,7 +105,7 @@ influxdb:
   #   dir = "/bitnami/influxdb/meta"
   #   ...
 
-  ## ConfigMap with InfluxDB configuration
+  ## ConfigMap with InfluxDB(TM) configuration
   ## NOTE: This will override influxdb.configuration
   ##
   # existingConfiguration:
@@ -137,7 +137,7 @@ influxdb:
   ##
   # extraEnvVars:
 
-  ## Number of InfluxDB replicas to deploy
+  ## Number of InfluxDB(TM) replicas to deploy
   ##
   replicaCount: 1
 
@@ -200,7 +200,7 @@ influxdb:
   ##
   tolerations: []
 
-  ## K8s Security Context for InfluxDB pods
+  ## K8s Security Context for InfluxDB(TM) pods
   ## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
   securityContext:
@@ -208,7 +208,7 @@ influxdb:
     fsGroup: 1001
     runAsUser: 1001
 
-  ## InfluxDB pods' resource requests and limits
+  ## InfluxDB(TM) pods' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
   resources:
@@ -223,7 +223,7 @@ influxdb:
     #   cpu: 100m
     #   memory: 128Mi
 
-  ## InfluxDB pods' liveness and readiness probes
+  ## InfluxDB(TM) pods' liveness and readiness probes
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   ##
   livenessProbe:
@@ -253,10 +253,10 @@ influxdb:
     ## Service type
     ##
     type: ClusterIP
-    ## InfluxDB HTTP Port
+    ## InfluxDB(TM) HTTP Port
     ##
     port: 8086
-    ## InfluxDB RPC Port
+    ## InfluxDB(TM) RPC Port
     ##
     rpcPort: 8088
     ## Specify the nodePort(s) value for the LoadBalancer and NodePort service types.
@@ -282,10 +282,10 @@ influxdb:
     ##
     annotations: {}
 
-## InfluxDB Relay parameters
+## InfluxDB Relay(TM) parameters
 ##
 relay:
-  ## Bitnami InfluxDB Relay image
+  ## Bitnami InfluxDB Relay(TM) image
   ## ref: https://hub.docker.com/r/bitnami/influxdb-relay/tags/
   ##
   image:
@@ -302,7 +302,7 @@ relay:
     # pullSecrets:
     #   - myRegistryKeySecretName
 
-  ## InfluxDB Relay Configuration
+  ## InfluxDB Relay(TM) Configuration
   ## Specify content for relay.toml
   ## Alternatively, you can put your relay.toml under the files/conf/ directory
   ##
@@ -314,7 +314,7 @@ relay:
     # TCP address to bind to, for HTTP server.
     bind-addr = "0.0.0.0:9096"
 
-    # Array of InfluxDB instances to use as backends for Relay.
+    # Array of InfluxDB(TM) instances to use as backends for Relay.
     output = [
         {{- $influxdbReplicaCount := int .Values.influxdb.replicaCount }}
         {{- $influxdbFullname := include "influxdb.fullname" . }}
@@ -326,12 +326,12 @@ relay:
         {{- end }}
     ]
 
-  ## ConfigMap with InfluxDB Relay configuration
+  ## ConfigMap with InfluxDB Relay(TM) configuration
   ## NOTE: This will override relay.configuration
   ##
   # existingConfiguration:
 
-  ## Number of InfluxDB Relay replicas to deploy
+  ## Number of InfluxDB Relay(TM) replicas to deploy
   ##
   replicaCount: 1
 
@@ -389,7 +389,7 @@ relay:
   ##
   tolerations: []
 
-  ## K8s Security Context for InfluxDB pods
+  ## K8s Security Context for InfluxDB(TM) pods
   ## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
   securityContext:
@@ -397,7 +397,7 @@ relay:
     fsGroup: 1001
     runAsUser: 1001
 
-  ## InfluxDB Relay pods' resource requests and limits
+  ## InfluxDB Relay(TM) pods' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
   resources:
@@ -412,7 +412,7 @@ relay:
     #   cpu: 100m
     #   memory: 128Mi
 
-  ## InfluxDB Relay pods' liveness and readiness probes
+  ## InfluxDB Relay(TM) pods' liveness and readiness probes
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   ##
   livenessProbe:
@@ -441,7 +441,7 @@ relay:
     ## Service type
     ##
     type: ClusterIP
-    ## InfluxDB Relay HTTP port
+    ## InfluxDB Relay(TM) HTTP port
     ##
     port: 9096
     ## Specify the nodePort value for the LoadBalancer and NodePort service types.
@@ -519,7 +519,7 @@ metrics:
     ## Service type
     ##
     type: ClusterIP
-    ## InfluxDB Prometheus port
+    ## InfluxDB(TM) Prometheus port
     ##
     port: 9122
     ## Specify the nodePort value for the LoadBalancer and NodePort service types.
@@ -576,8 +576,8 @@ networkPolicy:
   enabled: false
 
   ## The Policy model to apply. When set to false, only pods with the correct
-  ## client labels will have network access to the ports InfluxDB is listening
-  ## on. When true, InfluxDB will accept connections from any source
+  ## client labels will have network access to the ports InfluxDB(TM) is listening
+  ## on. When true, InfluxDB(TM) will accept connections from any source
   ## (with the correct destination port).
   ##
   allowExternal: true
@@ -640,7 +640,7 @@ volumePermissions:
   securityContext:
     runAsUser: 0
 
-## InfluxDB backup parameters
+## InfluxDB(TM) backup parameters
 ##
 backup:
   enabled: false
@@ -651,7 +651,7 @@ backup:
   ##
   retentionDays: 10
   ## Cronjob configuration
-  ## This cronjob is used to create InfluxDB backups
+  ## This cronjob is used to create InfluxDB(TM) backups
   ##
   cronjob:
     ## Schedule in Cron format to save snapshots


### PR DESCRIPTION
**Description of the change**

As a continuation of https://github.com/bitnami/charts/pull/2739, this PR is adding the trademark to other files different than the README and unifying the format

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
