### PR TITLE
[bitnami/grafana] Add hostAliases

### DIFF
--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -24,4 +24,4 @@ name: grafana
 sources:
   - https://github.com/bitnami/bitnami-docker-grafana
   - https://grafana.com/
-version: 5.0.2
+version: 5.1.0

--- a/bitnami/grafana/README.md
+++ b/bitnami/grafana/README.md
@@ -76,7 +76,8 @@ The following tables lists the configurable parameters of the grafana chart and 
 | `image.tag`                        | Grafana image tag                                                          | `{TAG_NAME}`                                            |
 | `image.pullPolicy`                 | Grafana image pull policy                                                  | `IfNotPresent`                                          |
 | `image.pullSecrets`                | Specify docker-registry secret names as an array                           | `[]` (does not add image pull secrets to deployed pods) |
-| `hostAliases`                    | Add deployment host aliases                                                               | `Check values.yaml`                                          || `admin.user`                       | Grafana admin username                                                     | `admin`                                                 |
+| `hostAliases`                      | Add deployment host aliases                                                | `[]`                                                    |
+| `admin.user`                       | Grafana admin username                                                     | `admin`                                                 |
 | `admin.password`                   | Grafana admin password                                                     | Randomly generated                                      |
 | `admin.existingSecret`             | Name of the existing secret containing admin password                      | `nil`                                                   |
 | `admin.existingSecretPasswordKey`  | Password key on the existing secret                                        | `password`                                              |

--- a/bitnami/grafana/README.md
+++ b/bitnami/grafana/README.md
@@ -76,7 +76,7 @@ The following tables lists the configurable parameters of the grafana chart and 
 | `image.tag`                        | Grafana image tag                                                          | `{TAG_NAME}`                                            |
 | `image.pullPolicy`                 | Grafana image pull policy                                                  | `IfNotPresent`                                          |
 | `image.pullSecrets`                | Specify docker-registry secret names as an array                           | `[]` (does not add image pull secrets to deployed pods) |
-| `admin.user`                       | Grafana admin username                                                     | `admin`                                                 |
+| `hostAliases`                    | Add deployment host aliases                                                               | `Check values.yaml`                                          || `admin.user`                       | Grafana admin username                                                     | `admin`                                                 |
 | `admin.password`                   | Grafana admin password                                                     | Randomly generated                                      |
 | `admin.existingSecret`             | Name of the existing secret containing admin password                      | `nil`                                                   |
 | `admin.existingSecretPasswordKey`  | Password key on the existing secret                                        | `password`                                              |

--- a/bitnami/grafana/templates/deployment.yaml
+++ b/bitnami/grafana/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
         {{- end }}
     spec:
       {{- include "grafana.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "grafana.serviceAccountName" . }}
       {{- if .Values.schedulerName }}
       schedulerName: {{ .Values.schedulerName | quote }}

--- a/bitnami/grafana/values.yaml
+++ b/bitnami/grafana/values.yaml
@@ -35,6 +35,11 @@ kubeVersion:
 ##
 extraDeploy: []
 
+## Deployment pod host aliases
+## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+##
+hostAliases: []
+
 ## String to partially override grafana.fullname template (will maintain the release name)
 ##
 # nameOverride:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This PR adds support to hostAliases to cover cases like https://github.com/bitnami/charts/issues/3427. 

**Benefits**

Allow custom aliases to cover more  cases, like 

> I'd like a value option to add hostAlias under spec, so I can access minikube externaldb, like so:

from https://github.com/bitnami/charts/issues/3427

**Possible drawbacks**

None known 


**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
