### PR TITLE
[bitnami/phpmyadmin] Fix wrong macro name

### DIFF
--- a/bitnami/phpmyadmin/Chart.yaml
+++ b/bitnami/phpmyadmin/Chart.yaml
@@ -29,4 +29,4 @@ name: phpmyadmin
 sources:
   - https://github.com/bitnami/bitnami-docker-phpmyadmin
   - https://www.phpmyadmin.net/
-version: 8.0.3
+version: 8.0.4

--- a/bitnami/phpmyadmin/templates/deployment.yaml
+++ b/bitnami/phpmyadmin/templates/deployment.yaml
@@ -72,7 +72,7 @@ spec:
               value: {{ .Values.db.port | quote }}
             {{- if .Values.db.chartName }}
             - name: DATABASE_HOST
-              value: {{ (include "phpmyadmin.dbfullnamee" .) | quote }}
+              value: {{ (include "phpmyadmin.dbfullname" .) | quote }}
             {{- else if .Values.db.bundleTestDB }}
             - name: DATABASE_HOST
               value: {{ (include "phpmyadmin.mariadb.fullname" .) | quote }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Fix typo in macro name.

**Benefits**

Uses can use an external databse.

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/4946

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
