### PR TITLE
[bitnami/harbor] fix conflict of azure storage key

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-harbor-registry
   - https://github.com/bitnami/bitnami-docker-harbor-registryctl
   - https://goharbor.io/
-version: 9.2.2
+version: 9.2.3

--- a/bitnami/harbor/templates/chartmuseum/chartmuseum-secret.yaml
+++ b/bitnami/harbor/templates/chartmuseum/chartmuseum-secret.yaml
@@ -17,7 +17,7 @@ data:
   CACHE_REDIS_PASSWORD: {{ include "harbor.redis.rawPassword" . | b64enc | quote }}
   {{- end }}
   {{- if eq .Values.persistence.imageChartStorage.type "azure" }}
-  AZURE_STORAGE_ACCESS_KEY: {{ .Values.persistence.imageChartStorage.azure.accountkey | quote }}
+  AZURE_STORAGE_ACCESS_KEY: {{ .Values.persistence.imageChartStorage.azure.accountkey | b64enc | quote }}
   {{- else if eq .Values.persistence.imageChartStorage.type "gcs" }}
   GCS_KEY_DATA: {{ .Values.persistence.imageChartStorage.gcs.encodedkey | quote }}
   {{- else if eq .Values.persistence.imageChartStorage.type "s3" }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
#2128 remove `AZURE_STORAGE_ACCESS_KEY` base64 encode inside the chartmuseum secret generation, makes it conflict with registry. This PR fixes that issue.

<!-- What benefits will be realized by the code change? -->

<!-- Describe any known limitations with your change -->

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
