### PR TITLE
[bitnami/nginx] add extraInitContainers

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -25,4 +25,4 @@ name: nginx
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx
   - http://www.nginx.org
-version: 8.3.0
+version: 8.4.0

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -121,6 +121,7 @@ The following tables lists the configurable parameters of the NGINX chart and th
 | `extraVolumes`              | Array to add extra volumes                                                                | `[]` (evaluated as a template) |
 | `extraVolumeMounts`         | Array to add extra mount                                                                  | `[]` (evaluated as a template) |
 | `sidecars`                  | Attach additional containers to nginx pods                                                | `nil`                          |
+| `initContainers`       | Additional init containers (this value is evaluated as a template)                        | `[]`                           |
 
 ### Custom NGINX application parameters
 

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -80,6 +80,10 @@ spec:
             - name: staticsite
               mountPath: /app
       {{- else }}
+      {{- with .Values.initContainers }}
+      initContainers:
+      {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8}}
+      {{- end }}
       containers:
       {{- end }}
         - name: nginx

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -491,6 +491,9 @@ ldapDaemon:
 #         containerPort: 1234
 sidecars:
 
+## Extra init containers
+initContainers:
+
 ## Configure the ingress resource that allows you to access the
 ## Nginx installation. Set up the URL
 ## ref: http://kubernetes.io/docs/user-guide/ingress/


### PR DESCRIPTION
**Description of the change**

Add extraInitContainers parameters

**Benefits**
Put python static into nginx.
I could not build nginx image with static because python collect static script requere database, But I don't want to create any shared volumes with python app.
Run `python manage.py collectstatic` in initcontainer of nginx is ideal scenario. 

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
