### PR TITLE
[bitnami/nginx] Adapt ingress rules to k8s 1.20

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -25,4 +25,4 @@ name: nginx
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx
   - http://www.nginx.org
-version: 8.2.4
+version: 8.3.0

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -58,17 +58,18 @@ The following tables lists the configurable parameters of the NGINX chart and th
 
 ### Common parameters
 
-| Parameter            | Description                                       | Default                        |
-|----------------------|---------------------------------------------------|--------------------------------|
-| `nameOverride`       | String to partially override nginx.fullname       | `nil`                          |
-| `fullnameOverride`   | String to fully override nginx.fullname           | `nil`                          |
-| `clusterDomain`      | Default Kubernetes cluster domain                 | `cluster.local`                |
-| `commonLabels`       | Labels to add to all deployed objects             | `{}`                           |
-| `commonAnnotations`  | Annotations to add to all deployed objects        | `{}`                           |
-| `extraDeploy`        | Array of extra objects to deploy with the release | `[]` (evaluated as a template) |
-| `pdb.create`         | Created a PodDisruptionBudget                     | `false`                        |
-| `pdb.minAvailable`   | Set PDB minAvailable value                        | `1`                            |
-| `pdb.maxUnavailable` | Set PDB maxUnavailable value                      | `nil`                          |
+| Parameter            | Description                                                          | Default                        |
+|----------------------|----------------------------------------------------------------------|--------------------------------|
+| `nameOverride`       | String to partially override nginx.fullname                          | `nil`                          |
+| `fullnameOverride`   | String to fully override nginx.fullname                              | `nil`                          |
+| `clusterDomain`      | Default Kubernetes cluster domain                                    | `cluster.local`                |
+| `commonLabels`       | Labels to add to all deployed objects                                | `{}`                           |
+| `commonAnnotations`  | Annotations to add to all deployed objects                           | `{}`                           |
+| `extraDeploy`        | Array of extra objects to deploy with the release                    | `[]` (evaluated as a template) |
+| `pdb.create`         | Created a PodDisruptionBudget                                        | `false`                        |
+| `pdb.minAvailable`   | Set PDB minAvailable value                                           | `1`                            |
+| `pdb.maxUnavailable` | Set PDB maxUnavailable value                                         | `nil`                          |
+| `kubeVersion`        | Force target Kubernetes version (using Helm capabilities if not set) | `nil`                          |
 
 ### NGINX parameters
 
@@ -178,7 +179,9 @@ The following tables lists the configurable parameters of the NGINX chart and th
 | `ingress.enabled`                | Enable ingress controller resource                                                      | `false`                        |
 | `ingress.certManager`            | Add annotations for cert-manager                                                        | `false`                        |
 | `ingress.hostname`               | Default host for the ingress resource                                                   | `nginx.local`                  |
-| `ingress.path`                   | Default path for the ingress resource                                                   | `/`                            |
+| `ingress.apiVersion`             | Force Ingress API version (automatically detected if not set)                           | ``                             |
+| `ingress.path`                   | Ingress path                                                                            | `/`                            |
+| `ingress.pathType`               | Ingress path type                                                                       | `ImplementationSpecific`       |
 | `ingress.tls`                    | Create TLS Secret                                                                       | `false`                        |
 | `ingress.annotations`            | Ingress annotations                                                                     | `[]` (evaluated as a template) |
 | `ingress.extraHosts[0].name`     | Additional hostnames to be covered                                                      | `nil`                          |
@@ -192,6 +195,8 @@ The following tables lists the configurable parameters of the NGINX chart and th
 | `healthIngress.enabled`          | Enable healthIngress controller resource                                                | `false`                        |
 | `healthIngress.certManager`      | Add annotations for cert-manager                                                        | `false`                        |
 | `healthIngress.hostname`         | Default host for the healthIngress resource                                             | `example.local`                |
+| `healthIngress.path`             | Ingress path                                                                            | `/`                            |
+| `healthIngress.pathType`         | Ingress path type                                                                       | `ImplementationSpecific`       |
 | `healthIngress.tls`              | Enable TLS configuration for the hostname defined at `healthIngress.hostname` parameter | `false`                        |
 | `healthIngress.annotations`      | Ingress annotations                                                                     | `[]`                           |
 | `healthIngress.extraHosts`       | Additional hostnames to be covered                                                      | `[]`                           |

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -51,167 +51,173 @@ The following tables lists the configurable parameters of the NGINX chart and th
 
 ### Global parameters
 
-| Parameter                               | Description                                                | Default                                                 |
-|-----------------------------------------|------------------------------------------------------------|---------------------------------------------------------|
-| `global.imageRegistry`                  | Global Docker image registry                               | `nil`                                                   |
-| `global.imagePullSecrets`               | Global Docker registry secret names as an array            | `[]` (does not add image pull secrets to deployed pods) |
+| Parameter                 | Description                                     | Default                                                 |
+|---------------------------|-------------------------------------------------|---------------------------------------------------------|
+| `global.imageRegistry`    | Global Docker image registry                    | `nil`                                                   |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
 
 ### Common parameters
 
