### PR TITLE
[bitnami/nats] Adapt ingress rules to k8s 1.20

### DIFF
--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -24,4 +24,4 @@ name: nats
 sources:
   - https://github.com/bitnami/bitnami-docker-nats
   - https://nats.io/
-version: 6.0.5
+version: 6.1.0

--- a/bitnami/nats/README.md
+++ b/bitnami/nats/README.md
@@ -48,121 +48,126 @@ The following tables lists the configurable parameters of the NATS chart and the
 
 ### Global parameters
 
-| Parameter                               | Description                                                | Default                                                 |
-|-----------------------------------------|------------------------------------------------------------|---------------------------------------------------------|
-| `global.imageRegistry`                  | Global Docker image registry                               | `nil`                                                   |
-| `global.imagePullSecrets`               | Global Docker registry secret names as an array            | `[]` (does not add image pull secrets to deployed pods) |
+| Parameter                 | Description                                     | Default                                                 |
+|---------------------------|-------------------------------------------------|---------------------------------------------------------|
+| `global.imageRegistry`    | Global Docker image registry                    | `nil`                                                   |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
 
 ### Common parameters
 
-| Parameter                               | Description                                                | Default                                                 |
-|-----------------------------------------|------------------------------------------------------------|---------------------------------------------------------|
-| `nameOverride`                          | String to partially override common.names.fullname         | `nil`                                                   |
-| `fullnameOverride`                      | String to fully override common.names.fullname             | `nil`                                                   |
-| `commonLabels`                          | Labels to add to all deployed objects                      | `{}`                                                    |
-| `commonAnnotations`                     | Annotations to add to all deployed objects                 | `{}`                                                    |
-| `clusterDomain`                         | Default Kubernetes cluster domain                          | `cluster.local`                                         |
-| `extraDeploy`                           | Array of extra objects to deploy with the release          | `[]` (evaluated as a template)                          |
+| Parameter           | Description                                                          | Default                        |
+|---------------------|----------------------------------------------------------------------|--------------------------------|
+| `nameOverride`      | String to partially override common.names.fullname                   | `nil`                          |
+| `fullnameOverride`  | String to fully override common.names.fullname                       | `nil`                          |
+| `commonLabels`      | Labels to add to all deployed objects                                | `{}`                           |
+| `commonAnnotations` | Annotations to add to all deployed objects                           | `{}`                           |
+| `clusterDomain`     | Default Kubernetes cluster domain                                    | `cluster.local`                |
+| `extraDeploy`       | Array of extra objects to deploy with the release                    | `[]` (evaluated as a template) |
+| `kubeVersion`       | Force target Kubernetes version (using Helm capabilities if not set) | `nil`                          |
 
 ### NATS parameters
 
