### PR TITLE
[bitnami/phpmyadmin] Adapt Ingress to k8s 1.20

### DIFF
--- a/bitnami/phpmyadmin/Chart.lock
+++ b/bitnami/phpmyadmin/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.2.3
+  version: 1.3.1
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 9.2.0
-digest: sha256:26fff2c7d428f3cb7b1c280c6590064fd0e27dd80e97365e2f72f19246810c19
-generated: "2021-01-07T07:55:02.483570784Z"
+  version: 9.2.2
+digest: sha256:01fe417fac8b9ca93061fcf99d66bdd642394684f89911174d472dfe96437b6c
+generated: "2021-01-13T17:20:41.490629+01:00"

--- a/bitnami/phpmyadmin/Chart.yaml
+++ b/bitnami/phpmyadmin/Chart.yaml
@@ -29,4 +29,4 @@ name: phpmyadmin
 sources:
   - https://github.com/bitnami/bitnami-docker-phpmyadmin
   - https://www.phpmyadmin.net/
-version: 8.0.4
+version: 8.1.0

--- a/bitnami/phpmyadmin/README.md
+++ b/bitnami/phpmyadmin/README.md
@@ -48,134 +48,136 @@ The following tables lists the configurable parameters of the phpMyAdmin chart a
 
 ### Global parameters
 
-| Parameter                               | Description                                                | Default                                                 |
-|-----------------------------------------|------------------------------------------------------------|---------------------------------------------------------|
-| `global.imageRegistry`                  | Global Docker image registry                               | `nil`                                                   |
-| `global.imagePullSecrets`               | Global Docker registry secret names as an array            | `[]` (does not add image pull secrets to deployed pods) |
+| Parameter                 | Description                                     | Default                                                 |
+|---------------------------|-------------------------------------------------|---------------------------------------------------------|
+| `global.imageRegistry`    | Global Docker image registry                    | `nil`                                                   |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
 
 ### Common parameters
 
-| Parameter                               | Description                                                | Default                                                 |
-|-----------------------------------------|------------------------------------------------------------|---------------------------------------------------------|
-| `nameOverride`                          | String to partially override common.names.fullname         | `nil`                                                   |
-| `fullnameOverride`                      | String to fully override common.names.fullname             | `nil`                                                   |
-| `commonLabels`                          | Labels to add to all deployed objects                      | `{}`                                                    |
-| `commonAnnotations`                     | Annotations to add to all deployed objects                 | `{}`                                                    |
-| `clusterDomain`                         | Default Kubernetes cluster domain                          | `cluster.local`                                         |
-| `extraDeploy`                           | Array of extra objects to deploy with the release          | `[]` (evaluated as a template)                          |
+| Parameter           | Description                                                          | Default                        |
+|---------------------|----------------------------------------------------------------------|--------------------------------|
+| `nameOverride`      | String to partially override common.names.fullname                   | `nil`                          |
+| `fullnameOverride`  | String to fully override common.names.fullname                       | `nil`                          |
+| `commonLabels`      | Labels to add to all deployed objects                                | `{}`                           |
+| `commonAnnotations` | Annotations to add to all deployed objects                           | `{}`                           |
+| `clusterDomain`     | Default Kubernetes cluster domain                                    | `cluster.local`                |
+| `extraDeploy`       | Array of extra objects to deploy with the release                    | `[]` (evaluated as a template) |
+| `kubeVersion`       | Force target Kubernetes version (using Helm capabilities if not set) | `nil`                          |
 
 ### phpMyAdmin parameters
 
