### PR TITLE
[bitnami/redis] [bitnami/redis-cluster] update README.md for the usage of metrics.extraArgs when redis tls is enabled

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -23,4 +23,4 @@ name: redis-cluster
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 4.2.9
+version: 4.2.8

--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -23,4 +23,4 @@ name: redis-cluster
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 4.2.9
+version: 4.2.10

--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -23,4 +23,4 @@ name: redis-cluster
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 4.2.7
+version: 4.2.9

--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -23,4 +23,4 @@ name: redis-cluster
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 4.2.8
+version: 4.2.9

--- a/bitnami/redis-cluster/README.md
+++ b/bitnami/redis-cluster/README.md
@@ -485,6 +485,16 @@ Alternatively, you can use a ConfigMap or a Secret with the environment variable
 
 The chart optionally can start a metrics exporter for [prometheus](https://prometheus.io). The metrics endpoint (port 9121) is exposed in the service. Metrics can be scraped from within the cluster using something similar as the described in the [example Prometheus scrape configuration](https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus-kubernetes.yml). If metrics are to be scraped from outside the cluster, the Kubernetes API proxy can be utilized to access the endpoint.
 
+If you have enabled TLS by specifying `tls.enabled=true` you also need to specify TLS option to the metrics exporter. You can do that via `metrics.extraArgs`. You can find the metrics exporter CLI flags for TLS [here](https://github.com/oliver006/redis_exporter#command-line-flags). For example:
+
+You can either specify `metrics.extraArgs.skip-tls-verification=true` to skip TLS verification or providing the following values under `metrics.extraArgs` for TLS client authentication:
+
+```console
+tls-client-key-file
+tls-client-cert-file
+tls-ca-cert-file
+```
+
 ### Host Kernel Settings
 Redis<sup>TM</sup> may require some changes in the kernel of the host machine to work as expected, in particular increasing the `somaxconn` value and disabling transparent huge pages.
 To do so, you can set up a privileged initContainer with the `sysctlImage` config values, for example:

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -25,4 +25,4 @@ name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 12.6.4
+version: 12.6.5

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -413,7 +413,7 @@ You can either specify `metrics.extraArgs.skip-tls-verification=true` to skip TL
 tls-client-key-file
 tls-client-cert-file
 tls-ca-cert-file
-...
+```
 
 ### Host Kernel Settings
 


### PR DESCRIPTION
authored-by: Dong, Hujun <Hujun.Dong@IGT.com>

Description of the change

Update redis README.md for the usage of metrics.extraArgs when redis tls is enabled

Benefits

User will know how to configure parameters of redis.metrics so that the metrics data can be retrived when redis TLS is enable.d

Possible drawbacks

N/A

Applicable issues

The change is an implementation of issue #5228.

Additional information

The change applies to the README.md for the bitnami/redis and bitnami/redis-cluster

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
