### PR TITLE
[bitnami/redis] update redis README.md for the usage of metrics.extraArgs when redis tls is enabled

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -25,4 +25,4 @@ name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 12.6.3
+version: 12.6.4

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -405,6 +405,16 @@ tls.certCAFilename="ca.pem"
 
 The chart optionally can start a metrics exporter for [prometheus](https://prometheus.io). The metrics endpoint (port 9121) is exposed in the service. Metrics can be scraped from within the cluster using something similar as the described in the [example Prometheus scrape configuration](https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus-kubernetes.yml). If metrics are to be scraped from outside the cluster, the Kubernetes API proxy can be utilized to access the endpoint.
 
+If you have enabled TLS by specifying `tls.enabled=true` you also need to specify TLS option to the metrics exporter. You can do that via `metrics.extraArgs`. You can find the metrics exporter CLI flags for TLS [here](https://github.com/oliver006/redis_exporter#command-line-flags). For example:
+
+You can either specify `metrics.extraArgs.skip-tls-verification=true` to skip TLS verification or providing the following values under `metrics.extraArgs` for TLS client authentication:
+
+```console
+tls-client-key-file
+tls-client-cert-file
+tls-ca-cert-file
+...
+
 ### Host Kernel Settings
 
 Redis<sup>TM</sup> may require some changes in the kernel of the host machine to work as expected, in particular increasing the `somaxconn` value and disabling transparent huge pages.


### PR DESCRIPTION

**Description of the change**

Update redis README.md for the usage of metrics.extraArgs when redis tls is enabled

**Benefits**

User will know how to configure parameters of redis.metrics so that the metrics data can be retrived when redis TLS is enable.d

**Possible drawbacks**

N/A

**Applicable issues**

The change is an implementation of issue [#4585](https://github.com/bitnami/charts/issues/4585).

**Additional information**

The change only applies to the README.md for the bitnami/redis chart.


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

