### PR TITLE
[bitnami/postgresql-ha] Trunc pgpool node hostname instead of showing an error

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -27,4 +27,4 @@ name: postgresql-ha
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 6.5.1
+version: 6.6.0

--- a/bitnami/postgresql-ha/templates/_helpers.tpl
+++ b/bitnami/postgresql-ha/templates/_helpers.tpl
@@ -57,10 +57,12 @@ Return the proper Node hostname
 {{- $postgresqlHeadlessServiceName := printf "%s-headless" (include "postgresql-ha.postgresql" $) }}
 {{- $releaseNamespace := .Release.Namespace }}
 {{- $clusterDomain:= .Values.clusterDomain }}
+{{- $nodeList := list }}
 {{- range $e, $i := until $postgresqlReplicaCount -}}
 {{- $nodeHostname := printf "%s-%d.%s.%s.svc.%s" $postgresqlFullname $i $postgresqlHeadlessServiceName $releaseNamespace $clusterDomain }}
-{{- printf "%d:%s:5432," $i ($nodeHostname | trunc 128 | trimSuffix "-" | trimSuffix ".") -}}
+{{- $nodeList = append $nodeList (printf "%d:%s:5432" $i ($nodeHostname | trunc 128 | trimSuffix "-" | trimSuffix ".")) }}
 {{- end -}}
