### PR TITLE
[bitnami/spring-cloud-dataflow] Add common annotations and labels and adapt ingress to k8s 1.20

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.lock
+++ b/bitnami/spring-cloud-dataflow/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.2.3
+  version: 1.3.2
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 9.2.0
+  version: 9.2.2
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
-  version: 8.6.1
+  version: 8.6.3
 - name: kafka
   repository: https://charts.bitnami.com/bitnami
   version: 12.5.0
-digest: sha256:ddc349511ce0d12c50122f93b3e808e1006cbcdd6c4b7768c6d33a2871b4ad2a
-generated: "2021-01-02T18:58:51.096088298Z"
+digest: sha256:a2d5afce8afc8713581911de3055e050d14adef2ec22ac0367e21b40353035c4
+generated: "2021-01-13T18:19:49.547081+01:00"

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -38,4 +38,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-spring-cloud-dataflow
   - https://github.com/bitnami/bitnami-docker-spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 2.4.2
+version: 2.5.0

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -48,256 +48,262 @@ The following tables lists the configurable parameters of the Spring Cloud Data 
 
 ### Global parameters
 
-| Parameter                                    | Description                                                                                            | Default                                                 |
-|----------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `global.imageRegistry`                       | Global Docker image registry                                                                           | `nil`                                                   |
-| `global.imagePullSecrets`                    | Global Docker registry secret names as an array                                                        | `[]` (does not add image pull secrets to deployed pods) |
-| `global.storageClass`                        | Global storage class for dynamic provisioning                                                          | `nil`                                                   |
+| Parameter                 | Description                                     | Default                                                 |
+|---------------------------|-------------------------------------------------|---------------------------------------------------------|
+| `global.imageRegistry`    | Global Docker image registry                    | `nil`                                                   |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
+| `global.storageClass`     | Global storage class for dynamic provisioning   | `nil`                                                   |
 
 ### Common parameters
 
-| Parameter                                    | Description                                                                                            | Default                                                 |
-|----------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `nameOverride`                               | String to partially override scdf.fullname                                                             | `nil`                                                   |
-| `fullnameOverride`                           | String to fully override scdf.fullname                                                                 | `nil`                                                   |
-| `clusterDomain`                              | Default Kubernetes cluster domain                                                                      | `cluster.local`                                         |
-| `deployer.resources.limits`                  | Streaming applications resource limits                                                                 | `{ cpu: "500m", memory: "1024Mi" }`                     |
-| `deployer.resources.requests`                | Streaming applications resource requests                                                               | `{}`                                                    |
-| `deployer.resources.readinessProbe`          | Streaming applications readiness probes requests                                                       | Check `values.yaml` file                                |
-| `deployer.resources.livenessProbe`           | Streaming applications liveness probes  requests                                                       | Check `values.yaml` file                                |
-| `deployer.nodeSelector`                      | Streaming applications nodeSelector                                                                    | `""`                                                    |
-| `deployer.tolerations`                       | Streaming applications tolerations                                                                     | `{}`                                                    |
-| `deployer.volumeMounts`                      | Streaming applications extra volume mounts                                                             | `{}`                                                    |
-| `deployer.volumes`                           | Streaming applications extra volumes                                                                   | `{}`                                                    |
-| `deployer.environmentVariables`              | Streaming applications environment variables                                                           | `""`                                                    |
-| `deployer.podSecurityContext`                | Streaming applications Security Context.                                                               | `{runAsUser: 1001}`                                     |
+| Parameter                           | Description                                                          | Default                             |
+|-------------------------------------|----------------------------------------------------------------------|-------------------------------------|
+| `nameOverride`                      | String to partially override scdf.fullname                           | `nil`                               |
+| `fullnameOverride`                  | String to fully override scdf.fullname                               | `nil`                               |
+| `clusterDomain`                     | Default Kubernetes cluster domain                                    | `cluster.local`                     |
+| `commonLabels`                      | Labels to add to all deployed objects                                | `{}`                                |
+| `commonAnnotations`                 | Annotations to add to all deployed objects                           | `{}`                                |
+| `extraDeploy`                       | Array of extra objects to deploy with the release                    | `[]` (evaluated as a template)      |
+| `kubeVersion`                       | Force target Kubernetes version (using Helm capabilities if not set) | `nil`                               |
+| `deployer.resources.limits`         | Streaming applications resource limits                               | `{ cpu: "500m", memory: "1024Mi" }` |
+| `deployer.resources.requests`       | Streaming applications resource requests                             | `{}`                                |
+| `deployer.resources.readinessProbe` | Streaming applications readiness probes requests                     | Check `values.yaml` file            |
+| `deployer.resources.livenessProbe`  | Streaming applications liveness probes  requests                     | Check `values.yaml` file            |
+| `deployer.nodeSelector`             | Streaming applications nodeSelector                                  | `""`                                |
+| `deployer.tolerations`              | Streaming applications tolerations                                   | `{}`                                |
+| `deployer.volumeMounts`             | Streaming applications extra volume mounts                           | `{}`                                |
+| `deployer.volumes`                  | Streaming applications extra volumes                                 | `{}`                                |
+| `deployer.environmentVariables`     | Streaming applications environment variables                         | `""`                                |
+| `deployer.podSecurityContext`       | Streaming applications Security Context.                             | `{runAsUser: 1001}`                 |
 
 ### Dataflow Server parameters
 
