### PR TITLE
[bitnami/grafana] Remove '-envvars' suffix from deployment

### DIFF
--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -24,4 +24,4 @@ name: grafana
 sources:
   - https://github.com/bitnami/bitnami-docker-grafana
   - https://grafana.com/
-version: 5.1.0
+version: 5.1.1

--- a/bitnami/grafana/templates/deployment.yaml
+++ b/bitnami/grafana/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "common.names.fullname" . }}-envvars
+  name: {{ include "common.names.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: grafana


### PR DESCRIPTION
I believe this was accidentally changed in #4965.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
