### PR TITLE
[bitnami/kiam] Add hostAliases

### DIFF
--- a/bitnami/kiam/Chart.yaml
+++ b/bitnami/kiam/Chart.yaml
@@ -23,4 +23,4 @@ name: kiam
 sources:
   - https://github.com/bitnami/bitnami-docker-kiam
   - https://github.com/uswitch/kiam
-version: 0.2.4
+version: 0.3.0

--- a/bitnami/kiam/README.md
+++ b/bitnami/kiam/README.md
@@ -97,6 +97,7 @@ The following tables lists the configurable parameters of the kiam chart and the
 | `server.tlsFiles.cert`                      | Base64-encoded certificate to use with the container                                        | `nil`                                    |
 | `server.tlsFiles.key`                       | Base64-encoded key to use with the container                                                | `nil`                                    |
 | `server.tlsCerts.certFileName`              | Name of the certificate filename                                                            | `cert.pem`                               |
+| `server.hostAliases`                        | Add deployment host aliases                                                                 | `[]`                                     |
 | `server.tlsCerts.keyFileName`               | Name of the certificate filename                                                            | `key.pem`                                |
 | `server.tlsCerts.caFileName`                | Name of the certificate filename                                                            | `ca.pem`                                 |
 | `server.gatewayTimeoutCreation`             | Timeout when creating the kiam gateway                                                      | `1s`                                     |
@@ -157,6 +158,7 @@ The following tables lists the configurable parameters of the kiam chart and the
 | `agent.extraArgs`                           | Extra arguments to add to the default kiam command                                         | `[]`                                     |
 | `agent.command`                             | Override kiam default command                                                              | `[]`                                     |
 | `agent.args`                                | Override kiam default args                                                                 | `[]`                                     |
+| `agent.hostAliases`                         | Add deployment host aliases                                                                | `[]`                                     |
 | `agent.logLevel`                            | Logging level                                                                              | `info`                                   |
 | `agent.sslCertHostPath`                     | Path to the host system SSL certificates (necessary for contacting the AWS metadata agent) | `/etc/ssl/certs`                         |
 | `agent.tlsFiles.ca`                         | Base64-encoded CA to use with the container                                                | `nil`                                    |
@@ -237,7 +239,7 @@ The following tables lists the configurable parameters of the kiam chart and the
 | Parameter                                         | Description                                                                  | Default                                                      |
 |---------------------------------------------------|------------------------------------------------------------------------------|--------------------------------------------------------------|
 | `agent.metrics.enabled`                           | Enable exposing kiam statistics                                              | `false`                                                      |
-| `agent.metrics.port`                              | Service HTTP management port                                                | `9990`                                                       |
+| `agent.metrics.port`                              | Service HTTP management port                                                 | `9990`                                                       |
 | `agent.metrics.syncInterval`                      | Metrics synchronization interval statistics                                  | `5s`                                                         |
 | `agent.metrics.annotations`                       | Annotations for enabling prometheus to access the metrics endpoints          | `{prometheus.io/scrape: "true", prometheus.io/port: "9990"}` |
 | `agent.metrics.serviceMonitor.enabled`            | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator | `false`                                                      |

--- a/bitnami/kiam/templates/agent/agent-daemonset.yaml
+++ b/bitnami/kiam/templates/agent/agent-daemonset.yaml
@@ -30,6 +30,9 @@ spec:
         {{- end }}
     spec:
       {{- include "kiam.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.agent.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.agent.hostAliases "context" $) | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "kiam.agent.serviceAccountName" . }}
       dnsPolicy: {{ .Values.agent.dnsPolicy }}
       hostNetwork: {{ .Values.agent.useHostNetwork }}

--- a/bitnami/kiam/templates/server/server-daemonset.yaml
+++ b/bitnami/kiam/templates/server/server-daemonset.yaml
@@ -30,6 +30,9 @@ spec:
         {{- end }}
     spec:
       {{- include "kiam.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.server.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.server.hostAliases "context" $) | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "kiam.server.serviceAccountName" . }}
       dnsPolicy: {{ .Values.server.dnsPolicy }}
       hostNetwork: {{ .Values.server.useHostNetwork }}

--- a/bitnami/kiam/templates/server/server-deployment.yaml
+++ b/bitnami/kiam/templates/server/server-deployment.yaml
@@ -31,6 +31,9 @@ spec:
         {{- end }}
     spec:
       {{- include "kiam.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.server.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.server.hostAliases "context" $) | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "kiam.server.serviceAccountName" . }}
       dnsPolicy: {{ .Values.server.dnsPolicy }}
       hostNetwork: {{ .Values.server.useHostNetwork }}

--- a/bitnami/kiam/values.yaml
+++ b/bitnami/kiam/values.yaml
@@ -91,6 +91,11 @@ server:
   ##
   resourceType: daemonset
 
+  ## Deployment pod host aliases
+  ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  ##
+  hostAliases: []
+
   ## Whether the kiam server should use host network
   ##
   useHostNetwork: false
@@ -442,6 +447,11 @@ agent:
   ## agent permits only request paths matching this reg-ex
   ##
   allowRouteRegExp:
+
+  ## Deployment pod host aliases
+  ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  ##
+  hostAliases: []
 
   ## Host networking settings
   ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This PR adds support to hostAliases to cover cases like https://github.com/bitnami/charts/issues/3427. 

**Benefits**

Allow custom aliases to cover more  cases, like 

> I'd like a value option to add hostAlias under spec, so I can access minikube externaldb, like so:

from https://github.com/bitnami/charts/issues/3427

**Possible drawbacks**

None known 


**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