-| Parameter                                    | Description                                                                                            | Default                                                 |
-|----------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `server.image.registry`                      | Spring Cloud Dataflow image registry                                                                   | `docker.io`                                             |
-| `server.image.repository`                    | Spring Cloud Dataflow image name                                                                       | `bitnami/spring-cloud-dataflow`                         |
-| `server.image.tag`                           | Spring Cloud Dataflow image tag                                                                        | `{TAG_NAME}`                                            |
-| `server.image.pullPolicy`                    | Spring Cloud Dataflow image pull policy                                                                | `IfNotPresent`                                          |
-| `server.image.pullSecrets`                   | Specify docker-registry secret names as an array                                                       | `[]` (does not add image pull secrets to deployed pods) |
-| `server.composedTaskRunner.image.registry`   | Spring Cloud Dataflow Composed Task Runner image registry                                              | `docker.io`                                             |
-| `server.composedTaskRunner.image.repository` | Spring Cloud Dataflow Composed Task Runner image name                                                  | `bitnami/spring-cloud-dataflow-composed-task-runner`    |
-| `server.composedTaskRunner.image.tag`        | Spring Cloud Dataflow Composed Task Runner image tag                                                   | `{TAG_NAME}`                                            |
-| `server.configuration.streamingEnabled`      | Enables or disables streaming data processing                                                          | `true`                                                  |
-| `server.configuration.batchEnabled`          | Enables or disables bath data (tasks and schedules) processing                                         | `true`                                                  |
-| `server.configuration.accountName`           | The name of the account to configure for the Kubernetes platform                                       | `default`                                               |
-| `server.configuration.trustK8sCerts`         | Trust K8s certificates when querying the Kubernetes API                                                | `false`                                                 |
-| `server.configuration.containerRegistries`   | Container registries configuration                                                                     | `{}` (check `values.yaml` for more information)         |
-| `server.configuration.metricsDashboard`      | Endpoint to the metricsDashboard instance                                                              | `nil`                                                   |
-| `server.existingConfigmap`                   | Name of existing ConfigMap with Dataflow server configuration                                          | `nil`                                                   |
-| `server.extraEnvVars`                        | Extra environment variables to be set on Dataflow server container                                     | `{}`                                                    |
-| `server.extraEnvVarsCM`                      | Name of existing ConfigMap containing extra env vars                                                   | `nil`                                                   |
-| `server.extraEnvVarsSecret`                  | Name of existing Secret containing extra env vars                                                      | `nil`                                                   |
-| `server.replicaCount`                        | Number of Dataflow server replicas to deploy                                                           | `1`                                                     |
-| `server.strategyType`                        | Deployment Strategy Type                                                                               | `RollingUpdate`                                         |
-| `server.podAffinityPreset`                   | Dataflow server pod affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`       | `""`                                          |
-| `server.podAntiAffinityPreset`               | Dataflow server pod anti-affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                        |
-| `server.nodeAffinityPreset.type`             | Dataflow server node affinity preset type. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard` | `""`                                          |
-| `server.nodeAffinityPreset.key`              | Dataflow server node label key to match Ignored if `server.affinity` is set.                                     | `""`                                          |
-| `server.nodeAffinityPreset.values`           | Dataflow server node label values to match. Ignored if `server.affinity` is set.                                 | `[]`                                          |
-| `server.affinity`                            | Dataflow server affinity for pod assignment                                                                      | `{}` (evaluated as a template)                |
-| `server.nodeSelector`                        | Dataflow server node labels for pod assignment                                                                   | `{}` (evaluated as a template)                |
-| `server.tolerations`                         | Dataflow server tolerations for pod assignment                                                                   | `[]` (evaluated as a template)                |
-| `server.priorityClassName`                   | Controller priorityClassName                                                                           | `nil`                                                   |
-| `server.podSecurityContext`                  | Dataflow server pods' Security Context                                                                 | `{ fsGroup: "1001" }`                                   |
-| `server.containerSecurityContext`            | Dataflow server containers' Security Context                                                           | `{ runAsUser: "1001" }`                                 |
-| `server.resources.limits`                    | The resources limits for the Dataflow server container                                                 | `{}`                                                    |
-| `server.resources.requests`                  | The requested resources for the Dataflow server container                                              | `{}`                                                    |
-| `server.podAnnotations`                      | Annotations for Dataflow server pods                                                                   | `{}`                                                    |
-| `server.livenessProbe`                       | Liveness probe configuration for Dataflow server                                                       | Check `values.yaml` file                                |
-| `server.readinessProbe`                      | Readiness probe configuration for Dataflow server                                                      | Check `values.yaml` file                                |
-| `server.customLivenessProbe`                 | Override default liveness probe                                                                        | `nil`                                                   |
-| `server.customReadinessProbe`                | Override default readiness probe                                                                       | `nil`                                                   |
-| `server.service.type`                        | Kubernetes service type                                                                                | `ClusterIP`                                             |
-| `server.service.port`                        | Service HTTP port                                                                                      | `8080`                                                  |
-| `server.service.nodePort`                    | Service HTTP node port                                                                                 | `nil`                                                   |
-| `server.service.clusterIP`                   | Dataflow server service clusterIP IP                                                                   | `None`                                                  |
-| `server.service.externalTrafficPolicy`       | Enable client source IP preservation                                                                   | `Cluster`                                               |
-| `server.service.loadBalancerIP`              | loadBalancerIP if service type is `LoadBalancer`                                                       | `nil`                                                   |
-| `server.service.loadBalancerSourceRanges`    | Address that are allowed when service is LoadBalancer                                                  | `[]`                                                    |
-| `server.service.annotations`                 | Annotations for Dataflow server service                                                                | `{}`                                                    |
-| `server.ingress.enabled`                     | Enable ingress controller resource                                                                     | `false`                                                 |
-| `server.ingress.certManager`                 | Add annotations for cert-manager                                                                       | `false`                                                 |
-| `server.ingress.hostname`                    | Default host for the ingress resource                                                                  | `dataflow.local`                                        |
-| `server.ingress.annotations`                 | Ingress annotations                                                                                    | `[]`                                                    |
-| `server.ingress.extraHosts[0].name`          | Additional hostnames to be covered                                                                     | `nil`                                                   |
-| `server.ingress.extraHosts[0].path`          | Additional hostnames to be covered                                                                     | `nil`                                                   |
-| `server.ingress.extraTls[0].hosts[0]`        | TLS configuration for additional hostnames to be covered                                               | `nil`                                                   |
-| `server.ingress.extraTls[0].secretName`      | TLS configuration for additional hostnames to be covered                                               | `nil`                                                   |
-| `server.ingress.secrets[0].name`             | TLS Secret Name                                                                                        | `nil`                                                   |
-| `server.ingress.secrets[0].certificate`      | TLS Secret Certificate                                                                                 | `nil`                                                   |
-| `server.ingress.secrets[0].key`              | TLS Secret Key                                                                                         | `nil`                                                   |
-| `server.initContainers`                      | Add additional init containers to the Dataflow server pods                                             | `{}` (evaluated as a template)                          |
-| `server.sidecars`                            | Add additional sidecar containers to the Dataflow server pods                                          | `{}` (evaluated as a template)                          |
-| `server.pdb.create`                          | Enable/disable a Pod Disruption Budget creation                                                        | `false`                                                 |
-| `server.pdb.minAvailable`                    | Minimum number/percentage of pods that should remain scheduled                                         | `1`                                                     |
-| `server.pdb.maxUnavailable`                  | Maximum number/percentage of pods that may be made unavailable                                         | `nil`                                                   |
-| `server.autoscaling.enabled`                 | Enable autoscaling for Dataflow server                                                                 | `false`                                                 |
-| `server.autoscaling.minReplicas`             | Minimum number of Dataflow server replicas                                                             | `nil`                                                   |
-| `server.autoscaling.maxReplicas`             | Maximum number of Dataflow server replicas                                                             | `nil`                                                   |
-| `server.autoscaling.targetCPU`               | Target CPU utilization percentage                                                                      | `nil`                                                   |
-| `server.autoscaling.targetMemory`            | Target Memory utilization percentage                                                                   | `nil`                                                   |
-| `server.jdwp.enabled`                        | Enable Java Debug Wire Protocol (JDWP)                                                                 | `false`                                                 |
-| `server.jdwp.port`                           | JDWP TCP port                                                                                          | `5005`                                                  |
-| `server.extraVolumes`                        | Extra Volumes to be set on the Dataflow Server Pod                                                     | `nil`                                                   |
-| `server.extraVolumeMounts`                   | Extra VolumeMounts to be set on the Dataflow Container                                                 | `nil`                                                   |
+| Parameter                                    | Description                                                                                                      | Default                                                 |
+|----------------------------------------------|------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `server.image.registry`                      | Spring Cloud Dataflow image registry                                                                             | `docker.io`                                             |
+| `server.image.repository`                    | Spring Cloud Dataflow image name                                                                                 | `bitnami/spring-cloud-dataflow`                         |
+| `server.image.tag`                           | Spring Cloud Dataflow image tag                                                                                  | `{TAG_NAME}`                                            |
+| `server.image.pullPolicy`                    | Spring Cloud Dataflow image pull policy                                                                          | `IfNotPresent`                                          |
+| `server.image.pullSecrets`                   | Specify docker-registry secret names as an array                                                                 | `[]` (does not add image pull secrets to deployed pods) |
+| `server.composedTaskRunner.image.registry`   | Spring Cloud Dataflow Composed Task Runner image registry                                                        | `docker.io`                                             |
+| `server.composedTaskRunner.image.repository` | Spring Cloud Dataflow Composed Task Runner image name                                                            | `bitnami/spring-cloud-dataflow-composed-task-runner`    |
+| `server.composedTaskRunner.image.tag`        | Spring Cloud Dataflow Composed Task Runner image tag                                                             | `{TAG_NAME}`                                            |
+| `server.configuration.streamingEnabled`      | Enables or disables streaming data processing                                                                    | `true`                                                  |
+| `server.configuration.batchEnabled`          | Enables or disables bath data (tasks and schedules) processing                                                   | `true`                                                  |
+| `server.configuration.accountName`           | The name of the account to configure for the Kubernetes platform                                                 | `default`                                               |
+| `server.configuration.trustK8sCerts`         | Trust K8s certificates when querying the Kubernetes API                                                          | `false`                                                 |
+| `server.configuration.containerRegistries`   | Container registries configuration                                                                               | `{}` (check `values.yaml` for more information)         |
+| `server.configuration.metricsDashboard`      | Endpoint to the metricsDashboard instance                                                                        | `nil`                                                   |
+| `server.existingConfigmap`                   | Name of existing ConfigMap with Dataflow server configuration                                                    | `nil`                                                   |
+| `server.extraEnvVars`                        | Extra environment variables to be set on Dataflow server container                                               | `{}`                                                    |
+| `server.extraEnvVarsCM`                      | Name of existing ConfigMap containing extra env vars                                                             | `nil`                                                   |
+| `server.extraEnvVarsSecret`                  | Name of existing Secret containing extra env vars                                                                | `nil`                                                   |
+| `server.replicaCount`                        | Number of Dataflow server replicas to deploy                                                                     | `1`                                                     |
+| `server.strategyType`                        | Deployment Strategy Type                                                                                         | `RollingUpdate`                                         |
+| `server.podAffinityPreset`                   | Dataflow server pod affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`       | `""`                                                    |
+| `server.podAntiAffinityPreset`               | Dataflow server pod anti-affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                                  |
+| `server.nodeAffinityPreset.type`             | Dataflow server node affinity preset type. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard` | `""`                                                    |
+| `server.nodeAffinityPreset.key`              | Dataflow server node label key to match Ignored if `server.affinity` is set.                                     | `""`                                                    |
+| `server.nodeAffinityPreset.values`           | Dataflow server node label values to match. Ignored if `server.affinity` is set.                                 | `[]`                                                    |
+| `server.affinity`                            | Dataflow server affinity for pod assignment                                                                      | `{}` (evaluated as a template)                          |
+| `server.nodeSelector`                        | Dataflow server node labels for pod assignment                                                                   | `{}` (evaluated as a template)                          |
+| `server.tolerations`                         | Dataflow server tolerations for pod assignment                                                                   | `[]` (evaluated as a template)                          |
+| `server.priorityClassName`                   | Controller priorityClassName                                                                                     | `nil`                                                   |
+| `server.podSecurityContext`                  | Dataflow server pods' Security Context                                                                           | `{ fsGroup: "1001" }`                                   |
+| `server.containerSecurityContext`            | Dataflow server containers' Security Context                                                                     | `{ runAsUser: "1001" }`                                 |
+| `server.resources.limits`                    | The resources limits for the Dataflow server container                                                           | `{}`                                                    |
+| `server.resources.requests`                  | The requested resources for the Dataflow server container                                                        | `{}`                                                    |
+| `server.podAnnotations`                      | Annotations for Dataflow server pods                                                                             | `{}`                                                    |
+| `server.livenessProbe`                       | Liveness probe configuration for Dataflow server                                                                 | Check `values.yaml` file                                |
+| `server.readinessProbe`                      | Readiness probe configuration for Dataflow server                                                                | Check `values.yaml` file                                |
+| `server.customLivenessProbe`                 | Override default liveness probe                                                                                  | `nil`                                                   |
+| `server.customReadinessProbe`                | Override default readiness probe                                                                                 | `nil`                                                   |
+| `server.service.type`                        | Kubernetes service type                                                                                          | `ClusterIP`                                             |
+| `server.service.port`                        | Service HTTP port                                                                                                | `8080`                                                  |
+| `server.service.nodePort`                    | Service HTTP node port                                                                                           | `nil`                                                   |
+| `server.service.clusterIP`                   | Dataflow server service clusterIP IP                                                                             | `None`                                                  |
+| `server.service.externalTrafficPolicy`       | Enable client source IP preservation                                                                             | `Cluster`                                               |
+| `server.service.loadBalancerIP`              | loadBalancerIP if service type is `LoadBalancer`                                                                 | `nil`                                                   |
+| `server.service.loadBalancerSourceRanges`    | Address that are allowed when service is LoadBalancer                                                            | `[]`                                                    |
+| `server.service.annotations`                 | Annotations for Dataflow server service                                                                          | `{}`                                                    |
+| `server.ingress.enabled`                     | Enable ingress controller resource                                                                               | `false`                                                 |
+| `server.ingress.pathType`                    | Ingress path type                                                                                                | `ImplementationSpecific`                                |
+| `server.ingress.path`                        | Ingress path                                                                                                     | `/`                                                     |
+| `server.ingress.certManager`                 | Add annotations for cert-manager                                                                                 | `false`                                                 |
+| `server.ingress.hostname`                    | Default host for the ingress resource                                                                            | `dataflow.local`                                        |
+| `server.ingress.annotations`                 | Ingress annotations                                                                                              | `[]`                                                    |
+| `server.ingress.extraHosts[0].name`          | Additional hostnames to be covered                                                                               | `nil`                                                   |
+| `server.ingress.extraHosts[0].path`          | Additional hostnames to be covered                                                                               | `nil`                                                   |
+| `server.ingress.extraTls[0].hosts[0]`        | TLS configuration for additional hostnames to be covered                                                         | `nil`                                                   |
+| `server.ingress.extraTls[0].secretName`      | TLS configuration for additional hostnames to be covered                                                         | `nil`                                                   |
+| `server.ingress.secrets[0].name`             | TLS Secret Name                                                                                                  | `nil`                                                   |
+| `server.ingress.secrets[0].certificate`      | TLS Secret Certificate                                                                                           | `nil`                                                   |
+| `server.ingress.secrets[0].key`              | TLS Secret Key                                                                                                   | `nil`                                                   |
+| `server.initContainers`                      | Add additional init containers to the Dataflow server pods                                                       | `{}` (evaluated as a template)                          |
+| `server.sidecars`                            | Add additional sidecar containers to the Dataflow server pods                                                    | `{}` (evaluated as a template)                          |
+| `server.pdb.create`                          | Enable/disable a Pod Disruption Budget creation                                                                  | `false`                                                 |
+| `server.pdb.minAvailable`                    | Minimum number/percentage of pods that should remain scheduled                                                   | `1`                                                     |
+| `server.pdb.maxUnavailable`                  | Maximum number/percentage of pods that may be made unavailable                                                   | `nil`                                                   |
+| `server.autoscaling.enabled`                 | Enable autoscaling for Dataflow server                                                                           | `false`                                                 |
+| `server.autoscaling.minReplicas`             | Minimum number of Dataflow server replicas                                                                       | `nil`                                                   |
+| `server.autoscaling.maxReplicas`             | Maximum number of Dataflow server replicas                                                                       | `nil`                                                   |
+| `server.autoscaling.targetCPU`               | Target CPU utilization percentage                                                                                | `nil`                                                   |
+| `server.autoscaling.targetMemory`            | Target Memory utilization percentage                                                                             | `nil`                                                   |
+| `server.jdwp.enabled`                        | Enable Java Debug Wire Protocol (JDWP)                                                                           | `false`                                                 |
+| `server.jdwp.port`                           | JDWP TCP port                                                                                                    | `5005`                                                  |
+| `server.extraVolumes`                        | Extra Volumes to be set on the Dataflow Server Pod                                                               | `nil`                                                   |
+| `server.extraVolumeMounts`                   | Extra VolumeMounts to be set on the Dataflow Container                                                           | `nil`                                                   |
 
 ### Dataflow Skipper parameters
 
