### PR TITLE
[bitnami/moodle] Unify trademark format across charts

### DIFF
--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -33,4 +33,4 @@ name: ghost
 sources:
   - https://github.com/bitnami/bitnami-docker-ghost
   - http://www.ghost.org/
-version: 11.2.2
+version: 11.2.3

--- a/bitnami/ghost/values.yaml
+++ b/bitnami/ghost/values.yaml
@@ -297,7 +297,7 @@ persistence:
   ##
   # existingClaim:
 
-  ## If defined, the moodle-data volume will mount to the specified path.
+  ## If defined, the ghost-data volume will mount to the specified path.
   ## Requires persistence.enabled: true
   ## Requires persistence.existingClaim: nil|false
   ## Default: nil.

--- a/bitnami/moodle/Chart.yaml
+++ b/bitnami/moodle/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
     version: 1.x.x
-description: Moodle is a learning platform designed to provide educators, administrators and learners with a single robust, secure and integrated system to create personalised learning environments
+description: Moodle(TM) is a learning platform designed to provide educators, administrators and learners with a single robust, secure and integrated system to create personalised learning environments
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/moodle
 icon: https://bitnami.com/assets/stacks/moodle/img/moodle-stack-110x117.png
@@ -25,4 +25,4 @@ name: moodle
 sources:
   - https://github.com/bitnami/bitnami-docker-moodle
   - http://www.moodle.org/
-version: 10.1.3
+version: 10.1.4

--- a/bitnami/moodle/README.md
+++ b/bitnami/moodle/README.md
@@ -1,6 +1,6 @@
 # Moodle<sup>TM</sup> LMS
 