-| Parameter                               | Description                                                | Default                                                 |
-|-----------------------------------------|------------------------------------------------------------|---------------------------------------------------------|
-| `nameOverride`                          | String to partially override nginx.fullname                | `nil`                                                   |
-| `fullnameOverride`                      | String to fully override nginx.fullname                    | `nil`                                                   |
-| `clusterDomain`                         | Default Kubernetes cluster domain                          | `cluster.local`                                         |
-| `commonLabels`                          | Labels to add to all deployed objects                      | `{}`                                                    |
-| `commonAnnotations`                     | Annotations to add to all deployed objects                 | `{}`                                                    |
-| `extraDeploy`                           | Array of extra objects to deploy with the release          | `[]` (evaluated as a template)                          |
-| `pdb.create`                            | Created a PodDisruptionBudget                              | `false`                                                 |
-| `pdb.minAvailable`                      | Set PDB minAvailable value                                 | `1`                                                     |
-| `pdb.maxUnavailable`                    | Set PDB maxUnavailable value                               | `nil`                                                   |
+| Parameter            | Description                                       | Default                        |
+|----------------------|---------------------------------------------------|--------------------------------|
+| `nameOverride`       | String to partially override nginx.fullname       | `nil`                          |
+| `fullnameOverride`   | String to fully override nginx.fullname           | `nil`                          |
+| `clusterDomain`      | Default Kubernetes cluster domain                 | `cluster.local`                |
+| `commonLabels`       | Labels to add to all deployed objects             | `{}`                           |
+| `commonAnnotations`  | Annotations to add to all deployed objects        | `{}`                           |
+| `extraDeploy`        | Array of extra objects to deploy with the release | `[]` (evaluated as a template) |
+| `pdb.create`         | Created a PodDisruptionBudget                     | `false`                        |
+| `pdb.minAvailable`   | Set PDB minAvailable value                        | `1`                            |
+| `pdb.maxUnavailable` | Set PDB maxUnavailable value                      | `nil`                          |
 
 ### NGINX parameters
 
-| Parameter                               | Description                                                                              | Default                                                 |
-|-----------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `image.registry`                        | NGINX image registry                                                                     | `docker.io`                                             |
-| `image.repository`                      | NGINX image name                                                                         | `bitnami/nginx`                                         |
-| `image.tag`                             | NGINX image tag                                                                          | `{TAG_NAME}`                                            |
-| `image.pullPolicy`                      | NGINX image pull policy                                                                  | `IfNotPresent`                                          |
-| `image.pullSecrets`                     | Specify docker-registry secret names as an array                                         | `[]` (does not add image pull secrets to deployed pods) |
-| `image.debug`                           | Set to true if you would like to see extra information on logs                           | `false`                                                 |
-| `command`                               | Override default container command (useful when using custom images)                     | `nil`                                                   |
-| `args`                                  | Override default container args (useful when using custom images)                        | `nil`                                                   |
-| `extraEnvVars`                          | Extra environment variables to be set on NGINX containers                                | `[]`                                                    |
-| `extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars                                     | `nil`                                                   |
-| `extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars                                        | `nil`                                                   |
+| Parameter            | Description                                                          | Default                                                 |
+|----------------------|----------------------------------------------------------------------|---------------------------------------------------------|
+| `image.registry`     | NGINX image registry                                                 | `docker.io`                                             |
+| `image.repository`   | NGINX image name                                                     | `bitnami/nginx`                                         |
+| `image.tag`          | NGINX image tag                                                      | `{TAG_NAME}`                                            |
+| `image.pullPolicy`   | NGINX image pull policy                                              | `IfNotPresent`                                          |
+| `image.pullSecrets`  | Specify docker-registry secret names as an array                     | `[]` (does not add image pull secrets to deployed pods) |
+| `image.debug`        | Set to true if you would like to see extra information on logs       | `false`                                                 |
+| `command`            | Override default container command (useful when using custom images) | `nil`                                                   |
+| `args`               | Override default container args (useful when using custom images)    | `nil`                                                   |
+| `extraEnvVars`       | Extra environment variables to be set on NGINX containers            | `[]`                                                    |
+| `extraEnvVarsCM`     | Name of existing ConfigMap containing extra env vars                 | `nil`                                                   |
+| `extraEnvVarsSecret` | Name of existing Secret containing extra env vars                    | `nil`                                                   |
 
 ### NGINX deployment parameters
 