-| Parameter                                    | Description                                                                                            | Default                                                 |
-|----------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `skipper.enabled`                            | Enable Spring Cloud Skipper component                                                                  | `true`                                                  |
-| `skipper.image.registry`                     | Spring Cloud Skipper image registry                                                                    | `docker.io`                                             |
-| `skipper.image.repository`                   | Spring Cloud Skipper image name                                                                        | `bitnami/spring-cloud-dataflow`                         |
-| `skipper.image.tag`                          | Spring Cloud Skipper image tag                                                                         | `{TAG_NAME}`                                            |
-| `skipper.image.pullPolicy`                   | Spring Cloud Skipper image pull policy                                                                 | `IfNotPresent`                                          |
-| `skipper.image.pullSecrets`                  | Specify docker-registry secret names as an array                                                       | `[]` (does not add image pull secrets to deployed pods) |
-| `skipper.configuration.accountName`          | The name of the account to configure for the Kubernetes platform                                       | `default`                                               |
-| `skipper.configuration.trustK8sCerts`        | Trust K8s certificates when querying the Kubernetes API                                                | `false`                                                 |
-| `skipper.existingConfigmap`                  | Name of existing ConfigMap with Skipper server configuration                                           | `nil`                                                   |
-| `skipper.extraEnvVars`                       | Extra environment variables to be set on Skipper server container                                      | `{}`                                                    |
-| `skipper.extraEnvVarsCM`                     | Name of existing ConfigMap containing extra env vars                                                   | `nil`                                                   |
-| `skipper.extraEnvVarsSecret`                 | Name of existing Secret containing extra env vars                                                      | `nil`                                                   |
-| `skipper.replicaCount`                       | Number of Skipper server replicas to deploy                                                            | `1`                                                     |
-| `skipper.strategyType`                       | Deployment Strategy Type                                                                               | `RollingUpdate`                                         |
-| `skipper.podAffinityPreset`                  | Skipper pod affinity preset. Ignored if `skipper.affinity` is set. Allowed values: `soft` or `hard`       | `""`                                                 |
-| `skipper.podAntiAffinityPreset`              | Skipper pod anti-affinity preset. Ignored if `skipper.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                               |
-| `skipper.nodeAffinityPreset.type`            | Skipper node affinity preset type. Ignored if `skipper.affinity` is set. Allowed values: `soft` or `hard` | `""`                                                 |
-| `skipper.nodeAffinityPreset.key`             | Skipper node label key to match Ignored if `skipper.affinity` is set.                                     | `""`                                                 |
-| `skipper.nodeAffinityPreset.values`          | Skipper node label values to match. Ignored if `skipper.affinity` is set.                                 | `[]`                                                 |
-| `skipper.affinity`                           | Skipper affinity for pod assignment                                                                       | `{}` (evaluated as a template)                       |
-| `skipper.nodeSelector`                       | Skipper node labels for pod assignment                                                                    | `{}` (evaluated as a template)                       |
-| `skipper.tolerations`                        | Skipper tolerations for pod assignment                                                                    | `[]` (evaluated as a template)                       |
-| `skipper.priorityClassName`                  | Controller priorityClassName                                                                           | `nil`                                                   |
-| `skipper.podSecurityContext`                 | Skipper server pods' Security Context                                                                  | `{ fsGroup: "1001" }`                                   |
-| `skipper.containerSecurityContext`           | Skipper server containers' Security Context                                                            | `{ runAsUser: "1001" }`                                 |
-| `skipper.resources.limits`                   | The resources limits for the Skipper server container                                                  | `{}`                                                    |
-| `skipper.resources.requests`                 | The requested resources for the Skipper server container                                               | `{}`                                                    |
-| `skipper.podAnnotations`                     | Annotations for Skipper server pods                                                                    | `{}`                                                    |
-| `skipper.livenessProbe`                      | Liveness probe configuration for Skipper server                                                        | Check `values.yaml` file                                |
-| `skipper.readinessProbe`                     | Readiness probe configuration for Skipper server                                                       | Check `values.yaml` file                                |
-| `skipper.customLivenessProbe`                | Override default liveness probe                                                                        | `nil`                                                   |
-| `skipper.customReadinessProbe`               | Override default readiness probe                                                                       | `nil`                                                   |
-| `skipper.service.type`                       | Kubernetes service type                                                                                | `ClusterIP`                                             |
-| `skipper.service.port`                       | Service HTTP port                                                                                      | `8080`                                                  |
-| `skipper.service.nodePort`                   | Service HTTP node port                                                                                 | `nil`                                                   |
-| `skipper.service.clusterIP`                  | Skipper server service clusterIP IP                                                                    | `None`                                                  |
-| `skipper.service.externalTrafficPolicy`      | Enable client source IP preservation                                                                   | `Cluster`                                               |
-| `skipper.service.loadBalancerIP`             | loadBalancerIP if service type is `LoadBalancer`                                                       | `nil`                                                   |
-| `skipper.service.loadBalancerSourceRanges`   | Address that are allowed when service is LoadBalancer                                                  | `[]`                                                    |
-| `skipper.service.annotations`                | Annotations for Skipper server service                                                                 | `{}`                                                    |
-| `skipper.initContainers`                     | Add additional init containers to the Skipper pods                                                     | `{}` (evaluated as a template)                          |
-| `skipper.sidecars`                           | Add additional sidecar containers to the Skipper pods                                                  | `{}` (evaluated as a template)                          |
-| `skipper.pdb.create`                         | Enable/disable a Pod Disruption Budget creation                                                        | `false`                                                 |
-| `skipper.pdb.minAvailable`                   | Minimum number/percentage of pods that should remain scheduled                                         | `1`                                                     |
-| `skipper.pdb.maxUnavailable`                 | Maximum number/percentage of pods that may be made unavailable                                         | `nil`                                                   |
-| `skipper.autoscaling.enabled`                | Enable autoscaling for Skipper server                                                                  | `false`                                                 |
-| `skipper.autoscaling.minReplicas`            | Minimum number of Skipper server replicas                                                              | `nil`                                                   |
-| `skipper.autoscaling.maxReplicas`            | Maximum number of Skipper server replicas                                                              | `nil`                                                   |
-| `skipper.autoscaling.targetCPU`              | Target CPU utilization percentage                                                                      | `nil`                                                   |
-| `skipper.autoscaling.targetMemory`           | Target Memory utilization percentage                                                                   | `nil`                                                   |
-| `skipper.jdwp.enabled`                       | Enable Java Debug Wire Protocol (JDWP)                                                                 | `false`                                                 |
-| `skipper.jdwp.port`                          | JDWP TCP port                                                                                          | `5005`                                                  |
-| `skipper.extraVolumes`                       | Extra Volumes to be set on the Skipper Pod                                                             | `nil`                                                   |
-| `skipper.extraVolumeMounts`                  | Extra VolumeMounts to be set on the Skipper Container                                                  | `nil`                                                   |
-| `externalSkipper.host`                       | Host of a external Skipper Server                                                                      | `localhost`                                             |
-| `externalSkipper.port`                       | External Skipper Server port number                                                                    | `7577`                                                  |
+| Parameter                                  | Description                                                                                               | Default                                                 |
+|--------------------------------------------|-----------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `skipper.enabled`                          | Enable Spring Cloud Skipper component                                                                     | `true`                                                  |
+| `skipper.image.registry`                   | Spring Cloud Skipper image registry                                                                       | `docker.io`                                             |
+| `skipper.image.repository`                 | Spring Cloud Skipper image name                                                                           | `bitnami/spring-cloud-dataflow`                         |
+| `skipper.image.tag`                        | Spring Cloud Skipper image tag                                                                            | `{TAG_NAME}`                                            |
+| `skipper.image.pullPolicy`                 | Spring Cloud Skipper image pull policy                                                                    | `IfNotPresent`                                          |
+| `skipper.image.pullSecrets`                | Specify docker-registry secret names as an array                                                          | `[]` (does not add image pull secrets to deployed pods) |
+| `skipper.configuration.accountName`        | The name of the account to configure for the Kubernetes platform                                          | `default`                                               |
+| `skipper.configuration.trustK8sCerts`      | Trust K8s certificates when querying the Kubernetes API                                                   | `false`                                                 |
+| `skipper.existingConfigmap`                | Name of existing ConfigMap with Skipper server configuration                                              | `nil`                                                   |
+| `skipper.extraEnvVars`                     | Extra environment variables to be set on Skipper server container                                         | `{}`                                                    |
+| `skipper.extraEnvVarsCM`                   | Name of existing ConfigMap containing extra env vars                                                      | `nil`                                                   |
+| `skipper.extraEnvVarsSecret`               | Name of existing Secret containing extra env vars                                                         | `nil`                                                   |
+| `skipper.replicaCount`                     | Number of Skipper server replicas to deploy                                                               | `1`                                                     |
+| `skipper.strategyType`                     | Deployment Strategy Type                                                                                  | `RollingUpdate`                                         |
+| `skipper.podAffinityPreset`                | Skipper pod affinity preset. Ignored if `skipper.affinity` is set. Allowed values: `soft` or `hard`       | `""`                                                    |
+| `skipper.podAntiAffinityPreset`            | Skipper pod anti-affinity preset. Ignored if `skipper.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                                  |
+| `skipper.nodeAffinityPreset.type`          | Skipper node affinity preset type. Ignored if `skipper.affinity` is set. Allowed values: `soft` or `hard` | `""`                                                    |
+| `skipper.nodeAffinityPreset.key`           | Skipper node label key to match Ignored if `skipper.affinity` is set.                                     | `""`                                                    |
+| `skipper.nodeAffinityPreset.values`        | Skipper node label values to match. Ignored if `skipper.affinity` is set.                                 | `[]`                                                    |
+| `skipper.affinity`                         | Skipper affinity for pod assignment                                                                       | `{}` (evaluated as a template)                          |
+| `skipper.nodeSelector`                     | Skipper node labels for pod assignment                                                                    | `{}` (evaluated as a template)                          |
+| `skipper.tolerations`                      | Skipper tolerations for pod assignment                                                                    | `[]` (evaluated as a template)                          |
+| `skipper.priorityClassName`                | Controller priorityClassName                                                                              | `nil`                                                   |
+| `skipper.podSecurityContext`               | Skipper server pods' Security Context                                                                     | `{ fsGroup: "1001" }`                                   |
+| `skipper.containerSecurityContext`         | Skipper server containers' Security Context                                                               | `{ runAsUser: "1001" }`                                 |
+| `skipper.resources.limits`                 | The resources limits for the Skipper server container                                                     | `{}`                                                    |
+| `skipper.resources.requests`               | The requested resources for the Skipper server container                                                  | `{}`                                                    |
+| `skipper.podAnnotations`                   | Annotations for Skipper server pods                                                                       | `{}`                                                    |
+| `skipper.livenessProbe`                    | Liveness probe configuration for Skipper server                                                           | Check `values.yaml` file                                |
+| `skipper.readinessProbe`                   | Readiness probe configuration for Skipper server                                                          | Check `values.yaml` file                                |
+| `skipper.customLivenessProbe`              | Override default liveness probe                                                                           | `nil`                                                   |
+| `skipper.customReadinessProbe`             | Override default readiness probe                                                                          | `nil`                                                   |
+| `skipper.service.type`                     | Kubernetes service type                                                                                   | `ClusterIP`                                             |
+| `skipper.service.port`                     | Service HTTP port                                                                                         | `8080`                                                  |
+| `skipper.service.nodePort`                 | Service HTTP node port                                                                                    | `nil`                                                   |
+| `skipper.service.clusterIP`                | Skipper server service clusterIP IP                                                                       | `None`                                                  |
+| `skipper.service.externalTrafficPolicy`    | Enable client source IP preservation                                                                      | `Cluster`                                               |
+| `skipper.service.loadBalancerIP`           | loadBalancerIP if service type is `LoadBalancer`                                                          | `nil`                                                   |
+| `skipper.service.loadBalancerSourceRanges` | Address that are allowed when service is LoadBalancer                                                     | `[]`                                                    |
+| `skipper.service.annotations`              | Annotations for Skipper server service                                                                    | `{}`                                                    |
+| `skipper.initContainers`                   | Add additional init containers to the Skipper pods                                                        | `{}` (evaluated as a template)                          |
+| `skipper.sidecars`                         | Add additional sidecar containers to the Skipper pods                                                     | `{}` (evaluated as a template)                          |
+| `skipper.pdb.create`                       | Enable/disable a Pod Disruption Budget creation                                                           | `false`                                                 |
+| `skipper.pdb.minAvailable`                 | Minimum number/percentage of pods that should remain scheduled                                            | `1`                                                     |
+| `skipper.pdb.maxUnavailable`               | Maximum number/percentage of pods that may be made unavailable                                            | `nil`                                                   |
+| `skipper.autoscaling.enabled`              | Enable autoscaling for Skipper server                                                                     | `false`                                                 |
+| `skipper.autoscaling.minReplicas`          | Minimum number of Skipper server replicas                                                                 | `nil`                                                   |
+| `skipper.autoscaling.maxReplicas`          | Maximum number of Skipper server replicas                                                                 | `nil`                                                   |
+| `skipper.autoscaling.targetCPU`            | Target CPU utilization percentage                                                                         | `nil`                                                   |
+| `skipper.autoscaling.targetMemory`         | Target Memory utilization percentage                                                                      | `nil`                                                   |
+| `skipper.jdwp.enabled`                     | Enable Java Debug Wire Protocol (JDWP)                                                                    | `false`                                                 |
+| `skipper.jdwp.port`                        | JDWP TCP port                                                                                             | `5005`                                                  |
+| `skipper.extraVolumes`                     | Extra Volumes to be set on the Skipper Pod                                                                | `nil`                                                   |
+| `skipper.extraVolumeMounts`                | Extra VolumeMounts to be set on the Skipper Container                                                     | `nil`                                                   |
+| `externalSkipper.host`                     | Host of a external Skipper Server                                                                         | `localhost`                                             |
+| `externalSkipper.port`                     | External Skipper Server port number                                                                       | `7577`                                                  |
 
 ### RBAC parameters
 
