### PR TITLE
[bitnami/mongodb] Enable psp for mongodb

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 10.4.1
+version: 10.5.0

--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -264,6 +264,8 @@ The following tables lists the configurable parameters of the MongoDB chart and 
 | `serviceAccount.name`                     | Name of the created serviceAccount                                                                         | Generated using the `mongodb.fullname` template         |
 | `serviceAccount.annotations`              | Additional Service Account annotations                                                                     | `{}`                                                    |
 | `rbac.create`                             | Weather to create & use RBAC resources or not                                                              | `false`                                                 |
+| `podSecurityPolicy.create                 | Whether to create & use PSP resource or not (Note: `rbac.create` needs to be `true`)                       | `false`                                                 |
+| `podSecurityPolicy.spec                   | The PSP Spec (See https://kubernetes.io/docs/concepts/policy/pod-security-policy/)                         | See values.yaml                                         |
 
 ### Volume Permissions parameters
 

--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -245,27 +245,29 @@ The following tables lists the configurable parameters of the MongoDB chart and 
 
 ### Persistence parameters
 
-| Parameter                                   | Description                                                                                                | Default                                                 |
-|---------------------------------------------|------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| Parameter                                 | Description                                                                                                | Default                                                 |
+|-------------------------------------------|------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
 | `persistence.enabled`                       | Enable MongoDB data persistence using PVC                                                                  | `true`                                                  |
 | `persistence.existingClaim`                 | Provide an existing `PersistentVolumeClaim` (only when `architecture=standalone`)                          | `nil` (evaluated as a template)                         |
 | `persistence.storageClass`                  | PVC Storage Class for MongoDB data volume                                                                  | `nil`                                                   |
 | `persistence.accessMode`                    | PVC Access Mode for MongoDB data volume                                                                    | `ReadWriteOnce`                                         |
 | `persistence.size`                          | PVC Storage Request for MongoDB data volume                                                                | `8Gi`                                                   |
-| `persistence.mountPath`                     | Path to mount the volume at                                                                                | `/bitnami/mongodb`                                      |
+| `persistence.mountPath`                     | Path to mount the volume at                                                                                | `/bitnami/mongodb`                                        |
 | `persistence.subPath`                       | Subdirectory of the volume to mount at                                                                     | `""`                                                    |
 | `persistence.volumeClaimTemplates.selector` | A label query over volumes to consider for binding (e.g. when using local volumes)                         | ``                                                      |
 
 ### RBAC parameters
 
-| Parameter                                 | Description                                                                                                | Default                                                 |
-|-------------------------------------------|------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `serviceAccount.create`                   | Enable creation of ServiceAccount for MongoDB pods                                                         | `true`                                                  |
-| `serviceAccount.name`                     | Name of the created serviceAccount                                                                         | Generated using the `mongodb.fullname` template         |
-| `serviceAccount.annotations`              | Additional Service Account annotations                                                                     | `{}`                                                    |
-| `rbac.create`                             | Weather to create & use RBAC resources or not                                                              | `false`                                                 |
-| `podSecurityPolicy.create                 | Whether to create & use PSP resource or not (Note: `rbac.create` needs to be `true`)                       | `false`                                                 |
-| `podSecurityPolicy.spec                   | The PSP Spec (See https://kubernetes.io/docs/concepts/policy/pod-security-policy/)                         | See values.yaml                                         |
+| Parameter                                    | Description                                                                                                | Default                                                 |
+|----------------------------------------------|------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `serviceAccount.create`                      | Enable creation of ServiceAccount for MongoDB pods                                                         | `true`                                                  |
+| `serviceAccount.name`                        | Name of the created serviceAccount                                                                         | Generated using the `mongodb.fullname` template         |
+| `serviceAccount.annotations`                 | Additional Service Account annotations                                                                     | `{}`                                                    |
+| `rbac.create`                                | Weather to create & use RBAC resources or not                                                              | `false`                                                 |
+| `podSecurityPolicy.create                    | Whether to create & use PSP resource or not (Note: `rbac.create` needs to be `true`)                       | `false`                                                 |
+| `podSecurityPolicy.allowPrivilegeEscalation` | Enable privilege escalation                                                                                | `false`                                                 |
+| `podSecurityPolicy.privileged`               | Allow privileged                                                                                           | `false`                                                 |
+| `podSecurityPolicy.spec                      | The PSP Spec (See https://kubernetes.io/docs/concepts/policy/pod-security-policy/), takes precedence       | `{}`                                                    |
 
 ### Volume Permissions parameters
 

--- a/bitnami/mongodb/templates/_helpers.tpl
+++ b/bitnami/mongodb/templates/_helpers.tpl
@@ -292,3 +292,26 @@ Validate values of MongoDB exporter URI string - auth.enabled and/or tls.enabled
 
     {{- printf "mongodb://%slocalhost:27017/admin?%s" $uriAuth $uriTlsArgs -}}
 {{- end -}}
+
+
+{{/*
+Return the appropriate apiGroup for PodSecurityPolicy.
+*/}}
+{{- define "podSecurityPolicy.apiGroup" -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "policy" -}}
+{{- else -}}
+{{- print "extensions" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for PodSecurityPolicy.
+*/}}
+{{- define "podSecurityPolicy.apiVersion" -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "policy/v1beta1" -}}
+{{- else -}}
+{{- print "extensions/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/bitnami/mongodb/templates/_helpers.tpl
+++ b/bitnami/mongodb/templates/_helpers.tpl
@@ -199,6 +199,7 @@ Compile all warnings into a single message, and call fail.
 */}}
 {{- define "mongodb.validateValues" -}}
 {{- $messages := list -}}
+{{- $messages := append $messages (include "mongodb.validateValues.pspAndRBAC" .) -}}
 {{- $messages := append $messages (include "mongodb.validateValues.architecture" .) -}}
 {{- $messages := append $messages (include "mongodb.validateValues.customDatabase" .) -}}
 {{- $messages := append $messages (include "mongodb.validateValues.externalAccessServiceType" .) -}}
@@ -210,6 +211,15 @@ Compile all warnings into a single message, and call fail.
 
 {{- if $message -}}
 {{-   printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Validate RBAC is created when using PSP */}}
+{{- define "mongodb.validateValues.pspAndRBAC" -}}
+{{- if and (.Values.podSecurityPolicy.create) (not .Values.rbac.create) -}}
+mongodb: podSecurityPolicy.create, rbac.create
+    Both podSecurityPolicy.create and rbac.create must be true, if you want
+    to create podSecurityPolicy
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/mongodb/templates/psp.yaml
+++ b/bitnami/mongodb/templates/psp.yaml
@@ -11,5 +11,38 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+{{- if .Values.podSecurityPolicy.spec }}
 {{ .Values.podSecurityPolicy.spec | toYaml | indent 2 }}
+{{- else }}
+  allowPrivilegeEscalation: {{ .Values.podSecurityPolicy.allowPrivilegeEscalation }}
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: {{ .Values.podSecurityContext.fsGroup }}
+        max: {{ .Values.podSecurityContext.fsGroup }}
+  hostIPC: false
+  hostNetwork: false
+  hostPID: false
+  privileged: {{ .Values.podSecurityPolicy.privileged }}
+  readOnlyRootFilesystem: false
+  requiredDropCapabilities:
+    - ALL
+  runAsUser:
+    rule: 'MustRunAs'
+    ranges:
+      - min: {{ .Values.containerSecurityContext.runAsUser }}
+        max: {{ .Values.containerSecurityContext.runAsUser }}
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: {{ .Values.containerSecurityContext.runAsUser }}
+        max: {{ .Values.containerSecurityContext.runAsUser }}
+  volumes:
+    - 'configMap'
+    - 'secret'
+    - 'emptyDir'
+    - 'persistentVolumeClaim'
+{{- end }}
 {{- end }}

--- a/bitnami/mongodb/templates/psp.yaml
+++ b/bitnami/mongodb/templates/psp.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 spec:
 {{- if .Values.podSecurityPolicy.spec }}
-{{ .Values.podSecurityPolicy.spec | toYaml | indent 2 }}
+{{ include "common.tplvalues.render" ( dict "value" .Values.podSecurityPolicy.spec "context" $ ) | nindent 2 }}
 {{- else }}
   allowPrivilegeEscalation: {{ .Values.podSecurityPolicy.allowPrivilegeEscalation }}
   fsGroup:

--- a/bitnami/mongodb/templates/psp.yaml
+++ b/bitnami/mongodb/templates/psp.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.podSecurityPolicy.create }}
+apiVersion: {{ template "podSecurityPolicy.apiVersion" . }}
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "mongodb.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+{{ .Values.podSecurityPolicy.spec | toYaml | indent 2 }}
+{{- end }}

--- a/bitnami/mongodb/templates/role.yaml
+++ b/bitnami/mongodb/templates/role.yaml
@@ -14,4 +14,10 @@ rules:
       - get
       - list
       - watch
+{{- if .Values.podSecurityPolicy.create }}
+  - apiGroups: ['{{ template "podSecurityPolicy.apiGroup" . }}']
+    resources: ['podsecuritypolicies']
+    verbs: ['use']
+    resourceNames: [{{ include "mongodb.fullname" . }}]
+{{- end -}}
 {{- end }}

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -844,6 +844,47 @@ rbac:
   ##
   create: false
 
+## PodSecurityPolicy configuration
+## Be sure to also set rbac.create to true, otherwise Role and RoleBinding
+## won't be created.
+## ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+##
+podSecurityPolicy:
+  ## Specifies whether a PodSecurityPolicy should be created
+  ##
+  create: false
+  spec:
+    allowPrivilegeEscalation: false
+    fsGroup:
+      rule: 'MustRunAs'
+      ranges:
+        - min: 1001
+          max: 1001
+    hostIPC: false
+    hostNetwork: false
+    hostPID: false
+    privileged: false
+    readOnlyRootFilesystem: false
+    requiredDropCapabilities:
+      - ALL
+    runAsUser:
+      rule: 'MustRunAs'
+      ranges:
+        - min: 1001
+          max: 1001
+    seLinux:
+      rule: 'RunAsAny'
+    supplementalGroups:
+      rule: 'MustRunAs'
+      ranges:
+        - min: 1001
+          max: 1001
+    volumes:
+      - 'configMap'
+      - 'secret'
+      - 'emptyDir'
+      - 'persistentVolumeClaim'
+
 ## Init Container parameters
 ## Change the owner and group of the persistent volume(s) mountpoint(s) to 'runAsUser:fsGroup' on each component
 ## values from the securityContext section of the component

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -853,37 +853,43 @@ podSecurityPolicy:
   ## Specifies whether a PodSecurityPolicy should be created
   ##
   create: false
-  spec:
-    allowPrivilegeEscalation: false
-    fsGroup:
-      rule: 'MustRunAs'
-      ranges:
-        - min: 1001
-          max: 1001
-    hostIPC: false
-    hostNetwork: false
-    hostPID: false
-    privileged: false
-    readOnlyRootFilesystem: false
-    requiredDropCapabilities:
-      - ALL
-    runAsUser:
-      rule: 'MustRunAs'
-      ranges:
-        - min: 1001
-          max: 1001
-    seLinux:
-      rule: 'RunAsAny'
-    supplementalGroups:
-      rule: 'MustRunAs'
-      ranges:
-        - min: 1001
-          max: 1001
-    volumes:
-      - 'configMap'
-      - 'secret'
-      - 'emptyDir'
-      - 'persistentVolumeClaim'
+  ## You can either use predefined policy with some adjustments
+  allowPrivilegeEscalation: false
+  privileged: false
+  ## Or you can specifiy the full spec to use for PSP
+  ## Defining a spec ignores the above values.
+  spec: {}
+  ## Example:
+  ##    allowPrivilegeEscalation: false
+  ##    fsGroup:
+  ##      rule: 'MustRunAs'
+  ##      ranges:
+  ##        - min: 1001
+  ##          max: 1001
+  ##    hostIPC: false
+  ##    hostNetwork: false
+  ##    hostPID: false
+  ##    privileged: false
+  ##    readOnlyRootFilesystem: false
+  ##    requiredDropCapabilities:
+  ##      - ALL
+  ##    runAsUser:
+  ##      rule: 'MustRunAs'
+  ##      ranges:
+  ##        - min: 1001
+  ##          max: 1001
+  ##    seLinux:
+  ##      rule: 'RunAsAny'
+  ##    supplementalGroups:
+  ##      rule: 'MustRunAs'
+  ##      ranges:
+  ##        - min: 1001
+  ##          max: 1001
+  ##    volumes:
+  ##      - 'configMap'
+  ##      - 'secret'
+  ##      - 'emptyDir'
+  ##      - 'persistentVolumeClaim'
 
 ## Init Container parameters
 ## Change the owner and group of the persistent volume(s) mountpoint(s) to 'runAsUser:fsGroup' on each component


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This PR adds the ability for a user to use PSP with MongoDB chart.

**Benefits**

For users that have PSP enabled in their clusters, they also need to have a PSP resource for Pods that use volumes. Without it, the user will see errors and permission related messages.

The implementation in this PR, is pretty flexible and can allow a user to create PSP resource best for their environment.

**Possible drawbacks**

By default the PSP creation is disabled. So by default, not changes should be seen by the user. However, if PSP is created, then an understanding of how PSP work would be required.

**Applicable issues**

N/A

**Additional information**

Without this PR, using this chart in clusters that have PSP would require manual creation of the PSP and also updating the Role. Since the Role is managed by this chart (with `rbac.create` set to `true`), that would be a bad idea.

If `rbac.create` is false, then the user would also have to create the Role and RoleBinding.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
