### PR TITLE
[bitnami/metallb] Add initcontainer support to the speaker

### DIFF
--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/metallb/metallb
   - https://github.com/bitnami/bitnami-docker-metallb
   - https://metallb.universe.tf
-version: 2.2.2
+version: 2.3.0

--- a/bitnami/metallb/README.md
+++ b/bitnami/metallb/README.md
@@ -149,6 +149,7 @@ The following tables lists the configurable parameters of the metallb chart and 
 | `speaker.serviceAccount.name`                         | use the serviceAccount with the specified name                                               | ""                                                      |
 | `speaker.daemonset.hostPorts.metrics`                 | the tcp port to listen on for the openmetrics endpoint.                                      | `7472`                                                  |
 | `speaker.daemonset.terminationGracePeriodSeconds`     | The terminationGracePeriod in seconds for the daemonset to stop                              | `2`                                                     |
+| `speaker.initContainers`                              | Extra initContainers to add to the daemonset                                                 | `[]`                                                     |
 | `speaker.securityContext.enabled`                     | Enable pods' security context                                                                | `true`                                                  |
 | `speaker.securityContext.runAsUser`                   | User ID for the pods.                                                                        | `0`                                                     |
 | `speaker.securityContext.allowPrivilegeEscalation`    | Enables privilege Escalation context for the pod.                                            | `false`                                                 |

--- a/bitnami/metallb/templates/speaker/daemonset.yaml
+++ b/bitnami/metallb/templates/speaker/daemonset.yaml
@@ -37,7 +37,7 @@ spec:
       hostNetwork: true
       {{- if .Values.speaker.initContainers }}
       initContainers:
-      {{ toYaml .Values.speaker.initContainers | nindent 8 }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.speaker.initContainers "context" $) | nindent 8 }} 
       {{- end }}
       containers:
         - name: metallb-speaker

--- a/bitnami/metallb/templates/speaker/daemonset.yaml
+++ b/bitnami/metallb/templates/speaker/daemonset.yaml
@@ -35,6 +35,10 @@ spec:
       serviceAccountName: {{ include "metallb.speakerServiceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.speaker.daemonset.terminationGracePeriodSeconds }}
       hostNetwork: true
+      {{- if gt (len .Values.speaker.initContainers) 0 }}
+      initContainers:
+      {{ toYaml .Values.speaker.initContainers | nindent 8 }}
+      {{- end }}
       containers:
         - name: metallb-speaker
           image: {{ include "common.images.image" (dict "imageRoot" .Values.speaker.image "global" .Values.global) }}

--- a/bitnami/metallb/templates/speaker/daemonset.yaml
+++ b/bitnami/metallb/templates/speaker/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: {{ include "metallb.speakerServiceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.speaker.daemonset.terminationGracePeriodSeconds }}
       hostNetwork: true
-      {{- if gt (len .Values.speaker.initContainers) 0 }}
+      {{- if .Values.speaker.initContainers }}
       initContainers:
       {{ toYaml .Values.speaker.initContainers | nindent 8 }}
       {{- end }}

--- a/bitnami/metallb/values.yaml
+++ b/bitnami/metallb/values.yaml
@@ -376,6 +376,10 @@ speaker:
   # secretKey:
   # secretValue:
 
+  ## Extra containers to add before the speaker starts
+  ##
+  initContainers: []
+
   ## Pod securityContext
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##


### PR DESCRIPTION
Adds support for user specifying initContainers to run before the speaker starts. We have needed this to work around:
https://github.com/metallb/metallb/issues/277

**Applicable issues**
https://github.com/metallb/metallb/issues/277

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
