### PR TITLE
[bitnami/postgresql] Add chmod `-R` option in init-chmod-data init-container

### DIFF
--- a/bitnami/postgresql/Chart.lock
+++ b/bitnami/postgresql/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.2.3
-digest: sha256:ef82cbc1e15eb074ed05cdec22538cacb27b5b2ad706ba4c5b18ffb1a14f701c
-generated: "2021-01-04T17:59:33.709728131Z"
+  version: 1.3.7
+digest: sha256:dce6f9e6008fccb36d6be49ca3ecfef811d43e08bdc76ff5cf5fdd4a44db97ed
+generated: "2021-01-25T14:19:32.668617+09:00"

--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -26,4 +26,4 @@ name: postgresql
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 10.2.4
+version: 10.2.5

--- a/bitnami/postgresql/templates/statefulset.yaml
+++ b/bitnami/postgresql/templates/statefulset.yaml
@@ -87,7 +87,7 @@ spec:
               chown {{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} {{ .Values.persistence.mountPath }}
               {{- end }}
               mkdir -p {{ .Values.persistence.mountPath }}/data {{- if (include "postgresql.mountConfigurationCM" .) }} {{ .Values.persistence.mountPath }}/conf {{- end }}
-              chmod 700 {{ .Values.persistence.mountPath }}/data {{- if (include "postgresql.mountConfigurationCM" .) }} {{ .Values.persistence.mountPath }}/conf {{- end }}
+              chmod -R 700 {{ .Values.persistence.mountPath }}/data {{- if (include "postgresql.mountConfigurationCM" .) }} {{ .Values.persistence.mountPath }}/conf {{- end }}
               find {{ .Values.persistence.mountPath }} -mindepth 1 -maxdepth 1 {{- if not (include "postgresql.mountConfigurationCM" .) }} -not -name "conf" {{- end }} -not -name ".snapshot" -not -name "lost+found" | \
               {{- if eq ( toString ( .Values.volumePermissions.securityContext.runAsUser )) "auto" }}
                 xargs chown -R `id -u`:`id -G | cut -d " " -f2`


### PR DESCRIPTION
Context.
Database Pod CrashLoopBackOff because wrong permission

After setting `volumePermissions.enabled` true, It still has problem.
because`/bitnami/postgresql/data/data` has permission problem in my case.

FYI) I didn't touch any variable about `persistence.mountPath` since first deploy