### PR TITLE
[bitnami/elasticsearch] Change metrics endpoint when no coordinating nodes are used

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/bitnami-docker-elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 14.1.1
+version: 14.2.0

--- a/bitnami/elasticsearch/templates/metrics-deploy.yaml
+++ b/bitnami/elasticsearch/templates/metrics-deploy.yaml
@@ -34,7 +34,13 @@ spec:
           image: {{ include "elasticsearch.metrics.image" . }}
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
           args:
+            {{- if gt .Values.coordinating.replicas 0 }}
+            # Prefer coordinating only nodes to do the initial metrics query
             - --es.uri=http://{{ template "elasticsearch.coordinating.fullname" . }}:{{ .Values.coordinating.service.port }}
+            {{- else }}
+            # Using master nodes as there are no coordinating only nodes
+            - --es.uri=http://{{ include "elasticsearch.master.fullname" . }}:{{ .Values.master.service.port }}
+            {{- end }}
             - --es.all
           ports:
             - name: metrics


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

In order to slightly improve the performance of the metrics gathering (in the end all the nodes are queries because we set the --es.all flag in elasticserach exporter), we were using the coordinating only nodes as the metrics target for elasticsearch_exporter. It is possible to deploy the chart without coordinating nodes and that was causing issues with the exporter. In this PR we set the master node as fallback in case there are no coordinating nodes available. I considered using a service that points for all the nodes but that caused issues in the past because of incompatibilities with istio (reason why we removed the headless service). 


**Benefits**

Metrics available even though we don't deploy coordinating only nodes.

**Possible drawbacks**

None known

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes https://github.com/bitnami/charts/issues/5337

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