-| Parameter                                    | Description                                                                                            | Default                                                 |
-|----------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `serviceAccount.create`                      | Enable the creation of a ServiceAccount for Dataflow server and Skipper server pods                    | `true`                                                  |
-| `serviceAccount.name`                        | Name of the created serviceAccount                                                                     | Generated using the `scdf.fullname` template            |
-| `rbac.create`                                | Weather to create & use RBAC resources or not                                                          | `true`                                                  |
+| Parameter               | Description                                                                         | Default                                      |
+|-------------------------|-------------------------------------------------------------------------------------|----------------------------------------------|
+| `serviceAccount.create` | Enable the creation of a ServiceAccount for Dataflow server and Skipper server pods | `true`                                       |
+| `serviceAccount.name`   | Name of the created serviceAccount                                                  | Generated using the `scdf.fullname` template |
+| `rbac.create`           | Weather to create & use RBAC resources or not                                       | `true`                                       |
 
 ### Metrics parameters
 
-| Parameter                                    | Description                                                                                            | Default                                                 |
-|----------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `metrics.metrics`                            | Enable the export of Prometheus metrics                                                                | `false`                                                 |
-| `metrics.image.registry`                     | Prometheus Rsocket Proxy image registry                                                                | `docker.io`                                             |
-| `metrics.image.repository`                   | Prometheus Rsocket Proxy image name                                                                    | `bitnami/prometheus-rsocket-proxy`                      |
-| `metrics.image.tag`                          | Prometheus Rsocket Proxy image tag                                                                     | `{TAG_NAME}`                                            |
-| `metrics.image.pullPolicy`                   | Prometheus Rsocket Proxy image pull policy                                                             | `IfNotPresent`                                          |
-| `metrics.image.pullSecrets`                  | Specify docker-registry secret names as an array                                                       | `[]` (does not add image pull secrets to deployed pods) |
-| `metrics.kafka.service.httpPort`             | Prometheus Rsocket Proxy HTTP port                                                                     | `8080`                                                  |
-| `metrics.kafka.service.rsocketPort`          | Prometheus Rsocket Proxy Rsocket port                                                                  | `8080`                                                  |
-| `metrics.kafka.service.annotations`          | Annotations for Prometheus Rsocket Proxy service                                                       | `Check values.yaml file`                                |
-| `metrics.serviceMonitor.enabled`             | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`) | `false`                                                 |
-| `metrics.serviceMonitor.namespace`           | Namespace in which Prometheus is running                                                               | `nil`                                                   |
-| `metrics.serviceMonitor.interval`            | Interval at which metrics should be scraped.                                                           | `nil` (Prometheus Operator default value)               |
-| `metrics.serviceMonitor.scrapeTimeout`       | Timeout after which the scrape is ended                                                                | `nil` (Prometheus Operator default value)               |
+| Parameter                              | Description                                                                                            | Default                                                 |
+|----------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `metrics.metrics`                      | Enable the export of Prometheus metrics                                                                | `false`                                                 |
+| `metrics.image.registry`               | Prometheus Rsocket Proxy image registry                                                                | `docker.io`                                             |
+| `metrics.image.repository`             | Prometheus Rsocket Proxy image name                                                                    | `bitnami/prometheus-rsocket-proxy`                      |
+| `metrics.image.tag`                    | Prometheus Rsocket Proxy image tag                                                                     | `{TAG_NAME}`                                            |
+| `metrics.image.pullPolicy`             | Prometheus Rsocket Proxy image pull policy                                                             | `IfNotPresent`                                          |
+| `metrics.image.pullSecrets`            | Specify docker-registry secret names as an array                                                       | `[]` (does not add image pull secrets to deployed pods) |
+| `metrics.kafka.service.httpPort`       | Prometheus Rsocket Proxy HTTP port                                                                     | `8080`                                                  |
+| `metrics.kafka.service.rsocketPort`    | Prometheus Rsocket Proxy Rsocket port                                                                  | `8080`                                                  |
+| `metrics.kafka.service.annotations`    | Annotations for Prometheus Rsocket Proxy service                                                       | `Check values.yaml file`                                |
+| `metrics.serviceMonitor.enabled`       | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`) | `false`                                                 |
+| `metrics.serviceMonitor.namespace`     | Namespace in which Prometheus is running                                                               | `nil`                                                   |
+| `metrics.serviceMonitor.interval`      | Interval at which metrics should be scraped.                                                           | `nil` (Prometheus Operator default value)               |
+| `metrics.serviceMonitor.scrapeTimeout` | Timeout after which the scrape is ended                                                                | `nil` (Prometheus Operator default value)               |
 
 ### Init Container parameters
 
