### PR TITLE
[bitnami/magento] Adapt ingress to k8s 1.20

### DIFF
--- a/bitnami/magento/Chart.yaml
+++ b/bitnami/magento/Chart.yaml
@@ -35,4 +35,4 @@ name: magento
 sources:
   - https://github.com/bitnami/bitnami-docker-magento
   - https://magento.com/
-version: 17.0.0
+version: 17.1.0

--- a/bitnami/magento/README.md
+++ b/bitnami/magento/README.md
@@ -72,6 +72,8 @@ The following table lists the configurable parameters of the Magento chart and t
 | `fullnameOverride`  | String to fully override magento.fullname template                           | `nil`                                                   |
 | `commonLabels`      | Labels to add to all deployed objects                                        | `nil`                                                   |
 | `commonAnnotations` | Annotations to add to all deployed objects                                   | `[]`                                                    |
+| `kubeVersion`       | Force target Kubernetes version (using Helm capabilities if not set)         | `nil` 
+|
 | `extraDeploy`       | Array of extra objects to deploy with the release (evaluated as a template). | `nil`                                                   |
 
 ### Magento parameters
@@ -192,27 +194,29 @@ The following table lists the configurable parameters of the Magento chart and t
 
 ### Traffic Exposure Parameters
 
-| Parameter                        | Description                                 | Default            |
-|----------------------------------|---------------------------------------------|--------------------|
-| `service.type`                   | Kubernetes Service type                     | `LoadBalancer`     |
-| `service.loadBalancerIP`         | Kubernetes LoadBalancerIP to request        | `LoadBalancer`     |
-| `service.port`                   | Service HTTP port                           | `80`               |
-| `service.httpsPort`              | Service HTTPS port                          | `443`              |
-| `service.externalTrafficPolicy`  | Enable client source IP preservation        | `Cluster`          |
-| `service.nodePorts.http`         | Kubernetes http node port                   | `""`               |
-| `service.nodePorts.https`        | Kubernetes https node port                  | `""`               |
-| `ingress.enabled`                | Enable ingress controller resource          | `false`            |
-| `ingress.certManager`            | Add annotations for cert-manager            | `false`            |
-| `ingress.hostname`               | Default host for the ingress resource       | `magento.local`    |
-| `ingress.tls`                    | Enable TLS for `ingress.hostname` parameter | `false`            |
-| `ingress.annotations`            | Ingress annotations                         | `{}`               |
-| `ingress.extraHosts[0].name`     | Hostname to your Magento installation       | `nil`              |
-| `ingress.extraHosts[0].path`     | Path within the url structure               | `nil`              |
-| `ingress.extraTls[0].hosts[0]`   | TLS configuration for additional hosts      | `nil`              |
-| `ingress.extraTls[0].secretName` | TLS Secret (certificates)                   | `nil`              |
-| `ingress.secrets[0].name`        | TLS Secret Name                             | `nil`              |
-| `ingress.secrets[0].certificate` | TLS Secret Certificate                      | `nil`              |
-| `ingress.secrets[0].key`         | TLS Secret Key                              | `nil`              |
+| Parameter                        | Description                                 | Default                 |
+|----------------------------------|---------------------------------------------|-------------------------|
+| `service.type`                   | Kubernetes Service type                     | `LoadBalancer`          |
+| `service.loadBalancerIP`         | Kubernetes LoadBalancerIP to request        | `LoadBalancer`          |
+| `service.port`                   | Service HTTP port                           | `80`                    |
+| `service.httpsPort`              | Service HTTPS port                          | `443`                   |
+| `service.externalTrafficPolicy`  | Enable client source IP preservation        | `Cluster`               |
+| `service.nodePorts.http`         | Kubernetes http node port                   | `""`                    |
+| `service.nodePorts.https`        | Kubernetes https node port                  | `""`                    |
+| `ingress.enabled`                | Enable ingress controller resource          | `false`                 |
+| `ingress.certManager`            | Add annotations for cert-manager            | `false`                 |
+| `ingress.hostname`               | Default host for the ingress resource       | `magento.local`         |
+| `ingress.path`                   | Default path for the ingress resource       | `/`                     |
+| `ingress.pathType`               | Default path type for the ingress resource  | `ImplementationSpecific`|
+| `ingress.tls`                    | Enable TLS for `ingress.hostname` parameter | `false`                 |
+| `ingress.annotations`            | Ingress annotations                         | `{}`                    |
+| `ingress.extraHosts[0].name`     | Hostname to your Magento installation       | `nil`                   |
+| `ingress.extraHosts[0].path`     | Path within the url structure               | `nil`                   |
+| `ingress.extraTls[0].hosts[0]`   | TLS configuration for additional hosts      | `nil`                   |
+| `ingress.extraTls[0].secretName` | TLS Secret (certificates)                   | `nil`                   |
+| `ingress.secrets[0].name`        | TLS Secret Name                             | `nil`                   |
+| `ingress.secrets[0].certificate` | TLS Secret Certificate                      | `nil`                   |
+| `ingress.secrets[0].key`         | TLS Secret Key                              | `nil`                   |
 
 ### Metrics parameters
 

