### PR TITLE
[bitnami/rabbitmq] Adapt ingress to k8s 1.20

### DIFF
--- a/bitnami/rabbitmq/Chart.lock
+++ b/bitnami/rabbitmq/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.2.3
-digest: sha256:3fc1fbf3ae204e0121f1e202d6d57f9381f3a45d8821647d1dfe0a475644da0c
-generated: "2021-01-07T19:08:31.101315421Z"
+  version: 1.3.1
+digest: sha256:770fcb0a0fac69c3c162533869fbe3528d387c991ca3da7236faaee8a74f0f6d
+generated: "2021-01-13T17:32:01.707249+01:00"

--- a/bitnami/rabbitmq/Chart.lock
+++ b/bitnami/rabbitmq/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.1
-digest: sha256:770fcb0a0fac69c3c162533869fbe3528d387c991ca3da7236faaee8a74f0f6d
-generated: "2021-01-13T17:32:01.707249+01:00"
+  version: 1.3.2
+digest: sha256:2561a4fdd0fcd76af4a2b04bf8d67585e8bc3fc3e366ae0a55a12541a85b4551
+generated: "2021-01-13T17:39:47.808573+01:00"

--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -23,4 +23,4 @@ name: rabbitmq
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq
   - https://www.rabbitmq.com
-version: 8.6.4
+version: 8.7.0

--- a/bitnami/rabbitmq/README.md
+++ b/bitnami/rabbitmq/README.md
@@ -47,211 +47,213 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the RabbitMQ chart and their default values.
 
-| Parameter                                 | Description                                                                                                              | Default                                                      |
-|-------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `global.imageRegistry`                    | Global Docker image registry                                                                                             | `nil`                                                        |
-| `global.imagePullSecrets`                 | Global Docker registry secret names as an array                                                                          | `[]` (does not add image pull secrets to deployed pods)      |
-| `global.storageClass`                     | Global storage class for dynamic provisioning                                                                            | `nil`                                                        |
+| Parameter                 | Description                                     | Default                                                 |
+|---------------------------|-------------------------------------------------|---------------------------------------------------------|
+| `global.imageRegistry`    | Global Docker image registry                    | `nil`                                                   |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
+| `global.storageClass`     | Global storage class for dynamic provisioning   | `nil`                                                   |
 
 ### Common parameters
 
-| Parameter                                 | Description                                                                                                              | Default                                                      |
-|-------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `nameOverride`                            | String to partially override rabbitmq.fullname                                                                           | `nil`                                                        |
-| `fullnameOverride`                        | String to fully override rabbitmq.fullname                                                                               | `nil`                                                        |
-| `clusterDomain`                           | Default Kubernetes cluster domain                                                                                        | `cluster.local`                                              |
+| Parameter          | Description                                                          | Default         |
+|--------------------|----------------------------------------------------------------------|-----------------|
+| `nameOverride`     | String to partially override rabbitmq.fullname                       | `nil`           |
+| `fullnameOverride` | String to fully override rabbitmq.fullname                           | `nil`           |
+| `clusterDomain`    | Default Kubernetes cluster domain                                    | `cluster.local` |
+| `kubeVersion`      | Force target Kubernetes version (using Helm capabilities if not set) | `nil`           |
 
 ### RabbitMQ parameters
 
