### PR TITLE
[bitnami/mongodb] fix: remove unnecesary hook

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 10.6.0
+version: 10.6.1

--- a/bitnami/mongodb/templates/secrets-ca.yaml
+++ b/bitnami/mongodb/templates/secrets-ca.yaml
@@ -5,8 +5,6 @@ kind: Secret
 metadata:
   name: {{ template "mongodb.caSecretName" . }}
   namespace: {{ template "mongodb.namespace" . }}
-  annotations:
-    "helm.sh/hook": "pre-install"
   labels:
    {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: mongodb


### PR DESCRIPTION
Signed-off-by: darteaga <darteaga@vmware.com>

**Description of the change**

Removing a hook that isn't actually required.

**Benefits**

Will allow gitops operations

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