--- a/bitnami/magento/templates/ingress.yaml
+++ b/bitnami/magento/templates/ingress.yaml
@@ -23,22 +23,24 @@ metadata:
 spec:
   rules:
     {{- if .Values.ingress.hostname }}
-    - host: {{ .Values.ingress.hostname }}
+    - host: {{ .Values.ingress.hostname | quote }}
       http:
         paths:
-          - path: /
-            backend:
-              serviceName: {{ include "common.names.fullname" . }}
-              servicePort: http
+          - path: {{ default "/" .Values.ingress.path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.ingress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
-    - host: {{ .name }}
+    - host: {{ .name | quote }}
       http:
         paths:
           - path: {{ default "/" .path }}
-            backend:
-              serviceName: {{ include "common.names.fullname" $ }}
-              servicePort: http
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
+            pathType: {{ default "ImplementationSpecific" .pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
   {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
   tls:

--- a/bitnami/magento/values.yaml
+++ b/bitnami/magento/values.yaml
@@ -359,7 +359,7 @@ ingress:
   hostname: magento.local
 
   ## Default path for the ingress resource
-  ## 
+  ##
   path: /
 
 

--- a/bitnami/magento/values.yaml
+++ b/bitnami/magento/values.yaml
@@ -350,7 +350,7 @@ ingress:
   ##
   pathType: ImplementationSpecific
 
-  ## Override API Version (automatically detected if nott set)
+  ## Override API Version (automatically detected if not set)
   ##
   apiVersion:
 

--- a/bitnami/magento/values.yaml
+++ b/bitnami/magento/values.yaml
@@ -31,6 +31,10 @@ image:
   ##
   debug: false
 
+## Force target Kubernetes version (using Helm capabilities if not set)
+##
+kubeVersion:
+
 ## String to partially override magento.fullname template (will maintain the release name)
 ##
 nameOverride:
@@ -342,9 +346,22 @@ ingress:
   ##
   certManager: false
 
+  ## Ingress Path type
+  ##
+  pathType: ImplementationSpecific
+
+  ## Override API Version (automatically detected if nott set)
+  ##
+  apiVersion:
+
   ## When the ingress is enabled, a host pointing to this will be created
   ##
   hostname: magento.local
+
+  ## Default path for the ingress resource
+  ## 
+  path: /
+
 
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see


### PR DESCRIPTION
**Description of the change**

In short, bitnami/magento is not compatible with k8s 1.20. I am simply following @javsalgar template for making the ingress compatible.

This PR updates the common library with the changes from #4859.

Depending on the Kubernetes version it will generate the proper Ingress object
It allows forcing a Kubernetes version so it is compatible with GitOps approaches

**Benefits**

Charts compatible with all Kubernetes versions

**Possible drawbacks**

n/a

**Applicable issues**

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