-[Moodle](https://www.moodle.org)<sup>TM</sup> LMS is a learning platform designed to provide educators, administrators and learners with a single robust, secure and integrated system to create personalized learning environments.
+[Moodle<sup>TM</sup>](https://www.moodle.org) LMS is a learning platform designed to provide educators, administrators and learners with a single robust, secure and integrated system to create personalized learning environments.
 
 Disclaimer: The respective trademarks mentioned in the offering are owned by the respective companies. Bitnami does not provide commercial license of any of these products. This listing has an open source license. Moodle<sup>TM</sup> LMS is run and maintained by Moodle HQ, that is a completely and separate project from Bitnami.
 
@@ -13,7 +13,7 @@ $ helm install my-release bitnami/moodle
 
 ## Introduction
 
-This chart bootstraps a [Moodle](https://github.com/bitnami/bitnami-docker-moodle)<sup>TM</sup> deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Moodle<sup>TM</sup>](https://github.com/bitnami/bitnami-docker-moodle) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 It also packages the [Bitnami MariaDB chart](https://github.com/kubernetes/charts/tree/master/bitnami/mariadb) which is required for bootstrapping a MariaDB deployment for the database requirements of the Moodle<sup>TM</sup> application.
 
@@ -64,10 +64,10 @@ The following table lists the configurable parameters of the Moodle<sup>TM</sup>
 
 | Parameter                                   | Description                                                                                                           | Default                                                      |
 |---------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `image.registry`                            | Moodle image registry                                                                                                 | `docker.io`                                                  |
-| `image.repository`                          | Moodle Image name                                                                                                     | `bitnami/moodle`                                             |
-| `image.tag`                                 | Moodle Image tag                                                                                                      | `{TAG_NAME}`                                                 |
-| `image.pullPolicy`                          | Moodle image pull policy                                                                                              | `IfNotPresent`                                               |
+| `image.registry`                            | Moodle<sup>TM</sup> image registry                                                                                    | `docker.io`                                                  |
+| `image.repository`                          | Moodle<sup>TM</sup> Image name                                                                                        | `bitnami/moodle`                                             |
+| `image.tag`                                 | Moodle<sup>TM</sup> Image tag                                                                                         | `{TAG_NAME}`                                                 |
+| `image.pullPolicy`                          | Moodle<sup>TM</sup> image pull policy                                                                                 | `IfNotPresent`                                               |
 | `image.pullSecrets`                         | Specify docker-registry secret names as an array                                                                      | `[]` (does not add image pull secrets to deployed pods)      |
 | `image.debug`                               | Specify if debug logs should be enabled                                                                               | `false`                                                      |
 | `nameOverride`                              | String to partially override moodle.fullname template                                                                 | `nil`                                                        |
@@ -84,10 +84,10 @@ The following table lists the configurable parameters of the Moodle<sup>TM</sup>
 | `allowEmptyPassword`                        | Allow DB blank passwords                                                                                              | true                                                         |
 | `args`                                      | Override default container args (useful when using custom images)                                                     | `nil`                                                        |
 | `command`                                   | Override default container command (useful when using custom images)                                                  | `nil`                                                        |
-| `containerPorts.http`                       | Sets http port inside Moodle container                                                                                | `8080`                                                       |
-| `containerPorts.https`                      | Sets https port inside Moodle container                                                                               | `8443`                                                       |
-| `containerSecurityContext.enabled`          | Enable Moodle containers' Security Context                                                                            | `true`                                                       |
-| `containerSecurityContext.runAsUser`        | Moodle containers' Security Context                                                                                   | `1001`                                                       |
+| `containerPorts.http`                       | Sets http port inside Moodle<sup>TM</sup> container                                                                   | `8080`                                                       |
+| `containerPorts.https`                      | Sets https port inside Moodle<sup>TM</sup> container                                                                  | `8443`                                                       |
+| `containerSecurityContext.enabled`          | Enable Moodle<sup>TM</sup> containers' Security Context                                                               | `true`                                                       |
+| `containerSecurityContext.runAsUser`        | Moodle<sup>TM</sup> containers' Security Context                                                                      | `1001`                                                       |
 | `customLivenessProbe`                       | Override default liveness probe                                                                                       | `nil`                                                        |
 | `customReadinessProbe`                      | Override default readiness probe                                                                                      | `nil`                                                        |
 | `existingSecret`                            | Name of a secret with the application password                                                                        | `nil`                                                        |
@@ -99,28 +99,28 @@ The following table lists the configurable parameters of the Moodle<sup>TM</sup>
 | `initContainers`                            | Add additional init containers to the pod (evaluated as a template)                                                   | `nil`                                                        |
 | `lifecycleHooks`                            | LifecycleHook to set additional configuration at startup Evaluated as a template                                      | ``                                                           |
 | `livenessProbe`                             | Liveness probe configuration                                                                                          | `Check values.yaml file`                                     |
-| `moodleSkipInstall`                         | Skip moodle installation wizard (true / false)                                                                        | `false`                                                      |
+| `moodleSkipInstall`                         | Skip Moodle<sup>TM</sup> installation wizard (true / false)                                                           | `false`                                                      |
 | `moodleSiteName`                            | Site Name                                                                                                             | `""`                                                         |
 | `moodleUsername`                            | User of the application                                                                                               | `user`                                                       |
 | `moodlePassword`                            | Application password                                                                                                  | _random 10 character alphanumeric string_                    |
 | `moodleEmail`                               | Admin email                                                                                                           | `user@example.com`                                           |
 | `nodeSelector`                              | Node labels for pod assignment                                                                                        | `{}` (The value is evaluated as a template)                  |
-| `persistence.accessMode`                    | PVC Access Mode for Moodle volume                                                                                     | `ReadWriteOnce`                                              |
+| `persistence.accessMode`                    | PVC Access Mode for Moodle<sup>TM</sup> volume                                                                        | `ReadWriteOnce`                                              |
 | `persistence.enabled`                       | Enable persistence using PVC                                                                                          | `true`                                                       |
 | `persistence.existingClaim`                 | An Existing PVC name                                                                                                  | `nil`                                                        |
-| `persistence.hostPath`                      | Host mount path for Moodle volume                                                                                     | `nil` (will not mount to a host path)                        |
-| `persistence.size`                          | PVC Storage Request for Moodle volume                                                                                 | `8Gi`                                                        |
-| `persistence.storageClass`                  | PVC Storage Class for Moodle volume                                                                                   | `nil` (uses alpha storage class annotation)                  |
+| `persistence.hostPath`                      | Host mount path for Moodle<sup>TM</sup> volume                                                                        | `nil` (will not mount to a host path)                        |
+| `persistence.size`                          | PVC Storage Request for Moodle<sup>TM</sup> volume                                                                    | `8Gi`                                                        |
+| `persistence.storageClass`                  | PVC Storage Class for Moodle<sup>TM</sup> volume                                                                      | `nil` (uses alpha storage class annotation)                  |
 | `podAnnotations`                            | Pod annotations                                                                                                       | `{}`                                                         |
 | `podLabels`                                 | Add additional labels to the pod (evaluated as a template)                                                            | `nil`                                                        |
-| `podSecurityContext.enabled`                | Enable Moodle pods' Security Context                                                                                  | `true`                                                       |
-| `podSecurityContext.fsGroup`                | Moodle pods' group ID                                                                                                 | `1001`                                                       |
+| `podSecurityContext.enabled`                | Enable Moodle<sup>TM</sup> pods' Security Context                                                                     | `true`                                                       |
+| `podSecurityContext.fsGroup`                | Moodle<sup>TM</sup> pods' group ID                                                                                    | `1001`                                                       |
 | `readinessProbe`                            | Readiness probe configuration                                                                                         | `Check values.yaml file`                                     |
-| `replicaCount`                              | Number of Moodle Pods to run                                                                                          | `1`                                                          |
+| `replicaCount`                              | Number of Moodle<sup>TM</sup> Pods to run                                                                             | `1`                                                          |
 | `resources`                                 | CPU/Memory resource requests/limits                                                                                   | Memory: `512Mi`, CPU: `300m`                                 |
 | `sidecars`                                  | Attach additional containers to the pod (evaluated as a template)                                                     | `nil`                                                        |
 | `smtpHost`                                  | SMTP host                                                                                                             | `nil`                                                        |
-| `smtpPort`                                  | SMTP port                                                                                                             | `nil` (but moodle internal default is 25)                    |
+| `smtpPort`                                  | SMTP port                                                                                                             | `nil` (but Moodle<sup>TM</sup> internal default is 25)       |
 | `smtpProtocol`                              | SMTP Protocol (options: ssl,tls, nil)                                                                                 | `nil`                                                        |
 | `smtpUser`                                  | SMTP user                                                                                                             | `nil`                                                        |
 | `smtpPassword`                              | SMTP password                                                                                                         | `nil`                                                        |
@@ -141,7 +141,7 @@ The following table lists the configurable parameters of the Moodle<sup>TM</sup>
 | `ingress.certManager`                       | Add annotations for cert-manager                                                                                      | `false`                                                      |
 | `ingress.hostname`                          | Default host for the ingress resource                                                                                 | `moodle.local`                                               |
 | `ingress.annotations`                       | Ingress annotations                                                                                                   | `{}`                                                         |
-| `ingress.hosts[0].name`                     | Hostname to your Moodle installation                                                                                  | `nil`                                                        |
+| `ingress.hosts[0].name`                     | Hostname to your Moodle<sup>TM</sup> installation                                                                     | `nil`                                                        |
 | `ingress.hosts[0].path`                     | Path within the url structure                                                                                         | `nil`                                                        |
 | `ingress.tls[0].hosts[0]`                   | TLS hosts                                                                                                             | `nil`                                                        |
 | `ingress.tls[0].secretName`                 | TLS Secret (certificates)                                                                                             | `nil`                                                        |
@@ -202,7 +202,7 @@ The following table lists the configurable parameters of the Moodle<sup>TM</sup>
 
 ### Certificate injection parameters
 
-| Parameter                                            | Description                                                                                                                                               | Default                                                      |
+| Parameter                                            | Description                                                                                                  | Default                                                      |
 |------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
 | `certificates.customCertificate.certificateSecret`   | Secret containing the certificate and key to add                                                             | `""`                                                         |
 | `certificates.customCertificate.chainSecret.name`    | Name of the secret containing the certificate chain                                                          | `""`                                                         |
@@ -274,11 +274,11 @@ To manually configure TLS, first create/retrieve a key & certificate pair for th
 
 ```yaml
 ingress:
-  ## If true, Moodle server Ingress will be created
+  ## If true, Moodle(TM) server Ingress will be created
   ##
   enabled: true
 
-  ## Moodle server Ingress annotations
+  ## Moodle(TM) server Ingress annotations
   ##
   annotations: {}
   #   kubernetes.io/ingress.class: nginx
@@ -290,7 +290,7 @@ ingress:
   hosts:
     - moodle.domain.com
 
-  ## Moodle server Ingress TLS configuration
+  ## Moodle(TM) server Ingress TLS configuration
   ## Secrets must be manually created in the namespace
   ##
   tls:
@@ -344,7 +344,7 @@ To upgrade to `9.0.0`, it should be done reusing the PVCs used to hold both the 
 
 > NOTE: Please, create a backup of your database before running any of those actions. The steps below would be only valid if your application (e.g. any plugins or custom code) is compatible with MariaDB 10.5.x
 
-Obtain the credentials and the names of the PVCs used to hold both the MariaDB and Moodle data on your current release:
+Obtain the credentials and the names of the PVCs used to hold both the MariaDB and Moodle<sup>TM</sup> data on your current release:
 
 ```console
 export MOODLE_PASSWORD=$(kubectl get secret --namespace default moodle -o jsonpath="{.data.moodle-password}" | base64 --decode)

--- a/bitnami/moodle/templates/NOTES.txt
+++ b/bitnami/moodle/templates/NOTES.txt
@@ -1,14 +1,14 @@
 {{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
 
 *******************************************************************
-*** PLEASE BE PATIENT: Moodle may take a few minutes to install ***
+*** PLEASE BE PATIENT: Moodle(TM) may take a few minutes to install ***
 *******************************************************************
 
-1. Get the Moodle URL:
+1. Get the Moodle(TM) URL:
 
 {{- if .Values.ingress.enabled }}
 
-  You should be able to access your new Moodle installation through
+  You should be able to access your new Moodle(TM) installation through
 
   http://{{- .Values.ingress.hostname }}/
 
@@ -20,11 +20,11 @@
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "common.names.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
 
 {{- $port:=.Values.service.port | toString }}
-  echo "Moodle URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}/"
+  echo "Moodle(TM) URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}/"
 
 {{- else if eq .Values.service.type "ClusterIP" }}
 
-  echo "Moodle URL: http://127.0.0.1:8080/"
+  echo "Moodle(TM) URL: http://127.0.0.1:8080/"
   kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "common.names.fullname" . }} 8080:{{ .Values.service.port }}
 
 {{- end }}
@@ -35,11 +35,11 @@
 
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "common.names.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo "Moodle URL: http://$NODE_IP:$NODE_PORT/"
+  echo "Moodle(TM) URL: http://$NODE_IP:$NODE_PORT/"
 
 {{- end }}
 
-2. Get your Moodle login credentials by running:
+2. Get your Moodle(TM) login credentials by running:
 
   echo Username: {{ .Values.moodleUsername }}
   echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "moodle.secretName" . }} -o jsonpath="{.data.moodle-password}" | base64 --decode)
