### PR TITLE
[bitnami/keycloak] fix: considere existing secret when validating passwords

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 1.4.0
+version: 1.4.1

--- a/bitnami/keycloak/templates/NOTES.txt
+++ b/bitnami/keycloak/templates/NOTES.txt
@@ -48,7 +48,7 @@ To access Keycloak from outside the cluster execute the following commands:
 3. Access the Administration Console using the following credentials:
 
   echo Username: {{ .Values.auth.adminUser }}
-  echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ printf "%s-env-vars" (include "common.names.fullname" .) }} -o jsonpath="{.data.KEYCLOAK_ADMIN_PASSWORD}" | base64 --decode)
+  echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ printf "%s-env-vars" (include "common.names.fullname" .) }} -o jsonpath="{.data.admin-password}" | base64 --decode)
 {{- end }}
 {{- if .Values.metrics.enabled }}
 
@@ -72,9 +72,12 @@ You can access the Prometheus metrics following the steps below:
 {{- $postgresqlPasswordValidationErrors := include "common.validations.values.postgresql.passwords" (dict "secret" $postgresqlSecretName "subchart" true "context" $) -}}
 {{- $passwordErrors = append $passwordErrors $postgresqlPasswordValidationErrors -}}
 
-{{- $keycloakSecretName := printf "%s-env-vars" (include "keycloak.fullname" .) -}}
-{{- $requiredAdminPassword := dict "valueKey" "auth.adminPassword" "secret" $keycloakSecretName "field" "KEYCLOAK_ADMIN_PASSWORD" -}}
-{{- $requiredKeycloakErrors := include "common.validations.values.multiple.empty" (dict "required" (list $requiredAdminPassword) "context" $) -}}
-{{- $passwordErrors = append $passwordErrors $requiredKeycloakErrors -}}
+{{- if not .Values.auth.existingSecret }}
+    {{- $keycloakSecretName := include "common.secrets.name" (dict "existingSecret" .Values.auth.existingSecret "context" $) -}}
+
+    {{- $requiredAdminPassword := dict "valueKey" "auth.adminPassword" "secret" $keycloakSecretName "field" "admin-password" -}}
+    {{- $requiredAdminKeycloakErrors := include "common.validations.values.multiple.empty" (dict "required" (list $requiredAdminPassword) "context" $) -}}
+    {{- $passwordErrors = append $passwordErrors $requiredAdminKeycloakErrors -}}
+{{- end }}
 
 {{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordErrors "context" $) -}}


### PR DESCRIPTION
Signed-off-by: darteaga <darteaga@vmware.com>

**Description of the change**

- Add condition before checking password must be provided.

**Benefits**

- We can use the existing secrets feature. 

**Possible drawbacks**

N/A

**Applicable issues**

  - fixes a bug introduced by #5189

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