-| Parameter                               | Description                                                                              | Default                                                 |
-|-----------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `image.registry`                        | NATS image registry                                                                      | `docker.io`                                             |
-| `image.repository`                      | NATS image name                                                                          | `bitnami/nats`                                          |
-| `image.tag`                             | NATS image tag                                                                           | `{TAG_NAME}`                                            |
-| `image.pullPolicy`                      | Image pull policy                                                                        | `IfNotPresent`                                          |
-| `image.pullSecrets`                     | Specify docker-registry secret names as an array                                         | `[]` (does not add image pull secrets to deployed pods) |
-| `auth.enabled`                          | Switch to enable/disable client authentication                                           | `true`                                                  |
-| `auth.user`                             | Client authentication user                                                               | `nats_client`                                           |
-| `auth.password`                         | Client authentication password                                                           | `random alhpanumeric string (10)`                       |
-| `auth.token`                            | Client authentication token                                                              | `nil`                                                   |
-| `clusterAuth.enabled`                   | Switch to enable/disable cluster authentication                                          | `true`                                                  |
-| `clusterAuth.user`                      | Cluster authentication user                                                              | `nats_cluster`                                          |
-| `clusterAuth.password`                  | Cluster authentication password                                                          | `random alhpanumeric string (10)`                       |
-| `clusterAuth.token`                     | Cluster authentication token                                                             | `nil`                                                   |
-| `debug.enabled`                         | Switch to enable/disable debug on logging                                                | `false`                                                 |
-| `debug.trace`                           | Switch to enable/disable trace debug level on logging                                    | `false`                                                 |
-| `debug.logtime`                         | Switch to enable/disable logtime on logging                                              | `false`                                                 |
-| `maxConnections`                        | Max. number of client connections                                                        | `nil`                                                   |
-| `maxControlLine`                        | Max. protocol control line                                                               | `nil`                                                   |
-| `maxPayload`                            | Max. payload                                                                             | `nil`                                                   |
-| `writeDeadline`                         | Duration the server can block on a socket write to a client                              | `nil`                                                   |
-| `natsFilename`                          | Filename used by several NATS files (binary, configurarion file, and pid file)           | `nats-server`                                           |
-| `command`                               | Override default container command (useful when using custom images)                     | `nil`                                                   |
-| `args`                                  | Override default container args (useful when using custom images)                        | `nil`                                                   |
-| `metrics.kafka.extraFlags`              | Extra flags to be passed to NATS                                                         | `{}`                                                    |
-| `extraEnvVars`                          | Extra environment variables to be set on NATS container                                  | `{}`                                                    |
-| `extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars                                     | `nil`                                                   |
-| `extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars                                        | `nil`                                                   |
+| Parameter                  | Description                                                                    | Default                                                 |
+|----------------------------|--------------------------------------------------------------------------------|---------------------------------------------------------|
+| `image.registry`           | NATS image registry                                                            | `docker.io`                                             |
+| `image.repository`         | NATS image name                                                                | `bitnami/nats`                                          |
+| `image.tag`                | NATS image tag                                                                 | `{TAG_NAME}`                                            |
+| `image.pullPolicy`         | Image pull policy                                                              | `IfNotPresent`                                          |
+| `image.pullSecrets`        | Specify docker-registry secret names as an array                               | `[]` (does not add image pull secrets to deployed pods) |
+| `auth.enabled`             | Switch to enable/disable client authentication                                 | `true`                                                  |
+| `auth.user`                | Client authentication user                                                     | `nats_client`                                           |
+| `auth.password`            | Client authentication password                                                 | `random alhpanumeric string (10)`                       |
+| `auth.token`               | Client authentication token                                                    | `nil`                                                   |
+| `clusterAuth.enabled`      | Switch to enable/disable cluster authentication                                | `true`                                                  |
+| `clusterAuth.user`         | Cluster authentication user                                                    | `nats_cluster`                                          |
+| `clusterAuth.password`     | Cluster authentication password                                                | `random alhpanumeric string (10)`                       |
+| `clusterAuth.token`        | Cluster authentication token                                                   | `nil`                                                   |
+| `debug.enabled`            | Switch to enable/disable debug on logging                                      | `false`                                                 |
+| `debug.trace`              | Switch to enable/disable trace debug level on logging                          | `false`                                                 |
+| `debug.logtime`            | Switch to enable/disable logtime on logging                                    | `false`                                                 |
+| `maxConnections`           | Max. number of client connections                                              | `nil`                                                   |
+| `maxControlLine`           | Max. protocol control line                                                     | `nil`                                                   |
+| `maxPayload`               | Max. payload                                                                   | `nil`                                                   |
+| `writeDeadline`            | Duration the server can block on a socket write to a client                    | `nil`                                                   |
+| `natsFilename`             | Filename used by several NATS files (binary, configurarion file, and pid file) | `nats-server`                                           |
+| `command`                  | Override default container command (useful when using custom images)           | `nil`                                                   |
+| `args`                     | Override default container args (useful when using custom images)              | `nil`                                                   |
+| `metrics.kafka.extraFlags` | Extra flags to be passed to NATS                                               | `{}`                                                    |
+| `extraEnvVars`             | Extra environment variables to be set on NATS container                        | `{}`                                                    |
+| `extraEnvVarsCM`           | Name of existing ConfigMap containing extra env vars                           | `nil`                                                   |
+| `extraEnvVarsSecret`       | Name of existing Secret containing extra env vars                              | `nil`                                                   |
 
 ### NATS deployment/statefulset parameters
 
