### PR TITLE
Keycloak missing postgresql parameters

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 1.4.2
+version: 1.4.3

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -226,8 +226,9 @@ The following tables lists the configurable parameters of the Keycloak chart and
 | Parameter                        | Description                                                                  | Default            |
 |----------------------------------|------------------------------------------------------------------------------|--------------------|
 | `postgresql.enabled`             | Deploy a PostgreSQL server to satisfy the applications database requirements | `true`             |
-| `postgresql.postgresqlUsername`  | PostgreSQL user to create (used by Keycloak)                                 | `bn_keycloak`      |
-| `postgresql.postgresqlPassword`  | Password for the Dicourse user - ignored if existingSecret is provided       | `some-password`    |
+| `postgresql.postgresqlUsername`  | Keycloak PostgreSQL user to create (used by Keycloak)                        | `bn_keycloak`      |
+| `postgresql.postgresqlPassword`  | Keycloak PostgreSQL password - ignored if existingSecret is provided         | `some-password`    |
+| `postgresql.existingSecret`      | Use an existing secret file with the PostgreSQL password                     | `nil`              |
 | `postgresql.postgresqlDatabase`  | Name of the database to create                                               | `bitnami_keycloak` |
 | `postgresql.persistence.enabled` | Enable database persistence using PVC                                        | `true`             |
 | `externalDatabase.host`          | Host of the external database                                                | `""`               |

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -680,7 +680,6 @@ postgresql:
   existingSecret:
   ## PostgreSQL data Persistent Volume Storage Class
   ##
-
   persistence:
     enabled: true
 

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -675,8 +675,12 @@ postgresql:
   ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#creating-a-database-on-first-run
   ##
   postgresqlDatabase: bitnami_keycloak
+  ## In case of postgresql.enabled = true, allow the usage of existing secrets for postgresql
+  ##
+  existingSecret:
   ## PostgreSQL data Persistent Volume Storage Class
   ##
+
   persistence:
     enabled: true
 


### PR DESCRIPTION
Signed-off-by: fdepaz <fdepaz@bitnami.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

There was a reference to `postgresql.existingSecret` in the README's `postgresql.postgresqlPassword` description but it was not documented nor present in `values.yaml`. 

Also, fixed a reported typo saying `Discourse`.

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #5237

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
