### PR TITLE
[bitnami/nginx-ingress-controller] Add service.targetPorts as a parameter

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -26,4 +26,4 @@ name: nginx-ingress-controller
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx-ingress-controller
   - https://github.com/kubernetes/ingress-nginx
-version: 7.0.11
+version: 7.1.0

--- a/bitnami/nginx-ingress-controller/README.md
+++ b/bitnami/nginx-ingress-controller/README.md
@@ -190,6 +190,8 @@ The following tables lists the configurable parameters of the Nginx Ingress Cont
 | `service.omitClusterIP`                 | To omit the `ClusterIP` from the controller service                                      | `false`                                                 |
 | `service.ports.http`                    | Controller Service HTTP port                                                             | `80`                                                    |
 | `service.ports.https`                   | Controller Service HTTPS port                                                            | `""`                                                    |
+| `service.targetPorts.http`              | Map the controller service HTTP port                                                     | `http`                                                  |
+| `service.targetPorts.https`             | Map the controller service HTTPS port                                                    | `https`                                                  |
 | `service.externalTrafficPolicy`         | Enable client source IP preservation                                                     | `Cluster`                                               |
 | `service.nodePorts.http`                | Kubernetes http node port for Controller                                                 | `""`                                                    |
 | `service.nodePorts.https`               | Kubernetes https node port for Controller                                                | `""`                                                    |

--- a/bitnami/nginx-ingress-controller/templates/controller-service.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-service.yaml
@@ -44,7 +44,7 @@ spec:
     - name: http
       port: {{ .Values.service.ports.http }}
       protocol: TCP
-      targetPort: http
+      targetPort: {{ .Values.service.targetPorts.http }}
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.http)) }}
       nodePort: {{ .Values.service.nodePorts.http }}
       {{- else if eq .Values.service.type "ClusterIP" }}
@@ -53,7 +53,7 @@ spec:
     - name: https
       port: {{ .Values.service.ports.https }}
       protocol: TCP
-      targetPort: https
+      targetPort: {{ .Values.service.targetPorts.https }}
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.https)) }}
       nodePort: {{ .Values.service.nodePorts.https }}
       {{- else if eq .Values.service.type "ClusterIP" }}

--- a/bitnami/nginx-ingress-controller/values-production.yaml
+++ b/bitnami/nginx-ingress-controller/values-production.yaml
@@ -394,11 +394,17 @@ service:
   ## Service type
   ##
   type: LoadBalancer
+
   ## Service ports
   ##
   ports:
     http: 80
     https: 443
+
+  targetPorts:
+    http: http
+    https: https
+
   ## Specify the nodePort value(s) for the LoadBalancer and NodePort service types.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
   ##

--- a/bitnami/nginx-ingress-controller/values.yaml
+++ b/bitnami/nginx-ingress-controller/values.yaml
@@ -394,11 +394,17 @@ service:
   ## Service type
   ##
   type: LoadBalancer
+
   ## Service ports
   ##
   ports:
     http: 80
     https: 443
+
+  targetPorts:
+    http: http
+    https: https
+
   ## Specify the nodePort value(s) for the LoadBalancer and NodePort service types.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
   ##


### PR DESCRIPTION
**Description of the change**
Adds the controller's service target ports as a configurable parameter.

**Benefits**
Give more customization to users.
Align `bitnami/nginx-ingress-controller` chart with the upstream chart.

**Possible drawbacks**
None. Default values are set to the originally hardcode values.

**Applicable issues**
  - fixes #4905 
 
**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

