### PR TITLE
[bitnami/postgresql-ha] Fixes pgpool PGPOOL_CHILD_LIFE_TIME not rendered when is 0

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -27,4 +27,4 @@ name: postgresql-ha
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 6.3.5
+version: 6.3.6

--- a/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
@@ -219,9 +219,10 @@ spec:
             - name: PGPOOL_CHILD_MAX_CONNECTIONS
               value: {{ .Values.pgpool.childMaxConnections | quote }}
             {{- end }}
-            {{- if or .Values.pgpool.childLifeTime (eq 0 .Values.pgpool.childLifeTime) }}
+            {{- $childlifetime := .Values.pgpool.childLifeTime | quote }}
+            {{- if or $childlifetime (eq "0" $childlifetime) }}
             - name: PGPOOL_CHILD_LIFE_TIME
-              value: {{ .Values.pgpool.childLifeTime | quote }}
+              value: {{ $childlifetime }}
             {{- end }}
             {{- if .Values.pgpool.clientIdleLimit }}
             - name: PGPOOL_CLIENT_IDLE_LIMIT

--- a/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
@@ -219,7 +219,7 @@ spec:
             - name: PGPOOL_CHILD_MAX_CONNECTIONS
               value: {{ .Values.pgpool.childMaxConnections | quote }}
             {{- end }}
-            {{- if .Values.pgpool.childLifeTime }}
+            {{- if or .Values.pgpool.childLifeTime (eq 0 .Values.pgpool.childLifeTime) }}
             - name: PGPOOL_CHILD_LIFE_TIME
               value: {{ .Values.pgpool.childLifeTime | quote }}
             {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

When `.Values.pgpool.childLifeTime` is set to `0` the related environment variable get not rendered in the generated yaml file.

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #4862, #4864

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [-] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [-] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
