### PR TITLE
[bitnami/node] fix invalid default var value in readme

### DIFF
--- a/bitnami/node/README.md
+++ b/bitnami/node/README.md
@@ -82,7 +82,7 @@ The following table lists the configurable parameters of the Node chart and thei
 | `command`                               | Override default container command (useful when using custom images)      | `['/bin/bash', '-ec', 'npm start']`                     |
 | `args`                                  | Override default container args (useful when using custom images)         | `[]`                                                    |
 | `hostAliases`                           | Add deployment host aliases                                               | `[]`                                                    |
-| `extraEnvVars`                          | Extra environment variables to be set on Node container                   | `{}`                                                    |
+| `extraEnvVars`                          | Extra environment variables to be set on Node container                   | `[]`                                                    |
 | `extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars                      | `nil`                                                   |
 | `extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars                         | `nil`                                                   |
 | `mongodb.enabled`                       | Whether to install or not the MongoDB chart                               | `true`                                                  |


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Just fixes the default value of the `extraEnvVars` variable in the readme

**Benefits**

People don't get confused when they read the README instead of the values.yml

**Possible drawbacks**
N/A

**Additional information**
N/A