-| Parameter                               | Description                                                                              | Default                                                 |
-|-----------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `replicaCount`                          | Number of NGINX replicas to deploy                                                       | `1`                                                     |
-| `strategyType`                          | Deployment Strategy Type                                                                 | `RollingUpdate`                                         |
-| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`      | `""`                                                    |
-| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `soft`                                                  |
-| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`| `""`                                                    |
-| `nodeAffinityPreset.key`                | Node label key to match Ignored if `affinity` is set.                                    | `""`                                                    |
-| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                | `[]`                                                    |
-| `affinity`                              | Affinity for pod assignment                                                              | `{}` (evaluated as a template)                          |
-| `nodeSelector`                          | Node labels for pod assignment                                                           | `{}` (evaluated as a template)                          |
-| `tolerations`                           | Tolerations for pod assignment                                                           | `[]` (evaluated as a template)                          |
-| `podLabels`                             | Additional labels for NGINX pods                                                         | `{}` (evaluated as a template)                          |
-| `podAnnotations`                        | Annotations for NGINX pods                                                               | `{}` (evaluated as a template)                          |
-| `podSecurityContext`                    | NGINX pods' Security Context                                                             | Check `values.yaml` file                                |
-| `containerSecurityContext`              | NGINX containers' Security Context                                                       | Check `values.yaml` file                                |
-| `containerPorts.http`                   | Sets http port inside NGINX container                                                    | `8080`                                                  |
-| `containerPorts.https`                  | Sets https port inside NGINX container                                                   | `nil`                                                   |
-| `resources.limits`                      | The resources limits for the NGINX container                                             | `{}`                                                    |
-| `resources.requests`                    | The requested resources for the NGINX container                                          | `{}`                                                    |
-| `livenessProbe`                         | Liveness probe configuration for NGINX                                                   | Check `values.yaml` file                                |
-| `readinessProbe`                        | Readiness probe configuration for NGINX                                                  | Check `values.yaml` file                                |
-| `customLivenessProbe`                   | Override default liveness probe                                                          | `nil`                                                   |
-| `customReadinessProbe`                  | Override default readiness probe                                                         | `nil`                                                   |
-| `autoscaling.enabled`                   | Enable autoscaling for NGINX deployment                                                  | `false`                                                 |
-| `autoscaling.minReplicas`               | Minimum number of replicas to scale back                                                 | `nil`                                                   |
-| `autoscaling.maxReplicas`               | Maximum number of replicas to scale out                                                  | `nil`                                                   |
-| `autoscaling.targetCPU`                 | Target CPU utilization percentage                                                        | `nil`                                                   |
-| `autoscaling.targetMemory`              | Target Memory utilization percentage                                                     | `nil`                                                   |
-| `extraVolumes`                          | Array to add extra volumes                                                               | `[]` (evaluated as a template)                          |
-| `extraVolumeMounts`                     | Array to add extra mount                                                                 | `[]` (evaluated as a template)                          |
-| `sidecars`                              | Attach additional containers to nginx pods                                               | `nil`
+| Parameter                   | Description                                                                               | Default                        |
+|-----------------------------|-------------------------------------------------------------------------------------------|--------------------------------|
+| `replicaCount`              | Number of NGINX replicas to deploy                                                        | `1`                            |
+| `strategyType`              | Deployment Strategy Type                                                                  | `RollingUpdate`                |
+| `podAffinityPreset`         | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                           |
+| `podAntiAffinityPreset`     | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                         |
+| `nodeAffinityPreset.type`   | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                           |
+| `nodeAffinityPreset.key`    | Node label key to match Ignored if `affinity` is set.                                     | `""`                           |
+| `nodeAffinityPreset.values` | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                           |
+| `affinity`                  | Affinity for pod assignment                                                               | `{}` (evaluated as a template) |
+| `nodeSelector`              | Node labels for pod assignment                                                            | `{}` (evaluated as a template) |
+| `tolerations`               | Tolerations for pod assignment                                                            | `[]` (evaluated as a template) |
+| `podLabels`                 | Additional labels for NGINX pods                                                          | `{}` (evaluated as a template) |
+| `podAnnotations`            | Annotations for NGINX pods                                                                | `{}` (evaluated as a template) |
+| `podSecurityContext`        | NGINX pods' Security Context                                                              | Check `values.yaml` file       |
+| `containerSecurityContext`  | NGINX containers' Security Context                                                        | Check `values.yaml` file       |
+| `containerPorts.http`       | Sets http port inside NGINX container                                                     | `8080`                         |
+| `containerPorts.https`      | Sets https port inside NGINX container                                                    | `nil`                          |
+| `resources.limits`          | The resources limits for the NGINX container                                              | `{}`                           |
+| `resources.requests`        | The requested resources for the NGINX container                                           | `{}`                           |
+| `livenessProbe`             | Liveness probe configuration for NGINX                                                    | Check `values.yaml` file       |
+| `readinessProbe`            | Readiness probe configuration for NGINX                                                   | Check `values.yaml` file       |
+| `customLivenessProbe`       | Override default liveness probe                                                           | `nil`                          |
+| `customReadinessProbe`      | Override default readiness probe                                                          | `nil`                          |
+| `autoscaling.enabled`       | Enable autoscaling for NGINX deployment                                                   | `false`                        |
+| `autoscaling.minReplicas`   | Minimum number of replicas to scale back                                                  | `nil`                          |
+| `autoscaling.maxReplicas`   | Maximum number of replicas to scale out                                                   | `nil`                          |
+| `autoscaling.targetCPU`     | Target CPU utilization percentage                                                         | `nil`                          |
+| `autoscaling.targetMemory`  | Target Memory utilization percentage                                                      | `nil`                          |
+| `extraVolumes`              | Array to add extra volumes                                                                | `[]` (evaluated as a template) |
+| `extraVolumeMounts`         | Array to add extra mount                                                                  | `[]` (evaluated as a template) |
+| `sidecars`                  | Attach additional containers to nginx pods                                                | `nil`                          |
 
 ### Custom NGINX application parameters
 
