### PR TITLE
[bitnami/mongodb] Make readiness probe only validate usable instance

### DIFF
--- a/bitnami/mongodb/Chart.lock
+++ b/bitnami/mongodb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.3
-digest: sha256:3422f8c1139c2f0f0d816e7ee7280705d2010e83c3e2367b28dcb4f7dd911135
-generated: "2020-12-22T11:27:07.137984504Z"
+  version: 1.2.3
+digest: sha256:3fc1fbf3ae204e0121f1e202d6d57f9381f3a45d8821647d1dfe0a475644da0c
+generated: "2021-01-12T13:11:04.410273076Z"

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 10.3.6
+version: 10.3.7

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -312,11 +312,13 @@ spec:
           readinessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - -ec
-                - |-
-                  {{- if .Values.tls.enabled }}OPTIONS="--tls --tlsCertificateKeyFile=/certs/mongodb.pem --tlsCAFile=/certs/mongodb-ca-cert"{{- end }}
-                  mongo --disableImplicitSessions $OPTIONS --eval "db.hello().isWritablePrimary || db.hello().secondary" | grep -q 'true'
+                - |
+                  {{- if .Values.tls.enabled }}
+                  TLS_OPTIONS='--tls --tlsCertificateKeyFile=/certs/mongodb.pem --tlsCAFile=/certs/mongodb-ca-cert'
+                  {{- end }}
+                  mongo --disableImplicitSessions $TLS_OPTIONS --eval 'db.hello().isWritablePrimary || db.hello().secondary' | grep -q 'true'
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -312,15 +312,11 @@ spec:
           readinessProbe:
             exec:
               command:
-                - mongo
-                - --disableImplicitSessions
-              {{- if .Values.tls.enabled }}
-                - --tls
-                - --tlsCertificateKeyFile=/certs/mongodb.pem
-                - --tlsCAFile=/certs/mongodb-ca-cert
-              {{- end }}
-                - --eval
-                - "db.adminCommand('ping')"
+                - sh
+                - -ec
+                - |-
+                  {{- if .Values.tls.enabled }}OPTIONS="--tls --tlsCertificateKeyFile=/certs/mongodb.pem --tlsCAFile=/certs/mongodb-ca-cert"{{- end }}
+                  mongo --disableImplicitSessions $OPTIONS --eval "db.hello().isWritablePrimary || db.hello().secondary" | grep -q 'true'
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/bitnami/mongodb/templates/standalone/dep-sts.yaml
+++ b/bitnami/mongodb/templates/standalone/dep-sts.yaml
@@ -253,11 +253,13 @@ spec:
           readinessProbe:
             exec:
               command:
-                - sh
+                - bash
                 - -ec
-                - |-
-                  {{- if .Values.tls.enabled }}OPTIONS="--tls --tlsCertificateKeyFile=/certs/mongodb.pem --tlsCAFile=/certs/mongodb-ca-cert"{{- end }}
-                  mongo --disableImplicitSessions $OPTIONS --eval "db.hello().isWritablePrimary || db.hello().secondary" | grep -q 'true'
+                - |
+                  {{- if .Values.tls.enabled }}
+                  TLS_OPTIONS='--tls --tlsCertificateKeyFile=/certs/mongodb.pem --tlsCAFile=/certs/mongodb-ca-cert'
+                  {{- end }}
+                  mongo --disableImplicitSessions $TLS_OPTIONS --eval 'db.hello().isWritablePrimary || db.hello().secondary' | grep -q 'true'
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/bitnami/mongodb/templates/standalone/dep-sts.yaml
+++ b/bitnami/mongodb/templates/standalone/dep-sts.yaml
@@ -253,15 +253,11 @@ spec:
           readinessProbe:
             exec:
               command:
-                - mongo
-                - --disableImplicitSessions
-              {{- if .Values.tls.enabled }}
-                - --tls
-                - --tlsCertificateKeyFile=/certs/mongodb.pem
-                - --tlsCAFile=/certs/mongodb-ca-cert
-              {{- end }}
-                - --eval
-                - "db.adminCommand('ping')"
+                - sh
+                - -ec
+                - |-
+                  {{- if .Values.tls.enabled }}OPTIONS="--tls --tlsCertificateKeyFile=/certs/mongodb.pem --tlsCAFile=/certs/mongodb-ca-cert"{{- end }}
+                  mongo --disableImplicitSessions $OPTIONS --eval "db.hello().isWritablePrimary || db.hello().secondary" | grep -q 'true'
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/bitnami/mongodb/values-production.yaml
+++ b/bitnami/mongodb/values-production.yaml
@@ -20,7 +20,7 @@ image:
   ## Bitnami MongoDB image tag
   ## ref: https://hub.docker.com/r/bitnami/mongodb/tags/
   ##
-  tag: 4.4.3-debian-10-r0
+  tag: 4.4.3-debian-10-r21
   ## Specify a imagePullPolicy
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -107,7 +107,7 @@ tls:
   image:
     registry: docker.io
     repository: bitnami/nginx
-    tag: 1.19.6-debian-10-r6
+    tag: 1.19.6-debian-10-r26
     pullPolicy: IfNotPresent
 
 ## Name of the replica set
@@ -523,7 +523,7 @@ externalAccess:
     image:
       registry: docker.io
       repository: bitnami/kubectl
-      tag: 1.18.13-debian-10-r12
+      tag: 1.18.14-debian-10-r20
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -902,7 +902,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mongodb-exporter
-    tag: 0.20.1-debian-10-r18
+    tag: 0.20.1-debian-10-r38
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -20,7 +20,7 @@ image:
   ## Bitnami MongoDB image tag
   ## ref: https://hub.docker.com/r/bitnami/mongodb/tags/
   ##
-  tag: 4.4.3-debian-10-r0
+  tag: 4.4.3-debian-10-r21
   ## Specify a imagePullPolicy
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -107,7 +107,7 @@ tls:
   image:
     registry: docker.io
     repository: bitnami/nginx
-    tag: 1.19.6-debian-10-r6
+    tag: 1.19.6-debian-10-r26
     pullPolicy: IfNotPresent
 
 ## Name of the replica set
@@ -523,7 +523,7 @@ externalAccess:
     image:
       registry: docker.io
       repository: bitnami/kubectl
-      tag: 1.18.13-debian-10-r12
+      tag: 1.18.14-debian-10-r20
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -902,7 +902,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mongodb-exporter
-    tag: 0.20.1-debian-10-r18
+    tag: 0.20.1-debian-10-r38
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION

**Description of the change**

Change the readiness probe code to return "true" only if the mongodb instance is PRIMARY or SECONDARY state.

**Benefits**

Before this change, the readiness probe was exactly the same than the liveness (it just detected if the mongodb instance was running). The main risk here is to tell that the member is "ready" while it is RECOVERING. This could lead to data loss, for example in a scenario where there is an helm upgrade (or a kubernetes update) which is rolling out all the members, and that for some reason one or several member need some time to recover their data. If Kubernetes has no way to know that the members are not ready, it can blindly shut down the other members at a fast pace, which could have major consequences

**Possible drawbacks**

None afaik

**Applicable issues**

none

**Additional information**

This commit has been tested on a 4.2 cluster, a 4.2 standalone instance and a 3.6 standalone instance.

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- (NA) Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- (NA)If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