+{{ join "," $nodeList }}
 {{- end -}}
 
 {{/*

--- a/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
@@ -89,11 +89,6 @@ spec:
       {{- if .Values.pgpool.initContainers }}
       {{- include "common.tplvalues.render" (dict "value" .Values.pgpool.initContainers "context" $) | nindent 8 }}
       {{- end }}
-      # Auxiliary vars to populate environment variables
-      {{- $postgresqlReplicaCount := int .Values.postgresql.replicaCount }}
-      {{- $postgresqlFullname := include "postgresql-ha.postgresql" . }}
-      {{- $postgresqlHeadlessServiceName := printf "%s-headless" (include "postgresql-ha.postgresql" .) }}
-      {{- $clusterDomain:= .Values.clusterDomain }}
       containers:
         - name: pgpool
           image: {{ include "postgresql-ha.pgpoolImage" . }}
@@ -130,7 +125,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: PGPOOL_BACKEND_NODES
-              value: {{range $e, $i := until $postgresqlReplicaCount }}{{ $i }}:{{ $postgresqlFullname }}-{{ $i }}.{{ $postgresqlHeadlessServiceName }}.$(PGPOOL_NAMESPACE).svc.{{ $clusterDomain }}:5432,{{ end }}
+              value: {{ include "postgresql-ha.nodesHostnames" . }}
             - name: PGPOOL_SR_CHECK_USER
               value: {{ (include "postgresql-ha.postgresqlRepmgrUsername" .) | quote }}
             {{- if .Values.postgresql.usePasswordFile }}


### PR DESCRIPTION
**Description of the change**

Currently, installing the chart with a "long" name (or long name + long namespace), an error is shown since the leght of the hostname should be less than 128chars:
```
$ helm template aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee bitnami/postgresql-ha
VALUES VALIDATION:
postgresql-ha: Nodes hostnames
    PostgreSQL nodes hostnames (aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq-00.aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq-headless.default.svc.cluster.local:1234) exceeds the characters limit for Pgpool: 128.
    Consider using a shorter release name or namespace.
```

Something similar happens for the app name but instead of giving an error, we're truncating the name to 63char (it is the DNS limit).

The solution proposed in this PR truncates the hostname in the same way we're truncating the app name.

**Applicable issues**

  - fixes #5387

**Additional information**

Those are the differences of templating the chart using:
```
helm template aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee .
```
VS
```
helm template artifactory-db bitnami/postgresql-ha
```
```diff
6c6
-  name: artifactory-db-postgresql-ha-pgpool
+  name: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq
10c10
-    app.kubernetes.io/instance: artifactory-db
+    app.kubernetes.io/instance: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee
21c21
-  name: artifactory-db-postgresql-ha-postgresql
+  name: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq
25c25
-    app.kubernetes.io/instance: artifactory-db
+    app.kubernetes.io/instance: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee
37c37
-  name: artifactory-db-postgresql-ha-postgresql-hooks-scripts
+  name: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq-hooks-scripts
41c41
-    app.kubernetes.io/instance: artifactory-db
+    app.kubernetes.io/instance: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee
109c109
-  name: artifactory-db-postgresql-ha-pgpool
+  name: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq
113c113
-    app.kubernetes.io/instance: artifactory-db
+    app.kubernetes.io/instance: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee
130c130
-    app.kubernetes.io/instance: artifactory-db
+    app.kubernetes.io/instance: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee
137c137
-  name: artifactory-db-postgresql-ha-postgresql-headless
+  name: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq-headless
141c141
-    app.kubernetes.io/instance: artifactory-db
+    app.kubernetes.io/instance: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee
153c153
-    app.kubernetes.io/instance: artifactory-db
+    app.kubernetes.io/instance: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee
160c160
-  name: artifactory-db-postgresql-ha-postgresql
+  name: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq
164c164
-    app.kubernetes.io/instance: artifactory-db
+    app.kubernetes.io/instance: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee
176c176
-    app.kubernetes.io/instance: artifactory-db
+    app.kubernetes.io/instance: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee
183c183
-  name: artifactory-db-postgresql-ha-pgpool
+  name: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq
187c187
-    app.kubernetes.io/instance: artifactory-db
+    app.kubernetes.io/instance: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee
195c195
-      app.kubernetes.io/instance: artifactory-db
+      app.kubernetes.io/instance: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee
202c202
-        app.kubernetes.io/instance: artifactory-db
+        app.kubernetes.io/instance: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee
216c216
-                    app.kubernetes.io/instance: artifactory-db
+                    app.kubernetes.io/instance: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee
219c219
-                  - default
+                  - "default"
227d226
-      # Auxiliary vars to populate environment variables
242c241
-              value: 0:artifactory-db-postgresql-ha-postgresql-0.artifactory-db-postgresql-ha-postgresql-headless.$(PGPOOL_NAMESPACE).svc.cluster.local:5432,1:artifactory-db-postgresql-ha-postgresql-1.artifactory-db-postgresql-ha-postgresql-headless.$(PGPOOL_NAMESPACE).svc.cluster.local:5432,
+              value: 0:aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq-0.aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgres:5432,1:aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq-1.aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgres:5432,
248c247
-                  name: artifactory-db-postgresql-ha-postgresql
+                  name: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq
259c258
-                  name: artifactory-db-postgresql-ha-postgresql
+                  name: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq
266c265
-                  name: artifactory-db-postgresql-ha-pgpool
+                  name: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq
313c312
-  name: artifactory-db-postgresql-ha-postgresql
+  name: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq
317c316
-    app.kubernetes.io/instance: artifactory-db
+    app.kubernetes.io/instance: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee
321c320
-  serviceName: artifactory-db-postgresql-ha-postgresql-headless
+  serviceName: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq-headless
329c328
-      app.kubernetes.io/instance: artifactory-db
+      app.kubernetes.io/instance: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee
336c335
-        app.kubernetes.io/instance: artifactory-db
+        app.kubernetes.io/instance: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee
350c349
-                    app.kubernetes.io/instance: artifactory-db
+                    app.kubernetes.io/instance: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee
353c352
-                  - default
+                  - "default"
386c385
-                  name: artifactory-db-postgresql-ha-postgresql
+                  name: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq
418c417
-              value: artifactory-db-postgresql-ha-postgresql-0.artifactory-db-postgresql-ha-postgresql-headless.$(REPMGR_NAMESPACE).svc.cluster.local,artifactory-db-postgresql-ha-postgresql-1.artifactory-db-postgresql-ha-postgresql-headless.$(REPMGR_NAMESPACE).svc.cluster.local,
+              value: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq-0.aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq-headless.$(REPMGR_NAMESPACE).svc.cluster.local,aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq-1.aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq-headless.$(REPMGR_NAMESPACE).svc.cluster.local,
420c419
-              value: "artifactory-db-postgresql-ha-postgresql-0.artifactory-db-postgresql-ha-postgresql-headless.$(REPMGR_NAMESPACE).svc.cluster.local"
+              value: "aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq-0.aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq-headless.$(REPMGR_NAMESPACE).svc.cluster.local"
424c423
-              value: "$(MY_POD_NAME).artifactory-db-postgresql-ha-postgresql-headless.$(REPMGR_NAMESPACE).svc.cluster.local"
+              value: "$(MY_POD_NAME).aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq-headless.$(REPMGR_NAMESPACE).svc.cluster.local"
438c437
-                  name: artifactory-db-postgresql-ha-postgresql
+                  name: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq
481c480
-            name: artifactory-db-postgresql-ha-postgresql-hooks-scripts
+            name: aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq-hooks-scripts
```

While when using a short name, this is the generated hostname:
```
artifactory-db-postgresql-ha-postgresql-0.artifactory-db-postgresql-ha-postgresql-headless.$(PGPOOL_NAMESPACE).svc.cluster.local:5432
```
With a long name, the generated hostname would be:
```
aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresql-ha-postgresql-0.aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresql-ha-postgresql-headless.$(PGPOOL_NAMESPACE).svc.cluster.local:5432
```
but with the new approach, it's truncated to (being the fullname previously truncated as well)
```
aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgresq-0.aaaaaaaaaaaaabbbbbbbbbbbbcccccccccccddddddddddddeeeee-postgres:5432
```

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