-| Parameter                                    | Description                                                                                            | Default                                                 |
-|----------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `waitForBackends.enabled`                    | Wait for the database and other services (such as Kafka or RabbitMQ) used when enabling streaming      | `true`                                                  |
-| `waitForBackends.image.registry`             | Init container wait-for-backend image registry                                                         | `docker.io`                                             |
-| `waitForBackends.image.repository`           | Init container wait-for-backend image name                                                             | `bitnami/kubectl`                                       |
-| `waitForBackends.image.tag`                  | Init container wait-for-backend image tag                                                              | `{TAG_NAME}`                                            |
-| `waitForBackends.image.pullPolicy`           | Init container wait-for-backend image pull policy                                                      | `IfNotPresent`                                          |
-| `waitForBackends.image.pullSecrets`          | Specify docker-registry secret names as an array                                                       | `[]` (does not add image pull secrets to deployed pods) |
-| `waitForBackends.resources.limits`           | Init container wait-for-backend resource  limits                                                       | `{}`                                                    |
-| `waitForBackends.resources.requests`         | Init container wait-for-backend resource  requests                                                     | `{}`                                                    |
+| Parameter                            | Description                                                                                       | Default                                                 |
+|--------------------------------------|---------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `waitForBackends.enabled`            | Wait for the database and other services (such as Kafka or RabbitMQ) used when enabling streaming | `true`                                                  |
+| `waitForBackends.image.registry`     | Init container wait-for-backend image registry                                                    | `docker.io`                                             |
+| `waitForBackends.image.repository`   | Init container wait-for-backend image name                                                        | `bitnami/kubectl`                                       |
+| `waitForBackends.image.tag`          | Init container wait-for-backend image tag                                                         | `{TAG_NAME}`                                            |
+| `waitForBackends.image.pullPolicy`   | Init container wait-for-backend image pull policy                                                 | `IfNotPresent`                                          |
+| `waitForBackends.image.pullSecrets`  | Specify docker-registry secret names as an array                                                  | `[]` (does not add image pull secrets to deployed pods) |
+| `waitForBackends.resources.limits`   | Init container wait-for-backend resource  limits                                                  | `{}`                                                    |
+| `waitForBackends.resources.requests` | Init container wait-for-backend resource  requests                                                | `{}`                                                    |
 
 ### Database parameters
 
