### PR TITLE
[bitnami/harbor] Fix indentantion when adding extraVolumes

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-harbor-registry
   - https://github.com/bitnami/bitnami-docker-harbor-registryctl
   - https://goharbor.io/
-version: 9.4.0
+version: 9.4.1

--- a/bitnami/harbor/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/bitnami/harbor/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -215,6 +215,6 @@ spec:
             secretName: {{ include "harbor.chartmuseum.tls.secretName" . }}
         {{- end }}
       {{- if .Values.chartmuseum.extraVolumes }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.chartmuseum.extraVolumes "context" $) | nindent 6 }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.chartmuseum.extraVolumes "context" $) | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/bitnami/harbor/templates/clair/clair-dpl.yaml
+++ b/bitnami/harbor/templates/clair/clair-dpl.yaml
@@ -262,6 +262,6 @@ spec:
 {{ include "harbor.caBundleVolume" . | indent 8 }}
         {{- end }}
       {{- if .Values.clair.extraVolumes }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.clair.extraVolumes "context" $) | nindent 6 }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.clair.extraVolumes "context" $) | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/bitnami/harbor/templates/core/core-dpl.yaml
+++ b/bitnami/harbor/templates/core/core-dpl.yaml
@@ -253,5 +253,5 @@ spec:
         - name: psc
           emptyDir: {}
       {{- if .Values.core.extraVolumes }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.core.extraVolumes "context" $) | nindent 6 }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.core.extraVolumes "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/harbor/templates/jobservice/jobservice-dpl.yaml
+++ b/bitnami/harbor/templates/jobservice/jobservice-dpl.yaml
@@ -216,5 +216,5 @@ spec:
             secretName: {{ include "harbor.jobservice.tls.secretName" . }}
         {{- end }}
       {{- if .Values.jobservice.extraVolumes }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.jobservice.extraVolumes "context" $) | nindent 6 }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.jobservice.extraVolumes "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/harbor/templates/nginx/deployment.yaml
+++ b/bitnami/harbor/templates/nginx/deployment.yaml
@@ -167,6 +167,6 @@ spec:
             {{- end }}
         {{- end }}
       {{- if .Values.nginx.extraVolumes }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.nginx.extraVolumes "context" $) | nindent 6 }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.nginx.extraVolumes "context" $) | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/bitnami/harbor/templates/notary/notary-server.yaml
+++ b/bitnami/harbor/templates/notary/notary-server.yaml
@@ -163,6 +163,6 @@ spec:
             secretName: {{ .Values.notary.secretName }}
         {{- end }}
       {{- if .Values.notary.server.extraVolumes }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.notary.server.extraVolumes "context" $) | nindent 6 }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.notary.server.extraVolumes "context" $) | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/bitnami/harbor/templates/notary/notary-signer.yaml
+++ b/bitnami/harbor/templates/notary/notary-signer.yaml
@@ -160,6 +160,6 @@ spec:
             secretName: {{ .Values.notary.secretName }}
         {{- end }}
       {{- if .Values.notary.signer.extraVolumes }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.notary.signer.extraVolumes "context" $) | nindent 6 }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.notary.signer.extraVolumes "context" $) | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/bitnami/harbor/templates/portal/portal-dpl.yaml
+++ b/bitnami/harbor/templates/portal/portal-dpl.yaml
@@ -150,5 +150,5 @@ spec:
             secretName: {{ include "harbor.portal.tls.secretName" . }}
         {{- end }}
       {{- if .Values.portal.extraVolumes }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.portal.extraVolumes "context" $) | nindent 6 }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.portal.extraVolumes "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/harbor/templates/registry/registry-dpl.yaml
+++ b/bitnami/harbor/templates/registry/registry-dpl.yaml
@@ -388,5 +388,5 @@ spec:
         {{- end }}
         {{- end }}
       {{- if .Values.registry.extraVolumes }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.registry.extraVolumes "context" $) | nindent 6 }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.registry.extraVolumes "context" $) | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
**Description of the change**

Fix indentation issue with extraVolumes templates

**Applicable issues**

  - fixes #5054

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)