-| Parameter                                         | Description                                                                    | Default                                                 |
-|---------------------------------------------------|--------------------------------------------------------------------------------|---------------------------------------------------------|
-| `cloneStaticSiteFromGit.enabled`                  | Get the server static content from a GIT repository                            | `false`                                                 |
-| `cloneStaticSiteFromGit.image.registry`           | GIT image registry                                                             | `docker.io`                                             |
-| `cloneStaticSiteFromGit.image.repository`         | GIT image name                                                                 | `bitnami/git`                                           |
-| `cloneStaticSiteFromGit.image.tag`                | GIT image tag                                                                  | `{TAG_NAME}`                                            |
-| `cloneStaticSiteFromGit.image.pullPolicy`         | GIT image pull policy                                                          | `Always`                                                |
-| `cloneStaticSiteFromGit.image.pullSecrets`        | Specify docker-registry secret names as an array                               | `[]` (does not add image pull secrets to deployed pods) |
-| `cloneStaticSiteFromGit.repository`               | GIT Repository to clone                                                        | `nil`                                                   |
-| `cloneStaticSiteFromGit.branch`                   | GIT revision to checkout                                                       | `nil`                                                   |
-| `cloneStaticSiteFromGit.interval`                 | Interval for sidecar container pull from the GIT repository                    | `60`                                                    |
-| `serverBlock`                                     | Custom NGINX server block                                                      | `nil`                                                   |
-| `existingServerBlockConfigmap`                    | Name of existing PVC with custom NGINX server block                            | `nil`                                                   |
-| `staticSiteConfigmap`                             | Name of existing ConfigMap with the server static content                      | `nil`                                                   |
-| `staticSitePVC`                                   | Name of existing PVC with the server static content                            | `nil`                                                   |
+| Parameter                                  | Description                                                 | Default                                                 |
+|--------------------------------------------|-------------------------------------------------------------|---------------------------------------------------------|
+| `cloneStaticSiteFromGit.enabled`           | Get the server static content from a GIT repository         | `false`                                                 |
+| `cloneStaticSiteFromGit.image.registry`    | GIT image registry                                          | `docker.io`                                             |
+| `cloneStaticSiteFromGit.image.repository`  | GIT image name                                              | `bitnami/git`                                           |
+| `cloneStaticSiteFromGit.image.tag`         | GIT image tag                                               | `{TAG_NAME}`                                            |
+| `cloneStaticSiteFromGit.image.pullPolicy`  | GIT image pull policy                                       | `Always`                                                |
+| `cloneStaticSiteFromGit.image.pullSecrets` | Specify docker-registry secret names as an array            | `[]` (does not add image pull secrets to deployed pods) |
+| `cloneStaticSiteFromGit.repository`        | GIT Repository to clone                                     | `nil`                                                   |
+| `cloneStaticSiteFromGit.branch`            | GIT revision to checkout                                    | `nil`                                                   |
+| `cloneStaticSiteFromGit.interval`          | Interval for sidecar container pull from the GIT repository | `60`                                                    |
+| `serverBlock`                              | Custom NGINX server block                                   | `nil`                                                   |
+| `existingServerBlockConfigmap`             | Name of existing PVC with custom NGINX server block         | `nil`                                                   |
+| `staticSiteConfigmap`                      | Name of existing ConfigMap with the server static content   | `nil`                                                   |
+| `staticSitePVC`                            | Name of existing PVC with the server static content         | `nil`                                                   |
 
 ### LDAP parameters
 