@@ -50,10 +50,10 @@
 ### ERROR: You did not provide an external database host in your 'helm install' call ###
 ########################################################################################
 
-This deployment will be incomplete until you configure Moodle with a resolvable database
-host. To configure Moodle to use and external database host:
+This deployment will be incomplete until you configure Moodle(TM) with a resolvable database
+host. To configure Moodle(TM) to use and external database host:
 
-1. Complete your Moodle deployment by running:
+1. Complete your Moodle(TM) deployment by running:
 
   export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "moodle.secretName" . }} -o jsonpath="{.data.moodle-password}" | base64 --decode)
 

--- a/bitnami/moodle/templates/_helpers.tpl
+++ b/bitnami/moodle/templates/_helpers.tpl
@@ -14,7 +14,7 @@ Return the proper certificate image name
 {{- end -}}
 
 {{/*
-Return the proper Moodle image name
+Return the proper Moodle(TM) image name
 */}}
 {{- define "moodle.image" -}}
 {{- include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) -}}
@@ -49,7 +49,7 @@ Return  the proper Storage Class
 {{- end -}}
 
 {{/*
-Moodle credential secret name
+Moodle(TM) credential secret name
 */}}
 {{- define "moodle.secretName" -}}
 {{- coalesce .Values.existingSecret (include "common.names.fullname" .) -}}

