### PR TITLE
[bitnami/consul] Add hostAliases

### DIFF
--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -19,4 +19,4 @@ name: consul
 sources:
   - https://github.com/bitnami/bitnami-docker-consul
   - https://www.consul.io/
-version: 9.1.2
+version: 9.2.0

--- a/bitnami/consul/README.md
+++ b/bitnami/consul/README.md
@@ -84,6 +84,7 @@ The following table lists the configurable parameters of the HashiCorp Consul ch
 | `raftMultiplier`           | Multiplier used to scale key Raft timing parameters                  | `1`                                                     |
 | `gossipKey`                | Gossip key for all members                                           | `nil`                                                   |
 | `tlsEncryptionSecretName`  | Name of existing secret with TLS encryption data                     | `nil`                                                   |
+| `hostAliases`              | Add deployment host aliases                                          | `[]`                                                    |
 | `configuration`            | HashiCorp Consul configuration to be injected as ConfigMap           | `{}`                                                    |
 | `existingConfigmap`        | Name of existing ConfigMap with HashiCorp Consul configuration       | `nil`                                                   |
 | `localConfig`              | Extra configuration that will be added to the default one            | `nil`                                                   |

--- a/bitnami/consul/templates/statefulset.yaml
+++ b/bitnami/consul/templates/statefulset.yaml
@@ -44,6 +44,9 @@ spec:
       {{- end }}
     spec:
       {{- include "consul.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
+      {{- end }}
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- else }}

--- a/bitnami/consul/values.yaml
+++ b/bitnami/consul/values.yaml
@@ -56,6 +56,11 @@ commonAnnotations: {}
 ##
 commonLabels: {}
 
+## Deployment pod host aliases
+## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+##
+hostAliases: []
+
 ## Datacenter name for consul. If not supplied, will use the consul
 ##
 datacenterName: dc1


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This PR adds support to hostAliases to cover cases like https://github.com/bitnami/charts/issues/3427. 

**Benefits**

Allow custom aliases to cover more  cases, like 

> I'd like a value option to add hostAlias under spec, so I can access minikube externaldb, like so:

from https://github.com/bitnami/charts/issues/3427

**Possible drawbacks**

None known 


**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