-| Parameter                                         | Description                                                                              | Default                                       |
-|---------------------------------------------------|------------------------------------------------------------------------------------------|-----------------------------------------------|
-| `ldapDaemon.enabled`                              | Enable LDAP Auth Daemon proxy                                                            | `false`                                       |
-| `ldapDaemon.image.registry`                       | LDAP AUth Daemon Image registry                                                          | `docker.io`                                   |
-| `ldapDaemon.image.repository`                     | LDAP Auth Daemon Image name                                                              | `bitnami/nginx-ldap-auth-daemon`              |
-| `ldapDaemon.image.tag`                            | LDAP Auth Daemon Image tag                                                               | `{TAG_NAME}`                                  |
-| `ldapDaemon.image.pullPolicy`                     | LDAP Auth Daemon Image pull policy                                                       | `IfNotPresent`                                |
-| `ldapDaemon.port`                                 | LDAP Auth Daemon port                                                                    | `8888`                                        |
-| `ldapDaemon.ldapConfig.uri`                       | LDAP Server URI, `ldap[s]:/<hostname>:<port>`                                            | `""`                                          |
-| `ldapDaemon.ldapConfig.baseDN`                    | LDAP root DN to begin the search for the user                                            | `""`                                          |
-| `ldapDaemon.ldapConfig.bindDN`                    | DN of user to bind to LDAP                                                               | `""`                                          |
-| `ldapDaemon.ldapConfig.bindPassword`              | Password for the user to bind to LDAP                                                    | `""`                                          |
-| `ldapDaemon.ldapConfig.filter`                    | LDAP search filter for search+bind authentication                                        | `""`                                          |
-| `ldapDaemon.ldapConfig.httpRealm`                 | LDAP HTTP auth realm                                                                     | `""`                                          |
-| `ldapDaemon.ldapConfig.httpCookieName`            | HTTP cookie name to be used in LDAP Auth                                                 | `""`                                          |
-| `ldapDaemon.nginxServerBlock`                     | NGINX server block that configures LDAP communication. Overrides `ldapDaemon.ldapConfig` | See `values.yaml`                             |
-| `ldapDaemon.existingNginxServerBlockSecret`       | Name of existing Secret with a NGINX server block to use for LDAP communication          | `nil`                                         |
-| `ldapDaemon.livenessProbe`                        | LDAP Auth Daemon Liveness Probe                                                          | See `values.yaml`                             |
-| `ldapDaemon.readinessProbe`                       | LDAP Auth Daemon Readiness Probe                                                         | See `values.yaml`                             |
+| Parameter                                   | Description                                                                              | Default                          |
+|---------------------------------------------|------------------------------------------------------------------------------------------|----------------------------------|
+| `ldapDaemon.enabled`                        | Enable LDAP Auth Daemon proxy                                                            | `false`                          |
+| `ldapDaemon.image.registry`                 | LDAP AUth Daemon Image registry                                                          | `docker.io`                      |
+| `ldapDaemon.image.repository`               | LDAP Auth Daemon Image name                                                              | `bitnami/nginx-ldap-auth-daemon` |
+| `ldapDaemon.image.tag`                      | LDAP Auth Daemon Image tag                                                               | `{TAG_NAME}`                     |
+| `ldapDaemon.image.pullPolicy`               | LDAP Auth Daemon Image pull policy                                                       | `IfNotPresent`                   |
+| `ldapDaemon.port`                           | LDAP Auth Daemon port                                                                    | `8888`                           |
+| `ldapDaemon.ldapConfig.uri`                 | LDAP Server URI, `ldap[s]:/<hostname>:<port>`                                            | `""`                             |
+| `ldapDaemon.ldapConfig.baseDN`              | LDAP root DN to begin the search for the user                                            | `""`                             |
+| `ldapDaemon.ldapConfig.bindDN`              | DN of user to bind to LDAP                                                               | `""`                             |
+| `ldapDaemon.ldapConfig.bindPassword`        | Password for the user to bind to LDAP                                                    | `""`                             |
+| `ldapDaemon.ldapConfig.filter`              | LDAP search filter for search+bind authentication                                        | `""`                             |
+| `ldapDaemon.ldapConfig.httpRealm`           | LDAP HTTP auth realm                                                                     | `""`                             |
+| `ldapDaemon.ldapConfig.httpCookieName`      | HTTP cookie name to be used in LDAP Auth                                                 | `""`                             |
+| `ldapDaemon.nginxServerBlock`               | NGINX server block that configures LDAP communication. Overrides `ldapDaemon.ldapConfig` | See `values.yaml`                |
+| `ldapDaemon.existingNginxServerBlockSecret` | Name of existing Secret with a NGINX server block to use for LDAP communication          | `nil`                            |
+| `ldapDaemon.livenessProbe`                  | LDAP Auth Daemon Liveness Probe                                                          | See `values.yaml`                |
+| `ldapDaemon.readinessProbe`                 | LDAP Auth Daemon Readiness Probe                                                         | See `values.yaml`                |
 
 ### Exposure parameters
 