-| Parameter                                 | Description                                                                                                              | Default                                                      |
-|-------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `image.registry`                          | RabbitMQ image registry                                                                                                  | `docker.io`                                                  |
-| `image.repository`                        | RabbitMQ image name                                                                                                      | `bitnami/rabbitmq`                                           |
-| `image.tag`                               | RabbitMQ image tag                                                                                                       | `{TAG_NAME}`                                                 |
-| `image.pullPolicy`                        | RabbitMQ image pull policy                                                                                               | `IfNotPresent`                                               |
-| `image.pullSecrets`                       | Specify docker-registry secret names as an array                                                                         | `[]` (does not add image pull secrets to deployed pods)      |
-| `image.debug`                             | Set to true if you would like to see extra information on logs                                                           | `false`                                                      |
-| `auth.username`                           | RabbitMQ application username                                                                                            | `user`                                                       |
-| `auth.password`                           | RabbitMQ application password                                                                                            | _random 10 character long alphanumeric string_               |
-| `auth.existingPasswordSecret`             | Existing secret with RabbitMQ credentials (must contain a value for `rabbitmq-password` key)                             | `nil` (evaluated as a template)                              |
-| `auth.erlangCookie`                       | Erlang cookie                                                                                                            | _random 32 character long alphanumeric string_               |
-| `auth.existingErlangSecret`               | Existing secret with RabbitMQ Erlang cookie (must contain a value for `rabbitmq-erlang-cookie` key)                      | `nil` (evaluated as a template)                                                        |
-| `auth.tls.enabled`                        | Enable TLS support on RabbitMQ                                                                                           | `false`                                                      |
-| `auth.tls.failIfNoPeerCert`               | When set to true, TLS connection will be rejected if client fails to provide a certificate                               | `true`                                                       |
-| `auth.tls.sslOptionsVerify`               | Should [peer verification](https://www.rabbitmq.com/ssl.html#peer-verification) be enabled?                              | `verify_peer`                                                |
-| `auth.tls.caCertificate`                  | Certificate Authority (CA) bundle content                                                                                | `nil`                                                        |
-| `auth.tls.serverCertificate`              | Server certificate content                                                                                               | `nil`                                                        |
-| `auth.tls.serverKey`                      | Server private key content                                                                                               | `nil`                                                        |
-| `auth.tls.existingSecret`                 | Existing secret with certificate content to RabbitMQ credentials                                                         | `nil`                                                        |
-| `logs`                                    | Path of the RabbitMQ server's Erlang log file                                                                            | `-`                                                          |
-| `ulimitNofiles`                           | Max File Descriptor limit                                                                                                | `65536`                                                      |
-| `maxAvailableSchedulers`                  | RabbitMQ maximum available scheduler threads                                                                             | `2`                                                          |
-| `onlineSchedulers`                        | RabbitMQ online scheduler threads                                                                                        | `1`                                                          |
-| `memoryHighWatermark.enabled`             | Enable configuring Memory high watermark on RabbitMQ                                                                     | `false`                                                      |
-| `memoryHighWatermark.type`                | Memory high watermark type. Either `absolute` or `relative`                                                              | `relative`                                                   |
-| `memoryHighWatermark.value`               | Memory high watermark value                                                                                              | `0.4`                                                        |
-| `plugins`                                 | List of default plugins to enable (should only be altered to remove defaults; for additional plugins use `extraPlugins`) | `rabbitmq_management rabbitmq_peer_discovery_k8s`            |
-| `communityPlugins`                        | List of custom plugins (URLs) to be downloaded during container initialization                                           | `nil`                                                        |
-| `extraPlugins`                            | Extra plugins to enable (single string containing a space-separated list)                                                | `nil`                                                        |
-| `clustering.addressType`                  | Switch clustering mode. Either `ip` or `hostname`                                                                        | `hostname`                                                   |
-| `clustering.rebalance`                    | Rebalance master for queues in cluster when new replica is created                                                       | `false`                                                      |
-| `clustering.forceBoot`                    | Rebalance master for queues in cluster when new replica is created                                                       | `false`                                                      |
-| `loadDefinition.enabled`                  | Enable loading a RabbitMQ definitions file to configure RabbitMQ                                                         | `false`                                                      |
-| `loadDefinition.existingSecret`           | Existing secret with the load definitions file                                                                           | `nil`                                                        |
-| `command`                                 | Override default container command (useful when using custom images)                                                     | `nil`                                                        |
-| `args`                                    | Override default container args (useful when using custom images)                                                        | `nil`                                                        |
-| `terminationGracePeriodSeconds`           | TerminationGracePeriodSeconds of container (time in excess of 10 seconds will be spent waiting for synchronization)      | `120`                                                        |
-| `extraEnvVars`                            | Extra environment variables to add to RabbitMQ pods                                                                      | `[]`                                                         |
-| `extraEnvVarsCM`                          | Name of existing ConfigMap containing extra env vars                                                                     | `nil`                                                        |
-| `extraEnvVarsSecret`                      | Name of existing Secret containing extra env vars (in case of sensitive data)                                            | `nil`                                                        |
-| `extraContainerPorts`                     | Extra ports to be included in container spec, primarily informational                                                    | `[]`                                                         |
-| `configuration`                           | RabbitMQ configuration                                                                                                   | Check `values.yaml` file                                     |
-| `extraConfiguration`                      | Extra configuration to be appended to RabbitMQ configuration                                                             | Check `values.yaml` file                                     |
-| `advancedConfiguration`                   | Extra configuration (in classic format)                                                                                  | Check `values.yaml` file                                     |
-| `ldap.enabled`                            | Enable LDAP support                                                                                                      | `false`                                                      |
-| `ldap.servers`                            | List of LDAP servers hostnames                                                                                           | `[]`                                                         |
-| `ldap.port`                               | LDAP servers port                                                                                                        | `389`                                                        |
-| `ldap.user_dn_pattern`                    | Pattern used to translate the provided username into a value to be used for the LDAP bind                                | `cn=${username},dc=example,dc=org`                           |
-| `ldap.tls.enabled`                        | Enable TLS for LDAP connections (check advancedConfiguration parameter in values.yml)                                    | `false`                                                      |
+| Parameter                       | Description                                                                                                              | Default                                                 |
+|---------------------------------|--------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `image.registry`                | RabbitMQ image registry                                                                                                  | `docker.io`                                             |
+| `image.repository`              | RabbitMQ image name                                                                                                      | `bitnami/rabbitmq`                                      |
+| `image.tag`                     | RabbitMQ image tag                                                                                                       | `{TAG_NAME}`                                            |
+| `image.pullPolicy`              | RabbitMQ image pull policy                                                                                               | `IfNotPresent`                                          |
+| `image.pullSecrets`             | Specify docker-registry secret names as an array                                                                         | `[]` (does not add image pull secrets to deployed pods) |
+| `image.debug`                   | Set to true if you would like to see extra information on logs                                                           | `false`                                                 |
+| `auth.username`                 | RabbitMQ application username                                                                                            | `user`                                                  |
+| `auth.password`                 | RabbitMQ application password                                                                                            | _random 10 character long alphanumeric string_          |
+| `auth.existingPasswordSecret`   | Existing secret with RabbitMQ credentials (must contain a value for `rabbitmq-password` key)                             | `nil` (evaluated as a template)                         |
+| `auth.erlangCookie`             | Erlang cookie                                                                                                            | _random 32 character long alphanumeric string_          |
+| `auth.existingErlangSecret`     | Existing secret with RabbitMQ Erlang cookie (must contain a value for `rabbitmq-erlang-cookie` key)                      | `nil` (evaluated as a template)                         |
+| `auth.tls.enabled`              | Enable TLS support on RabbitMQ                                                                                           | `false`                                                 |
+| `auth.tls.failIfNoPeerCert`     | When set to true, TLS connection will be rejected if client fails to provide a certificate                               | `true`                                                  |
+| `auth.tls.sslOptionsVerify`     | Should [peer verification](https://www.rabbitmq.com/ssl.html#peer-verification) be enabled?                              | `verify_peer`                                           |
+| `auth.tls.caCertificate`        | Certificate Authority (CA) bundle content                                                                                | `nil`                                                   |
+| `auth.tls.serverCertificate`    | Server certificate content                                                                                               | `nil`                                                   |
+| `auth.tls.serverKey`            | Server private key content                                                                                               | `nil`                                                   |
+| `auth.tls.existingSecret`       | Existing secret with certificate content to RabbitMQ credentials                                                         | `nil`                                                   |
+| `logs`                          | Path of the RabbitMQ server's Erlang log file                                                                            | `-`                                                     |
+| `ulimitNofiles`                 | Max File Descriptor limit                                                                                                | `65536`                                                 |
+| `maxAvailableSchedulers`        | RabbitMQ maximum available scheduler threads                                                                             | `2`                                                     |
+| `onlineSchedulers`              | RabbitMQ online scheduler threads                                                                                        | `1`                                                     |
+| `memoryHighWatermark.enabled`   | Enable configuring Memory high watermark on RabbitMQ                                                                     | `false`                                                 |
+| `memoryHighWatermark.type`      | Memory high watermark type. Either `absolute` or `relative`                                                              | `relative`                                              |
+| `memoryHighWatermark.value`     | Memory high watermark value                                                                                              | `0.4`                                                   |
+| `plugins`                       | List of default plugins to enable (should only be altered to remove defaults; for additional plugins use `extraPlugins`) | `rabbitmq_management rabbitmq_peer_discovery_k8s`       |
+| `communityPlugins`              | List of custom plugins (URLs) to be downloaded during container initialization                                           | `nil`                                                   |
+| `extraPlugins`                  | Extra plugins to enable (single string containing a space-separated list)                                                | `nil`                                                   |
+| `clustering.addressType`        | Switch clustering mode. Either `ip` or `hostname`                                                                        | `hostname`                                              |
+| `clustering.rebalance`          | Rebalance master for queues in cluster when new replica is created                                                       | `false`                                                 |
+| `clustering.forceBoot`          | Rebalance master for queues in cluster when new replica is created                                                       | `false`                                                 |
+| `loadDefinition.enabled`        | Enable loading a RabbitMQ definitions file to configure RabbitMQ                                                         | `false`                                                 |
+| `loadDefinition.existingSecret` | Existing secret with the load definitions file                                                                           | `nil`                                                   |
+| `command`                       | Override default container command (useful when using custom images)                                                     | `nil`                                                   |
+| `args`                          | Override default container args (useful when using custom images)                                                        | `nil`                                                   |
+| `terminationGracePeriodSeconds` | TerminationGracePeriodSeconds of container (time in excess of 10 seconds will be spent waiting for synchronization)      | `120`                                                   |
+| `extraEnvVars`                  | Extra environment variables to add to RabbitMQ pods                                                                      | `[]`                                                    |
+| `extraEnvVarsCM`                | Name of existing ConfigMap containing extra env vars                                                                     | `nil`                                                   |
+| `extraEnvVarsSecret`            | Name of existing Secret containing extra env vars (in case of sensitive data)                                            | `nil`                                                   |
+| `extraContainerPorts`           | Extra ports to be included in container spec, primarily informational                                                    | `[]`                                                    |
+| `configuration`                 | RabbitMQ configuration                                                                                                   | Check `values.yaml` file                                |
+| `extraConfiguration`            | Extra configuration to be appended to RabbitMQ configuration                                                             | Check `values.yaml` file                                |
+| `advancedConfiguration`         | Extra configuration (in classic format)                                                                                  | Check `values.yaml` file                                |
+| `ldap.enabled`                  | Enable LDAP support                                                                                                      | `false`                                                 |
+| `ldap.servers`                  | List of LDAP servers hostnames                                                                                           | `[]`                                                    |
+| `ldap.port`                     | LDAP servers port                                                                                                        | `389`                                                   |
+| `ldap.user_dn_pattern`          | Pattern used to translate the provided username into a value to be used for the LDAP bind                                | `cn=${username},dc=example,dc=org`                      |
+| `ldap.tls.enabled`              | Enable TLS for LDAP connections (check advancedConfiguration parameter in values.yml)                                    | `false`                                                 |
 
 ### Statefulset parameters
 
-| Parameter                                 | Description                                                                                                              | Default                                                      |
-|-------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `replicaCount`                            | Number of RabbitMQ nodes                                                                                                 | `1`                                                          |
-| `schedulerName`                           | Name of the k8s service (other than default)                                                                             | `nil`                                                        |
-| `podManagementPolicy`                     | Pod management policy                                                                                                    | `OrderedReady`                                               |
-| `updateStrategyType`                      | Update strategy type for the statefulset                                                                                 | `RollingUpdate`                                              |
-| `rollingUpdatePartition`                  | Partition update strategy                                                                                                | `nil`                                                        |
-| `statefulsetLabels`                       | RabbitMQ statefulset labels                                                                                              | `{}` (evaluated as a template)                               |
-| `podLabels`                               | RabbitMQ pod labels                                                                                                      | `{}` (evaluated as a template)                               |
-| `podAnnotations`                          | RabbitMQ Pod annotations                                                                                                 | `{}` (evaluated as a template)                               |
-| `podAffinityPreset`                       | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                      | `""`                                                         |
-| `podAntiAffinityPreset`                   | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                 | `soft`                                                       |
-| `nodeAffinityPreset.type`                 | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                | `""`                                                         |
-| `nodeAffinityPreset.key`                  | Node label key to match Ignored if `affinity` is set.                                                                    | `""`                                                         |
-| `nodeAffinityPreset.values`               | Node label values to match. Ignored if `affinity` is set.                                                                | `[]`                                                         |
-| `nodeSelector`                            | Node labels for pod assignment                                                                                           | `{}` (evaluated as a template)                               |
-| `tolerations`                             | Tolerations for pod assignment                                                                                           | `[]` (evaluated as a template)                               |
-| `affinity`                                | Affinity for pod assignment                                                                                              | `{}` (evaluated as a template)                               |
-| `priorityClassName`                       | Name of the existing priority class to be used by rabbitmq pods                                                          | `""`                                                         |
-| `podSecurityContext`                      | RabbitMQ pods' Security Context                                                                                          | `{}`                                                         |
-| `containerSecurityContext`                | RabbitMQ containers' Security Context                                                                                    | `{}`                                                         |
-| `resources.limits`                        | The resources limits for RabbitMQ containers                                                                             | `{}`                                                         |
-| `resources.requests`                      | The requested resources for RabbitMQ containers                                                                          | `{}`                                                         |
-| `livenessProbe`                           | Liveness probe configuration for RabbitMQ                                                                                | Check `values.yaml` file                                     |
-| `readinessProbe`                          | Readiness probe configuration for RabbitMQ                                                                               | Check `values.yaml` file                                     |
-| `customLivenessProbe`                     | Override default liveness probe                                                                                          | `nil`                                                        |
-| `customReadinessProbe`                    | Override default readiness probe                                                                                         | `nil`                                                        |
-| `customStartupProbe`                      | Define a custom startup probe                                                                                            | `nil`                                                        |
-| `pdb.create`                              | Enable/disable a Pod Disruption Budget creation                                                                          | `false`                                                      |
-| `pdb.minAvailable`                        | Minimum number/percentage of pods that should remain scheduled                                                           | `nil`                                                        |
-| `pdb.maxUnavailable`                      | Maximum number/percentage of pods that may be made unavailable                                                           | `1`                                                          |
-| `initContainers`                          | Add additional init containers to the RabbitMQ pod                                                                       | `{}` (evaluated as a template)                               |
-| `sidecars`                                | Add additional sidecar containers to the RabbitMQ pod                                                                    | `{}` (evaluated as a template)                               |
-| `extraVolumeMounts`                       | Optionally specify extra list of additional volumeMounts .                                                               | `{}`                                                         |
-| `extraVolumes`                            | Optionally specify extra list of additional volumes .                                                                    | `{}`                                                         |
-| `extraSecrets`                            | Optionally specify extra secrets to be created by the chart.                                                             | `{}` (evaluated as a template)                               |
+| Parameter                   | Description                                                                               | Default                        |
+|-----------------------------|-------------------------------------------------------------------------------------------|--------------------------------|
+| `replicaCount`              | Number of RabbitMQ nodes                                                                  | `1`                            |
+| `schedulerName`             | Name of the k8s service (other than default)                                              | `nil`                          |
+| `podManagementPolicy`       | Pod management policy                                                                     | `OrderedReady`                 |
+| `updateStrategyType`        | Update strategy type for the statefulset                                                  | `RollingUpdate`                |
+| `rollingUpdatePartition`    | Partition update strategy                                                                 | `nil`                          |
+| `statefulsetLabels`         | RabbitMQ statefulset labels                                                               | `{}` (evaluated as a template) |
+| `podLabels`                 | RabbitMQ pod labels                                                                       | `{}` (evaluated as a template) |
+| `podAnnotations`            | RabbitMQ Pod annotations                                                                  | `{}` (evaluated as a template) |
+| `podAffinityPreset`         | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                           |
+| `podAntiAffinityPreset`     | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                         |
+| `nodeAffinityPreset.type`   | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                           |
+| `nodeAffinityPreset.key`    | Node label key to match Ignored if `affinity` is set.                                     | `""`                           |
+| `nodeAffinityPreset.values` | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                           |
+| `nodeSelector`              | Node labels for pod assignment                                                            | `{}` (evaluated as a template) |
+| `tolerations`               | Tolerations for pod assignment                                                            | `[]` (evaluated as a template) |
+| `affinity`                  | Affinity for pod assignment                                                               | `{}` (evaluated as a template) |
+| `priorityClassName`         | Name of the existing priority class to be used by rabbitmq pods                           | `""`                           |
+| `podSecurityContext`        | RabbitMQ pods' Security Context                                                           | `{}`                           |
+| `containerSecurityContext`  | RabbitMQ containers' Security Context                                                     | `{}`                           |
+| `resources.limits`          | The resources limits for RabbitMQ containers                                              | `{}`                           |
+| `resources.requests`        | The requested resources for RabbitMQ containers                                           | `{}`                           |
+| `livenessProbe`             | Liveness probe configuration for RabbitMQ                                                 | Check `values.yaml` file       |
+| `readinessProbe`            | Readiness probe configuration for RabbitMQ                                                | Check `values.yaml` file       |
+| `customLivenessProbe`       | Override default liveness probe                                                           | `nil`                          |
+| `customReadinessProbe`      | Override default readiness probe                                                          | `nil`                          |
+| `customStartupProbe`        | Define a custom startup probe                                                             | `nil`                          |
+| `pdb.create`                | Enable/disable a Pod Disruption Budget creation                                           | `false`                        |
+| `pdb.minAvailable`          | Minimum number/percentage of pods that should remain scheduled                            | `nil`                          |
+| `pdb.maxUnavailable`        | Maximum number/percentage of pods that may be made unavailable                            | `1`                            |
+| `initContainers`            | Add additional init containers to the RabbitMQ pod                                        | `{}` (evaluated as a template) |
+| `sidecars`                  | Add additional sidecar containers to the RabbitMQ pod                                     | `{}` (evaluated as a template) |
+| `extraVolumeMounts`         | Optionally specify extra list of additional volumeMounts .                                | `{}`                           |
+| `extraVolumes`              | Optionally specify extra list of additional volumes .                                     | `{}`                           |
+| `extraSecrets`              | Optionally specify extra secrets to be created by the chart.                              | `{}` (evaluated as a template) |
 
 ### Exposure parameters
 
-| Parameter                                 | Description                                                                                                              | Default                                                      |
-|-------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `service.type`                            | Kubernetes Service type                                                                                                  | `ClusterIP`                                                  |
-| `service.port`                            | Amqp port                                                                                                                | `5672`                                                       |
-| `service.portName`                        | Amqp service port name                                                                                                   | `amqp`                                                       |
-| `service.tlsPort`                         | Amqp TLS port                                                                                                            | `5671`                                                       |
-| `service.tlsPortName`                     | Amqp TLS service port name                                                                                               | `amqp-ssl`                                                   |
-| `service.nodePort`                        | Node port override for `amqp` port, if serviceType NodePort or LoadBalancer                                              | `nil`                                                        |
-| `service.tlsNodePort`                     | Node port override for `amqp-ssl` port, if serviceType NodePort or LoadBalancer                                          | `nil`                                                        |
-| `service.distPort`                        | Erlang distribution server port                                                                                          | `25672`                                                      |
-| `service.distPortName`                    | Erlang distribution service port name                                                                                    | `dist`                                                       |
-| `service.distNodePort`                    | Node port override for `dist` port, if serviceType NodePort                                                              | `nil`                                                        |
-| `service.managerPort`                     | RabbitMQ Manager port                                                                                                    | `15672`                                                      |
-| `service.managerPortName`                 | RabbitMQ Manager service port name                                                                                       | `http-stats`                                                 |
-| `service.managerNodePort`                 | Node port override for `http-stats` port, if serviceType NodePort                                                        | `nil`                                                        |
-| `service.metricsPort`                     | RabbitMQ Prometheues metrics port                                                                                        | `9419`                                                       |
-| `service.metricsPortName`                 | RabbitMQ Prometheues metrics service port name                                                                           | `metrics`                                                    |
-| `service.metricsNodePort`                 | Node port override for `metrics` port, if serviceType NodePort                                                           | `nil`                                                        |
-| `service.epmdPortName`                    | EPMD Discovery service port name                                                                                         | `epmd`                                                       |
-| `service.epmdNodePort`                    | Node port override for `epmd` port, if serviceType NodePort                                                              | `nil`                                                        |
-| `service.extraPorts`                      | Extra ports to expose in the service                                                                                     | `[]`                                                         |
-| `service.loadBalancerSourceRanges`        | Address(es) that are allowed when service is LoadBalancer                                                                | `[]`                                                         |
-| `service.loadBalancerIP`                  | LoadBalancerIP for the service                                                                                           | `nil`                                                        |
-| `service.externalIP`                      | ExternalIP for the service                                                                                               | `nil`                                                        |
-| `service.externalTrafficPolicy`           | Enable client source IP preservation                                                                                     | `Cluster`                                                    |
-| `service.labels`                          | Service labels                                                                                                           | `{}` (evaluated as a template)                               |
-| `service.annotations`                     | Service annotations                                                                                                      | `{}` (evaluated as a template)                               |
-| `ingress.enabled`                         | Enable ingress resource for Management console                                                                           | `false`                                                      |
-| `ingress.path`                            | Path for the default host                                                                                                | `/`                                                          |
-| `ingress.certManager`                     | Add annotations for cert-manager                                                                                         | `false`                                                      |
-| `ingress.hostname`                        | Default host for the ingress resource                                                                                    | `rabbitmq.local`                                             |
-| `ingress.annotations`                     | Ingress annotations                                                                                                      | `[]`                                                         |
-| `ingress.tls`                             | Enable TLS configuration for the hostname defined at `ingress.hostname` parameter                                        | `false`                                                      |
-| `ingress.existingSecret`                  | Existing secret for the Ingress TLS certificate                                                                          | `nil`                                                        |
-| `ingress.extraHosts[0].name`              | Additional hostnames to be covered                                                                                       | `nil`                                                        |
-| `ingress.extraHosts[0].path`              | Additional hostnames to be covered                                                                                       | `nil`                                                        |
-| `ingress.extraTls[0].hosts[0]`            | TLS configuration for additional hostnames to be covered                                                                 | `nil`                                                        |
-| `ingress.extraTls[0].secretName`          | TLS configuration for additional hostnames to be covered                                                                 | `nil`                                                        |
-| `ingress.secrets[0].name`                 | TLS Secret Name                                                                                                          | `nil`                                                        |
-| `ingress.secrets[0].certificate`          | TLS Secret Certificate                                                                                                   | `nil`                                                        |
-| `ingress.secrets[0].key`                  | TLS Secret Key                                                                                                           | `nil`                                                        |
-| `networkPolicy.enabled`                   | Enable NetworkPolicy                                                                                                     | `false`                                                      |
-| `networkPolicy.allowExternal`             | Don't require client label for connections                                                                               | `true`                                                       |
-| `networkPolicy.additionalRules`           | Additional NetworkPolicy rules                                                                                           | `nil`                                                        |
+| Parameter                          | Description                                                                       | Default                        |
+|------------------------------------|-----------------------------------------------------------------------------------|--------------------------------|
+| `service.type`                     | Kubernetes Service type                                                           | `ClusterIP`                    |
+| `service.port`                     | Amqp port                                                                         | `5672`                         |
+| `service.portName`                 | Amqp service port name                                                            | `amqp`                         |
+| `service.tlsPort`                  | Amqp TLS port                                                                     | `5671`                         |
+| `service.tlsPortName`              | Amqp TLS service port name                                                        | `amqp-ssl`                     |
+| `service.nodePort`                 | Node port override for `amqp` port, if serviceType NodePort or LoadBalancer       | `nil`                          |
+| `service.tlsNodePort`              | Node port override for `amqp-ssl` port, if serviceType NodePort or LoadBalancer   | `nil`                          |
+| `service.distPort`                 | Erlang distribution server port                                                   | `25672`                        |
+| `service.distPortName`             | Erlang distribution service port name                                             | `dist`                         |
+| `service.distNodePort`             | Node port override for `dist` port, if serviceType NodePort                       | `nil`                          |
+| `service.managerPort`              | RabbitMQ Manager port                                                             | `15672`                        |
+| `service.managerPortName`          | RabbitMQ Manager service port name                                                | `http-stats`                   |
+| `service.managerNodePort`          | Node port override for `http-stats` port, if serviceType NodePort                 | `nil`                          |
+| `service.metricsPort`              | RabbitMQ Prometheues metrics port                                                 | `9419`                         |
+| `service.metricsPortName`          | RabbitMQ Prometheues metrics service port name                                    | `metrics`                      |
+| `service.metricsNodePort`          | Node port override for `metrics` port, if serviceType NodePort                    | `nil`                          |
+| `service.epmdPortName`             | EPMD Discovery service port name                                                  | `epmd`                         |
+| `service.epmdNodePort`             | Node port override for `epmd` port, if serviceType NodePort                       | `nil`                          |
+| `service.extraPorts`               | Extra ports to expose in the service                                              | `[]`                           |
+| `service.loadBalancerSourceRanges` | Address(es) that are allowed when service is LoadBalancer                         | `[]`                           |
+| `service.loadBalancerIP`           | LoadBalancerIP for the service                                                    | `nil`                          |
+| `service.externalIP`               | ExternalIP for the service                                                        | `nil`                          |
+| `service.externalTrafficPolicy`    | Enable client source IP preservation                                              | `Cluster`                      |
+| `service.labels`                   | Service labels                                                                    | `{}` (evaluated as a template) |
+| `service.annotations`              | Service annotations                                                               | `{}` (evaluated as a template) |
+| `ingress.enabled`                  | Enable ingress resource for Management console                                    | `false`                        |
+| `ingress.path`                     | Path for the default host                                                         | `/`                            |
+| `ingress.certManager`              | Add annotations for cert-manager                                                  | `false`                        |
+| `ingress.hostname`                 | Default host for the ingress resource                                             | `rabbitmq.local`               |
+| `ingress.pathType`                 | Ingress path type                                                                 | `ImplementationSpecific`       |
+| `ingress.annotations`              | Ingress annotations                                                               | `[]`                           |
+| `ingress.tls`                      | Enable TLS configuration for the hostname defined at `ingress.hostname` parameter | `false`                        |
+| `ingress.existingSecret`           | Existing secret for the Ingress TLS certificate                                   | `nil`                          |
+| `ingress.extraHosts[0].name`       | Additional hostnames to be covered                                                | `nil`                          |
+| `ingress.extraHosts[0].path`       | Additional hostnames to be covered                                                | `nil`                          |
+| `ingress.extraTls[0].hosts[0]`     | TLS configuration for additional hostnames to be covered                          | `nil`                          |
+| `ingress.extraTls[0].secretName`   | TLS configuration for additional hostnames to be covered                          | `nil`                          |
+| `ingress.secrets[0].name`          | TLS Secret Name                                                                   | `nil`                          |
+| `ingress.secrets[0].certificate`   | TLS Secret Certificate                                                            | `nil`                          |
+| `ingress.secrets[0].key`           | TLS Secret Key                                                                    | `nil`                          |
+| `networkPolicy.enabled`            | Enable NetworkPolicy                                                              | `false`                        |
+| `networkPolicy.allowExternal`      | Don't require client label for connections                                        | `true`                         |
+| `networkPolicy.additionalRules`    | Additional NetworkPolicy rules                                                    | `nil`                          |
 
 ### Persistence parameters
 
-| Parameter                                 | Description                                                                                                              | Default                                                      |
-|-------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `persistence.enabled`                     | Enable RabbitMQ data persistence using PVC                                                                               | `true`                                                       |
-| `persistence.existingClaim`               | Provide an existing `PersistentVolumeClaim`, the value is evaluated as a template                                        | `nil`                                                        |
-| `persistence.storageClass`                | PVC Storage Class for RabbitMQ data volume                                                                               | `nil`                                                        |
-| `persistence.accessMode`                  | PVC Access Mode for RabbitMQ data volume                                                                                 | `ReadWriteOnce`                                              |
-| `persistence.size`                        | PVC Storage Request for RabbitMQ data volume                                                                             | `8Gi`                                                        |
-| `persistence.selector`                    | Selector to match an existing Persistent Volume                                                                          | `{}`(evaluated as a template)                                |
-| `persistence.volumes`                     | Additional volumes without creating PVC                                                                                  | `{}`(evaluated as a template)                                |
+| Parameter                   | Description                                                                       | Default                       |
+|-----------------------------|-----------------------------------------------------------------------------------|-------------------------------|
+| `persistence.enabled`       | Enable RabbitMQ data persistence using PVC                                        | `true`                        |
+| `persistence.existingClaim` | Provide an existing `PersistentVolumeClaim`, the value is evaluated as a template | `nil`                         |
+| `persistence.storageClass`  | PVC Storage Class for RabbitMQ data volume                                        | `nil`                         |
+| `persistence.accessMode`    | PVC Access Mode for RabbitMQ data volume                                          | `ReadWriteOnce`               |
+| `persistence.size`          | PVC Storage Request for RabbitMQ data volume                                      | `8Gi`                         |
+| `persistence.selector`      | Selector to match an existing Persistent Volume                                   | `{}`(evaluated as a template) |
+| `persistence.volumes`       | Additional volumes without creating PVC                                           | `{}`(evaluated as a template) |
 
 ### RBAC parameters
 
-| Parameter                                 | Description                                                                                                              | Default                                                      |
-|-------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `serviceAccount.create`                   | Enable creation of ServiceAccount for RabbitMQ pods                                                                      | `true`                                                       |
-| `serviceAccount.name`                     | Name of the created serviceAccount                                                                                       | Generated using the `rabbitmq.fullname` template             |
-| `rbac.create`                             | Weather to create & use RBAC resources or not                                                                            | `true`                                                       |
+| Parameter               | Description                                         | Default                                          |
+|-------------------------|-----------------------------------------------------|--------------------------------------------------|
+| `serviceAccount.create` | Enable creation of ServiceAccount for RabbitMQ pods | `true`                                           |
+| `serviceAccount.name`   | Name of the created serviceAccount                  | Generated using the `rabbitmq.fullname` template |
+| `rbac.create`           | Weather to create & use RBAC resources or not       | `true`                                           |
 
 ### Volume Permissions parameters
 
-| Parameter                                 | Description                                                                                                              | Default                                                      |
-|-------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `volumePermissions.enabled`               | Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup`     | `false`                                                      |
-| `volumePermissions.image.registry`        | Init container volume-permissions image registry                                                                         | `docker.io`                                                  |
-| `volumePermissions.image.repository`      | Init container volume-permissions image name                                                                             | `bitnami/minideb`                                            |
-| `volumePermissions.image.tag`             | Init container volume-permissions image tag                                                                              | `buster`                                                     |
-| `volumePermissions.image.pullPolicy`      | Init container volume-permissions image pull policy                                                                      | `Always`                                                     |
-| `volumePermissions.image.pullSecrets`     | Specify docker-registry secret names as an array                                                                         | `[]` (does not add image pull secrets to deployed pods)      |
-| `volumePermissions.resources.limits`      | Init container volume-permissions resource  limits                                                                       | `{}`                                                         |
-| `volumePermissions.resources.requests`    | Init container volume-permissions resource  requests                                                                     | `{}`                                                         |
+| Parameter                              | Description                                                                                                          | Default                                                 |
+|----------------------------------------|----------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `volumePermissions.enabled`            | Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup` | `false`                                                 |
+| `volumePermissions.image.registry`     | Init container volume-permissions image registry                                                                     | `docker.io`                                             |
+| `volumePermissions.image.repository`   | Init container volume-permissions image name                                                                         | `bitnami/minideb`                                       |
+| `volumePermissions.image.tag`          | Init container volume-permissions image tag                                                                          | `buster`                                                |
+| `volumePermissions.image.pullPolicy`   | Init container volume-permissions image pull policy                                                                  | `Always`                                                |
+| `volumePermissions.image.pullSecrets`  | Specify docker-registry secret names as an array                                                                     | `[]` (does not add image pull secrets to deployed pods) |
+| `volumePermissions.resources.limits`   | Init container volume-permissions resource  limits                                                                   | `{}`                                                    |
+| `volumePermissions.resources.requests` | Init container volume-permissions resource  requests                                                                 | `{}`                                                    |
 
 ### Metrics parameters
 
-| Parameter                                 | Description                                                                                                              | Default                                                      |
-|-------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `metrics.enabled`                         | Enable exposing RabbitMQ metrics to be gathered by Prometheus                                                            | `false`                                                      |
-| `metrics.plugins`                         | Plugins to enable Prometheus metrics in RabbitMQ                                                                         | `rabbitmq_prometheus`                                        |
-| `metrics.podAnnotations`                  | Annotations for enabling prometheus to access the metrics endpoint                                                       | `{prometheus.io/scrape: "true", prometheus.io/port: "9419"}` |
-| `metrics.serviceMonitor.enabled`          | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                                             | `false`                                                      |
-| `metrics.serviceMonitor.namespace`        | Namespace which Prometheus is running in                                                                                 | `monitoring`                                                 |
-| `metrics.serviceMonitor.interval`         | Interval at which metrics should be scraped                                                                              | `30s`                                                        |
-| `metrics.serviceMonitor.scrapeTimeout`    | Specify the timeout after which the scrape is ended                                                                      | `nil`                                                        |
-| `metrics.serviceMonitor.relabellings`     | Specify Metric Relabellings to add to the scrape endpoint                                                                | `nil`                                                        |
-| `metrics.serviceMonitor.honorLabels`      | honorLabels chooses the metric's labels on collisions with target labels.                                                | `false`                                                      |
-| `metrics.serviceMonitor.additionalLabels` | Used to pass Labels that are required by the Installed Prometheus Operator                                               | `{}`                                                         |
-| `metrics.serviceMonitor.release`          | Used to pass Labels release that sometimes should be custom for Prometheus Operator                                      | `nil`                                                        |
-| `metrics.prometheusRule.enabled`          | Set this to true to create prometheusRules for Prometheus operator                                                       | `false`                                                      |
-| `metrics.prometheusRule.additionalLabels` | Additional labels that can be used so prometheusRules will be discovered by Prometheus                                   | `{}`                                                         |
-| `metrics.prometheusRule.namespace`        | namespace where prometheusRules resource should be created                                                               | `monitoring`                                                 |
-| `metrics.prometheusRule.rules`            | Rules to be created, check values for an example.                                                                        | `[]`                                                         |
+| Parameter                                 | Description                                                                            | Default                                                      |
+|-------------------------------------------|----------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `metrics.enabled`                         | Enable exposing RabbitMQ metrics to be gathered by Prometheus                          | `false`                                                      |
+| `metrics.plugins`                         | Plugins to enable Prometheus metrics in RabbitMQ                                       | `rabbitmq_prometheus`                                        |
+| `metrics.podAnnotations`                  | Annotations for enabling prometheus to access the metrics endpoint                     | `{prometheus.io/scrape: "true", prometheus.io/port: "9419"}` |
+| `metrics.serviceMonitor.enabled`          | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator           | `false`                                                      |
+| `metrics.serviceMonitor.namespace`        | Namespace which Prometheus is running in                                               | `monitoring`                                                 |
+| `metrics.serviceMonitor.interval`         | Interval at which metrics should be scraped                                            | `30s`                                                        |
+| `metrics.serviceMonitor.scrapeTimeout`    | Specify the timeout after which the scrape is ended                                    | `nil`                                                        |
+| `metrics.serviceMonitor.relabellings`     | Specify Metric Relabellings to add to the scrape endpoint                              | `nil`                                                        |
+| `metrics.serviceMonitor.honorLabels`      | honorLabels chooses the metric's labels on collisions with target labels.              | `false`                                                      |
+| `metrics.serviceMonitor.additionalLabels` | Used to pass Labels that are required by the Installed Prometheus Operator             | `{}`                                                         |
+| `metrics.serviceMonitor.release`          | Used to pass Labels release that sometimes should be custom for Prometheus Operator    | `nil`                                                        |
+| `metrics.prometheusRule.enabled`          | Set this to true to create prometheusRules for Prometheus operator                     | `false`                                                      |
+| `metrics.prometheusRule.additionalLabels` | Additional labels that can be used so prometheusRules will be discovered by Prometheus | `{}`                                                         |
+| `metrics.prometheusRule.namespace`        | namespace where prometheusRules resource should be created                             | `monitoring`                                                 |
+| `metrics.prometheusRule.rules`            | Rules to be created, check values for an example.                                      | `[]`                                                         |
 
 The above parameters map to the env variables defined in [bitnami/rabbitmq](http://github.com/bitnami/bitnami-docker-rabbitmq). For more information please refer to the [bitnami/rabbitmq](http://github.com/bitnami/bitnami-docker-rabbitmq) image documentation.
 
@@ -576,7 +578,6 @@ extraConfiguration: |-
   default_permissions.read = .*
   default_permissions.write = .*
 ```
-
 
 ## Troubleshooting
 

--- a/bitnami/rabbitmq/templates/ingress.yaml
+++ b/bitnami/rabbitmq/templates/ingress.yaml
@@ -18,19 +18,24 @@ spec:
     - host: {{ .Values.ingress.hostname }}
       http:
         paths:
+          {{- if .Values.ingress.extraPaths }}
+          {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
+          {{- end }}
           - path: {{ .Values.ingress.path }}
-            backend:
-              serviceName: {{ template "rabbitmq.fullname" . }}
-              servicePort: http-stats
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.ingress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http-stats" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
     - host: {{ .name }}
       http:
         paths:
           - path: {{ default "/" .path }}
-            backend:
-              serviceName: {{ template "rabbitmq.fullname" $ }}
-              servicePort: http-stats
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
+            pathType: {{ default "ImplementationSpecific" .pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http-stats" "context" $) | nindent 14 }}
     {{- end }}
   {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
   tls:

--- a/bitnami/rabbitmq/values-production.yaml
+++ b/bitnami/rabbitmq/values-production.yaml
@@ -42,6 +42,10 @@ image:
 ##
 # fullnameOverride:
 
+## Force target Kubernetes version (using Helm capabilites if not set)
+##
+kubeVersion:
+
 ## Kubernetes Cluster Domain
 ##
 clusterDomain: cluster.local
@@ -81,13 +85,13 @@ auth:
 ## Value for the RABBITMQ_LOGS environment variable
 ## ref: https://www.rabbitmq.com/logging.html#log-file-location
 ##
-logs: '-'
+logs: "-"
 
 ## RabbitMQ Max File Descriptors
 ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
 ## ref: https://www.rabbitmq.com/install-debian.html#kernel-resource-limits
 ##
-ulimitNofiles: '65536'
+ulimitNofiles: "65536"
 
 ## RabbitMQ maximum available scheduler threads and online scheduler threads. By default it will create a thread per CPU detected, with the following parameters you can tune it manually.
 ## ref: https://hamidreza-s.github.io/erlang/scheduling/real-time/preemptive/migration/2016/02/09/erlang-scheduler-details.html#scheduler-threads
@@ -104,7 +108,7 @@ memoryHighWatermark:
   enabled: true
   ## Memory high watermark type. Either absolute or relative
   ##
-  type: 'relative'
+  type: "relative"
   ## Memory high watermark value.
   ## The default value of 0.4 stands for 40% of available RAM
   ## Note: the memory relative limit is applied to the resource.limits.memory to calculate the memory threshold
@@ -114,7 +118,7 @@ memoryHighWatermark:
 
 ## Plugins to enable
 ##
-plugins: 'rabbitmq_management rabbitmq_peer_discovery_k8s'
+plugins: "rabbitmq_management rabbitmq_peer_discovery_k8s"
 
 ## Community plugins to download during container initialization.
 ## Combine it with extraPlugins to also enable them.
@@ -124,7 +128,7 @@ plugins: 'rabbitmq_management rabbitmq_peer_discovery_k8s'
 ## Extra plugins to enable
 ## Use this instead of `plugins` to add new plugins
 ##
-extraPlugins: 'rabbitmq_auth_backend_ldap'
+extraPlugins: "rabbitmq_auth_backend_ldap"
 
 ## Clustering settings
 ##
@@ -157,6 +161,7 @@ loadDefinition:
 
 ## Default duration in seconds k8s waits for container to exit before sending kill signal. Any time in excess of
 ## 10 seconds will be spent waiting for any synchronization necessary for cluster not to lose data.
+##
 terminationGracePeriodSeconds: 120
 
 ## Additional environment variables to set
@@ -189,9 +194,11 @@ extraContainerPorts: []
 ##
 configuration: |-
   ## Username and password
+  ##
   default_user = {{ .Values.auth.username }}
   default_pass = CHANGEME
   ## Clustering
+  ##
   cluster_formation.peer_discovery_backend  = rabbit_peer_discovery_k8s
   cluster_formation.k8s.host = kubernetes.default.svc.{{ .Values.clusterDomain }}
   cluster_formation.node_cleanup.interval = 10
@@ -223,10 +230,12 @@ configuration: |-
   {{- end }}
   {{- if .Values.metrics.enabled }}
   ## Prometheus metrics
+  ##
   prometheus.tcp.port = 9419
   {{- end }}
   {{- if .Values.memoryHighWatermark.enabled }}
   ## Memory Threshold
+  ##
   total_memory_available_override_value = {{ include "rabbitmq.toBytes" .Values.resources.limits.memory }}
   vm_memory_high_watermark.{{ .Values.memoryHighWatermark.type }} = {{ .Values.memoryHighWatermark.value }}
   {{- end }}
@@ -268,7 +277,7 @@ ldap:
   servers: []
   ## LDAP servers port
   ##
-  port: '389'
+  port: "389"
   ## Pattern used to translate the provided username into a value to be used for the LDAP bind
   ## ref: https://www.rabbitmq.com/ldap.html#usernames-and-dns
   ##
@@ -287,6 +296,7 @@ ldap:
 ## extraVolumes:
 ##   - name: extras
 ##     emptyDir: {}
+##
 extraVolumeMounts: []
 extraVolumes: []
 
@@ -346,7 +356,7 @@ statefulsetLabels: {}
 ## Name of the priority class to be used by RabbitMQ pods, priority class needs to be created beforehand
 ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
 ##
-priorityClassName: ''
+priorityClassName: ""
 
 ## Pod affinity preset
 ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
@@ -367,6 +377,7 @@ podAntiAffinityPreset: soft
 nodeAffinityPreset:
   ## Node affinity type
   ## Allowed values: soft, hard
+  ##
   type: ""
   ## Node label key to match
   ## E.g.
@@ -519,6 +530,7 @@ persistence:
   ## selector:
   ##   matchLabels:
   ##     app: my-app
+  ##
   selector: {}
   accessMode: ReadWriteOnce
 
@@ -572,6 +584,7 @@ networkPolicy:
   #        - frontend
 
 ## Kubernetes service type
+##
 service:
   type: ClusterIP
   ## Amqp port
@@ -694,6 +707,10 @@ ingress:
   ##
   path: /
 
+  ## Ingress Path type
+  ##
+  pathType: ImplementationSpecific
+
   ## Set this to true in order to add the corresponding annotations for cert-manager
   ##
   certManager: false
@@ -717,6 +734,7 @@ ingress:
   ##
   tls: false
   ## existingSecret: name-of-existing-secret
+  ##
 
   ## The list of additional hostnames to be covered with this ingress record.
   ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
@@ -753,13 +771,13 @@ ingress:
 ##
 metrics:
   enabled: true
-  plugins: 'rabbitmq_prometheus'
+  plugins: "rabbitmq_prometheus"
   ## Prometheus pod annotations
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##
   podAnnotations:
-    prometheus.io/scrape: 'true'
-    prometheus.io/port: '{{ .Values.service.metricsPort }}'
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "{{ .Values.service.metricsPort }}"
 
   ## Prometheus Service Monitor
   ## ref: https://github.com/coreos/prometheus-operator
@@ -798,7 +816,7 @@ metrics:
   prometheusRule:
     enabled: false
     additionalLabels: {}
-    namespace: ''
+    namespace: ""
     ## List of rules, used as template by Helm.
     ## These are just examples rules inspired from https://awesome-prometheus-alerts.grep.to/rules.html
     # rules:

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -42,6 +42,10 @@ image:
 ##
 # fullnameOverride:
 
+## Force target Kubernetes version (using Helm capabilites if not set)
+##
+kubeVersion:
+
 ## Kubernetes Cluster Domain
 ##
 clusterDomain: cluster.local
@@ -157,6 +161,7 @@ loadDefinition:
 
 ## Default duration in seconds k8s waits for container to exit before sending kill signal. Any time in excess of
 ## 10 seconds will be spent waiting for any synchronization necessary for cluster not to lose data.
+##
 terminationGracePeriodSeconds: 120
 
 ## Additional environment variables to set
@@ -189,9 +194,11 @@ extraContainerPorts: []
 ##
 configuration: |-
   ## Username and password
+  ##
   default_user = {{ .Values.auth.username }}
   default_pass = CHANGEME
   ## Clustering
+  ##
   cluster_formation.peer_discovery_backend  = rabbit_peer_discovery_k8s
   cluster_formation.k8s.host = kubernetes.default.svc.{{ .Values.clusterDomain }}
   cluster_formation.node_cleanup.interval = 10
@@ -224,10 +231,12 @@ configuration: |-
   {{- end }}
   {{- if .Values.metrics.enabled }}
   ## Prometheus metrics
+  ##
   prometheus.tcp.port = 9419
   {{- end }}
   {{- if .Values.memoryHighWatermark.enabled }}
   ## Memory Threshold
+  ##
   total_memory_available_override_value = {{ include "rabbitmq.toBytes" .Values.resources.limits.memory }}
   vm_memory_high_watermark.{{ .Values.memoryHighWatermark.type }} = {{ .Values.memoryHighWatermark.value }}
   {{- end }}
@@ -288,6 +297,7 @@ ldap:
 ## extraVolumes:
 ##   - name: extras
 ##     emptyDir: {}
+##
 extraVolumeMounts: []
 extraVolumes: []
 
@@ -302,6 +312,7 @@ extraVolumes: []
 ##       }
 ##
 ## Set this flag to true if extraSecrets should be created with <release-name> prepended.
+##
 extraSecretsPrependReleaseName: false
 extraSecrets: {}
 
@@ -370,6 +381,7 @@ podAntiAffinityPreset: soft
 nodeAffinityPreset:
   ## Node affinity type
   ## Allowed values: soft, hard
+  ##
   type: ""
   ## Node label key to match
   ## E.g.
@@ -527,6 +539,7 @@ persistence:
   ## selector:
   ##   matchLabels:
   ##     app: my-app
+  ##
   selector: {}
   accessMode: ReadWriteOnce
 
@@ -580,6 +593,7 @@ networkPolicy:
   #        - frontend
 
 ## Kubernetes service type
+##
 service:
   type: ClusterIP
   ## Amqp port
@@ -706,6 +720,10 @@ ingress:
   ##
   path: /
 
+  ## Ingress Path type
+  ##
+  pathType: ImplementationSpecific
+
   ## Set this to true in order to add the corresponding annotations for cert-manager
   ##
   certManager: false
@@ -729,6 +747,7 @@ ingress:
   ##
   tls: false
   ## existingSecret: name-of-existing-secret
+  ##
 
   ## The list of additional hostnames to be covered with this ingress record.
   ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This PR updates the common library with the changes from https://github.com/bitnami/charts/pull/4859. 

- Depending on the Kubernetes version it will generate the proper Ingress object
- It allows forcing a Kubernetes version so it is compatible with GitOps approaches

**Benefits**

Charts compatible with all Kubernetes versions
**Possible drawbacks**

n/a
**Applicable issues**

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
