### PR TITLE
[bitnami/rabbitmq]: use managerPortName in ingress target port

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -23,4 +23,4 @@ name: rabbitmq
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq
   - https://www.rabbitmq.com
-version: 8.7.3
+version: 8.7.4

--- a/bitnami/rabbitmq/templates/ingress.yaml
+++ b/bitnami/rabbitmq/templates/ingress.yaml
@@ -25,7 +25,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http-stats" "context" $)  | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" .Values.service.managerPortName "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
     - host: {{ .name }}


### PR DESCRIPTION
In the ingress route, the target port is hard-coded and change the service port name disables the ingress route.
As an example the following value changes the service port name for the manager port:

```yml
service:
  managerPortName: stats
```

Then because of the hard-coded value in the ingress route it will be disabled.