### PR TITLE
[bitnami/etcd] Reuse startFromSnapshot volume in the disasterRecovery mode

### DIFF
--- a/bitnami/etcd/Chart.lock
+++ b/bitnami/etcd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.4
-digest: sha256:07fdb584e5f355f86e844163e48a6307a7175be1ebe693f72afc7d62cabc644a
-generated: "2020-12-25T21:53:49.212073929Z"
+  version: 1.2.3
+digest: sha256:3fc1fbf3ae204e0121f1e202d6d57f9381f3a45d8821647d1dfe0a475644da0c
+generated: "2021-01-11T19:46:53.405970325Z"

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -25,4 +25,4 @@ name: etcd
 sources:
   - https://github.com/bitnami/bitnami-docker-etcd
   - https://coreos.com/etcd/
-version: 5.4.2
+version: 5.5.0

--- a/bitnami/etcd/README.md
+++ b/bitnami/etcd/README.md
@@ -303,6 +303,8 @@ disasterRecovery.pvc.size=2Gi
 disasterRecovery.pvc.storageClassName=nfs
 ```
 
+If `startFromSnapshot` is enabled at the same time than `disasterRecovery`, the PVC provided via `startFromSnapshot.existingClaim` will be used to store the periodical snapshots.
+
 > **Note**: Disaster recovery feature requires using volumes with ReadWriteMany access mode. For instance, you can use the stable/nfs-server-provisioner chart to provide NFS PVCs.
 
 ### Setting Pod's affinity

--- a/bitnami/etcd/templates/_helpers.tpl
+++ b/bitnami/etcd/templates/_helpers.tpl
@@ -48,7 +48,6 @@ app.kubernetes.io/name: {{ include "etcd.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
-
 {{/*
 Return the proper etcd image name
 */}}
@@ -102,6 +101,8 @@ Return the proper Disaster Recovery PVC name
 {{- with .Values.disasterRecovery.pvc.existingClaim -}}
 {{ tpl . $ }}
 {{- end -}}
+{{- else if .Values.startFromSnapshot.existingClaim -}}
+{{- .Values.startFromSnapshot.existingClaim -}}
 {{- else -}}
 {{ template "etcd.fullname" . }}-snapshotter
 {{- end -}}

--- a/bitnami/etcd/templates/scripts-configmap.yaml
+++ b/bitnami/etcd/templates/scripts-configmap.yaml
@@ -8,7 +8,10 @@
 {{- $clusterDomain := .Values.clusterDomain }}
 {{- $etcdPeerProtocol := include "etcd.peerProtocol" . }}
 {{- $etcdClientProtocol := include "etcd.clientProtocol" . }}
-{{- $initSnapshotFilename := .Values.startFromSnapshot.snapshotFilename }}
+{{- $initSnapshotPath := printf "/init-snapshot/%s" .Values.startFromSnapshot.snapshotFilename }}
+{{- if and .Values.disasterRecovery.enabled .Values.startFromSnapshot.enabled }}
+{{- $initSnapshotPath := printf "/snapshots/%s" .Values.startFromSnapshot.snapshotFilename }}
+{{- end }}
 {{- $snapshotHistoryLimit := .Values.disasterRecovery.cronjob.snapshotHistoryLimit }}
 {{- $endpoints := list }}
 {{- range $e, $i := until $replicaCount }}
@@ -122,9 +125,9 @@ data:
         echo "==> Creating data dir..." 1>&3 2>&4
         echo "==> There is no data at all. Initializing a new member of the cluster..." 1>&3 2>&4
 {{- if .Values.startFromSnapshot.enabled }}
-        if [[ -f "/init-snapshot/{{ $initSnapshotFilename }}" ]]; then
+        if [[ -f "{{ $initSnapshotPath }}" ]]; then
             echo "==> Initializing member by restoring etcd cluster from snapshot..." 1>&3 2>&4
-            etcdctl snapshot restore /init-snapshot/{{ $initSnapshotFilename }} \
+            etcdctl snapshot restore {{ $initSnapshotPath }} \
             {{- if gt $replicaCount 1 }}
               --name $ETCD_NAME \
               --initial-cluster $ETCD_INITIAL_CLUSTER \

--- a/bitnami/etcd/templates/scripts-configmap.yaml
+++ b/bitnami/etcd/templates/scripts-configmap.yaml
@@ -9,7 +9,7 @@
 {{- $etcdPeerProtocol := include "etcd.peerProtocol" . }}
 {{- $etcdClientProtocol := include "etcd.clientProtocol" . }}
 {{- $initSnapshotPath := printf "/init-snapshot/%s" .Values.startFromSnapshot.snapshotFilename }}
-{{- if and .Values.disasterRecovery.enabled .Values.startFromSnapshot.enabled }}
+{{- if and .Values.disasterRecovery.enabled .Values.startFromSnapshot.enabled (not .Values.disasterRecovery.pvc.existingClaim) }}
 {{- $initSnapshotPath = printf "/snapshots/%s" .Values.startFromSnapshot.snapshotFilename }}
 {{- end }}
 {{- $snapshotHistoryLimit := .Values.disasterRecovery.cronjob.snapshotHistoryLimit }}

--- a/bitnami/etcd/templates/scripts-configmap.yaml
+++ b/bitnami/etcd/templates/scripts-configmap.yaml
@@ -10,7 +10,7 @@
 {{- $etcdClientProtocol := include "etcd.clientProtocol" . }}
 {{- $initSnapshotPath := printf "/init-snapshot/%s" .Values.startFromSnapshot.snapshotFilename }}
 {{- if and .Values.disasterRecovery.enabled .Values.startFromSnapshot.enabled }}
-{{- $initSnapshotPath := printf "/snapshots/%s" .Values.startFromSnapshot.snapshotFilename }}
+{{- $initSnapshotPath = printf "/snapshots/%s" .Values.startFromSnapshot.snapshotFilename }}
 {{- end }}
 {{- $snapshotHistoryLimit := .Values.disasterRecovery.cronjob.snapshotHistoryLimit }}
 {{- $endpoints := list }}

--- a/bitnami/etcd/templates/snapshot-pvc.yaml
+++ b/bitnami/etcd/templates/snapshot-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.disasterRecovery.enabled (not .Values.disasterRecovery.pvc.existingClaim) -}}
+{{- if and .Values.disasterRecovery.enabled (not .Values.disasterRecovery.pvc.existingClaim) (not .Values.startFromSnapshot.enabled) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/bitnami/etcd/templates/statefulset.yaml
+++ b/bitnami/etcd/templates/statefulset.yaml
@@ -238,12 +238,13 @@ spec:
               subPath: probes.sh
             - name: data
               mountPath: /bitnami/etcd
+            {{- if or (and .Values.startFromSnapshot.enabled (not .Values.disasterRecovery.enabled)) (and .Values.disasterRecovery.enabled .Values.startFromSnapshot.enabled .Values.disasterRecovery.pvc.existingClaim) }}
+            - name: init-snapshot-volume
+              mountPath: /init-snapshot
+            {{- end }}
             {{- if or .Values.disasterRecovery.enabled (and .Values.disasterRecovery.enabled .Values.startFromSnapshot.enabled) }}
             - name: snapshot-volume
               mountPath: /snapshots
-            {{- else if .Values.startFromSnapshot.enabled }}
-            - name: init-snapshot-volume
-              mountPath: /init-snapshot
             {{- end }}
             {{- if .Values.configFileConfigMap }}
             - name: etcd-config
@@ -264,14 +265,15 @@ spec:
           configMap:
             name: {{ include "etcd.fullname" . }}-scripts
             defaultMode: 0755
+        {{- if or (and .Values.startFromSnapshot.enabled (not .Values.disasterRecovery.enabled)) (and .Values.disasterRecovery.enabled .Values.startFromSnapshot.enabled .Values.disasterRecovery.pvc.existingClaim) }}
+        - name: init-snapshot-volume
+          persistentVolumeClaim:
+            claimName: {{ .Values.startFromSnapshot.existingClaim }}
+        {{- end }}
         {{- if or .Values.disasterRecovery.enabled (and .Values.disasterRecovery.enabled .Values.startFromSnapshot.enabled) }}
         - name: snapshot-volume
           persistentVolumeClaim:
             claimName: {{ include "etcd.disasterRecovery.pvc.name" . }}
-        {{- else if .Values.startFromSnapshot.enabled }}
-        - name: init-snapshot-volume
-          persistentVolumeClaim:
-            claimName: {{ .Values.startFromSnapshot.existingClaim }}
         {{- end }}
         {{- if .Values.configFileConfigMap }}
         - name: etcd-config

--- a/bitnami/etcd/templates/statefulset.yaml
+++ b/bitnami/etcd/templates/statefulset.yaml
@@ -238,13 +238,12 @@ spec:
               subPath: probes.sh
             - name: data
               mountPath: /bitnami/etcd
-            {{- if .Values.startFromSnapshot.enabled }}
-            - name: init-snapshot-volume
-              mountPath: /init-snapshot
-            {{- end }}
-            {{- if .Values.disasterRecovery.enabled }}
+            {{- if or .Values.disasterRecovery.enabled (and .Values.disasterRecovery.enabled .Values.startFromSnapshot.enabled) }}
             - name: snapshot-volume
               mountPath: /snapshots
+            {{- else if .Values.startFromSnapshot.enabled }}
+            - name: init-snapshot-volume
+              mountPath: /init-snapshot
             {{- end }}
             {{- if .Values.configFileConfigMap }}
             - name: etcd-config
@@ -265,15 +264,14 @@ spec:
           configMap:
             name: {{ include "etcd.fullname" . }}-scripts
             defaultMode: 0755
-        {{- if .Values.startFromSnapshot.enabled }}
-        - name: init-snapshot-volume
-          persistentVolumeClaim:
-            claimName: {{ .Values.startFromSnapshot.existingClaim }}
-        {{- end }}
-        {{- if .Values.disasterRecovery.enabled }}
+        {{- if or .Values.disasterRecovery.enabled (and .Values.disasterRecovery.enabled .Values.startFromSnapshot.enabled) }}
         - name: snapshot-volume
           persistentVolumeClaim:
             claimName: {{ include "etcd.disasterRecovery.pvc.name" . }}
+        {{- else if .Values.startFromSnapshot.enabled }}
+        - name: init-snapshot-volume
+          persistentVolumeClaim:
+            claimName: {{ .Values.startFromSnapshot.existingClaim }}
         {{- end }}
         {{- if .Values.configFileConfigMap }}
         - name: etcd-config

--- a/bitnami/etcd/values-production.yaml
+++ b/bitnami/etcd/values-production.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/etcd
-  tag: 3.4.14-debian-10-r28
+  tag: 3.4.14-debian-10-r44
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/etcd/values.yaml
+++ b/bitnami/etcd/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/etcd
-  tag: 3.4.14-debian-10-r28
+  tag: 3.4.14-debian-10-r44
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
**Description of the change**

Regardless of data volume, there are different combinations for **disasterRecovery** and/or **startFromSnapshot**:
- **Case 1**: disasterRecovery:white_check_mark: startFromSnapshot:red_circle: -> No volumes in play
- **Case 2**: disasterRecovery:white_check_mark: startFromSnapshot:red_circle: -> The volume is created on-demand or provided by users. This case does not change (Total 1 volume)
- **Case 3**: disasterRecovery:red_circle: startFromSnapshot:white_check_mark: -> Users always give us the volume. This case does not change (Total 1 volume)

The complex case that we want to improve in this PR:
- **Case 4**: disasterRecovery:white_check_mark: startFromSnapshot:white_check_mark:

_**Right now**_: _disasterRecovery_ volume is created or an existing one is used. _startFromSnapshot_ give us the volume (Total 2 volumes)
**_Desired_**: _disasterRecovery_ if the users give it to us, it is used and apart from that, the one provided for _startFromSnapshot_ (Total 2 volumes). But if users don't give us the _disasterRecovery_ volume, the one they give us in _startFromSnapshot_ is used instead of creating a new one (Total 1 volume)

So only in the case of
> `disasterRecovery.enabled = true` && `startFromSnapshot.enabled = true` && ! `disasterRecovery.pvc.existingClaim`

it is when the volume passed as `startFromSnapshot.existingClaim` would be used to make the function of the one that we would create for the _disasterRecovery_

-----------------------------------------------------------
Manual tests:
- **Case 2.1**, no changes with the new behavior
```console
$ helm template bitnami/etcd --set disasterRecovery.enabled=true > old.yaml
$ helm template . --set disasterRecovery.enabled=true > new.yaml
```
```diff
$ colordiff old.yaml new.yaml
14c14
-   etcd-root-password: "SzdpUkZyc3BKcA=="
+   etcd-root-password: "SHJDRjF1TXJFeQ=="
```
- **Case 2.2**, no changes with the new behavior
```console
$ helm template bitnami/etcd --set disasterRecovery.enabled=true --set disasterRecovery.pvc.existingClaim="foo" > old.yaml
$ helm template . --set disasterRecovery.enabled=true --set disasterRecovery.pvc.existingClaim="foo" > new.yaml
```
```diff
$ colordiff old.yaml new.yaml
14c14
-   etcd-root-password: "aTlnSngxV2ROcQ=="
+   etcd-root-password: "ME9NcjdxVDBUUw=="
```
- **Case 3**, no changes with the new behavior
```console
$ helm template bitnami/etcd --set startFromSnapshot.enabled=true --set startFromSnapshot.snapshotFilename="xxxx" --set startFromSnapshot.existingClaim="xxxx" > old.yaml
$ helm template . --set startFromSnapshot.enabled=true --set startFromSnapshot.snapshotFilename="xxxx" --set startFromSnapshot.existingClaim="xxxx" > new.yaml
```
```diff
$ colordiff old.yaml new.yaml
14c14
-   etcd-root-password: "ejJFR3EzVFpWQQ=="
+   etcd-root-password: "YWRwUUlHZmZJOA=="
```
- **Case 4.1**, no changes with the new behavior
```console
$ helm template bitnami/etcd \
--set startFromSnapshot.enabled=true --set startFromSnapshot.snapshotFilename="xxxx" --set startFromSnapshot.existingClaim="xxxx" \
--set disasterRecovery.enabled=true --set disasterRecovery.pvc.existingClaim="foo" > old.yaml
$ helm template . \
--set startFromSnapshot.enabled=true --set startFromSnapshot.snapshotFilename="xxxx" --set startFromSnapshot.existingClaim="xxxx" \
--set disasterRecovery.enabled=true --set disasterRecovery.pvc.existingClaim="foo" > new.yaml
```
```diff
$ colordiff old.yaml new.yaml
14c14
-   etcd-root-password: "Y1BwV3JsVEZFMw=="
+   etcd-root-password: "QXc3UlB4VTB3Yg=="
```
- **Case 4.2**, expected changes reducing the number of volumes
```console
$ helm template bitnami/etcd \
--set startFromSnapshot.enabled=true --set startFromSnapshot.snapshotFilename="xxxx" --set startFromSnapshot.existingClaim="xxxx" \
--set disasterRecovery.enabled=true > old.yaml
$ helm template . \
--set startFromSnapshot.enabled=true --set startFromSnapshot.snapshotFilename="xxxx" --set startFromSnapshot.existingClaim="xxxx" \
--set disasterRecovery.enabled=true > new.yaml
```
```diff
$ colordiff old.yaml new.yaml
14c14
-   etcd-root-password: "eWlrbm02aHRaSg=="
+   etcd-root-password: "dTZueDM0anY2dQ=="
120c120
-         if [[ -f "/init-snapshot/xxxx" ]]; then
+         if [[ -f "/snapshots/xxxx" ]]; then
122c122
-             etcdctl snapshot restore /init-snapshot/xxxx \
+             etcdctl snapshot restore /snapshots/xxxx \
267,284d266
- # Source: etcd/templates/snapshot-pvc.yaml
- kind: PersistentVolumeClaim
- apiVersion: v1
- metadata:
-   name: RELEASE-NAME-etcd-snapshotter
-   labels:
-     app.kubernetes.io/name: etcd
-     helm.sh/chart: etcd-5.4.2
-     app.kubernetes.io/instance: RELEASE-NAME
-     app.kubernetes.io/managed-by: Helm
- spec:
-   accessModes:
-     - ReadWriteMany
-   resources:
-     requests:
-       storage: "2Gi"
-   storageClassName: "nfs"
466,467d447
-             - name: init-snapshot-volume
-               mountPath: /init-snapshot
475,477d454
-         - name: init-snapshot-volume
-           persistentVolumeClaim:
-             claimName: xxxx
480c457
-             claimName: RELEASE-NAME-etcd-snapshotter
+             claimName: xxxx
551c528
-                 claimName: RELEASE-NAME-etcd-snapshotter
+                 claimName: xxxx
```

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -▶
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files