### PR TITLE
[bitnami/keycloak] fix: error with secret when release name too long

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 1.3.0
+version: 1.3.1

--- a/bitnami/keycloak/templates/secrets.yaml
+++ b/bitnami/keycloak/templates/secrets.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ (include "keycloak.fullname" .) }}
+  name: {{ include "common.secrets.name" (dict "existingSecret" .Values.auth.existingSecret "context" $) }}
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: keycloak


### PR DESCRIPTION
Signed-off-by: darteaga <darteaga@vmware.com>

**Description of the change**

Change the helper used to build the secret name

**Benefits**

It will permit us to use larger release names

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