-| Parameter                                    | Description                                                                                            | Default                                                 |
-|----------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `mariadb.enabled`                            | Enable/disable MariaDB chart installation                                                              | `true`                                                  |
-| `mariadb.architecture`                       | MariaDB architecture (`standalone` or `replication`)                                                   | `standalone`                                            |
-| `mariadb.auth.database`                      | Database name to create                                                                                | `dataflow`                                              |
-| `mariadb.auth.username`                      | Username of new user to create                                                                         | `dataflow`                                              |
-| `mariadb.auth.password`                      | Password for the new user                                                                              | `change-me`                                             |
-| `mariadb.auth.rootPassword`                  | Password for the MariaDB `root` user                                                                   | _random 10 character alphanumeric string_               |
-| `mariadb.initdbScripts`                      | Dictionary of initdb scripts                                                                           | Check `values.yaml` file                                |
-| `externalDatabase.driver`                    | The fully qualified name of the JDBC Driver class                                                      | `""`                                                    |
-| `externalDatabase.scheme`                    | The scheme is a vendor-specific or shared protocol string that follows the "jdbc:" of the URL          | `""`                                                    |
-| `externalDatabase.host`                      | Host of the external database                                                                          | `localhost`                                             |
-| `externalDatabase.port`                      | External database port number                                                                          | `3306`                                                  |
-| `externalDatabase.password`                  | Password for the above username                                                                        | `""`                                                    |
-| `externalDatabase.existingPasswordSecret`    | Existing secret with database password                                                                 | `""`                                                    |
-| `externalDatabase.existingPasswordKey`       | Key of the existing secret with database password                                                      | `datasource-password`                                   |
-| `externalDatabase.dataflow.url`              | JDBC URL for dataflow server. Overrides external scheme, host, port, database, and jdbc parameters.    | `""`                                                    |
-| `externalDatabase.dataflow.username`         | Existing username in the external db to be used by Dataflow server                                     | `dataflow`                                              |
-| `externalDatabase.dataflow.database`         | Name of the existing database to be used by Dataflow server                                            | `dataflow`                                              |
-| `externalDatabase.skipper.url`               | JDBC URL for skipper. Overrides external scheme, host, port, database, and jdbc parameters.            | `""`                                                    |
-| `externalDatabase.skipper.username`          | Existing username in the external db to be used by Skipper server                                      | `skipper`                                               |
-| `externalDatabase.skipper.database`          | Name of the existing database to be used by Skipper server                                             | `skipper`                                               |
-| `externalDatabase.hibernateDialect`          | Hibernate Dialect used by Dataflow/Skipper servers                                                     | `""`                                                    |
+| Parameter                                 | Description                                                                                         | Default                                   |
+|-------------------------------------------|-----------------------------------------------------------------------------------------------------|-------------------------------------------|
+| `mariadb.enabled`                         | Enable/disable MariaDB chart installation                                                           | `true`                                    |
+| `mariadb.architecture`                    | MariaDB architecture (`standalone` or `replication`)                                                | `standalone`                              |
+| `mariadb.auth.database`                   | Database name to create                                                                             | `dataflow`                                |
+| `mariadb.auth.username`                   | Username of new user to create                                                                      | `dataflow`                                |
+| `mariadb.auth.password`                   | Password for the new user                                                                           | `change-me`                               |
+| `mariadb.auth.rootPassword`               | Password for the MariaDB `root` user                                                                | _random 10 character alphanumeric string_ |
+| `mariadb.initdbScripts`                   | Dictionary of initdb scripts                                                                        | Check `values.yaml` file                  |
+| `externalDatabase.driver`                 | The fully qualified name of the JDBC Driver class                                                   | `""`                                      |
+| `externalDatabase.scheme`                 | The scheme is a vendor-specific or shared protocol string that follows the "jdbc:" of the URL       | `""`                                      |
+| `externalDatabase.host`                   | Host of the external database                                                                       | `localhost`                               |
+| `externalDatabase.port`                   | External database port number                                                                       | `3306`                                    |
+| `externalDatabase.password`               | Password for the above username                                                                     | `""`                                      |
+| `externalDatabase.existingPasswordSecret` | Existing secret with database password                                                              | `""`                                      |
+| `externalDatabase.existingPasswordKey`    | Key of the existing secret with database password                                                   | `datasource-password`                     |
+| `externalDatabase.dataflow.url`           | JDBC URL for dataflow server. Overrides external scheme, host, port, database, and jdbc parameters. | `""`                                      |
+| `externalDatabase.dataflow.username`      | Existing username in the external db to be used by Dataflow server                                  | `dataflow`                                |
+| `externalDatabase.dataflow.database`      | Name of the existing database to be used by Dataflow server                                         | `dataflow`                                |
+| `externalDatabase.skipper.url`            | JDBC URL for skipper. Overrides external scheme, host, port, database, and jdbc parameters.         | `""`                                      |
+| `externalDatabase.skipper.username`       | Existing username in the external db to be used by Skipper server                                   | `skipper`                                 |
+| `externalDatabase.skipper.database`       | Name of the existing database to be used by Skipper server                                          | `skipper`                                 |
+| `externalDatabase.hibernateDialect`       | Hibernate Dialect used by Dataflow/Skipper servers                                                  | `""`                                      |
 
 ### RabbitMQ chart parameters
 
-| Parameter                                    | Description                                                                                            | Default                                                 |
-|----------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `rabbitmq.enabled`                           | Enable/disable RabbitMQ chart installation                                                             | `true`                                                  |
-| `rabbitmq.auth.username`                     | RabbitMQ username                                                                                      | `user`                                                  |
-| `rabbitmq.auth.password`                     | RabbitMQ password                                                                                      | _random 40 character alphanumeric string_               |
-| `externalRabbitmq.enabled`                   | Enable/disable external RabbitMQ                                                                       | `false`                                                 |
-| `externalRabbitmq.host`                      | Host of the external RabbitMQ                                                                          | `localhost`                                             |
-| `externalRabbitmq.port`                      | External RabbitMQ port number                                                                          | `5672`                                                  |
-| `externalRabbitmq.username`                  | External RabbitMQ username                                                                             | `guest`                                                 |
-| `externalRabbitmq.password`                  | External RabbitMQ password                                                                             | `guest`                                                 |
-| `externalRabbitmq.vhost`                     | External RabbitMQ virtual host                                                                         | `/`                                                     |
-| `externalRabbitmq.existingPasswordSecret`    | Existing secret with RabbitMQ password                                                                 | `""`                                                    |
+| Parameter                                 | Description                                | Default                                   |
+|-------------------------------------------|--------------------------------------------|-------------------------------------------|
+| `rabbitmq.enabled`                        | Enable/disable RabbitMQ chart installation | `true`                                    |
+| `rabbitmq.auth.username`                  | RabbitMQ username                          | `user`                                    |
+| `rabbitmq.auth.password`                  | RabbitMQ password                          | _random 40 character alphanumeric string_ |
+| `externalRabbitmq.enabled`                | Enable/disable external RabbitMQ           | `false`                                   |
+| `externalRabbitmq.host`                   | Host of the external RabbitMQ              | `localhost`                               |
+| `externalRabbitmq.port`                   | External RabbitMQ port number              | `5672`                                    |
+| `externalRabbitmq.username`               | External RabbitMQ username                 | `guest`                                   |
+| `externalRabbitmq.password`               | External RabbitMQ password                 | `guest`                                   |
+| `externalRabbitmq.vhost`                  | External RabbitMQ virtual host             | `/`                                       |
+| `externalRabbitmq.existingPasswordSecret` | Existing secret with RabbitMQ password     | `""`                                      |
 
 ### Kafka chart parameters
 