-| Parameter                               | Description                                                                              | Default                                                 |
-|-----------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `image.registry`                        | phpMyAdmin image registry                                                                | `docker.io`                                             |
-| `image.repository`                      | phpMyAdmin image name                                                                    | `bitnami/phpmyadmin`                                    |
-| `image.tag`                             | phpMyAdmin image tag                                                                     | `{TAG_NAME}`                                            |
-| `image.pullPolicy`                      | Image pull policy                                                                        | `IfNotPresent`                                          |
-| `image.pullSecrets`                     | Specify docker-registry secret names as an array                                         | `[]` (does not add image pull secrets to deployed pods) |
-| `command`                               | Override default container command (useful when using custom images)                     | `nil`                                                   |
-| `args`                                  | Override default container args (useful when using custom images)                        | `nil`                                                   |
-| `extraEnvVars`                          | Extra environment variables to be set on PhpMyAdmin container                            | `{}`                                                    |
-| `extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars                                     | `nil`                                                   |
-| `extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars                                        | `nil`                                                   |
+| Parameter            | Description                                                          | Default                                                 |
+|----------------------|----------------------------------------------------------------------|---------------------------------------------------------|
+| `image.registry`     | phpMyAdmin image registry                                            | `docker.io`                                             |
+| `image.repository`   | phpMyAdmin image name                                                | `bitnami/phpmyadmin`                                    |
+| `image.tag`          | phpMyAdmin image tag                                                 | `{TAG_NAME}`                                            |
+| `image.pullPolicy`   | Image pull policy                                                    | `IfNotPresent`                                          |
+| `image.pullSecrets`  | Specify docker-registry secret names as an array                     | `[]` (does not add image pull secrets to deployed pods) |
+| `command`            | Override default container command (useful when using custom images) | `nil`                                                   |
+| `args`               | Override default container args (useful when using custom images)    | `nil`                                                   |
+| `extraEnvVars`       | Extra environment variables to be set on PhpMyAdmin container        | `{}`                                                    |
+| `extraEnvVarsCM`     | Name of existing ConfigMap containing extra env vars                 | `nil`                                                   |
+| `extraEnvVarsSecret` | Name of existing Secret containing extra env vars                    | `nil`                                                   |
 
 ### phpMyAdmin deployment parameters
 
