### PR TITLE
bitnami/kafka Fix Upgrade regression from PR #4683

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 12.6.0
+version: 12.6.1

--- a/bitnami/kafka/templates/scripts-configmap.yaml
+++ b/bitnami/kafka/templates/scripts-configmap.yaml
@@ -71,10 +71,10 @@ data:
   setup.sh: |-
     #!/bin/bash
 
+    ID="${MY_POD_NAME#"{{ $fullname }}-"}"
     if [[ -f "/bitnami/kafka/data/meta.properties" ]]; then
         export KAFKA_CFG_BROKER_ID="$(grep "broker.id" /bitnami/kafka/data/meta.properties | awk -F '=' '{print $2}')"
     else
-        ID="${MY_POD_NAME#"{{ $fullname }}-"}"
         export KAFKA_CFG_BROKER_ID="$((ID + {{ .Values.minBrokerId }}))"
     fi
 


### PR DESCRIPTION
### Fix Upgrade Regression cause by PR #4683

**Benefits**
Put back ID variable as expected to fix bug from PR #4683 that cause serious Regression when need to Upgrade from the Helm Chart version >= 12.4.0. This is for the fix of #4947 

**Possible drawbacks**
No

**Applicable issues**
#4947 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [ ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

