### PR TITLE
[bitnami/memcached] Add hostAlias

### DIFF
--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -22,4 +22,4 @@ name: memcached
 sources:
   - https://github.com/bitnami/bitnami-docker-memcached
   - http://memcached.org/
-version: 5.4.5
+version: 5.5.0

--- a/bitnami/memcached/README.md
+++ b/bitnami/memcached/README.md
@@ -47,61 +47,62 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the Memcached chart and their default values.
 
-| Parameter                                | Description                                                                                            | Default                                                      |
-|------------------------------------------|--------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `global.imageRegistry`                   | Global Docker image registry                                                                           | `nil`                                                        |
-| `global.imagePullSecrets`                | Global Docker registry secret names as an array                                                        | `[]` (does not add image pull secrets to deployed pods)      |
-| `image.registry`                         | Memcached image registry                                                                               | `docker.io`                                                  |
-| `image.repository`                       | Memcached Image name                                                                                   | `bitnami/memcached`                                          |
-| `image.tag`                              | Memcached Image tag                                                                                    | `{TAG_NAME}`                                                 |
-| `image.pullPolicy`                       | Memcached image pull policy                                                                            | `IfNotPresent`                                               |
-| `image.pullSecrets`                      | Specify docker-registry secret names as an array                                                       | `[]` (does not add image pull secrets to deployed pods)      |
-| `nameOverride`                           | String to partially override common.names.fullname template with a string                              | `nil`                                                        |
-| `fullnameOverride`                       | String to fully override common.names.fullname template with a string                                  | `nil`                                                        |
-| `clusterDomain`                          | Kubernetes cluster domain                                                                              | `cluster.local`                                              |
-| `architecture`                           | Memcached architecture. Allowed values: standalone or high-availability                                 | `standalone`                                                 |
-| `replicaCount`                           | Number of containers                                                                                   | `1`                                                          |
-| `extraEnv`                               | Additional env vars to pass                                                                            | `{}`                                                         |
-| `arguments`                              | Arguments to pass                                                                                      | `["/run.sh"]`                                                |
-| `memcachedUsername`                      | Memcached admin user                                                                                   | `nil`                                                        |
-| `memcachedPassword`                      | Memcached admin password                                                                               | `nil`                                                        |
-| `service.type`                           | Kubernetes service type for Memcached                                                                  | `ClusterIP`                                                  |
-| `service.port`                           | Memcached service port                                                                                 | `11211`                                                      |
-| `service.clusterIP`                      | Specific cluster IP when service type is cluster IP. Use `None` for headless service                   | `nil`                                                        |
-| `service.nodePort`                       | Kubernetes Service nodePort                                                                            | `nil`                                                        |
-| `service.loadBalancerIP`                 | `loadBalancerIP` if service type is `LoadBalancer`                                                     | `nil`                                                        |
-| `service.annotations`                    | Additional annotations for Memcached service                                                           | `{}`                                                         |
-| `resources.requests`                     | CPU/Memory resource requests                                                                           | `{memory: "256Mi", cpu: "250m"}`                             |
-| `resources.limits`                       | CPU/Memory resource limits                                                                             | `{}`                                                         |
-| `persistence.enabled`                    | Enable persistence using PVC (Requires architecture: "high-availability")                              | `true`                                                       |
-| `persistence.storageClass`               | PVC Storage Class for Memcached volume                                                                 | `nil` (uses alpha storage class annotation)                  |
-| `persistence.accessMode`                 | PVC Access Mode for Memcached volume                                                                   | `ReadWriteOnce`                                              |
-| `persistence.size`                       | PVC Storage Request for Memcached volume                                                               | `8Gi`                                                        |
-| `securityContext.enabled`                | Enable security context                                                                                | `true`                                                       |
-| `securityContext.fsGroup`                | Group ID for the container                                                                             | `1001`                                                       |
-| `securityContext.runAsUser`              | User ID for the container                                                                              | `1001`                                                       |
-| `securityContext.readOnlyRootFilesystem` | Enable read-only filesystem                                                                            | `false`                                                      |
-| `podAnnotations`                         | Pod annotations                                                                                        | `{}`                                                         |
-| `podAffinityPreset`                      | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                    | `""`                                                         |
-| `podAntiAffinityPreset`                  | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`               | `soft`                                                       |
-| `nodeAffinityPreset.type`                | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`              | `""`                                                         |
-| `nodeAffinityPreset.key`                 | Node label key to match. Ignored if `affinity` is set.                                                 | `""`                                                         |
-| `nodeAffinityPreset.values`              | Node label values to match. Ignored if `affinity` is set.                                              | `[]`                                                         |
-| `affinity`                               | Affinity for pod assignment                                                                            | `{}` (evaluated as a template)                               |
-| `nodeSelector`                           | Node labels for pod assignment                                                                         | `{}` (evaluated as a template)                               |
-| `tolerations`                            | Tolerations for pod assignment                                                                         | `[]` (evaluated as a template)                               |
-| `priorityClassName`                      | Controller priorityClassName                                                                           | `nil`                                                        |
-| `metrics.enabled`                        | Start a side-car prometheus exporter                                                                   | `false`                                                      |
-| `metrics.image.registry`                 | Memcached exporter image registry                                                                      | `docker.io`                                                  |
-| `metrics.image.repository`               | Memcached exporter image name                                                                          | `bitnami/memcached-exporter`                                 |
-| `metrics.image.tag`                      | Memcached exporter image tag                                                                           | `{TAG_NAME}`                                                 |
-| `metrics.image.pullPolicy`               | Image pull policy                                                                                      | `IfNotPresent`                                               |
-| `metrics.image.pullSecrets`              | Specify docker-registry secret names as an array                                                       | `[]` (does not add image pull secrets to deployed pods)      |
-| `metrics.podAnnotations`                 | Additional annotations for Metrics exporter                                                            | `{prometheus.io/scrape: "true", prometheus.io/port: "9150"}` |
-| `metrics.resources`                      | Exporter resource requests/limit                                                                       | `{}`                                                         |
-| `metrics.service.type`                   | Kubernetes service type for Prometheus metrics                                                         | `ClusterIP`                                                  |
-| `metrics.service.port`                   | Prometheus metrics service port                                                                        | `9150`                                                       |
-| `metrics.service.annotations`            | Prometheus exporter svc annotations                                                                    | `{prometheus.io/scrape: "true", prometheus.io/port: "9150"}` |
+| Parameter                                | Description                                                                               | Default                                                      |
+|------------------------------------------|-------------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `global.imageRegistry`                   | Global Docker image registry                                                              | `nil`                                                        |
+| `global.imagePullSecrets`                | Global Docker registry secret names as an array                                           | `[]` (does not add image pull secrets to deployed pods)      |
+| `image.registry`                         | Memcached image registry                                                                  | `docker.io`                                                  |
+| `image.repository`                       | Memcached Image name                                                                      | `bitnami/memcached`                                          |
+| `image.tag`                              | Memcached Image tag                                                                       | `{TAG_NAME}`                                                 |
+| `image.pullPolicy`                       | Memcached image pull policy                                                               | `IfNotPresent`                                               |
+| `image.pullSecrets`                      | Specify docker-registry secret names as an array                                          | `[]` (does not add image pull secrets to deployed pods)      |
+| `nameOverride`                           | String to partially override common.names.fullname template with a string                 | `nil`                                                        |
+| `fullnameOverride`                       | String to fully override common.names.fullname template with a string                     | `nil`                                                        |
+| `clusterDomain`                          | Kubernetes cluster domain                                                                 | `cluster.local`                                              |
+| `architecture`                           | Memcached architecture. Allowed values: standalone or high-availability                   | `standalone`                                                 |
+| `replicaCount`                           | Number of containers                                                                      | `1`                                                          |
+| `extraEnv`                               | Additional env vars to pass                                                               | `{}`                                                         |
+| `arguments`                              | Arguments to pass                                                                         | `["/run.sh"]`                                                |
+| `hostAliases`                            | Add deployment host aliases                                                               | `[]`                                                         |
+| `memcachedUsername`                      | Memcached admin user                                                                      | `nil`                                                        |
+| `memcachedPassword`                      | Memcached admin password                                                                  | `nil`                                                        |
+| `service.type`                           | Kubernetes service type for Memcached                                                     | `ClusterIP`                                                  |
+| `service.port`                           | Memcached service port                                                                    | `11211`                                                      |
+| `service.clusterIP`                      | Specific cluster IP when service type is cluster IP. Use `None` for headless service      | `nil`                                                        |
+| `service.nodePort`                       | Kubernetes Service nodePort                                                               | `nil`                                                        |
+| `service.loadBalancerIP`                 | `loadBalancerIP` if service type is `LoadBalancer`                                        | `nil`                                                        |
+| `service.annotations`                    | Additional annotations for Memcached service                                              | `{}`                                                         |
+| `resources.requests`                     | CPU/Memory resource requests                                                              | `{memory: "256Mi", cpu: "250m"}`                             |
+| `resources.limits`                       | CPU/Memory resource limits                                                                | `{}`                                                         |
+| `persistence.enabled`                    | Enable persistence using PVC (Requires architecture: "high-availability")                 | `true`                                                       |
+| `persistence.storageClass`               | PVC Storage Class for Memcached volume                                                    | `nil` (uses alpha storage class annotation)                  |
+| `persistence.accessMode`                 | PVC Access Mode for Memcached volume                                                      | `ReadWriteOnce`                                              |
+| `persistence.size`                       | PVC Storage Request for Memcached volume                                                  | `8Gi`                                                        |
+| `securityContext.enabled`                | Enable security context                                                                   | `true`                                                       |
+| `securityContext.fsGroup`                | Group ID for the container                                                                | `1001`                                                       |
+| `securityContext.runAsUser`              | User ID for the container                                                                 | `1001`                                                       |
+| `securityContext.readOnlyRootFilesystem` | Enable read-only filesystem                                                               | `false`                                                      |
+| `podAnnotations`                         | Pod annotations                                                                           | `{}`                                                         |
+| `podAffinityPreset`                      | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                                                         |
+| `podAntiAffinityPreset`                  | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                                       |
+| `nodeAffinityPreset.type`                | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                                                         |
+| `nodeAffinityPreset.key`                 | Node label key to match. Ignored if `affinity` is set.                                    | `""`                                                         |
+| `nodeAffinityPreset.values`              | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                                                         |
+| `affinity`                               | Affinity for pod assignment                                                               | `{}` (evaluated as a template)                               |
+| `nodeSelector`                           | Node labels for pod assignment                                                            | `{}` (evaluated as a template)                               |
+| `tolerations`                            | Tolerations for pod assignment                                                            | `[]` (evaluated as a template)                               |
+| `priorityClassName`                      | Controller priorityClassName                                                              | `nil`                                                        |
+| `metrics.enabled`                        | Start a side-car prometheus exporter                                                      | `false`                                                      |
+| `metrics.image.registry`                 | Memcached exporter image registry                                                         | `docker.io`                                                  |
+| `metrics.image.repository`               | Memcached exporter image name                                                             | `bitnami/memcached-exporter`                                 |
+| `metrics.image.tag`                      | Memcached exporter image tag                                                              | `{TAG_NAME}`                                                 |
+| `metrics.image.pullPolicy`               | Image pull policy                                                                         | `IfNotPresent`                                               |
+| `metrics.image.pullSecrets`              | Specify docker-registry secret names as an array                                          | `[]` (does not add image pull secrets to deployed pods)      |
+| `metrics.podAnnotations`                 | Additional annotations for Metrics exporter                                               | `{prometheus.io/scrape: "true", prometheus.io/port: "9150"}` |
+| `metrics.resources`                      | Exporter resource requests/limit                                                          | `{}`                                                         |
+| `metrics.service.type`                   | Kubernetes service type for Prometheus metrics                                            | `ClusterIP`                                                  |
+| `metrics.service.port`                   | Prometheus metrics service port                                                           | `9150`                                                       |
+| `metrics.service.annotations`            | Prometheus exporter svc annotations                                                       | `{prometheus.io/scrape: "true", prometheus.io/port: "9150"}` |
 
 The above parameters map to the env variables defined in [bitnami/memcached](http://github.com/bitnami/bitnami-docker-memcached). For more information please refer to the [bitnami/memcached](http://github.com/bitnami/bitnami-docker-memcached) image documentation.
 

--- a/bitnami/memcached/templates/deployment.yaml
+++ b/bitnami/memcached/templates/deployment.yaml
@@ -22,6 +22,9 @@ spec:
       {{- end }}
     spec:
       {{- include "memcached.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
+      {{- end }}
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- else }}

--- a/bitnami/memcached/templates/statefulset.yaml
+++ b/bitnami/memcached/templates/statefulset.yaml
@@ -23,6 +23,9 @@ spec:
       {{- end }}
     spec:
       {{- include "memcached.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
+      {{- end }}
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- else }}

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -33,6 +33,7 @@ image:
 
 ## Extra environment vars to pass.
 ## ref: https://github.com/bitnami/bitnami-docker-memcached#configuration
+##
 extraEnv: []
 
 ## String to partially override common.names.fullname template (will maintain the release name)
@@ -40,6 +41,7 @@ extraEnv: []
 # nameOverride:
 
 ## Number of containers to run
+##
 replicaCount: 1
 
 ## String to fully override common.names.fullname template
@@ -52,6 +54,11 @@ clusterDomain: cluster.local
 ## Memcached architecture. Allowed values: standalone or high-availability
 ##
 architecture: standalone
+
+## Deployment pod host aliases
+## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+##
+hostAliases: []
 
 ## Memcached admin user
 ## ref: https://github.com/bitnami/bitnami-docker-memcached#creating-the-memcached-admin-user
@@ -133,6 +140,7 @@ podAntiAffinityPreset: soft
 nodeAffinityPreset:
   ## Node affinity type
   ## Allowed values: soft, hard
+  ##
   type: ""
   ## Node label key to match
   ## E.g.
@@ -170,6 +178,7 @@ tolerations: []
 
 ## Persistence - used for dumping and restoring states between recreations
 ## Ref: https://github.com/memcached/memcached/wiki/WarmRestart
+##
 persistence:
   enabled: false
   ## Persistent Volume Storage Class
@@ -193,12 +202,12 @@ persistence:
 
 ## Args for running memcached
 ## Ref: https://github.com/memcached/memcached/wiki/ConfiguringServer
+##
 arguments:
   - /run.sh
   # - -m <maxMemoryLimit>
   # - -I <maxItemSize>
   # - -vv
-
 
 ## Prometheus Exporter / Metrics
 ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This PR adds support to hostAliases to cover cases like https://github.com/bitnami/charts/issues/3427. 

**Benefits**

Allow custom aliases to cover more  cases, like 

> I'd like a value option to add hostAlias under spec, so I can access minikube externaldb, like so:

from https://github.com/bitnami/charts/issues/3427

**Possible drawbacks**

None known 


**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