-| Parameter                               | Description                                                                              | Default                                                 |
-|-----------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `service.type`                          | Kubernetes Service type                                                                  | `LoadBalancer`                                          |
-| `service.port`                          | Service HTTP port                                                                        | `80`                                                    |
-| `service.httpsPort`                     | Service HTTPS port                                                                       | `443`                                                   |
-| `service.nodePorts.http`                | Kubernetes http node port                                                                | `""`                                                    |
-| `service.nodePorts.https`               | Kubernetes https node port                                                               | `""`                                                    |
-| `service.targetPort.http`               | Kubernetes http targetPort                                                               | `http`                                                  |
-| `service.targetPort.https`              | Kubernetes https targetPort                                                              | `https`                                                 |
-| `service.externalTrafficPolicy`         | Enable client source IP preservation                                                     | `Cluster`                                               |
-| `service.loadBalancerIP`                | LoadBalancer service IP address                                                          | `""`                                                    |
-| `service.annotations`                   | Service annotations                                                                      | `{}`                                                    |
-| `ingress.enabled`                       | Enable ingress controller resource                                                       | `false`                                                 |
-| `ingress.certManager`                   | Add annotations for cert-manager                                                         | `false`                                                 |
-| `ingress.hostname`                      | Default host for the ingress resource                                                    | `example.local`                                         |
-| `ingress.tls`                           | Enable TLS configuration for the hostname defined at `ingress.hostname` parameter        | `false`                                                 |
-| `ingress.annotations`                   | Ingress annotations                                                                      | `[]`                                                    |
-| `ingress.extraHosts`                    | Additional hostnames to be covered                                                       | `[]`                                                    |
-| `ingress.extraTls`                      | TLS configuration for additional hostnames to be covered                                 | `[]`                                                    |
-| `ingress.secrets`                       | TLS Secret configuration                                                                 | `[]`                                                    |
-| `healthIngress.enabled`                 | Enable healthIngress controller resource                                                 | `false`                                                 |
-| `healthIngress.certManager`             | Add annotations for cert-manager                                                         | `false`                                                 |
-| `healthIngress.hostname`                | Default host for the healthIngress resource                                              | `example.local`                                         |
-| `healthIngress.tls`                     | Enable TLS configuration for the hostname defined at `healthIngress.hostname` parameter  | `false`                                                 |
-| `healthIngress.annotations`             | Ingress annotations                                                                      | `[]`                                                    |
-| `healthIngress.extraHosts`              | Additional hostnames to be covered                                                       | `[]`                                                    |
-| `healthIngress.extraTls`                | TLS configuration for additional hostnames to be covered                                 | `[]`                                                    |
-| `healthIngress.secrets`                 | TLS Secret configuration                                                                 | `[]`                                                    |
+| Parameter                        | Description                                                                             | Default                        |
+|----------------------------------|-----------------------------------------------------------------------------------------|--------------------------------|
+| `service.type`                   | Kubernetes Service type                                                                 | `LoadBalancer`                 |
+| `service.port`                   | Service HTTP port                                                                       | `80`                           |
+| `service.httpsPort`              | Service HTTPS port                                                                      | `443`                          |
+| `service.nodePorts.http`         | Kubernetes http node port                                                               | `""`                           |
+| `service.nodePorts.https`        | Kubernetes https node port                                                              | `""`                           |
+| `service.targetPort.http`        | Kubernetes http targetPort                                                              | `http`                         |
+| `service.targetPort.https`       | Kubernetes https targetPort                                                             | `https`                        |
+| `service.externalTrafficPolicy`  | Enable client source IP preservation                                                    | `Cluster`                      |
+| `service.loadBalancerIP`         | LoadBalancer service IP address                                                         | `""`                           |
+| `service.annotations`            | Service annotations                                                                     | `{}`                           |
+| `ingress.enabled`                | Enable ingress controller resource                                                      | `false`                        |
+| `ingress.certManager`            | Add annotations for cert-manager                                                        | `false`                        |
+| `ingress.hostname`               | Default host for the ingress resource                                                   | `nginx.local`                  |
+| `ingress.path`                   | Default path for the ingress resource                                                   | `/`                            |
+| `ingress.tls`                    | Create TLS Secret                                                                       | `false`                        |
+| `ingress.annotations`            | Ingress annotations                                                                     | `[]` (evaluated as a template) |
+| `ingress.extraHosts[0].name`     | Additional hostnames to be covered                                                      | `nil`                          |
+| `ingress.extraHosts[0].path`     | Additional hostnames to be covered                                                      | `nil`                          |
+| `ingress.extraPaths`             | Additional arbitrary path/backend objects                                               | `nil`                          |
+| `ingress.extraTls[0].hosts[0]`   | TLS configuration for additional hostnames to be covered                                | `nil`                          |
+| `ingress.extraTls[0].secretName` | TLS configuration for additional hostnames to be covered                                | `nil`                          |
+| `ingress.secrets[0].name`        | TLS Secret Name                                                                         | `nil`                          |
+| `ingress.secrets[0].certificate` | TLS Secret Certificate                                                                  | `nil`                          |
+| `ingress.secrets[0].key`         | TLS Secret Key                                                                          | `nil`                          |
+| `healthIngress.enabled`          | Enable healthIngress controller resource                                                | `false`                        |
+| `healthIngress.certManager`      | Add annotations for cert-manager                                                        | `false`                        |
+| `healthIngress.hostname`         | Default host for the healthIngress resource                                             | `example.local`                |
+| `healthIngress.tls`              | Enable TLS configuration for the hostname defined at `healthIngress.hostname` parameter | `false`                        |
+| `healthIngress.annotations`      | Ingress annotations                                                                     | `[]`                           |
+| `healthIngress.extraHosts`       | Additional hostnames to be covered                                                      | `[]`                           |
+| `healthIngress.extraTls`         | TLS configuration for additional hostnames to be covered                                | `[]`                           |
+| `healthIngress.secrets`          | TLS Secret configuration                                                                | `[]`                           |
 
 ### Metrics parameters
 
