### PR TITLE
[bitnami/Postgresql] Add explicit namespace field on resources

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -26,4 +26,4 @@ name: postgresql
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 10.2.5
+version: 10.2.6

--- a/bitnami/postgresql/templates/configmap.yaml
+++ b/bitnami/postgresql/templates/configmap.yaml
@@ -8,6 +8,7 @@ metadata:
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
+  namespace: {{ .Release.Namespace }}
 data:
 {{- if (.Files.Glob "files/postgresql.conf") }}
 {{ (.Files.Glob "files/postgresql.conf").AsConfig | indent 2 }}

--- a/bitnami/postgresql/templates/extended-config-configmap.yaml
+++ b/bitnami/postgresql/templates/extended-config-configmap.yaml
@@ -8,6 +8,7 @@ metadata:
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
+  namespace: {{ .Release.Namespace }}
 data:
 {{- with .Files.Glob "files/conf.d/*.conf" }}
 {{ .AsConfig | indent 2 }}

--- a/bitnami/postgresql/templates/initialization-configmap.yaml
+++ b/bitnami/postgresql/templates/initialization-configmap.yaml
@@ -8,6 +8,7 @@ metadata:
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
+  namespace: {{ .Release.Namespace }}
 {{- with .Files.Glob "files/docker-entrypoint-initdb.d/*.sql.gz" }}
 binaryData:
 {{- range $path, $bytes := . }}

--- a/bitnami/postgresql/templates/metrics-configmap.yaml
+++ b/bitnami/postgresql/templates/metrics-configmap.yaml
@@ -8,6 +8,7 @@ metadata:
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
+  namespace: {{ .Release.Namespace }}
 data:
   custom-metrics.yaml: {{ toYaml .Values.metrics.customMetrics | quote }}
 {{- end }}

--- a/bitnami/postgresql/templates/metrics-svc.yaml
+++ b/bitnami/postgresql/templates/metrics-svc.yaml
@@ -10,6 +10,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
     {{- toYaml .Values.metrics.service.annotations | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
 spec:
   type: {{ .Values.metrics.service.type }}
   {{- if and (eq .Values.metrics.service.type "LoadBalancer") .Values.metrics.service.loadBalancerIP }}

--- a/bitnami/postgresql/templates/networkpolicy.yaml
+++ b/bitnami/postgresql/templates/networkpolicy.yaml
@@ -8,6 +8,7 @@ metadata:
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
+  namespace: {{ .Release.Namespace }}
 spec:
   podSelector:
     matchLabels:

--- a/bitnami/postgresql/templates/podsecuritypolicy.yaml
+++ b/bitnami/postgresql/templates/podsecuritypolicy.yaml
@@ -8,6 +8,7 @@ metadata:
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
+  namespace: {{ .Release.Namespace }}
 spec:
   privileged: false
   volumes:

--- a/bitnami/postgresql/templates/role.yaml
+++ b/bitnami/postgresql/templates/role.yaml
@@ -8,6 +8,7 @@ metadata:
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
+  namespace: {{ .Release.Namespace }}
 rules:
   {{- if .Values.psp.create }}
   - apiGroups: ["extensions"]

--- a/bitnami/postgresql/templates/rolebinding.yaml
+++ b/bitnami/postgresql/templates/rolebinding.yaml
@@ -8,6 +8,7 @@ metadata:
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
   name: {{ template "common.names.fullname" . }}

--- a/bitnami/postgresql/templates/secrets.yaml
+++ b/bitnami/postgresql/templates/secrets.yaml
@@ -8,6 +8,7 @@ metadata:
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
+  namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
   postgresql-postgres-password: {{ include "postgresql.postgres.password" . | b64enc | quote }}

--- a/bitnami/postgresql/templates/serviceaccount.yaml
+++ b/bitnami/postgresql/templates/serviceaccount.yaml
@@ -8,4 +8,5 @@ metadata:
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
+  namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/bitnami/postgresql/templates/statefulset-readreplicas.yaml
+++ b/bitnami/postgresql/templates/statefulset-readreplicas.yaml
@@ -16,6 +16,7 @@ metadata:
   {{- with .Values.readReplicas.annotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
+  namespace: {{ .Release.Namespace }}
 spec:
   serviceName: {{ template "common.names.fullname" . }}-headless
   replicas: {{ .Values.replication.readReplicas }}

--- a/bitnami/postgresql/templates/statefulset.yaml
+++ b/bitnami/postgresql/templates/statefulset.yaml
@@ -14,6 +14,7 @@ metadata:
   {{- with .Values.primary.annotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
+  namespace: {{ .Release.Namespace }}
 spec:
   serviceName: {{ template "common.names.fullname" . }}-headless
   replicas: 1

--- a/bitnami/postgresql/templates/svc-headless.yaml
+++ b/bitnami/postgresql/templates/svc-headless.yaml
@@ -12,6 +12,7 @@ metadata:
     # field is broken in some versions of Kubernetes:
     # https://github.com/kubernetes/kubernetes/issues/58662
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  namespace: {{ .Release.Namespace }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/bitnami/postgresql/templates/svc-read.yaml
+++ b/bitnami/postgresql/templates/svc-read.yaml
@@ -18,6 +18,7 @@ metadata:
   {{- if $serviceAnnotations }}
   {{- include "common.tplvalues.render" (dict "value" $serviceAnnotations "context" $) | nindent 4 }}
   {{- end }}
+  namespace: {{ .Release.Namespace }}
 spec:
   type: {{ $serviceType }}
   {{- if and $serviceLoadBalancerIP (eq $serviceType "LoadBalancer") }}

--- a/bitnami/postgresql/templates/svc.yaml
+++ b/bitnami/postgresql/templates/svc.yaml
@@ -17,6 +17,7 @@ metadata:
   {{- if $serviceAnnotations }}
   {{- include "common.tplvalues.render" (dict "value" $serviceAnnotations "context" $) | nindent 4 }}
   {{- end }}
+  namespace: {{ .Release.Namespace }}
 spec:
   type: {{ $serviceType }}
   {{- if and $serviceLoadBalancerIP (eq $serviceType "LoadBalancer") }}


### PR DESCRIPTION
**Description of the change**

This PR adds support for explicitly adding a namespace field in resources. when `helm template`  command is run to generate YAML files, it does not add the namespace field which results in resources getting created in the default namespace.

**Benefits**

Add namespace field in manifests generated from `helm template`

**Possible drawbacks**

None known

**Additional information**