-| Parameter                                    | Description                                                                                            | Default                                                 |
-|----------------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `kafka.enabled`                              | Enable/disable Kafka chart installation                                                                | `false`                                                 |
-| `kafka.replicaCount`                         | Number of Kafka brokers                                                                                | `1`                                                     |
-| `kafka.offsetsTopicReplicationFactor`        | Kafka Secret Key                                                                                       | `1`                                                     |
-| `kafka.zookeeper.enabled`                    | Enable/disable Zookeeper chart installation                                                            | `nil`                                                   |
-| `kafka.zookeeper.replicaCount`               | Number of Zookeeper replicas                                                                           | `1`                                                     |
+| Parameter                             | Description                                 | Default |
+|---------------------------------------|---------------------------------------------|---------|
+| `kafka.enabled`                       | Enable/disable Kafka chart installation     | `false` |
+| `kafka.replicaCount`                  | Number of Kafka brokers                     | `1`     |
+| `kafka.offsetsTopicReplicationFactor` | Kafka Secret Key                            | `1`     |
+| `kafka.zookeeper.enabled`             | Enable/disable Zookeeper chart installation | `nil`   |
+| `kafka.zookeeper.replicaCount`        | Number of Zookeeper replicas                | `1`     |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/spring-cloud-dataflow/templates/externaldb-secrets.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/externaldb-secrets.yaml
@@ -4,6 +4,12 @@ kind: Secret
 metadata:
   name: {{ printf "%s-%s" (include "scdf.fullname" .) "externaldb" }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   mariadb-password: {{ .Values.externalDatabase.password | b64enc | quote }}

--- a/bitnami/spring-cloud-dataflow/templates/externalrabbitmq-secrets.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/externalrabbitmq-secrets.yaml
@@ -4,6 +4,12 @@ kind: Secret
 metadata:
   name: {{ printf "%s-%s" (include "scdf.fullname" .) "externalrabbitmq" }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   rabbitmq-password: {{ .Values.externalRabbitmq.password | b64enc | quote }}

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/deployment.yaml
@@ -5,6 +5,12 @@ metadata:
   name: {{ include "scdf.fullname" . }}-prometheus-proxy
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: prometheus-proxy
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   selector:
@@ -32,4 +38,3 @@ spec:
           resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
           {{- end }}
 {{- end }}
-

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/service.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/service.yaml
@@ -5,8 +5,15 @@ metadata:
   name: {{ include "scdf.fullname" . }}-prometheus-proxy
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: prometheus-proxy
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+  {{- if .Values.commonAnnotations }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
   {{- if .Values.metrics.service.annotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.service.annotations "context" $) | nindent 4 }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.service.annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   type: ClusterIP

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/servicemonitor-metrics.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/servicemonitor-metrics.yaml
@@ -8,6 +8,12 @@ metadata:
   {{- end }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: prometheus-proxy
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}

--- a/bitnami/spring-cloud-dataflow/templates/role.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/role.yaml
@@ -4,6 +4,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "scdf.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups:
       - ""

--- a/bitnami/spring-cloud-dataflow/templates/rolebinding.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/rolebinding.yaml
@@ -4,6 +4,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "scdf.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 roleRef:
   kind: Role
   name: {{ include "scdf.fullname" . }}

--- a/bitnami/spring-cloud-dataflow/templates/scripts-configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/scripts-configmap.yaml
@@ -4,6 +4,12 @@ kind: ConfigMap
 metadata:
   name: {{ include "scdf.fullname" . }}-scripts
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 data:
   {{- $mariadbFullname := include "scdf.mariadb.fullname" . }}
   {{- $rabbitmqFullname := include "scdf.rabbitmq.fullname" . }}

--- a/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
@@ -5,11 +5,17 @@ metadata:
   name: {{ include "scdf.fullname" . }}-server
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: server
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 data:
   application.yaml: |-
     {{- if .Values.metrics.enabled }}
     {{- $fullname := include "scdf.fullname" . }}
-    {{- $rsocketPort := int .Values.metrics.service.rsocketPort }}     
+    {{- $rsocketPort := int .Values.metrics.service.rsocketPort }}
     management:
       metrics:
          export:
@@ -19,7 +25,7 @@ data:
                   enabled: true
                   host: {{ $fullname }}-prometheus-proxy
                   port: {{ $rsocketPort }}
-    {{- end }}     
+    {{- end }}
     spring:
       cloud:
         dataflow:

--- a/bitnami/spring-cloud-dataflow/templates/server/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/deployment.yaml
@@ -9,6 +9,12 @@ metadata:
   name: {{ include "scdf.fullname" . }}-server
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: server
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.server.replicaCount }}
   selector:

--- a/bitnami/spring-cloud-dataflow/templates/server/hpa.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/hpa.yaml
@@ -5,6 +5,12 @@ metadata:
   name: {{ include "scdf.fullname" . }}-server
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: server
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}

--- a/bitnami/spring-cloud-dataflow/templates/server/ingress.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/ingress.yaml
@@ -1,16 +1,22 @@
 {{- if .Values.server.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "scdf.fullname" . }}-server
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: server
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   annotations:
     {{- if .Values.server.ingress.certManager }}
     kubernetes.io/tls-acme: "true"
     {{- end }}