-| Parameter                               | Description                                                                              | Default                                                 |
-|-----------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `resourceType`                          | NATS cluster resource type under Kubernetes (Supported: StatefulSets, or Deployment)     | `statefulset`                                           |
-| `replicaCount`                          | Number of NATS nodes                                                                     | `1`                                                     |
-| `schedulerName`                         | Name of an alternate                                                                     | `nil`                                                   |
-| `priorityClassName`                     | Name of pod priority class                                                               | `nil`                                                   |
-| `podSecurityContext`                    | NATS pods' Security Context                                                              | Check `values.yaml` file                                |
-| `updateStrategy`                        | Strategy to use to update Pods                                                           | Check `values.yaml` file                                |
-| `containerSecurityContext`              | NATS containers' Security Context                                                        | Check `values.yaml` file                                |
-| `resources.limits`                      | The resources limits for the NATS container                                              | `{}`                                                    |
-| `resources.requests`                    | The requested resources for the NATS container                                           | `{}`                                                    |
-| `livenessProbe`                         | Liveness probe configuration for NATS                                                    | Check `values.yaml` file                                |
-| `readinessProbe`                        | Readiness probe configuration for NATS                                                   | Check `values.yaml` file                                |
-| `customLivenessProbe`                   | Override default liveness probe                                                          | `nil`                                                   |
-| `customReadinessProbe`                  | Override default readiness probe                                                         | `nil`                                                   |
-| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`      | `""`                                                    |
-| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `soft`                                                  |
-| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`| `""`                                                    |
-| `nodeAffinityPreset.key`                | Node label key to match. Ignored if `affinity` is set.                                   | `""`                                                    |
-| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                | `[]`                                                    |
-| `affinity`                              | Affinity for pod assignment                                                              | `{}` (evaluated as a template)                          |
-| `nodeSelector`                          | Node labels for pod assignment                                                           | `{}` (evaluated as a template)                          |
-| `tolerations`                           | Tolerations for pod assignment                                                           | `[]` (evaluated as a template)                          |
-| `podLabels`                             | Extra labels for NATS pods                                                               | `{}` (evaluated as a template)                          |
-| `podAnnotations`                        | Annotations for NATS pods                                                                | `{}` (evaluated as a template)                          |
-| `extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for NATS container(s)           | `[]`                                                    |
-| `extraVolumes`                          | Optionally specify extra list of additional volumes for NATS pods                        | `[]`                                                    |
-| `initContainers`                        | Add additional init containers to the NATS pods                                          | `{}` (evaluated as a template)                          |
-| `sidecars`                              | Add additional sidecar containers to the NATS pods                                       | `{}` (evaluated as a template)                          |
+| Parameter                   | Description                                                                               | Default                        |
+|-----------------------------|-------------------------------------------------------------------------------------------|--------------------------------|
+| `resourceType`              | NATS cluster resource type under Kubernetes (Supported: StatefulSets, or Deployment)      | `statefulset`                  |
+| `replicaCount`              | Number of NATS nodes                                                                      | `1`                            |
+| `schedulerName`             | Name of an alternate                                                                      | `nil`                          |
+| `priorityClassName`         | Name of pod priority class                                                                | `nil`                          |
+| `podSecurityContext`        | NATS pods' Security Context                                                               | Check `values.yaml` file       |
+| `updateStrategy`            | Strategy to use to update Pods                                                            | Check `values.yaml` file       |
+| `containerSecurityContext`  | NATS containers' Security Context                                                         | Check `values.yaml` file       |
+| `resources.limits`          | The resources limits for the NATS container                                               | `{}`                           |
+| `resources.requests`        | The requested resources for the NATS container                                            | `{}`                           |
+| `livenessProbe`             | Liveness probe configuration for NATS                                                     | Check `values.yaml` file       |
+| `readinessProbe`            | Readiness probe configuration for NATS                                                    | Check `values.yaml` file       |
+| `customLivenessProbe`       | Override default liveness probe                                                           | `nil`                          |
+| `customReadinessProbe`      | Override default readiness probe                                                          | `nil`                          |
+| `podAffinityPreset`         | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                           |
+| `podAntiAffinityPreset`     | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                         |
+| `nodeAffinityPreset.type`   | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                           |
+| `nodeAffinityPreset.key`    | Node label key to match. Ignored if `affinity` is set.                                    | `""`                           |
+| `nodeAffinityPreset.values` | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                           |
+| `affinity`                  | Affinity for pod assignment                                                               | `{}` (evaluated as a template) |
+| `nodeSelector`              | Node labels for pod assignment                                                            | `{}` (evaluated as a template) |
+| `tolerations`               | Tolerations for pod assignment                                                            | `[]` (evaluated as a template) |
+| `podLabels`                 | Extra labels for NATS pods                                                                | `{}` (evaluated as a template) |
+| `podAnnotations`            | Annotations for NATS pods                                                                 | `{}` (evaluated as a template) |
+| `extraVolumeMounts`         | Optionally specify extra list of additional volumeMounts for NATS container(s)            | `[]`                           |
+| `extraVolumes`              | Optionally specify extra list of additional volumes for NATS pods                         | `[]`                           |
+| `initContainers`            | Add additional init containers to the NATS pods                                           | `{}` (evaluated as a template) |
+| `sidecars`                  | Add additional sidecar containers to the NATS pods                                        | `{}` (evaluated as a template) |
 
 ### Exposure parameters
 
-| Parameter                               | Description                                                                              | Default                                                 |
-|-----------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `client.service.type`                   | Kubernetes Service type (NATS client)                                                    | `ClusterIP`                                             |
-| `client.service.port`                   | NATS client port                                                                         | `4222`                                                  |
-| `client.service.nodePort`               | Port to bind to for NodePort service type (NATS client)                                  | `nil`                                                   |
-| `client.service.annotations`            | Annotations for NATS client service                                                      | {}                                                      |
-| `client.service.loadBalancerIP`         | loadBalancerIP if NATS client service type is `LoadBalancer`                             | `nil`                                                   |
-| `cluster.service.type`                  | Kubernetes Service type (NATS cluster)                                                   | `ClusterIP`                                             |
-| `cluster.service.port`                  | NATS cluster port                                                                        | `6222`                                                  |
-| `cluster.service.nodePort`              | Port to bind to for NodePort service type (NATS cluster)                                 | `nil`                                                   |
-| `cluster.service.annotations`           | Annotations for NATS cluster service                                                     | {}                                                      |
-| `cluster.service.loadBalancerIP`        | loadBalancerIP if NATS cluster service type is `LoadBalancer`                            | `nil`                                                   |
-| `cluster.connectRetries`                | Configure number of connect retries for implicit routes                                  | `nil`                                                   |
-| `monitoring.service.type`               | Kubernetes Service type (NATS monitoring)                                                | `ClusterIP`                                             |
-| `monitoring.service.port`               | NATS monitoring port                                                                     | `8222`                                                  |
-| `monitoring.service.nodePort`           | Port to bind to for NodePort service type (NATS monitoring)                              | `nil`                                                   |
-| `monitoring.service.annotations`        | Annotations for NATS monitoring service                                                  | {}                                                      |
-| `monitoring.service.loadBalancerIP`     | loadBalancerIP if NATS monitoring service type is `LoadBalancer`                         | `nil`                                                   |
-| `ingress.enabled`                       | Enable ingress controller resource                                                       | `false`                                                 |
-| `ingress.certManager`                   | Add annotations for cert-manager                                                         | `false`                                                 |
-| `ingress.hostname`                      | Default hostname for the NATS monitoring ingress resource                                | `nats.local`                                            |
-| `ingress.tls`                           | Enable TLS configuration for the hostname defined at `ingress.hostname` parameter        | `false`                                                 |
-| `ingress.annotations`                   | Ingress annotations                                                                      | `{}` (evaluated as a template)                          |
-| `ingress.extraHosts[0].name`            | Additional hostnames to be covered                                                       | `nil`                                                   |
-| `ingress.extraHosts[0].path`            | Additional hostnames to be covered                                                       | `nil`                                                   |
-| `ingress.extraTls[0].hosts[0]`          | TLS configuration for additional hostnames to be covered                                 | `nil`                                                   |
-| `ingress.extraTls[0].secretName`        | TLS configuration for additional hostnames to be covered                                 | `nil`                                                   |
-| `ingress.secrets[0].name`               | TLS Secret Name                                                                          | `nil`                                                   |
-| `ingress.secrets[0].certificate`        | TLS Secret Certificate                                                                   | `nil`                                                   |
-| `ingress.secrets[0].key`                | TLS Secret Key                                                                           | `nil`                                                   |
-| `networkPolicy.enabled`                 | Enable the default NetworkPolicy policy                                                  | `false`                                                 |
-| `networkPolicy.allowExternal`           | Don't require client label for connections                                               | `true`                                                  |
-| `networkPolicy.additionalRules`         | Additional NetworkPolicy rules                                                           | `{}` (evaluated as a template)                          |
+| Parameter                           | Description                                                      | Default                        |
+|-------------------------------------|------------------------------------------------------------------|--------------------------------|
+| `client.service.type`               | Kubernetes Service type (NATS client)                            | `ClusterIP`                    |
+| `client.service.port`               | NATS client port                                                 | `4222`                         |
+| `client.service.nodePort`           | Port to bind to for NodePort service type (NATS client)          | `nil`                          |
+| `client.service.annotations`        | Annotations for NATS client service                              | {}                             |
+| `client.service.loadBalancerIP`     | loadBalancerIP if NATS client service type is `LoadBalancer`     | `nil`                          |
+| `cluster.service.type`              | Kubernetes Service type (NATS cluster)                           | `ClusterIP`                    |
+| `cluster.service.port`              | NATS cluster port                                                | `6222`                         |
+| `cluster.service.nodePort`          | Port to bind to for NodePort service type (NATS cluster)         | `nil`                          |
+| `cluster.service.annotations`       | Annotations for NATS cluster service                             | {}                             |
+| `cluster.service.loadBalancerIP`    | loadBalancerIP if NATS cluster service type is `LoadBalancer`    | `nil`                          |
+| `cluster.connectRetries`            | Configure number of connect retries for implicit routes          | `nil`                          |
+| `monitoring.service.type`           | Kubernetes Service type (NATS monitoring)                        | `ClusterIP`                    |
+| `monitoring.service.port`           | NATS monitoring port                                             | `8222`                         |
+| `monitoring.service.nodePort`       | Port to bind to for NodePort service type (NATS monitoring)      | `nil`                          |
+| `monitoring.service.annotations`    | Annotations for NATS monitoring service                          | {}                             |
+| `monitoring.service.loadBalancerIP` | loadBalancerIP if NATS monitoring service type is `LoadBalancer` | `nil`                          |
+| `ingress.enabled`                   | Enable ingress controller resource                               | `false`                        |
+| `ingress.certManager`               | Add annotations for cert-manager                                 | `false`                        |
+| `ingress.enabled`                   | Enable ingress controller resource                               | `false`                        |
+| `ingress.certManager`               | Add annotations for cert-manager                                 | `false`                        |
+| `ingress.hostname`                  | Default host for the ingress resource                            | `nats.local`                   |
+| `ingress.path`                      | Default path for the ingress resource                            | `/`                            |
+| `ingress.tls`                       | Create TLS Secret                                                | `false`                        |
+| `ingress.annotations`               | Ingress annotations                                              | `[]` (evaluated as a template) |
+| `ingress.extraHosts[0].name`        | Additional hostnames to be covered                               | `nil`                          |
+| `ingress.extraHosts[0].path`        | Additional hostnames to be covered                               | `nil`                          |
+| `ingress.extraPaths`                | Additional arbitrary path/backend objects                        | `nil`                          |
+| `ingress.extraTls[0].hosts[0]`      | TLS configuration for additional hostnames to be covered         | `nil`                          |
+| `ingress.extraTls[0].secretName`    | TLS configuration for additional hostnames to be covered         | `nil`                          |
+| `ingress.secrets[0].name`           | TLS Secret Name                                                  | `nil`                          |
+| `ingress.secrets[0].certificate`    | TLS Secret Certificate                                           | `nil`                          |
+| `ingress.secrets[0].key`            | TLS Secret Key                                                   | `nil`                          |
+| `networkPolicy.enabled`             | Enable the default NetworkPolicy policy                          | `false`                        |
+| `networkPolicy.allowExternal`       | Don't require client label for connections                       | `true`                         |
+| `networkPolicy.additionalRules`     | Additional NetworkPolicy rules                                   | `{}` (evaluated as a template) |
 
 ### Metrics parameters
 
@@ -193,11 +198,11 @@ The following tables lists the configurable parameters of the NATS chart and the
 
 ### Other parameters
 
-| Parameter                               | Description                                                         | Default                                                 |
-|-----------------------------------------|---------------------------------------------------------------------|---------------------------------------------------------|
-| `pdb.create`                            | Enable/disable a Pod Disruption Budget creation                     | `false`                                                 |
-| `pdb.minAvailable`                      | Minimum number/percentage of pods that should remain scheduled      | `1`                                                     |
-| `pdb.maxUnavailable`                    | Maximum number/percentage of pods that may be made unavailable      | `nil`                                                   |
+| Parameter            | Description                                                    | Default |
+|----------------------|----------------------------------------------------------------|---------|
+| `pdb.create`         | Enable/disable a Pod Disruption Budget creation                | `false` |
+| `pdb.minAvailable`   | Minimum number/percentage of pods that should remain scheduled | `1`     |
+| `pdb.maxUnavailable` | Maximum number/percentage of pods that may be made unavailable | `nil`   |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/nats/templates/ingress.yaml
+++ b/bitnami/nats/templates/ingress.yaml
@@ -21,33 +21,63 @@ metadata:
   {{- end }}
 spec:
   rules:
+{{- if .Values.ingress.enabled }}
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
+kind: Ingress
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.ingress.certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- if .Values.ingress.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+spec:
+  rules:
     {{- if .Values.ingress.hostname }}
     - host: {{ .Values.ingress.hostname }}
       http:
         paths:
-          - path: /
-            backend:
-              serviceName: {{ printf "%s-monitoring" (include "common.names.fullname" .) }}
-              servicePort: monitoring
+          {{- if .Values.ingress.extraPaths }}
+          {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
+          {{- end }}
+          - path: {{ .Values.ingress.path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.ingress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "monitoring" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
-    - host: {{ .name }}
+    - host: {{ .name | quote }}
       http:
         paths:
           - path: {{ default "/" .path }}
-            backend:
-              serviceName: {{ printf "%s-monitoring" (include "common.names.fullname" .) }}
-              servicePort: monitoring
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
+            pathType: {{ default "ImplementationSpecific" .pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "monitoring" "context" $) | nindent 14 }}
     {{- end }}
   {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
   tls:
     {{- if .Values.ingress.tls }}
     - hosts:
         - {{ .Values.ingress.hostname }}
-      secretName: {{ printf "%s-monitoring-tls" .Values.ingress.hostname }}
+        {{- range .Values.ingress.extraHosts }}
+        - {{ .name }}
+        {{- end }}
+      secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
     {{- end }}
     {{- if .Values.ingress.extraTls }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.extraTls "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/bitnami/nats/templates/ingress.yaml
+++ b/bitnami/nats/templates/ingress.yaml
@@ -21,27 +21,6 @@ metadata:
   {{- end }}
 spec:
   rules:
-{{- if .Values.ingress.enabled }}
-apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
-kind: Ingress
-metadata:
-  name: {{ include "common.names.fullname" . }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
-    {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
-    {{- end }}
-  annotations:
-    {{- if .Values.ingress.certManager }}
-    kubernetes.io/tls-acme: "true"
-    {{- end }}
-    {{- if .Values.ingress.annotations }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
-    {{- end }}
-    {{- if .Values.commonAnnotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
-    {{- end }}
-spec:
-  rules:
     {{- if .Values.ingress.hostname }}
     - host: {{ .Values.ingress.hostname }}
       http:
@@ -79,5 +58,4 @@ spec:
     {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.extraTls "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
-{{- end }}
 {{- end }}

--- a/bitnami/nats/values-production.yaml
+++ b/bitnami/nats/values-production.yaml
@@ -27,6 +27,10 @@ image:
   ##
   pullSecrets: []
 
+## Force target Kubernetes version (using Helm capabilites if not set)
+##
+kubeVersion:
+
 ## String to partially override common.names.fullname template (will maintain the release name)
 ##
 # nameOverride:
@@ -157,6 +161,7 @@ updateStrategy:
 podSecurityContext:
   enabled: false
   ## fsGroup: 1001
+  ##
 
 ## NATS containers' SecurityContext
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
@@ -165,6 +170,7 @@ containerSecurityContext:
   enabled: false
   ## runAsUser: 1001
   ## runAsNonRoot: true
+  ##
 
 ## NATS resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -242,6 +248,7 @@ podAntiAffinityPreset: soft
 nodeAffinityPreset:
   ## Node affinity type
   ## Allowed values: soft, hard
+  ##
   type: ""
   ## Node label key to match
   ## E.g.
@@ -310,6 +317,7 @@ sidecars: {}
 client:
   service:
     ## Kubernetes service type
+    ##
     type: ClusterIP
     port: 4222
     ## Specify the nodePort value for the LoadBalancer and NodePort service types.
@@ -336,6 +344,7 @@ cluster:
   # connectRetries:
   service:
     ## Kubernetes service type
+    ##
     type: ClusterIP
     port: 6222
     ## Specify the nodePort value for the LoadBalancer and NodePort service types.
@@ -358,6 +367,7 @@ cluster:
 monitoring:
   service:
     ## Kubernetes service type
+    ##
     type: ClusterIP
     port: 8222
     ## Specify the nodePort value for the LoadBalancer and NodePort service types.
@@ -374,20 +384,35 @@ monitoring:
     ##
     loadBalancerIP:
 
-## Ingress configuration
+## Configure the ingress resource that allows you to access the
+## NATS installation. Set up the URL
+## ref: http://kubernetes.io/docs/user-guide/ingress/
 ##
 ingress:
   ## Set to true to enable ingress record generation
   ##
-  enabled: true
+  enabled: false
 
   ## Set this to true in order to add the corresponding annotations for cert-manager
   ##
   certManager: false
 
+  ## Ingress Path type
+  ##
+  pathType: ImplementationSpecific
+
+  ## Override API Version (automatically detected if not set)
+  ##
+  apiVersion:
+
   ## When the ingress is enabled, a host pointing to this will be created
   ##
   hostname: nats.local
+
+  ## The Path to NATS. You may need to set this to '/*' in order to use this
+  ## with ALB ingress controllers.
+  ##
+  path: /
 
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
@@ -399,46 +424,49 @@ ingress:
 
   ## Enable TLS configuration for the hostname defined at ingress.hostname parameter
   ## TLS certificates will be retrieved from a TLS secret with name: {{- printf "%s-tls" .Values.ingress.hostname }}
-  ## You can use the ingress.secrets parameter to create this TLS secret, relay on cert-manager to create it, or
-  ## let the chart create self-signed certificates for you
+  ## You can use the ingress.secrets parameter to create this TLS secret or relay on cert-manager to create it
   ##
   tls: false
 
   ## The list of additional hostnames to be covered with this ingress record.
   ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
-  ## Example:
   ## extraHosts:
-  ##   - name: nats.local
-  ##     path: /
+  ## - name: nats.local
+  ##   path: /
   ##
-  extraHosts: []
+
+  ## Any additional arbitrary paths that may need to be added to the ingress under the main host.
+  ## For example: The ALB ingress controller requires a special rule for handling SSL redirection.
+  ## extraPaths:
+  ## - path: /*
+  ##   backend:
+  ##     serviceName: ssl-redirect
+  ##     servicePort: use-annotation
+  ##
 
   ## The tls configuration for additional hostnames to be covered with this ingress record.
   ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
-  ## Example:
   ## extraTls:
   ## - hosts:
   ##     - nats.local
   ##   secretName: nats.local-tls
   ##
-  extraTls: []
 
   ## If you're providing your own certificates, please use this to add the certificates as secrets
-  ## key and certificate should start with -----BEGIN CERTIFICATE----- or -----BEGIN RSA PRIVATE KEY-----
-  ## name should line up with a secretName set further up
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+  ## -----BEGIN RSA PRIVATE KEY-----
   ##
-  ## If it is not set and you're using cert-manager, this is unneeded, as it will create the secret for you
-  ## If it is not set and you're NOT using cert-manager either, self-signed certificates will be created
+  ## name should line up with a tlsSecret set further up
+  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+  ##
   ## It is also possible to create and manage the certificates outside of this helm chart
   ## Please see README.md for more information
   ##
-  ## Example
-  ## secrets:
-  ##   - name: nats.local-tls
-  ##     key: ""
-  ##     certificate: ""
-  ##
   secrets: []
+  ## - name: nats.local-tls
+  ##   key:
+  ##   certificate:
+  ##
 
 ## Network Policy configuration
 ## ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
@@ -481,6 +509,7 @@ pdb:
 ## Metrics / Prometheus NATS Exporter
 ##
 ## ref: https://github.com/nats-io/prometheus-nats-exporter
+##
 metrics:
   enabled: true
   image:
@@ -531,5 +560,6 @@ metrics:
     ## Defaults to what's used if you follow CoreOS [Prometheus Install Instructions](https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#tldr)
     ## [Prometheus Selector Label](https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-operator-1)
     ## [Kube Prometheus Selector Label](https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#exporters)
+    ##
     selector:
       prometheus: kube-prometheus

--- a/bitnami/nats/values.yaml
+++ b/bitnami/nats/values.yaml
@@ -27,6 +27,10 @@ image:
   ##
   pullSecrets: []
 
+## Force target Kubernetes version (using Helm capabilites if not set)
+##
+kubeVersion:
+
 ## String to partially override common.names.fullname template (will maintain the release name)
 ##
 # nameOverride:
@@ -157,6 +161,7 @@ updateStrategy:
 podSecurityContext:
   enabled: false
   ## fsGroup: 1001
+  ##
 
 ## NATS containers' SecurityContext
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
@@ -165,6 +170,7 @@ containerSecurityContext:
   enabled: false
   ## runAsUser: 1001
   ## runAsNonRoot: true
+  ##
 
 ## NATS resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -242,6 +248,7 @@ podAntiAffinityPreset: soft
 nodeAffinityPreset:
   ## Node affinity type
   ## Allowed values: soft, hard
+  ##
   type: ""
   ## Node label key to match
   ## E.g.
@@ -310,6 +317,7 @@ sidecars: {}
 client:
   service:
     ## Kubernetes service type
+    ##
     type: ClusterIP
     port: 4222
     ## Specify the nodePort value for the LoadBalancer and NodePort service types.
@@ -336,6 +344,7 @@ cluster:
   # connectRetries:
   service:
     ## Kubernetes service type
+    ##
     type: ClusterIP
     port: 6222
     ## Specify the nodePort value for the LoadBalancer and NodePort service types.
@@ -358,6 +367,7 @@ cluster:
 monitoring:
   service:
     ## Kubernetes service type
+    ##
     type: ClusterIP
     port: 8222
     ## Specify the nodePort value for the LoadBalancer and NodePort service types.
@@ -374,7 +384,9 @@ monitoring:
     ##
     loadBalancerIP:
 
-## Ingress configuration
+## Configure the ingress resource that allows you to access the
+## NATS installation. Set up the URL
+## ref: http://kubernetes.io/docs/user-guide/ingress/
 ##
 ingress:
   ## Set to true to enable ingress record generation
@@ -385,9 +397,22 @@ ingress:
   ##
   certManager: false
 
+  ## Ingress Path type
+  ##
+  pathType: ImplementationSpecific
+
+  ## Override API Version (automatically detected if not set)
+  ##
+  apiVersion:
+
   ## When the ingress is enabled, a host pointing to this will be created
   ##
   hostname: nats.local
+
+  ## The Path to NATS. You may need to set this to '/*' in order to use this
+  ## with ALB ingress controllers.
+  ##
+  path: /
 
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
@@ -399,46 +424,49 @@ ingress:
 
   ## Enable TLS configuration for the hostname defined at ingress.hostname parameter
   ## TLS certificates will be retrieved from a TLS secret with name: {{- printf "%s-tls" .Values.ingress.hostname }}
-  ## You can use the ingress.secrets parameter to create this TLS secret, relay on cert-manager to create it, or
-  ## let the chart create self-signed certificates for you
+  ## You can use the ingress.secrets parameter to create this TLS secret or relay on cert-manager to create it
   ##
   tls: false
 
   ## The list of additional hostnames to be covered with this ingress record.
   ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
-  ## Example:
   ## extraHosts:
-  ##   - name: nats.local
-  ##     path: /
+  ## - name: nats.local
+  ##   path: /
   ##
-  extraHosts: []
+
+  ## Any additional arbitrary paths that may need to be added to the ingress under the main host.
+  ## For example: The ALB ingress controller requires a special rule for handling SSL redirection.
+  ## extraPaths:
+  ## - path: /*
+  ##   backend:
+  ##     serviceName: ssl-redirect
+  ##     servicePort: use-annotation
+  ##
 
   ## The tls configuration for additional hostnames to be covered with this ingress record.
   ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
-  ## Example:
   ## extraTls:
   ## - hosts:
   ##     - nats.local
   ##   secretName: nats.local-tls
   ##
-  extraTls: []
 
   ## If you're providing your own certificates, please use this to add the certificates as secrets
-  ## key and certificate should start with -----BEGIN CERTIFICATE----- or -----BEGIN RSA PRIVATE KEY-----
-  ## name should line up with a secretName set further up
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+  ## -----BEGIN RSA PRIVATE KEY-----
   ##
-  ## If it is not set and you're using cert-manager, this is unneeded, as it will create the secret for you
-  ## If it is not set and you're NOT using cert-manager either, self-signed certificates will be created
+  ## name should line up with a tlsSecret set further up
+  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+  ##
   ## It is also possible to create and manage the certificates outside of this helm chart
   ## Please see README.md for more information
   ##
-  ## Example
-  ## secrets:
-  ##   - name: nats.local-tls
-  ##     key: ""
-  ##     certificate: ""
-  ##
   secrets: []
+  ## - name: nats.local-tls
+  ##   key:
+  ##   certificate:
+  ##
 
 ## Network Policy configuration
 ## ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
@@ -481,6 +509,7 @@ pdb:
 ## Metrics / Prometheus NATS Exporter
 ##
 ## ref: https://github.com/nats-io/prometheus-nats-exporter
+##
 metrics:
   enabled: false
   image:
@@ -531,5 +560,6 @@ metrics:
     ## Defaults to what's used if you follow CoreOS [Prometheus Install Instructions](https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#tldr)
     ## [Prometheus Selector Label](https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-operator-1)
     ## [Kube Prometheus Selector Label](https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#exporters)
+    ##
     selector:
       prometheus: kube-prometheus


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This PR updates the common library with the changes from https://github.com/bitnami/charts/pull/4859. 

- Depending on the Kubernetes version it will generate the proper Ingress object
- It allows forcing a Kubernetes version so it is compatible with GitOps approaches

**Benefits**

Charts compatible with all Kubernetes versions
**Possible drawbacks**

n/a
**Applicable issues**

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
