### PR TITLE
[bitnami/postgresql-ha] Remove support to load conf/scripts from 'files/' directory

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -27,4 +27,4 @@ name: postgresql-ha
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 6.3.7
+version: 6.4.0

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -414,28 +414,21 @@ Next, login to the PostgreSQL server using the `psql` client and add the PAM aut
 
 This helm chart also supports to customize the whole configuration file.
 
-Add your custom files to "files" in your working directory. Those files will be mounted as configMap to the containers and it will be used for configuring Pgpool, Repmgr and the PostgreSQL server.
+You can specify the Pgpool, PostgreSQL and Repmgr configuration using the `pgpool.configuration`, `postgresql.configuration`, `postgresql.pgHbaConfiguration`, and `postgresql.repmgrConfiguration` parameters. The corresponding files will be mounted as ConfigMap to the containers and it will be used for configuring Pgpool, Repmgr and the PostgreSQL server.
 
-Alternatively, you can specify the Pgpool, PostgreSQL and Repmgr configuration using the `pgpool.configuration`, `postgresql.configuration`, `postgresql.pgHbaConfiguration`, and `postgresql.repmgrConfiguration` parameters.
-
-In addition to these options, you can also set an external ConfigMap(s) with all the configuration files. This is done by setting the `postgresql.configurationCM` and `pgpool.configurationCM` parameters. Note that this will override the two previous options.
+In addition to this option, you can also set an external ConfigMap(s) with all the configuration files. This is done by setting the `postgresql.configurationCM` and `pgpool.configurationCM` parameters. Note that this will override the previous options.
 
 ### Allow settings to be loaded from files other than the default `postgresql.conf`
 
-If you don't want to provide the whole PostgreSQL configuration file and only specify certain parameters, you can add your extended `.conf` files to "files/conf.d/" in your working directory.
-Those files will be mounted as configMap to the containers adding/overwriting the default configuration using the `include_dir` directive that allows settings to be loaded from files other than the default `postgresql.conf`.
+If you don't want to provide the whole PostgreSQL configuration file and only specify certain parameters, you can specify the extended configuration using the `postgresql.extendedConf` parameter. A file will be mounted as configMap to the containers adding/overwriting the default configuration using the `include_dir` directive that allows settings to be loaded from files other than the default `postgresql.conf`.
 
-Alternatively, you can specify the extended configuration using the `postgresql.extendedConf` parameter.
-
-In addition to these options, you can also set an external ConfigMap with all the extra configuration files. This is done by setting the `postgresql.extendedConfCM` parameter. Note that this will override the two previous options.
+In addition to this option, you can also set an external ConfigMap with all the extra configuration files. This is done by setting the `postgresql.extendedConfCM` parameter. Note that this will override the previous option.
 
 ### Initialize a fresh instance
 
