### PR TITLE
[bitnami/common] same behavior with empty string when the secret obje…

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -20,4 +20,4 @@ sources:
   - https://github.com/bitnami/charts
   - http://www.bitnami.com/
 type: library
-version: 1.3.4
+version: 1.3.5

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -20,8 +20,4 @@ sources:
   - https://github.com/bitnami/charts
   - http://www.bitnami.com/
 type: library
-
 version: 1.3.6
-
-
-

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -20,4 +20,4 @@ sources:
   - https://github.com/bitnami/charts
   - http://www.bitnami.com/
 type: library
-version: 1.3.5
+version: 1.3.6

--- a/bitnami/common/README.md
+++ b/bitnami/common/README.md
@@ -56,7 +56,7 @@ The following table lists the helpers available in the library which are scoped 
 | `common.capabilities.deployment.apiVersion`  | Return the appropriate apiVersion for deployment.                                              | `.` Chart context |
 | `common.capabilities.statefulset.apiVersion` | Return the appropriate apiVersion for statefulset.                                             | `.` Chart context |
 | `common.capabilities.ingress.apiVersion`     | Return the appropriate apiVersion for ingress.                                                 | `.` Chart context |
-| `common.capabilities.helmVersion`            | Returns true if the used Helm version is 3.3+                                                  | `.` Chart context |
+| `common.capabilities.supportsHelmVersion`    | Returns true if the used Helm version is 3.3+                                                  | `.` Chart context |
 
 ### Errors
 

--- a/bitnami/common/templates/_secrets.tpl
+++ b/bitnami/common/templates/_secrets.tpl
@@ -21,7 +21,9 @@ Params:
 
 {{- with .existingSecret -}}
 {{- if not (typeIs "string" .) -}}
-{{- $name = .name -}}
+{{- with .name -}}
+{{- $name = . -}}
+{{- end -}}
 {{- else -}}
 {{- $name = . -}}
 {{- end -}}


### PR DESCRIPTION
…ct is used.

When you pass in an empty string as the existingSecret the with statement ensures that the default name is used.
If you pass in the new existingSecret object which is a dict it uses the empty  string and not use the emptyString as reference to use the default string.
Implementing another with statement ensures that the variable is set.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

Please merge after #5056 

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
