### PR TITLE
fix a typo in the readme.md file for usage of redis metrics extraarge when enable tls

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -25,4 +25,4 @@ name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 12.6.5
+version: 12.6.4

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -25,4 +25,4 @@ name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 12.6.4
+version: 12.6.5

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -413,7 +413,7 @@ You can either specify `metrics.extraArgs.skip-tls-verification=true` to skip TL
 tls-client-key-file
 tls-client-cert-file
 tls-ca-cert-file
-...
+```
 
 ### Host Kernel Settings
 


### PR DESCRIPTION
authored-by: Dong, Hujun Hujun.Dong@IGT.com

Description of the change

Update redis README.md for the usage of metrics.extraArgs when redis tls is enabled.
Fix a typo in the readme.md file. 

Benefits

User will know how to configure parameters of redis.metrics so that the metrics data can be retrived when redis TLS is enable.d

Possible drawbacks

Fixes #5228

Applicable issues

The change is an implementation of issue #5228.

Additional information

The change applies to the README.md for the bitnami/redis.


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