--- a/bitnami/moodle/values.yaml
+++ b/bitnami/moodle/values.yaml
@@ -8,7 +8,7 @@
 #     - myRegistryKeySecretName
 #   storageClass: myStorageClass
 
-## Bitnami Moodle image version
+## Bitnami Moodle(TM) image version
 ## ref: https://hub.docker.com/r/bitnami/moodle/tags/
 ##
 image:
@@ -44,7 +44,7 @@ fullnameOverride:
 ##
 replicaCount: 1
 
-## Skip Moodle installation wizard. Useful for migrations and restoring from SQL dump
+## Skip Moodle(TM) installation wizard. Useful for migrations and restoring from SQL dump
 ## ref: https://github.com/bitnami/bitnami-docker-moodle#configuration
 ##
 moodleSkipInstall: false
@@ -240,7 +240,7 @@ service:
   ## Control hosts connecting to "LoadBalancer" only
   ## loadBalancerSourceRanges:
   ##   - 0.0.0.0/0
-  ## loadBalancerIP for the Moodle Service (optional, cloud specific)
+  ## loadBalancerIP for the Moodle(TM) Service (optional, cloud specific)
   ## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
   ## loadBalancerIP:
   ##
@@ -256,7 +256,7 @@ service:
   externalTrafficPolicy: Cluster
 
 ## Configure the ingress resource that allows you to access the
-## Moodle installation. Set up the URL
+## Moodle(TM) installation. Set up the URL
 ## ref: http://kubernetes.io/docs/user-guide/ingress/
 ##
 ingress:
@@ -324,7 +324,7 @@ sessionAffinity: "None"
 ##
 persistence:
   enabled: true
-  ## Moodle Data Persistent Volume Storage Class
+  ## Moodle(TM) Data Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning
   ## If undefined (the default) or set to null, no storageClassName spec is
@@ -455,10 +455,10 @@ containerSecurityContext:
   runAsUser: 1001
 
 ## Configure extra options for liveness and readiness probes
-## Moodle core exposes /user/login to unauthenticated requests, making it a good
+## Moodle(TM) core exposes /user/login to unauthenticated requests, making it a good
 ## default liveness and readiness path. However, that may not always be the
 ## case. For example, if the image value is overridden to an image containing a
-## module that alters that route, or an image that does not auto-install Moodle.
+## module that alters that route, or an image that does not auto-install Moodle(TM).
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
 livenessProbe:
   enabled: true


### PR DESCRIPTION
**Description of the change**

Unify trademark format across charts by adding `(TM)` in templates and notes apart from the README

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
