### PR TITLE
[bitnami/redmine] Fix Pod/Container SecurityContext(s)

### DIFF
--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -36,4 +36,4 @@ name: redmine
 sources:
   - https://github.com/bitnami/bitnami-docker-redmine
   - http://www.redmine.org/
-version: 15.1.0
+version: 15.1.1

--- a/bitnami/redmine/README.md
+++ b/bitnami/redmine/README.md
@@ -207,10 +207,10 @@ The following table lists the configurable parameters of the Redmine chart and t
 | `nodeAffinityPreset.values`          | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                                        |
 | `affinity`                           | Affinity for pod assignment                                                               | `{}` (evaluated as a template)              |
 | `podAnnotations`                     | Pod annotations                                                                           | `{}`                                        |
-| `podSecurityContext.enabled`         | Enable security context for Redmine pods                                                  | `true`                                      |
-| `podSecurityContext.fsGroup`         | Group ID for the volumes of the pod                                                       | `1001`                                      |
+| `podSecurityContext.enabled`         | Enable security context for Redmine pods                                                  | `false`                                     |
+| `podSecurityContext.fsGroup`         | Group ID for the volumes of the pod                                                       | `0`                                         |
 | `containerSecurityContext.enabled`   | Redmine Container securityContext                                                         | `false`                                     |
-| `containerSecurityContext.runAsUser` | User ID for the Redmine container                                                         | `1001`                                      |
+| `containerSecurityContext.runAsUser` | User ID for the Redmine container                                                         | `0`                                         |
 | `livenessProbe.enabled`              | Whether to enable the livenessProbe or not                                                | `true`                                      |
 | `livenessProbe.enabled`              | The path against which to perform the livenessProbe                                       | `/`                                         |
 | `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                                                  | 300                                         |

--- a/bitnami/redmine/values.yaml
+++ b/bitnami/redmine/values.yaml
@@ -131,12 +131,11 @@ replicas: 1
 ##
 containerSecurityContext:
   enabled: false
-  runAsUser: 1001
-  runAsNonRoot: true
+  runAsUser: 0
 
 podSecurityContext:
-  enabled: true
-  fsGroup: 1001
+  enabled: false
+  fsGroup: 0
 
 ## Redmine containers' resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

On [this PR](https://github.com/bitnami/charts/pull/4159) (major version) we modified the default pod/container security context so it treats Redmine container as a "non-root" container. This is a common practice on Bitnami containers, **but Redmine hasn't adopted it yet**. Therefore, we should ensure that, by default, the `runAsUser` and `fsGroup` are set to `0` (root user)

**Benefits**

SecurityContext properly configured

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/5038

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files