-The [Bitnami PostgreSQL with Repmgr](https://github.com/bitnami/bitnami-docker-postgresql-repmgr) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, they must be located inside the chart folder `files/docker-entrypoint-initdb.d` so they can be consumed as a ConfigMap.
+The [Bitnami PostgreSQL with Repmgr](https://github.com/bitnami/bitnami-docker-postgresql-repmgr) image allows you to use your custom scripts to initialize a fresh instance. You can specify custom scripts using the `initdbScripts` parameter as dict so they can be consumed as a ConfigMap.
 
-Alternatively, you can specify custom scripts using the `initdbScripts` parameter as dict.
-
-In addition to these options, you can also set an external ConfigMap with all the initialization scripts. This is done by setting the `postgresql.initdbScriptsCM` parameter. Note that this will override the two previous options. If your initialization scripts contain sensitive information such as credentials or passwords, you can use the `initdbScriptsSecret` parameter.
+In addition to this option, you can also set an external ConfigMap with all the initialization scripts. This is done by setting the `postgresql.initdbScriptsCM` parameter. Note that this will override the two previous option. If your initialization scripts contain sensitive information such as credentials or passwords, you can use the `initdbScriptsSecret` parameter.
 
 The allowed extensions are `.sh`, `.sql` and `.sql.gz`.
 
@@ -509,6 +502,11 @@ $ helm upgrade my-release bitnami/postgresql-ha \
 > Note: you need to substitute the placeholders _[POSTGRESQL_PASSWORD]_, and _[REPMGR_PASSWORD]_ with the values obtained from instructions in the installation notes.
 
 > Note: As general rule, it is always wise to do a backup before the upgrading procedures.
+
+### To 6.4.0
+
+Support for adding custom configuration files or initialization scripts by placing them under the "files" directory in the working directory was removed. This functionality was very confusing for users since they do not usually clone the repo nor they fetch the charts to their working directories.
+As an alternative to this feature, users can still use the equivalent parameters available in the `values.yaml` to load their custom configuration & scripts.
 
 ### To 6.0.0
 

--- a/bitnami/postgresql-ha/files/README.md
+++ b/bitnami/postgresql-ha/files/README.md
@@ -1,1 +1,0 @@
-Copy here your postgresql.conf and/or pg_hba.conf files to use it as a config map.

--- a/bitnami/postgresql-ha/files/conf.d/README.md
+++ b/bitnami/postgresql-ha/files/conf.d/README.md
@@ -1,4 +1,0 @@
-If you don't want to provide the whole configuration file and only specify certain parameters, you can copy here your extended `.conf` files.
-These files will be injected as a config maps and add/overwrite the default configuration using the `include_dir` directive that allows settings to be loaded from files other than the default `postgresql.conf`.
-
-More info in the [bitnami-docker-postgresql-repmgr README](https://github.com/bitnami/bitnami-docker-postgresql#configuration-file).

--- a/bitnami/postgresql-ha/files/docker-entrypoint-initdb.d/README.md
+++ b/bitnami/postgresql-ha/files/docker-entrypoint-initdb.d/README.md
@@ -1,3 +1,0 @@
-You can copy here your custom `.sh`, `.sql` or `.sql.gz` file so they are executed during the first boot of the image.
-
-More info in the [bitnami-docker-postgresql-repmgr](https://github.com/bitnami/bitnami-docker-postgresql-repmgr#initializing-a-new-instance) repository.

--- a/bitnami/postgresql-ha/files/pgpool-entrypoint-initdb.d/README.md
+++ b/bitnami/postgresql-ha/files/pgpool-entrypoint-initdb.d/README.md
@@ -1,3 +1,0 @@
-You can copy here your custom `.sh` file(s) so they are executed every time Pgpool container is initialized
-
-More info in the [bitnami-docker-pgpool](https://github.com/bitnami/bitnami-docker-postgresql-repmgr#initializing-with-custom-scripts) repository.

--- a/bitnami/postgresql-ha/templates/pgpool/configmap.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and (or (.Files.Glob "files/pgpool.conf") .Values.pgpool.configuration) (not .Values.pgpool.configurationCM) }}
+{{- if and .Values.pgpool.configuration (not .Values.pgpool.configurationCM) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -12,10 +12,6 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
-  {{- if (.Files.Glob "files/pgpool.conf") }}
-  {{- (.Files.Glob "files/pgpool.conf").AsConfig | nindent 2 }}
-  {{- else if .Values.pgpool.configuration }}
-  pgpool.conf: |
-  {{- include "common.tplvalues.render" (dict "value" .Values.pgpool.configuration "context" $) | nindent 4 }}
-  {{- end }}
+  pgpool.conf: |-
+    {{- include "common.tplvalues.render" (dict "value" .Values.pgpool.configuration "context" $) | nindent 4 }}
 {{- end }}

--- a/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
@@ -232,7 +232,7 @@ spec:
             - name: PGPOOL_CONNECTION_LIFE_TIME
               value: {{ .Values.pgpool.connectionLifeTime | quote }}
             {{- end }}
-            {{- if or (.Files.Glob "files/pgpool.conf") .Values.pgpool.configuration .Values.pgpool.configurationCM }}
+            {{- if or .Values.pgpool.configuration .Values.pgpool.configurationCM }}
             - name: PGPOOL_USER_CONF_FILE
               value: "/opt/bitnami/pgpool/user_config/pgpool.conf"
             {{- end }}
@@ -298,11 +298,11 @@ spec:
           resources: {{- toYaml .Values.pgpool.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
-            {{- if or (.Files.Glob "files/pgpool.conf") .Values.pgpool.configuration .Values.pgpool.configurationCM }}
+            {{- if or .Values.pgpool.configuration .Values.pgpool.configurationCM }}
             - name: pgpool-config
               mountPath: /opt/bitnami/pgpool/user_config/
             {{- end }}
-            {{- if or (.Files.Glob "files/pgpool-entrypoint-initdb.d/*.sh") .Values.pgpool.initdbScripts .Values.pgpool.initdbScriptsCM  }}
+            {{- if or .Values.pgpool.initdbScripts .Values.pgpool.initdbScriptsCM  }}
             - name: custom-init-scripts
               mountPath: /docker-entrypoint-initdb.d/
             {{- end }}
@@ -334,12 +334,12 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.pgpool.sidecars "context" $) | nindent 8 }}
         {{- end }}
       volumes:
-        {{- if or (.Files.Glob "files/pgpool.conf") .Values.pgpool.configuration .Values.pgpool.configurationCM }}
+        {{- if or .Values.pgpool.configuration .Values.pgpool.configurationCM }}
         - name: pgpool-config
           configMap:
             name: {{ include "postgresql-ha.pgpoolConfigurationCM" . }}
         {{- end }}
-        {{- if or (.Files.Glob "files/pgpool-entrypoint-initdb.d/*.sh") .Values.pgpool.initdbScripts .Values.pgpool.initdbScriptsCM }}
+        {{- if or .Values.pgpool.initdbScripts .Values.pgpool.initdbScriptsCM }}
         - name: custom-init-scripts
           configMap:
             name: {{ template "postgresql-ha.pgpoolInitdbScriptsCM" . }}

--- a/bitnami/postgresql-ha/templates/pgpool/initdb-scripts-configmap.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/initdb-scripts-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and (or (.Files.Glob "files/pgpool-entrypoint-initdb.d/*.sh") .Values.pgpool.initdbScripts) (not .Values.pgpool.initdbScriptsCM) }}
+{{- if and .Values.pgpool.initdbScripts (not .Values.pgpool.initdbScriptsCM) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -12,10 +12,5 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
-  {{- with .Files.Glob "files/pgpool-entrypoint-initdb.d/*.sh" }}
-  {{- .AsConfig | nindent 2 }}
-  {{- end }}
-  {{- with .Values.pgpool.initdbScripts }}
-  {{- toYaml . | nindent 2 }}
-  {{- end }}
+  {{- include "common.tplvalues.render" (dict "value" .Values.pgpool.initdbScripts "context" $) | nindent 4 }}
 {{- end }}

--- a/bitnami/postgresql-ha/templates/postgresql/configmap.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and (or (.Files.Glob "files/repmgr.conf") (.Files.Glob "files/postgresql.conf") (.Files.Glob "files/pg_hba.conf") .Values.postgresql.repmgrConfiguration .Values.postgresql.configuration .Values.postgresql.pgHbaConfiguration) (not .Values.postgresql.configurationCM) }}
+{{- if and (or .Values.postgresql.repmgrConfiguration .Values.postgresql.configuration .Values.postgresql.pgHbaConfiguration) (not .Values.postgresql.configurationCM) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -12,24 +12,16 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
-  {{- if (.Files.Glob "files/repmgr.conf") }}
-  {{- (.Files.Glob "files/repmgr.conf").AsConfig | nindent 2 }}
-  {{- else if .Values.postgresql.repmgrConfiguration }}
-  repmgr.conf: |
-  {{- .Values.postgresql.repmgrConfiguration | nindent 4 }}
+  {{- if .Values.postgresql.repmgrConfiguration }}
+  repmgr.conf: |-
+    {{- include "common.tplvalues.render" ( dict "value" .Values.postgresql.repmgrConfiguration "context" $ ) | nindent 4 }}
   {{- end }}
-  {{- if (.Files.Glob "files/postgresql.conf") }}
-  {{- (.Files.Glob "files/postgresql.conf").AsConfig | nindent 2 }}
-  {{- else if .Values.postgresql.configuration }}
-  postgresql.conf: |
-  {{- range $key, $value := default dict .Values.postgresql.configuration }}
-    {{ $key | snakecase }}={{ $value }}
+  {{- if .Values.postgresql.configuration }}
+  postgresql.conf: |-
+    {{- include "common.tplvalues.render" ( dict "value" .Values.postgresql.configuration "context" $ ) | nindent 4 }}
   {{- end }}
-  {{- end }}
-  {{- if (.Files.Glob "files/pg_hba.conf") }}
-  {{- (.Files.Glob "files/pg_hba.conf").AsConfig | nindent 2 }}
-  {{- else if .Values.postgresql.pgHbaConfiguration }}
-  pg_hba.conf: |
-  {{- .Values.postgresql.pgHbaConfiguration | nindent 4 }}
+  {{- if .Values.postgresql.pgHbaConfiguration }}
+  pg_hba.conf: |-
+    {{- include "common.tplvalues.render" ( dict "value" .Values.postgresql.pgHbaConfiguration "context" $ ) | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/bitnami/postgresql-ha/templates/postgresql/extended-configmap.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/extended-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and (or (.Files.Glob "files/conf.d/*.conf") .Values.postgresql.extendedConf) (not .Values.postgresql.extendedConfCM) }}
+{{- if and .Values.postgresql.extendedConf (not .Values.postgresql.extendedConfCM) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -12,13 +12,6 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
-  {{- with .Files.Glob "files/conf.d/*.conf" }}
-  {{- .AsConfig | nindent 2 }}
-  {{- end }}
-  {{- with .Values.postgresql.extendedConf }}
-  override.conf: |
-  {{- range $key, $value := . }}
-    {{ $key | snakecase }}={{ $value }}
-  {{- end }}
-  {{- end }}
+  override.conf: |-
+    {{- include "common.tplvalues.render" ( dict "value" .Values.postgresql.extendedConf "context" $ ) | nindent 4 }}
 {{- end }}

--- a/bitnami/postgresql-ha/templates/postgresql/initdb-scripts-configmap.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/initdb-scripts-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and (or (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql,sql.gz}") .Values.postgresql.initdbScripts) (not .Values.postgresql.initdbScriptsCM) }}
+{{- if and .Values.postgresql.initdbScripts (not .Values.postgresql.initdbScriptsCM) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,17 +11,6 @@ metadata:
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
-{{- with .Files.Glob "files/docker-entrypoint-initdb.d/*.sql.gz" }}
-binaryData:
-{{- range $path, $bytes := . }}
-  {{ base $path }}: {{ $.Files.Get $path | b64enc | quote }}
-{{- end }}
-{{- end }}
 data:
-  {{- with .Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql}" }}
-  {{- .AsConfig | nindent 2 }}
-  {{- end }}
-  {{- with .Values.postgresql.initdbScripts }}
-  {{- toYaml . | nindent 2 }}
-  {{- end }}
+  {{- include "common.tplvalues.render" (dict "value" .Values.postgresql.initdbScripts "context" $) | nindent 4 }}
 {{- end }}

--- a/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
@@ -307,15 +307,15 @@ spec:
           resources: {{- toYaml .Values.postgresql.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
-            {{- if or (.Files.Glob "files/repmgr.conf") (.Files.Glob "files/postgresql.conf") (.Files.Glob "files/pg_hba.conf") .Values.postgresql.repmgrConfiguration .Values.postgresql.configuration .Values.postgresql.pgHbaConfiguration .Values.postgresql.configurationCM }}
+            {{- if or .Values.postgresql.repmgrConfiguration .Values.postgresql.configuration .Values.postgresql.pgHbaConfiguration .Values.postgresql.configurationCM }}
             - name: postgresql-config
               mountPath: /bitnami/repmgr/conf
             {{- end }}
-            {{- if or (.Files.Glob "files/conf.d/*.conf") .Values.postgresql.extendedConf .Values.postgresql.extendedConfCM }}
+            {{- if or .Values.postgresql.extendedConf .Values.postgresql.extendedConfCM }}
             - name: postgresql-extended-config
               mountPath: /bitnami/postgresql/conf/conf.d/
             {{- end }}
-            {{- if or (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql,sql.gz}") .Values.postgresql.initdbScriptsCM .Values.postgresql.initdbScripts }}
+            {{- if or .Values.postgresql.initdbScriptsCM .Values.postgresql.initdbScripts }}
             - name: custom-init-scripts
               mountPath: /docker-entrypoint-initdb.d/
             {{- end }}
@@ -403,12 +403,12 @@ spec:
           configMap:
             name: {{ printf "%s-hooks-scripts" (include "postgresql-ha.postgresql" .) }}
             defaultMode: 0755
-        {{- if or (.Files.Glob "files/repmgr.conf") (.Files.Glob "files/postgresql.conf") (.Files.Glob "files/pg_hba.conf") .Values.postgresql.repmgrConfiguration .Values.postgresql.configuration .Values.postgresql.pgHbaConfiguration .Values.postgresql.configurationCM }}
+        {{- if or .Values.postgresql.repmgrConfiguration .Values.postgresql.configuration .Values.postgresql.pgHbaConfiguration .Values.postgresql.configurationCM }}
         - name: postgresql-config
           configMap:
             name: {{ include "postgresql-ha.postgresqlConfigurationCM" . }}
         {{- end }}
-        {{- if or (.Files.Glob "files/conf.d/*.conf") .Values.postgresql.extendedConf .Values.postgresql.extendedConfCM }}
+        {{- if or .Values.postgresql.extendedConf .Values.postgresql.extendedConfCM }}
         - name: postgresql-extended-config
           configMap:
             name: {{ template "postgresql-ha.postgresqlExtendedConfCM" . }}
@@ -423,7 +423,7 @@ spec:
           secret:
             secretName: {{ include "postgresql-ha.postgresqlSecretName" . }}
         {{- end }}
-        {{- if or (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql,sql.gz}") .Values.postgresql.initdbScriptsCM .Values.postgresql.initdbScripts }}
+        {{- if or .Values.postgresql.initdbScriptsCM .Values.postgresql.initdbScripts }}
         - name: custom-init-scripts
           configMap:
             name: {{ template "postgresql-ha.postgresqlInitdbScriptsCM" . }}

--- a/bitnami/postgresql-ha/values.yaml
+++ b/bitnami/postgresql-ha/values.yaml
@@ -427,46 +427,67 @@ postgresql:
   extraInitContainers: []
 
   ## Repmgr configuration
-  ## Specify content for repmgr.conf
-  ## Default: do not create repmgr.conf
-  ## Alternatively, you can put your repmgr.conf under the files/ directory
+  ## You can use this parameter to specify the content for repmgr.conf
+  ## Otherwise, a repmgr.conf will be generated based on the environment variables
+  ## ref: https://github.com/bitnami/bitnami-docker-postgresql-repmgr#configuration
   ## ref: https://github.com/bitnami/bitnami-docker-postgresql-repmgr#configuration-file
+  ## Example:
+  ## repmgrConfiguration: |-
+  ##   ssh_options='-o "StrictHostKeyChecking no" -v'
+  ##   use_replication_slots='1'
+  ##   ...
   ##
-  # repmgrConfiguration: |-
+  repmgrConfiguration: ""
+
   ## PostgreSQL configuration
-  ## Specify runtime configuration parameters as a dict, using camelCase, e.g.
-  ## {"sharedBuffers": "500MB"}
-  ## Alternatively, you can put your postgresql.conf under the files/ directory
+  ## You can use this parameter to specify the content for postgresql.conf
+  ## Otherwise, a repmgr.conf will be generated based on the environment variables
+  ## ref: https://github.com/bitnami/bitnami-docker-postgresql-repmgr#configuration
   ## ref: https://github.com/bitnami/bitnami-docker-postgresql-repmgr#configuration-file
+  ## Example:
+  ## configuration: |-
+  ##   listen_addresses = '*'
+  ##   port = '5432'
+  ##   ...
   ##
-  # configuration:
+  configuration: ""
+
   ## PostgreSQL client authentication configuration
-  ## Specify content for pg_hba.conf
-  ## Default: do not create pg_hba.conf
-  ## Alternatively, you can put your pg_hba.conf under the files/ directory
+  ## You can use this parameter to specify the content for pg_hba.conf
+  ## Otherwise, a repmgr.conf will be generated based on the environment variables
+  ## ref: https://github.com/bitnami/bitnami-docker-postgresql-repmgr#configuration
   ## ref: https://github.com/bitnami/bitnami-docker-postgresql-repmgr#configuration-file
+  ## Example:
+  ## pgHbaConfiguration: |-
+  ##   host     all            repmgr    0.0.0.0/0    md5
+  ##   host     repmgr         repmgr    0.0.0.0/0    md
+  ##   ...
   ##
-  # pgHbaConfiguration: |-
-  #   local all all trust
-  #   host all all localhost trust
-  #   host mydatabase mysuser 192.168.0.0/24 md5
-  ## ConfigMap with PostgreSQL configuration
-  ## NOTE: This will override repmgrConfiguration, configuration and pgHbaConfiguration
+  pgHbaConfiguration: ""
+
+  ## Name of existing ConfigMap with configuration files
+  ## NOTE: This will override postgresql.repmgrConfiguration, postgresql.configuration and postgresql.pgHbaConfiguration
   ##
   # configurationCM:
+
   ## PostgreSQL extended configuration
-  ## As above, but _appended_ to the main configuration
-  ## Alternatively, you can put your *.conf under the files/conf.d/ directory
+  ## Similar to postgresql.configuration, but _appended_ to the main configuration
   ## ref: https://github.com/bitnami/bitnami-docker-postgresql-repmgr#allow-settings-to-be-loaded-from-files-other-than-the-default-postgresqlconf
+  ## Example:
+  ## extendedConf: |-
+  ##   deadlock_timeout = 1s
+  ##   max_locks_per_transaction = 64
+  ##   ...
   ##
-  # extendedConf:
+  extendedConf: ""
+
   ## ConfigMap with PostgreSQL extended configuration
-  ## NOTE: This will override extendedConf
+  ## NOTE: This will override postgresql.extendedConf
   ##
   # extendedConfCM:
+
   ## initdb scripts
   ## Specify dictionary of scripts to be run at first boot
-  ## Alternatively, you can put your scripts under the files/docker-entrypoint-initdb.d directory
   ##
   # initdbScripts:
   #   my_init_script.sh: |
@@ -763,11 +784,17 @@ pgpool:
   useLoadBalancing: true
 
   ## Pgpool configuration
-  ## Specify content for pgpool.conf
-  ## Alternatively, you can put your pgpool.conf under the files/ directory
+  ## You can use this parameter to specify the content for pgpool.conf
+  ## Otherwise, a repmgr.conf will be generated based on the environment variables
+  ## ref: https://github.com/bitnami/bitnami-docker-pgpool#configuration
   ## ref: https://github.com/bitnami/bitnami-docker-pgpool#configuration-file
+  ## Example:
+  ## configuration: |-
+  ##   listen_addresses = '*'
+  ##   port = '5432'
+  ##   ...
   ##
-  # configuration:
+  configuration: ""
 
   ## ConfigMap with Pgpool configuration
   ## NOTE: This will override pgpool.configuration parameter
@@ -776,7 +803,6 @@ pgpool:
 
   ## initdb scripts
   ## Specify dictionary of scripts to be run every time Pgpool container is initialized
-  ## Alternatively, you can put your scripts under the files/pgpool-entrypoint-initdb.d directory
   ##
   # initdbScripts:
   #   my_init_script.sh: |


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR:

- Removes support to load configuration and init scripts from `files/` directory
- Treats `postgresql.configuration` & `postgresql.extendedConf` parameters as plain configuration (instead of doing weird `camelCase` to `sneak_case` transformation). 

**Benefits**

Avoid confusion and have a most intuitive approach for loading custom configuration & scripts.

**Possible drawbacks**

Users can no longer load their configuration from the `files/` directory.

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/5075

**Additional information**

Adding custom configuration files or initialization scripts by placing them under the "files" directory is very confusing for users since they do not usually clone the repo nor they fetch the charts to their working directories.
On the other hand, doing a `camelCase` to `sneak_case` transformation to pass custom configuration for PostgreSQL makes no sense at all.

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)