### PR TITLE
[bitnami/kong] Fix png url

### DIFF
--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
 description: Kong is a scalable, open source API layer (aka API gateway or API middleware) that runs in front of any RESTful API. Extra functionalities beyond the core platform are extended through plugins. Kong is built on top of reliable technologies like NGINX and provides an easy-to-use RESTful API to operate and configure the system.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/kong
-icon: https://bitnami.com/assets/stacks/kong/img/kong-stack-3.0.034.png
+icon: https://bitnami.com/assets/stacks/kong/img/kong-stack-220x234.png
 keywords:
   - kong
   - ingress
@@ -34,4 +34,4 @@ name: kong
 sources:
   - https://github.com/bitnami/bitnami-docker-kong
   - https://konghq.com/
-version: 3.3.0
+version: 3.3.1


### PR DESCRIPTION
**Description of the change**

Wrong url for the png


**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)