-| Parameter                               | Description                                                                                 | Default                                                      |
-|-----------------------------------------|---------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `metrics.enabled`                       | Start a Prometheus exporter sidecar container                                               | `false`                                                      |
-| `metrics.image.registry`                | NGINX Prometheus exporter image registry                                                    | `docker.io`                                                  |
-| `metrics.image.repository`              | NGINX Prometheus exporter image name                                                        | `bitnami/nginx-exporter`                                     |
-| `metrics.image.tag`                     | NGINX Prometheus exporter image tag                                                         | `{TAG_NAME}`                                                 |
-| `metrics.image.pullPolicy`              | NGINX Prometheus exporter image pull policy                                                 | `IfNotPresent`                                               |
-| `metrics.image.pullSecrets`             | Specify docker-registry secret names as an array                                            | `[]` (does not add image pull secrets to deployed pods)      |
-| `metrics.podAnnotations`                | Additional annotations for NGINX Prometheus exporter pod(s)                                 | `{}`                                                         |
-| `metrics.resources.limits`              | The resources limits for the NGINX Prometheus exporter container                            | `{}`                                                         |
-| `metrics.resources.requests`            | The requested resources for the NGINX Prometheus exporter container                         | `{}`                                                         |
-| `metrics.service.port`                  | NGINX Prometheus exporter service port                                                      | `9113`                                                       |
-| `metrics.service.annotations`           | Annotations for Jenkins Prometheus exporter service                                         | `{prometheus.io/scrape: "true", prometheus.io/port: "9113"}` |
-| `metrics.serviceMonitor.enabled`        | Creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`) | `false`                                                      |
-| `metrics.serviceMonitor.namespace`      | Namespace in which Prometheus is running                                                    | `nil`                                                        |
-| `metrics.serviceMonitor.interval`       | Interval at which metrics should be scraped.                                                | `nil` (Prometheus Operator default value)                    |
-| `metrics.serviceMonitor.scrapeTimeout`  | Timeout after which the scrape is ended                                                     | `nil` (Prometheus Operator default value)                    |
-| `metrics.serviceMonitor.selector`       | Prometheus instance selector labels                                                         | `nil`                                                        |
+| Parameter                              | Description                                                                                 | Default                                                      |
+|----------------------------------------|---------------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `metrics.enabled`                      | Start a Prometheus exporter sidecar container                                               | `false`                                                      |
+| `metrics.image.registry`               | NGINX Prometheus exporter image registry                                                    | `docker.io`                                                  |
+| `metrics.image.repository`             | NGINX Prometheus exporter image name                                                        | `bitnami/nginx-exporter`                                     |
+| `metrics.image.tag`                    | NGINX Prometheus exporter image tag                                                         | `{TAG_NAME}`                                                 |
+| `metrics.image.pullPolicy`             | NGINX Prometheus exporter image pull policy                                                 | `IfNotPresent`                                               |
+| `metrics.image.pullSecrets`            | Specify docker-registry secret names as an array                                            | `[]` (does not add image pull secrets to deployed pods)      |
+| `metrics.podAnnotations`               | Additional annotations for NGINX Prometheus exporter pod(s)                                 | `{}`                                                         |
+| `metrics.resources.limits`             | The resources limits for the NGINX Prometheus exporter container                            | `{}`                                                         |
+| `metrics.resources.requests`           | The requested resources for the NGINX Prometheus exporter container                         | `{}`                                                         |
+| `metrics.service.port`                 | NGINX Prometheus exporter service port                                                      | `9113`                                                       |
+| `metrics.service.annotations`          | Annotations for Jenkins Prometheus exporter service                                         | `{prometheus.io/scrape: "true", prometheus.io/port: "9113"}` |
+| `metrics.serviceMonitor.enabled`       | Creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`) | `false`                                                      |
+| `metrics.serviceMonitor.namespace`     | Namespace in which Prometheus is running                                                    | `nil`                                                        |
+| `metrics.serviceMonitor.interval`      | Interval at which metrics should be scraped.                                                | `nil` (Prometheus Operator default value)                    |
+| `metrics.serviceMonitor.scrapeTimeout` | Timeout after which the scrape is ended                                                     | `nil` (Prometheus Operator default value)                    |
+| `metrics.serviceMonitor.selector`      | Prometheus instance selector labels                                                         | `nil`                                                        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/nginx/templates/health-ingress.yaml
+++ b/bitnami/nginx/templates/health-ingress.yaml
@@ -23,19 +23,24 @@ spec:
     - host: {{ .Values.healthIngress.hostname }}
       http:
         paths:
-          - path: /
-            backend:
-              serviceName: {{ template "common.names.fullname" . }}
-              servicePort: http
+          {{- if .Values.healthIngress.extraPaths }}
+          {{- toYaml .Values.healthIngress.extraPaths | nindent 10 }}
+          {{- end }}
+          - path: {{ .Values.healthIngress.path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.healthIngress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.healthIngress.extraHosts }}
     - host: {{ .name }}
       http:
         paths:
           - path: {{ default "/" .path }}
-            backend:
-              serviceName: {{ template "common.names.fullname" $ }}
-              servicePort: http
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
+            pathType: {{ default "ImplementationSpecific" .pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
   {{- if or .Values.healthIngress.tls .Values.healthIngress.extraTls }}
   tls:

--- a/bitnami/nginx/templates/health-ingress.yaml
+++ b/bitnami/nginx/templates/health-ingress.yaml
@@ -33,7 +33,7 @@ spec:
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.healthIngress.extraHosts }}
-    - host: {{ .name }}
+    - host: {{ .name | quote }}
       http:
         paths:
           - path: {{ default "/" .path }}
@@ -50,7 +50,7 @@ spec:
       secretName: {{ printf "%s-tls" .Values.healthIngress.hostname }}
     {{- end }}
     {{- if .Values.healthIngress.extraTls }}
