### PR TITLE
[bitnami/fluentd] 5077: Fluentd typo in ingress template

### DIFF
--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -25,4 +25,4 @@ name: fluentd
 sources:
   - https://github.com/bitnami/bitnami-docker-fluentd
   - https://www.fluentd.org/
-version: 3.4.0
+version: 3.4.1

--- a/bitnami/fluentd/templates/ingress.yaml
+++ b/bitnami/fluentd/templates/ingress.yaml
@@ -27,7 +27,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.aggregator.ingress.pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" "$serviceName" "servicePort" "http" "context" $)  | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" $serviceName "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.aggregator.ingress.extraHosts }}
     - host: {{ .name | quote }}
@@ -37,7 +37,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" "$serviceName" "servicePort" "http" "context" $) | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" $serviceName "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
   {{- if or .Values.aggregator.ingress.tls .Values.aggregator.ingress.extraTls }}
   tls:


### PR DESCRIPTION
This change removes the quotes around the $serviceName variable
which currently prevents interpolation.

**Description of the change**

Remove the quotes surrounding a variable.

**Benefits**

Enables the ability to use the ingress for fluentd-aggregator

**Possible drawbacks**

None identified.

**Applicable issues**
#5077 

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

