### PR TITLE
[bitnami/rabbitmq] Update ingress io.k8s.api.networking.v1

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -23,4 +23,4 @@ name: rabbitmq
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq
   - https://www.rabbitmq.com
-version: 8.6.4
+version: 8.7.0

--- a/bitnami/rabbitmq/templates/ingress.yaml
+++ b/bitnami/rabbitmq/templates/ingress.yaml
@@ -19,18 +19,24 @@ spec:
       http:
         paths:
           - path: {{ .Values.ingress.path }}
+            pathType: Prefix
             backend:
-              serviceName: {{ template "rabbitmq.fullname" . }}
-              servicePort: http-stats
+              service:
+                name: {{ template "rabbitmq.fullname" . }}
+                port:
+                  number: http-stats
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
     - host: {{ .name }}
       http:
         paths:
           - path: {{ default "/" .path }}
+            pathType: Prefix
             backend:
-              serviceName: {{ template "rabbitmq.fullname" $ }}
-              servicePort: http-stats
+              service:
+                name: {{ template "rabbitmq.fullname" $ }}
+                port:
+                  number: http-stats
     {{- end }}
   {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
   tls:


### PR DESCRIPTION
Resolve problem deploy to k8s 1.19

```
"bitnami" already exists with the same configuration, skipping
Error: UPGRADE FAILED: error validating "": error validating data: [ValidationError(Ingress.spec.rules[0].http.paths[0].backend): unknown field "serviceName" in io.k8s.api.networking.v1.IngressBackend, ValidationError(Ingress.spec.rules[0].http.paths[0].backend): unknown field "servicePort" in io.k8s.api.networking.v1.IngressBackend]
```

**Description of the change**
Update ingress to 
apiVersion: networking.k8s.io/v1

**Possible drawbacks**
need kubernetes v1.19+


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