-| Parameter                               | Description                                                                              | Default                                                 |
-|-----------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `containerPorts.http`                   | HTTP port to expose at container level                                                   | `8080`                                                  |
-| `containerPorts.https`                  | HTTPS port to expose at container level                                                  | `8443`                                                  |
-| `podSecurityContext`                    | PhpMyAdmin pods' Security Context                                                        | Check `values.yaml` file                                |
-| `containerSecurityContext`              | PhpMyAdmin containers' Security Context                                                  | Check `values.yaml` file                                |
-| `resources.limits`                      | The resources limits for the PhpMyAdmin container                                        | `{}`                                                    |
-| `resources.requests`                    | The requested resources for the PhpMyAdmin container                                     | `{"memory": "512Mi", "cpu": "300m"}`                    |
-| `livenessProbe`                         | Liveness probe configuration for PhpMyAdmin                                              | Check `values.yaml` file                                |
-| `readinessProbe`                        | Readiness probe configuration for PhpMyAdmin                                             | Check `values.yaml` file                                |
-| `customLivenessProbe`                   | Override default liveness probe                                                          | `nil`                                                   |
-| `customReadinessProbe`                  | Override default readiness probe                                                         | `nil`                                                   |
-| `updateStrategy`                        | Strategy to use to update Pods                                                           | Check `values.yaml` file                                |
-| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`      | `""`                                                    |
-| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `soft`                                                  |
-| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`| `""`                                                    |
-| `nodeAffinityPreset.key`                | Node label key to match. Ignored if `affinity` is set.                                   | `""`                                                    |
-| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                | `[]`                                                    |
-| `affinity`                              | Affinity for pod assignment                                                              | `{}` (evaluated as a template)                          |
-| `nodeSelector`                          | Node labels for pod assignment                                                           | `{}` (evaluated as a template)                          |
-| `tolerations`                           | Tolerations for pod assignment                                                           | `[]` (evaluated as a template)                          |
-| `podLabels`                             | Extra labels for PhpMyAdmin pods                                                         | `{}` (evaluated as a template)                          |
-| `podAnnotations`                        | Annotations for PhpMyAdmin pods                                                          | `{}` (evaluated as a template)                          |
-| `extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for PhpMyAdmin container(s)     | `[]`                                                    |
-| `extraVolumes`                          | Optionally specify extra list of additional volumes for PhpMyAdmin pods                  | `[]`                                                    |
-| `initContainers`                        | Add additional init containers to the PhpMyAdmin pods                                    | `{}` (evaluated as a template)                          |
-| `sidecars`                              | Add additional sidecar containers to the PhpMyAdmin pods                                 | `{}` (evaluated as a template)                          |
+| Parameter                   | Description                                                                               | Default                              |
+|-----------------------------|-------------------------------------------------------------------------------------------|--------------------------------------|
+| `containerPorts.http`       | HTTP port to expose at container level                                                    | `8080`                               |
+| `containerPorts.https`      | HTTPS port to expose at container level                                                   | `8443`                               |
+| `podSecurityContext`        | PhpMyAdmin pods' Security Context                                                         | Check `values.yaml` file             |
+| `containerSecurityContext`  | PhpMyAdmin containers' Security Context                                                   | Check `values.yaml` file             |
+| `resources.limits`          | The resources limits for the PhpMyAdmin container                                         | `{}`                                 |
+| `resources.requests`        | The requested resources for the PhpMyAdmin container                                      | `{"memory": "512Mi", "cpu": "300m"}` |
+| `livenessProbe`             | Liveness probe configuration for PhpMyAdmin                                               | Check `values.yaml` file             |
+| `readinessProbe`            | Readiness probe configuration for PhpMyAdmin                                              | Check `values.yaml` file             |
+| `customLivenessProbe`       | Override default liveness probe                                                           | `nil`                                |
+| `customReadinessProbe`      | Override default readiness probe                                                          | `nil`                                |
+| `updateStrategy`            | Strategy to use to update Pods                                                            | Check `values.yaml` file             |
+| `podAffinityPreset`         | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                                 |
+| `podAntiAffinityPreset`     | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                               |
+| `nodeAffinityPreset.type`   | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                                 |
+| `nodeAffinityPreset.key`    | Node label key to match. Ignored if `affinity` is set.                                    | `""`                                 |
+| `nodeAffinityPreset.values` | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                                 |
+| `affinity`                  | Affinity for pod assignment                                                               | `{}` (evaluated as a template)       |
+| `nodeSelector`              | Node labels for pod assignment                                                            | `{}` (evaluated as a template)       |
+| `tolerations`               | Tolerations for pod assignment                                                            | `[]` (evaluated as a template)       |
+| `podLabels`                 | Extra labels for PhpMyAdmin pods                                                          | `{}` (evaluated as a template)       |
+| `podAnnotations`            | Annotations for PhpMyAdmin pods                                                           | `{}` (evaluated as a template)       |
+| `extraVolumeMounts`         | Optionally specify extra list of additional volumeMounts for PhpMyAdmin container(s)      | `[]`                                 |
+| `extraVolumes`              | Optionally specify extra list of additional volumes for PhpMyAdmin pods                   | `[]`                                 |
+| `initContainers`            | Add additional init containers to the PhpMyAdmin pods                                     | `{}` (evaluated as a template)       |
+| `sidecars`                  | Add additional sidecar containers to the PhpMyAdmin pods                                  | `{}` (evaluated as a template)       |
 
 ### Exposure parameters
 
-| Parameter                               | Description                                                                              | Default                                                 |
-|-----------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `service.type`                          | Kubernetes Service type                                                                  | `LoadBalancer`                                          |
-| `service.port`                          | Service HTTP port                                                                        | `80`                                                    |
-| `service.httpsPort`                     | Service HTTPS port                                                                       | `""`                                                    |
-| `service.nodePorts.http`                | Kubernetes http node port                                                                | `""`                                                    |
-| `service.nodePorts.https`               | Kubernetes https node port                                                               | `""`                                                    |
-| `service.clusterIP`                     | PhpMyAdmin service clusterIP IP                                                          | `None`                                                  |
-| `service.externalTrafficPolicy`         | Enable client source IP preservation                                                     | `Cluster`                                               |
-| `service.loadBalancerIP`                | loadBalancerIP if service type is `LoadBalancer`                                         | `nil`                                                   |
-| `service.loadBalancerSourceRanges`      | Address that are allowed when service is LoadBalancer                                    | `[]`                                                    |
-| `service.annotations`                   | Annotations for PhpMyAdmin service                                                       | `{}` (evaluated as a template)                          |
-| `ingress.enabled`                       | Enable ingress controller resource                                                       | `false`                                                 |
-| `ingress.certManager`                   | Add annotations for cert-manager                                                         | `false`                                                 |
-| `ingress.hostname`                      | Default host for the ingress resource                                                    | `phpmyadmin.local`                                      |
-| `ingress.tls`                           | Enable TLS configuration for the hostname defined at `ingress.hostname` parameter        | `false`                                                 |
-| `ingress.annotations`                   | Ingress annotations                                                                      | `{}` (evaluated as a template)                          |
-| `ingress.extraHosts[0].name`            | Additional hostnames to be covered                                                       | `nil`                                                   |
-| `ingress.extraHosts[0].path`            | Additional hostnames to be covered                                                       | `nil`                                                   |
-| `ingress.extraTls[0].hosts[0]`          | TLS configuration for additional hostnames to be covered                                 | `nil`                                                   |
-| `ingress.extraTls[0].secretName`        | TLS configuration for additional hostnames to be covered                                 | `nil`                                                   |
-| `ingress.secrets[0].name`               | TLS Secret Name                                                                          | `nil`                                                   |
-| `ingress.secrets[0].certificate`        | TLS Secret Certificate                                                                   | `nil`                                                   |
-| `ingress.secrets[0].key`                | TLS Secret Key                                                                           | `nil`                                                   |
+| Parameter                          | Description                                                                       | Default                        |
+|------------------------------------|-----------------------------------------------------------------------------------|--------------------------------|
+| `service.type`                     | Kubernetes Service type                                                           | `LoadBalancer`                 |
+| `service.port`                     | Service HTTP port                                                                 | `80`                           |
+| `service.httpsPort`                | Service HTTPS port                                                                | `""`                           |
+| `service.nodePorts.http`           | Kubernetes http node port                                                         | `""`                           |
+| `service.nodePorts.https`          | Kubernetes https node port                                                        | `""`                           |
+| `service.clusterIP`                | PhpMyAdmin service clusterIP IP                                                   | `None`                         |
+| `service.externalTrafficPolicy`    | Enable client source IP preservation                                              | `Cluster`                      |
+| `service.loadBalancerIP`           | loadBalancerIP if service type is `LoadBalancer`                                  | `nil`                          |
+| `service.loadBalancerSourceRanges` | Address that are allowed when service is LoadBalancer                             | `[]`                           |
+| `service.annotations`              | Annotations for PhpMyAdmin service                                                | `{}` (evaluated as a template) |
+| `ingress.enabled`                  | Enable ingress controller resource                                                | `false`                        |
+| `ingress.certManager`              | Add annotations for cert-manager                                                  | `false`                        |
+| `ingress.hostname`                 | Default host for the ingress resource                                             | `phpmyadmin.local`             |
+| `ingress.pathType`                 | Ingress path type                                                                 | `ImplementationSpecific`       |
+| `ingress.tls`                      | Enable TLS configuration for the hostname defined at `ingress.hostname` parameter | `false`                        |
+| `ingress.annotations`              | Ingress annotations                                                               | `{}` (evaluated as a template) |
+| `ingress.extraHosts[0].name`       | Additional hostnames to be covered                                                | `nil`                          |
+| `ingress.extraHosts[0].path`       | Additional hostnames to be covered                                                | `nil`                          |
+| `ingress.extraTls[0].hosts[0]`     | TLS configuration for additional hostnames to be covered                          | `nil`                          |
+| `ingress.extraTls[0].secretName`   | TLS configuration for additional hostnames to be covered                          | `nil`                          |
+| `ingress.secrets[0].name`          | TLS Secret Name                                                                   | `nil`                          |
+| `ingress.secrets[0].certificate`   | TLS Secret Certificate                                                            | `nil`                          |
+| `ingress.secrets[0].key`           | TLS Secret Key                                                                    | `nil`                          |
 
 ### Database parameters
 
-| Parameter                               | Description                                                                              | Default                                                 |
-|-----------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `db.allowArbitraryServer`               | Enable connection to arbitrary MySQL server                                              | `true`                                                  |
-| `db.port`                               | Database port to use to connect                                                          | `3306`                                                  |
-| `db.chartName`                          | Database suffix if included in the same release                                          | `nil`                                                   |
-| `db.host`                               | Database host to connect to                                                              | `nil`                                                   |
-| `db.bundleTestDB`                       | Deploy a MariaDB instance for testing purposes                                           | `false`                                                 |
-| `db.enableSsl`                          | Enable SSL for the connection between phpMyAdmin and the database                        | `false`                                                 |
-| `db.ssl.clientKey`                      | Client key file when using SSL                                                           | `nil`                                                   |
-| `db.ssl.clientCertificate`              | Client certificate file when using SSL                                                   | `nil`                                                   |
-| `db.ssl.caCertificate`                  | CA file when using SSL                                                                   | `nil`                                                   |
-| `db.ssl.ciphers`                        | List of allowable ciphers for connections when using SSL                                 | `nil`                                                   |
-| `db.ssl.verify`                         | Enable SSL certificate validation                                                        | `true`                                                  |
+| Parameter                  | Description                                                       | Default |
+|----------------------------|-------------------------------------------------------------------|---------|
+| `db.allowArbitraryServer`  | Enable connection to arbitrary MySQL server                       | `true`  |
+| `db.port`                  | Database port to use to connect                                   | `3306`  |
+| `db.chartName`             | Database suffix if included in the same release                   | `nil`   |
+| `db.host`                  | Database host to connect to                                       | `nil`   |
+| `db.bundleTestDB`          | Deploy a MariaDB instance for testing purposes                    | `false` |
+| `db.enableSsl`             | Enable SSL for the connection between phpMyAdmin and the database | `false` |
+| `db.ssl.clientKey`         | Client key file when using SSL                                    | `nil`   |
+| `db.ssl.clientCertificate` | Client certificate file when using SSL                            | `nil`   |
+| `db.ssl.caCertificate`     | CA file when using SSL                                            | `nil`   |
+| `db.ssl.ciphers`           | List of allowable ciphers for connections when using SSL          | `nil`   |
+| `db.ssl.verify`            | Enable SSL certificate validation                                 | `true`  |
 
 ### Metrics parameters
 
-| Parameter                                 | Description                                                                            | Default                                                      |
-|-------------------------------------------|----------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `metrics.enabled`                         | Start a side-car prometheus exporter                                                   | `false`                                                      |
-| `metrics.image.registry`                  | Apache exporter image registry                                                         | `docker.io`                                                  |
-| `metrics.image.repository`                | Apache exporter image name                                                             | `bitnami/apache-exporter`                                    |
-| `metrics.image.tag`                       | Apache exporter image tag                                                              | `{TAG_NAME}`                                                 |
-| `metrics.image.pullPolicy`                | Image pull policy                                                                      | `IfNotPresent`                                               |
-| `metrics.image.pullSecrets`               | Specify docker-registry secret names as an array                                       | `[]` (does not add image pull secrets to deployed pods)      |
-| `metrics.resources`                       | Exporter resource requests/limit                                                       | `{}`                                                         |
-| `metrics.service.type`                    | Prometheus metrics service type                                                        | `LoadBalancer`                                               |
-| `metrics.service.port`                    | Prometheus metrics service port                                                        | `9117`                                                       |
-| `metrics.service.loadBalancerIP`          | Load Balancer IP if the Prometheus metrics server type is `LoadBalancer`               | `nil`                                                        |
-| `metrics.service.annotations`             | Annotations for Prometheus metrics service                                             | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
-| `metrics.serviceMonitor.enabled`          | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator           | `false`                                                      |
-| `metrics.serviceMonitor.namespace`        | Namespace where servicemonitor resource should be created                              | `nil`                                                        |
-| `metrics.serviceMonitor.interval`         | Specify the interval at which metrics should be scraped                                | `30s`                                                        |
-| `metrics.serviceMonitor.jobLabel`         | The name of the label on the target service to use as the job name in prometheus.      | `nil`                                                        |
-| `metrics.serviceMonitor.scrapeTimeout`    | Specify the timeout after which the scrape is ended                                    | `nil`                                                        |
-| `metrics.serviceMonitor.relabellings`     | Specify Relabellings to add to the scrape endpoint                                     | `nil`                                                        |
-| `metrics.serviceMonitor.metricRelabelings`| Specify Metric Relabellings to add to the scrape endpoint                              | `nil`                                                        |
-| `metrics.serviceMonitor.honorLabels`      | honorLabels chooses the metric's labels on collisions with target labels.              | `false`                                                      |
-| `metrics.serviceMonitor.additionalLabels` | Used to pass Labels that are required by the Installed Prometheus Operator             | `{}`                                                         |
+| Parameter                                  | Description                                                                       | Default                                                      |
+|--------------------------------------------|-----------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `metrics.enabled`                          | Start a side-car prometheus exporter                                              | `false`                                                      |
+| `metrics.image.registry`                   | Apache exporter image registry                                                    | `docker.io`                                                  |
+| `metrics.image.repository`                 | Apache exporter image name                                                        | `bitnami/apache-exporter`                                    |
+| `metrics.image.tag`                        | Apache exporter image tag                                                         | `{TAG_NAME}`                                                 |
+| `metrics.image.pullPolicy`                 | Image pull policy                                                                 | `IfNotPresent`                                               |
+| `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                                  | `[]` (does not add image pull secrets to deployed pods)      |
+| `metrics.resources`                        | Exporter resource requests/limit                                                  | `{}`                                                         |
+| `metrics.service.type`                     | Prometheus metrics service type                                                   | `LoadBalancer`                                               |
+| `metrics.service.port`                     | Prometheus metrics service port                                                   | `9117`                                                       |
+| `metrics.service.loadBalancerIP`           | Load Balancer IP if the Prometheus metrics server type is `LoadBalancer`          | `nil`                                                        |
+| `metrics.service.annotations`              | Annotations for Prometheus metrics service                                        | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
+| `metrics.serviceMonitor.enabled`           | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator      | `false`                                                      |
+| `metrics.serviceMonitor.namespace`         | Namespace where servicemonitor resource should be created                         | `nil`                                                        |
+| `metrics.serviceMonitor.interval`          | Specify the interval at which metrics should be scraped                           | `30s`                                                        |
+| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus. | `nil`                                                        |
+| `metrics.serviceMonitor.scrapeTimeout`     | Specify the timeout after which the scrape is ended                               | `nil`                                                        |
+| `metrics.serviceMonitor.relabellings`      | Specify Relabellings to add to the scrape endpoint                                | `nil`                                                        |
+| `metrics.serviceMonitor.metricRelabelings` | Specify Metric Relabellings to add to the scrape endpoint                         | `nil`                                                        |
+| `metrics.serviceMonitor.honorLabels`       | honorLabels chooses the metric's labels on collisions with target labels.         | `false`                                                      |
+| `metrics.serviceMonitor.additionalLabels`  | Used to pass Labels that are required by the Installed Prometheus Operator        | `{}`                                                         |
 
 For more information please refer to the [bitnami/phpmyadmin](http://github.com/bitnami/bitnami-docker-Phpmyadmin) image documentation.
 

--- a/bitnami/phpmyadmin/templates/ingress.yaml
+++ b/bitnami/phpmyadmin/templates/ingress.yaml
@@ -25,19 +25,24 @@ spec:
     - host: {{ .Values.ingress.hostname }}
       http:
         paths:
-          - path: /
-            backend:
-              serviceName: {{ include "common.names.fullname" . }}
-              servicePort: http
+          {{- if .Values.ingress.extraPaths }}
+          {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
+          {{- end }}
+          - path: {{ .Values.ingress.path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.ingress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
-    - host: {{ .name }}
+    - host: {{ .name | quote }}
       http:
         paths:
           - path: {{ default "/" .path }}
-            backend:
-              serviceName: {{ include "common.names.fullname" $ }}
-              servicePort: http
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
+            pathType: {{ default "ImplementationSpecific" .pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
   {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
   tls:

--- a/bitnami/phpmyadmin/values.yaml
+++ b/bitnami/phpmyadmin/values.yaml
@@ -15,6 +15,7 @@ image:
   repository: bitnami/phpmyadmin
   tag: 5.0.4-debian-10-r80
   ## Specify a imagePullPolicy
+  ##
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -22,6 +23,10 @@ image:
   ##
   # pullSecrets:
   #   - myRegistryKeySecretName
+
+## Force target Kubernetes version (using Helm capabilites if not set)
+##
+kubeVersion:
 
 ## String to partially override common.names.fullname template (will maintain the release name)
 ##
@@ -171,6 +176,7 @@ podAntiAffinityPreset: soft
 nodeAffinityPreset:
   ## Node affinity type
   ## Allowed values: soft, hard
+  ##
   type: ""
   ## Node label key to match
   ## E.g.
@@ -287,6 +293,10 @@ ingress:
   ## When the ingress is enabled, a host pointing to this will be created
   ##
   hostname: phpmyadmin.local
+
+  ## Ingress Path type
+  ##
+  pathType: ImplementationSpecific
 
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
@@ -416,6 +426,7 @@ metrics:
 db:
   ## If you do not want the user to be able to specify an arbitrary MySQL server
   ## at login time, set this to false
+  ##
   allowArbitraryServer: true
 
   ## Database port


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This PR updates the common library with the changes from https://github.com/bitnami/charts/pull/4859. 

- Depending on the Kubernetes version it will generate the proper Ingress object
- It allows forcing a Kubernetes version so it is compatible with GitOps approaches

**Benefits**

Charts compatible with all Kubernetes versions
**Possible drawbacks**

n/a
**Applicable issues**

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