-    {{- toYaml .Values.healthIngress.extraTls | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.healthIngress.extraTls "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/bitnami/nginx/templates/ingress.yaml
+++ b/bitnami/nginx/templates/ingress.yaml
@@ -23,19 +23,24 @@ spec:
     - host: {{ .Values.ingress.hostname }}
       http:
         paths:
-          - path: /
-            backend:
-              serviceName: {{ template "common.names.fullname" . }}
-              servicePort: http
+          {{- if .Values.ingress.extraPaths }}
+          {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
+          {{- end }}
+          - path: {{ .Values.ingress.path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.ingress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
-    - host: {{ .name }}
+    - host: {{ .name | quote }}
       http:
         paths:
           - path: {{ default "/" .path }}
-            backend:
-              serviceName: {{ template "common.names.fullname" $ }}
-              servicePort: http
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
+            pathType: {{ default "ImplementationSpecific" .pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
   {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
   tls:
@@ -45,7 +50,7 @@ spec:
       secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
     {{- end }}
     {{- if .Values.ingress.extraTls }}
-    {{- toYaml .Values.ingress.extraTls | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.extraTls "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -39,6 +39,10 @@ image:
 ##
 # fullnameOverride:
 
+## Force target Kubernetes version (using Helm capabilites if not set)
+##
+kubeVersion:
+
 ## Kubernetes Cluster Domain
 ##
 clusterDomain: cluster.local
@@ -174,6 +178,7 @@ podAntiAffinityPreset: soft
 nodeAffinityPreset:
   ## Node affinity type
   ## Allowed values: soft, hard
+  ##
   type: ""
   ## Node label key to match
   ## E.g.
@@ -315,6 +320,7 @@ service:
   ## Target port reference value for the Loadbalancer service types can be specified explicitly.
   ## Listeners for the Loadbalancer can be custom mapped to the http or https service.
   ## Example: Mapping the https listener to targetPort http [http: https]
+  ##
   targetPort:
     http: http
     https: https
@@ -370,24 +376,31 @@ ldapDaemon:
 
     ## LDAP URI where to query the server
     ## Must follow the pattern -> ldap[s]:/<hostname>:<port>
+    ##
     uri: ""
 
     ## LDAP search base DN
+    ##
     baseDN: ""
 
     ## LDAP bind DN
+    ##
     bindDN: ""
 
     ## LDAP bind Password
+    ##
     bindPassword: ""
 
     ## LDAP search filter
+    ##
     filter: ""
 
     ## LDAP auth realm
+    ##
     httpRealm: ""
 
     ## LDAP cookie name
+    ##
     httpCookieName: ""
 
   ## NGINX Configuration File containing the directives (that define
@@ -477,7 +490,10 @@ ldapDaemon:
 #       - name: portname
 #         containerPort: 1234
 sidecars:
-## Ingress parameters
+
+## Configure the ingress resource that allows you to access the
+## Nginx installation. Set up the URL
+## ref: http://kubernetes.io/docs/user-guide/ingress/
 ##
 ingress:
   ## Set to true to enable ingress record generation
@@ -488,9 +504,22 @@ ingress:
   ##
   certManager: false
 
+  ## Ingress Path type
+  ##
+  pathType: ImplementationSpecific
+
+  ## Override API Version (automatically detected if not set)
+  ##
+  apiVersion:
+
   ## When the ingress is enabled, a host pointing to this will be created
   ##
-  hostname: example.local
+  hostname: nginx.local
+
+  ## The Path to Nginx. You may need to set this to '/*' in order to use this
+  ## with ALB ingress controllers.
+  ##
+  path: /
 
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
@@ -502,45 +531,49 @@ ingress:
 
   ## Enable TLS configuration for the hostname defined at ingress.hostname parameter
   ## TLS certificates will be retrieved from a TLS secret with name: {{- printf "%s-tls" .Values.ingress.hostname }}
-  ## You can use the ingress.secrets parameter to create this TLS secret, relay on cert-manager to create it, or
-  ## let the chart create self-signed certificates for you
+  ## You can use the ingress.secrets parameter to create this TLS secret or relay on cert-manager to create it
   ##
   tls: false
 
   ## The list of additional hostnames to be covered with this ingress record.
   ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
-  ## E.g.
   ## extraHosts:
-  ##   - name: example.local
-  ##     path: /
+  ## - name: nginx.local
+  ##   path: /
   ##
-  extraHosts: []
+
+  ## Any additional arbitrary paths that may need to be added to the ingress under the main host.
+  ## For example: The ALB ingress controller requires a special rule for handling SSL redirection.
+  ## extraPaths:
+  ## - path: /*
+  ##   backend:
+  ##     serviceName: ssl-redirect
+  ##     servicePort: use-annotation
+  ##
 
   ## The tls configuration for additional hostnames to be covered with this ingress record.
   ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
-  ## E.g.
   ## extraTls:
-  ##   - hosts:
-  ##       - example.local
-  ##     secretName: example.local-tls
+  ## - hosts:
+  ##     - nginx.local
+  ##   secretName: nginx.local-tls
   ##
-  extraTls: []
 
   ## If you're providing your own certificates, please use this to add the certificates as secrets
-  ## key and certificate should start with -----BEGIN CERTIFICATE----- or -----BEGIN RSA PRIVATE KEY-----
-  ## name should line up with a secretName set further up
-  ## If it is not set and you're using cert-manager, this is unneeded, as it will create the secret for you
-  ## If it is not set and you're NOT using cert-manager either, self-signed certificates will be created
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+  ## -----BEGIN RSA PRIVATE KEY-----
+  ##
+  ## name should line up with a tlsSecret set further up
+  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+  ##
   ## It is also possible to create and manage the certificates outside of this helm chart
   ## Please see README.md for more information
   ##
-  ## E.g.
-  ## secrets:
-  ##   - name: example.local-tls
-  ##     key:
-  ##     certificate:
-  ##
   secrets: []
+  ## - name: nginx.local-tls
+  ##   key:
+  ##   certificate:
+  ##
 
 ## Health Ingress parameters
 ##
@@ -552,6 +585,10 @@ healthIngress:
   ## Set this to true in order to add the corresponding annotations for cert-manager
   ##
   certManager: false
+
+  ## Ingress Path type
+  ##
+  pathType: ImplementationSpecific
 
   ## When the health ingress is enabled, a host pointing to this will be created
   ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This PR updates the common library with the changes from https://github.com/bitnami/charts/pull/4859. 

- Depending on the Kubernetes version it will generate the proper Ingress object
- It allows forcing a Kubernetes version so it is compatible with GitOps approaches

**Benefits**

Charts compatible with all Kubernetes versions
**Possible drawbacks**

n/a
**Applicable issues**

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