-    {{- range $key, $value := .Values.server.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
+    {{- if .Values.server.ingress.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.server.ingress.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
 spec:
   rules:
@@ -18,19 +24,24 @@ spec:
     - host: {{ .Values.server.ingress.hostname }}
       http:
         paths:
-          - path: /
-            backend:
-              serviceName: {{ include "scdf.fullname" . }}-server
-              servicePort: http
+          {{- if .Values.server.ingress.extraPaths }}
+          {{- toYaml .Values.server.ingress.extraPaths | nindent 10 }}
+          {{- end }}
+          - path: {{ .Values.server.ingress.path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.server.ingress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-server" (include "common.names.fullname" .)) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.server.ingress.extraHosts }}
     - host: {{ .name }}
       http:
         paths:
           - path: {{ default "/" .path }}
-            backend:
-              serviceName: {{ include "scdf.fullname" . }}-server
-              servicePort: http
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
+            pathType: {{ default "ImplementationSpecific" .pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-server" (include "common.names.fullname" $)) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
   {{- if or .Values.server.ingress.tls .Values.server.ingress.extraTls .Values.server.ingress.hosts }}
   tls:

--- a/bitnami/spring-cloud-dataflow/templates/server/pdb.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/pdb.yaml
@@ -5,6 +5,12 @@ metadata:
   name: {{ include "scdf.fullname" . }}-server
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: server
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.server.pdb.minAvailable }}
   minAvailable: {{ .Values.server.pdb.minAvailable }}

--- a/bitnami/spring-cloud-dataflow/templates/server/service.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/service.yaml
@@ -4,8 +4,15 @@ metadata:
   name: {{ include "scdf.fullname" . }}-server
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: server
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+  {{- if .Values.commonAnnotations }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
   {{- if .Values.server.service.annotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.server.service.annotations "context" $) | nindent 4 }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.server.service.annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.server.service.type }}

--- a/bitnami/spring-cloud-dataflow/templates/serviceaccount.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/serviceaccount.yaml
@@ -4,7 +4,14 @@ kind: ServiceAccount
 metadata:
   name: {{ include "scdf.serviceAccountName" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+  {{- if .Values.commonAnnotations }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
   {{- if .Values.serviceAccount.annotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.serviceAccount.annotations "context" $) | nindent 4 }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.serviceAccount.annotations "context" $) | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
@@ -5,11 +5,17 @@ metadata:
   name: {{ include "scdf.fullname" . }}-skipper
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: skipper
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 data:
   application.yaml: |-
     {{- if .Values.metrics.enabled }}
     {{- $fullname := include "scdf.fullname" . }}
-    {{- $rsocketPort := int .Values.metrics.service.rsocketPort }}     
+    {{- $rsocketPort := int .Values.metrics.service.rsocketPort }}
     management:
       metrics:
          export:
@@ -19,7 +25,7 @@ data:
                   enabled: true
                   host: {{ $fullname }}-prometheus-proxy
                   port: {{ $rsocketPort }}
-    {{- end }}          
+    {{- end }}
     spring:
       cloud:
         skipper:

--- a/bitnami/spring-cloud-dataflow/templates/skipper/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/deployment.yaml
@@ -5,6 +5,12 @@ metadata:
   name: {{ include "scdf.fullname" . }}-skipper
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: skipper
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.skipper.replicaCount }}
   selector:

--- a/bitnami/spring-cloud-dataflow/templates/skipper/hpa.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/hpa.yaml
@@ -5,6 +5,12 @@ metadata:
   name: {{ include "scdf.fullname" . }}-skipper
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: skipper
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}

--- a/bitnami/spring-cloud-dataflow/templates/skipper/pdb.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/pdb.yaml
@@ -5,6 +5,12 @@ metadata:
   name: {{ include "scdf.fullname" . }}-skipper
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: skipper
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.skipper.pdb.minAvailable }}
   minAvailable: {{ .Values.skipper.pdb.minAvailable }}

--- a/bitnami/spring-cloud-dataflow/templates/skipper/service.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/service.yaml
@@ -5,8 +5,15 @@ metadata:
   name: {{ include "scdf.fullname" . }}-skipper
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: skipper
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+  {{- if .Values.commonAnnotations }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
   {{- if .Values.skipper.service.annotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.skipper.service.annotations "context" $) | nindent 4 }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.skipper.service.annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.skipper.service.type }}

--- a/bitnami/spring-cloud-dataflow/values-production.yaml
+++ b/bitnami/spring-cloud-dataflow/values-production.yaml
@@ -16,6 +16,10 @@
 ##
 # fullnameOverride:
 
+## Force target Kubernetes version (using Helm capabilites if not set)
+##
+kubeVersion:
+
 ## Kubernetes Cluster Domain.
 ##
 clusterDomain: cluster.local
@@ -132,6 +136,7 @@ server:
   nodeAffinityPreset:
     ## Node affinity type
     ## Allowed values: soft, hard
+    ##
     type: ""
     ## Node label key to match
     ## E.g.
@@ -273,6 +278,15 @@ server:
     ##
     hostname: dataflow.local
 
+    ## The Path to WordPress. You may need to set this to '/*' in order to use this
+    ## with ALB ingress controllers.
+    ##
+    path: /
+
+    ## Ingress Path type
+    ##
+    pathType: ImplementationSpecific
+
     ## Ingress annotations done as key:value pairs
     ## For a full list of possible ingress annotations, please see
     ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
@@ -292,6 +306,7 @@ server:
     ## extraHosts:
     ## - name: dataflow.local
     ##   path: /
+    ##
 
     ## The tls configuration for additional hostnames to be covered with this ingress record.
     ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
@@ -299,6 +314,7 @@ server:
     ## - hosts:
     ##     - dataflow.local
     ##   secretName: dataflow.local-tls
+    ##
 
     ## If you're providing your own certificates, please use this to add the certificates as secrets
     ## key and certificate should start with -----BEGIN CERTIFICATE----- or
@@ -314,6 +330,7 @@ server:
     ## - name: dataflow.local-tls
     ##   key:
     ##   certificate:
+    ##
 
   ## Add init containers to the Dataflow Server pods.
   ## Example:
@@ -468,6 +485,7 @@ skipper:
   nodeAffinityPreset:
     ## Node affinity type
     ## Allowed values: soft, hard
+    ##
     type: ""
     ## Node label key to match
     ## E.g.
@@ -690,7 +708,7 @@ deployer:
   ## The node selectors to apply to the streaming applications deployments in "key:value" format.
   ## Multiple node selectors are comma separated.
   ##
-  nodeSelector: ''
+  nodeSelector: ""
   tolerations: {}
   ## Extra volume mounts.
   ##
@@ -700,7 +718,7 @@ deployer:
   volumes: {}
   ## List of environment variables to set for any deployed app container. Multiple values are comma separated.
   ##
-  environmentVariables: ''
+  environmentVariables: ""
   ## Streams containers' Security Context. This security context will be use in every deployed stream.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ##
@@ -736,6 +754,7 @@ waitForBackends:
     ## choice for the user. This also increases chances charts run on environments with little
     ## resources, such as Minikube. If you do want to specify resources, uncomment the following
     ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    ##
     limits: {}
     #   cpu: 100m
     #   memory: 128Mi
@@ -795,9 +814,9 @@ metrics:
     ## Annotations for the Prometheus Rsocket Proxy service
     ##
     annotations:
-      prometheus.io/scrape: 'true'
-      prometheus.io/port: '{{ .Values.metrics.service.httpPort }}'
-      prometheus.io/path: '/metrics/proxy'
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "{{ .Values.metrics.service.httpPort }}"
+      prometheus.io/path: "/metrics/proxy"
   ## Prometheus Operator ServiceMonitor configuration
   ##
   serviceMonitor:
@@ -830,7 +849,7 @@ mariadb:
     ## MariaDB root password
     ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
     ##
-    rootPassword: ''
+    rootPassword: ""
     ## MariaDB custom user and database
     ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
     ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
@@ -869,7 +888,7 @@ externalDatabase:
   ##
   # driver:
   # scheme:
-  password: ''
+  password: ""
   # existingPasswordSecret: name-of-existing-secret
   # existingPasswordKey: key in existingPasswordSecret, defaults to "datasource-password"
   ## Data Flow user and database
@@ -879,7 +898,8 @@ externalDatabase:
     ## This provides a mechanism to define a fully customized JDBC URL for the data flow server rather than having it
     ## derived from the common, individual attributes. This property, when defined, has precedence over the
     ## individual attributes (scheme, host, port, database)
-    url: ''
+    ##
+    url: ""
     database: dataflow
     user: dataflow
   ## Skipper and database
@@ -889,13 +909,14 @@ externalDatabase:
     ## This provides a mechanism to define a fully customized JDBC URL for skipper rather than having it
     ## derived from the common, individual attributes. This property, when defined, has precedence over the
     ## individual attributes (scheme, host, port, database)
-    url: ''
+    ##
+    url: ""
     database: skipper
     user: skipper
   ## Hibernate Dialect
   ## e.g: org.hibernate.dialect.MariaDB102Dialect
   ##
-  hibernateDialect: ''
+  hibernateDialect: ""
 
 ##
 ## RabbitMQ chart configuration
@@ -906,7 +927,7 @@ rabbitmq:
   enabled: true
   rabbitmq:
     username: user
-    password: ''
+    password: ""
 
 ##
 ## External RabbitMQ Configuration
@@ -944,3 +965,7 @@ kafka:
   ##
   zookeeper:
     replicaCount: 1
+
+## Extra objects to deploy (value evaluated as a template)
+##
+extraDeploy: []

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -16,6 +16,10 @@
 ##
 # fullnameOverride:
 
+## Force target Kubernetes version (using Helm capabilites if not set)
+##
+kubeVersion:
+
 ## Kubernetes Cluster Domain.
 ##
 clusterDomain: cluster.local
@@ -132,6 +136,7 @@ server:
   nodeAffinityPreset:
     ## Node affinity type
     ## Allowed values: soft, hard
+    ##
     type: ""
     ## Node label key to match
     ## E.g.
@@ -265,6 +270,15 @@ server:
     ##
     enabled: false
 
+    ## The Path to WordPress. You may need to set this to '/*' in order to use this
+    ## with ALB ingress controllers.
+    ##
+    path: /
+
+    ## Ingress Path type
+    ##
+    pathType: ImplementationSpecific
+
     ## Set this to true in order to add the corresponding annotations for cert-manager
     ##
     certManager: false
@@ -292,6 +306,7 @@ server:
     ## extraHosts:
     ## - name: dataflow.local
     ##   path: /
+    ##
 
     ## The tls configuration for additional hostnames to be covered with this ingress record.
     ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
@@ -299,6 +314,7 @@ server:
     ## - hosts:
     ##     - dataflow.local
     ##   secretName: dataflow.local-tls
+    ##
 
     ## If you're providing your own certificates, please use this to add the certificates as secrets
     ## key and certificate should start with -----BEGIN CERTIFICATE----- or
@@ -314,6 +330,7 @@ server:
     ## - name: dataflow.local-tls
     ##   key:
     ##   certificate:
+    ##
 
   ## Add init containers to the Dataflow Server pods.
   ## Example:
@@ -468,6 +485,7 @@ skipper:
   nodeAffinityPreset:
     ## Node affinity type
     ## Allowed values: soft, hard
+    ##
     type: ""
     ## Node label key to match
     ## E.g.
@@ -736,6 +754,7 @@ waitForBackends:
     ## choice for the user. This also increases chances charts run on environments with little
     ## resources, such as Minikube. If you do want to specify resources, uncomment the following
     ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    ##
     limits: {}
     #   cpu: 100m
     #   memory: 128Mi
@@ -880,6 +899,7 @@ externalDatabase:
     ## This provides a mechanism to define a fully customized JDBC URL for the data flow server rather than having it
     ## derived from the common, individual attributes. This property, when defined, has precedence over the
     ## individual attributes (scheme, host, port, database)
+    ##
     url: ""
     database: dataflow
     username: dataflow
@@ -890,6 +910,7 @@ externalDatabase:
     ## This provides a mechanism to define a fully customized JDBC URL for skipper rather than having it
     ## derived from the common, individual attributes. This property, when defined, has precedence over the
     ## individual attributes (scheme, host, port, database)
+    ##
     url: ""
     database: skipper
     username: skipper
@@ -944,3 +965,7 @@ kafka:
   ##
   zookeeper:
     replicaCount: 1
+
+## Extra objects to deploy (value evaluated as a template)
+##
+extraDeploy: []


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This PR updates the common library with the changes from https://github.com/bitnami/charts/pull/4859. 

- Depending on the Kubernetes version it will generate the proper Ingress object
- It allows forcing a Kubernetes version so it is compatible with GitOps approaches

**Benefits**

Charts compatible with all Kubernetes versions
**Possible drawbacks**

n/a
**Applicable issues**

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
