### PR TITLE
[bitnami/wordpress] Fix issue with wildcard domains

### DIFF
--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -31,4 +31,4 @@ name: wordpress
 sources:
   - https://github.com/bitnami/bitnami-docker-wordpress
   - http://www.wordpress.com/
-version: 10.4.4
+version: 10.4.5

--- a/bitnami/wordpress/ci/ingress-wildcard-values.yaml
+++ b/bitnami/wordpress/ci/ingress-wildcard-values.yaml
@@ -1,0 +1,6 @@
+ingress:
+  enabled: true
+  extraHosts:
+    - name: "*.domain.tld"
+      path: /
+  tls: true

--- a/bitnami/wordpress/ci/ingress-wildcard-values.yaml
+++ b/bitnami/wordpress/ci/ingress-wildcard-values.yaml
@@ -1,6 +1,9 @@
+service:
+  type: ClusterIP
+
 ingress:
   enabled: true
+  tls: true
   extraHosts:
     - name: "*.domain.tld"
       path: /
-  tls: true

--- a/bitnami/wordpress/templates/ingress.yaml
+++ b/bitnami/wordpress/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   rules:
     {{- if .Values.ingress.hostname }}
-    - host: {{ .Values.ingress.hostname }}
+    - host: {{ .Values.ingress.hostname | quote }}
       http:
         paths:
           {{- if .Values.ingress.extraPaths }}
@@ -46,11 +46,11 @@ spec:
   tls:
     {{- if .Values.ingress.tls }}
     - hosts:
-        - {{ .Values.ingress.hostname }}
+        - {{ .Values.ingress.hostname | quote }}
         {{- range .Values.ingress.extraHosts }}
-        - {{ .name }}
+        - {{ .name | quote }}
         {{- end }}
-      secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
+      secretName: {{ (printf "%s-tls" .Values.ingress.hostname) | quote}}
     {{- end }}
     {{- if .Values.ingress.extraTls }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.extraTls "context" $ ) | nindent 4 }}

--- a/bitnami/wordpress/templates/ingress.yaml
+++ b/bitnami/wordpress/templates/ingress.yaml
@@ -50,7 +50,7 @@ spec:
         {{- range .Values.ingress.extraHosts }}
         - {{ .name | quote }}
         {{- end }}
-      secretName: {{ (printf "%s-tls" .Values.ingress.hostname) | quote}}
+      secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
     {{- end }}
     {{- if .Values.ingress.extraTls }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.extraTls "context" $ ) | nindent 4 }}

--- a/bitnami/wordpress/templates/tls-secrets.yaml
+++ b/bitnami/wordpress/templates/tls-secrets.yaml
@@ -25,7 +25,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ (printf "%s-tls" .Values.ingress.hostname) | quote }}
+  name: {{ printf "%s-tls" .Values.ingress.hostname }}
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/bitnami/wordpress/templates/tls-secrets.yaml
+++ b/bitnami/wordpress/templates/tls-secrets.yaml
@@ -25,7 +25,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-tls" .Values.ingress.hostname }}
+  name: {{ (printf "%s-tls" .Values.ingress.hostname) | quote }}
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}


### PR DESCRIPTION
**Description of the change**
Quote the hostnames to be able to use wildcard domains

**Applicable issues**
  - fixes #5079

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

