### PR TITLE
[bitnami/rabbitmq] Fix critical rabbitmq helm scope bug

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -23,4 +23,4 @@ name: rabbitmq
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq
   - https://www.rabbitmq.com
-version: 8.7.0
+version: 8.7.1

--- a/bitnami/rabbitmq/templates/secrets.yaml
+++ b/bitnami/rabbitmq/templates/secrets.yaml
@@ -22,12 +22,13 @@ data:
   {{- end }}
   {{- end }}
 {{- end }}
+{{- $extraSecretsPrependReleaseName := .Values.extraSecretsPrependReleaseName }}
 {{- range $key, $value := .Values.extraSecrets }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  {{- if .Values.extraSecretsPrependReleaseName }}
+  {{- if $extraSecretsPrependReleaseName }}
   name: {{ $.Release.Name }}-{{ $key }}
   {{- else }}
   name: {{ $key }}


### PR DESCRIPTION
**Description of the change**

.Values used in non-root scope, so from 8.6.4 you can't install chart due to variable scope problems

Fix scope problems https://github.com/bitnami/charts/pull/4960

**Applicable issues**

https://github.com/bitnami/charts/pull/4960

**Additional information**

```
fatal: [node1]: FAILED! => {"changed": false, "command": "/usr/local/bin/helm --namespace=rabbitmq --version=8.7.0 upgrade -i --reset-values --create-namespace -f=/tmp/tmp5s1azey8.yml rabbitmq bitnami/rabbitmq", "msg": "Failure when executing Helm command. Exited 1.\nstdout: \nstderr: Error: UPGRADE FAILED: template: rabbitmq/templates/statefulset.yaml:30:28: executing \"rabbitmq/templates/statefulset.yaml\" at <include (print $.Template.BasePath \"/secrets.yaml\") .>: error calling include: template: rabbitmq/templates/secrets.yaml:30:16: executing \"rabbitmq/templates/secrets.yaml\" at <.Values.extraSecretsPrependReleaseName>: nil pointer evaluating interface {}.extraSecretsPrependReleaseName\n", "stderr": "Error: UPGRADE FAILED: template: rabbitmq/templates/statefulset.yaml:30:28: executing \"rabbitmq/templates/statefulset.yaml\" at <include (print $.Template.BasePath \"/secrets.yaml\") .>: error calling include: template: rabbitmq/templates/secrets.yaml:30:16: executing \"rabbitmq/templates/secrets.yaml\" at <.Values.extraSecretsPrependReleaseName>: nil pointer evaluating interface {}.extraSecretsPrependReleaseName\n", "stderr_lines": ["Error: UPGRADE FAILED: template: rabbitmq/templates/statefulset.yaml:30:28: executing \"rabbitmq/templates/statefulset.yaml\" at <include (print $.Template.BasePath \"/secrets.yaml\") .>: error calling include: template: rabbitmq/templates/secrets.yaml:30:16: executing \"rabbitmq/templates/secrets.yaml\" at <.Values.extraSecretsPrependReleaseName>: nil pointer evaluating interface {}.extraSecretsPrependReleaseName"], "stdout": "", "stdout_lines": []}
```

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
