### PR TITLE
[bitnami/common] Remove helm version checker from secret helper

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: Infrastructure
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 1.3.5
+appVersion: 1.3.7
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://github.com/bitnami/charts/tree/master/bitnami/common
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -20,4 +20,4 @@ sources:
   - https://github.com/bitnami/charts
   - http://www.bitnami.com/
 type: library
-version: 1.3.6
+version: 1.3.7

--- a/bitnami/common/templates/_secrets.tpl
+++ b/bitnami/common/templates/_secrets.tpl
@@ -75,14 +75,13 @@ Params:
 */}}
 {{- define "common.secrets.passwords.manage" -}}
 
-{{- $secret := "" }}
 {{- $password := "" }}
 {{- $subchart := "" }}
 {{- $chartName := default "" .chartName }}
 {{- $passwordLength := default 10 .length }}
 {{- $providedPasswordKey := include "common.utils.getKeyFromList" (dict "keys" .providedValues "context" $.context) }}
 {{- $providedPasswordValue := include "common.utils.getValueFromKey" (dict "key" $providedPasswordKey "context" $.context) }}
-{{- $secret = (lookup "v1" "Secret" $.context.Release.Namespace .secret) }}
+{{- $secret := (lookup "v1" "Secret" $.context.Release.Namespace .secret) }}
 {{- if $secret }}
   {{- if index $secret.data .key }}
   {{- $password = index $secret.data .key }}

--- a/bitnami/common/templates/_secrets.tpl
+++ b/bitnami/common/templates/_secrets.tpl
@@ -82,9 +82,7 @@ Params:
 {{- $passwordLength := default 10 .length }}
 {{- $providedPasswordKey := include "common.utils.getKeyFromList" (dict "keys" .providedValues "context" $.context) }}
 {{- $providedPasswordValue := include "common.utils.getValueFromKey" (dict "key" $providedPasswordKey "context" $.context) }}
-{{- if (include "common.capabilities.supportsHelmVersion" $.context) }}
-  {{- $secret = (lookup "v1" "Secret" $.context.Release.Namespace .secret) }}
-{{- end -}}
+{{- $secret = (lookup "v1" "Secret" $.context.Release.Namespace .secret) }}
 {{- if $secret }}
   {{- if index $secret.data .key }}
   {{- $password = index $secret.data .key }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Removed the check on the `common.secrets.passwords.manage` helper implemented in #5018 to ensure that the used helm version was below 3.3 (the target was to avoid a version `>3.1` but helm source code made impossible to check anything below 3.3). As the minimum Helm version in our charts has been bumped to Helm 3.1 #5091, this check is no longer necessary.

**Benefits**

<!-- What benefits will be realized by the code change? -->

Users using versions 3.1.x-3.2.x will have a smoother password management experience.

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
