### PR TITLE
[bitnami/kafka] Separate tls encryption helpers

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 12.7.4
+version: 12.7.5

--- a/bitnami/kafka/templates/_helpers.tpl
+++ b/bitnami/kafka/templates/_helpers.tpl
@@ -144,11 +144,30 @@ Return true if authentication via SASL should be configured for inter-broker com
 {{- end -}}
 
 {{/*
+Return true if encryption via TLS for client connections should be configured
+*/}}
+{{- define "kafka.client.tlsEncryption" -}}
+{{- $tlsProtocols := list "tls" "mtls" "sasl_tls" -}}
+{{- if (has .Values.auth.clientProtocol $tlsProtocols) -}}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if encryption via TLS for inter broker communication connections should be configured
+*/}}
+{{- define "kafka.interBroker.tlsEncryption" -}}
+{{- $tlsProtocols := list "tls" "mtls" "sasl_tls" -}}
+{{- if (has .Values.auth.interBrokerProtocol $tlsProtocols) -}}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return true if encryption via TLS should be configured
 */}}
 {{- define "kafka.tlsEncryption" -}}
-{{- $tlsProtocols := list "tls" "mtls" "sasl_tls" -}}
-{{- if or (has .Values.auth.clientProtocol $tlsProtocols) (has .Values.auth.interBrokerProtocol $tlsProtocols) -}}
+{{- if or (include "kafka.client.tlsEncryption" .) (include "kafka.interBroker.tlsEncryption" .) -}}
     {{- true -}}
 {{- end -}}
 {{- end -}}

--- a/bitnami/kafka/templates/kafka-metrics-deployment.yaml
+++ b/bitnami/kafka/templates/kafka-metrics-deployment.yaml
@@ -45,7 +45,7 @@ spec:
               --sasl.username="$SASL_USERNAME" \
               --sasl.password="${sasl_passwords[0]}" \
               {{- end }}
-              {{- if (include "kafka.tlsEncryption" .) }}
+              {{- if (include "kafka.client.tlsEncryption" .) }}
               --tls.enabled \
               {{- if .Values.metrics.kafka.certificatesSecret }}
               --tls.ca-file="/opt/bitnami/kafka-exporter/certs/ca-file" \
@@ -73,7 +73,7 @@ spec:
           {{- if .Values.metrics.kafka.resources }}
           resources: {{ toYaml .Values.metrics.kafka.resources | nindent 12 }}
           {{- end }}
-      {{- if and (include "kafka.tlsEncryption" .) .Values.metrics.kafka.certificatesSecret }}
+      {{- if and (include "kafka.client.tlsEncryption" .) .Values.metrics.kafka.certificatesSecret }}
           volumeMounts:
             - name: kafka-exporter-certificates
               mountPath: /opt/bitnami/kafka-exporter/certs/


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This change provides two separate helper templates returning `true` if the client connections to Kafka and the inter broker communication connections are encrypted with TLS (i.e. are using tls or mtls).
The new `(include "kafka.client.tlsEncryption" .)` helper template is used in kafka metric exporter deployment to decide if tls command line options should be applied.

**Benefits**

If the kafka release is configured so that both or neither client connections and inter broker connections are using TLS, the metric exporter deployment works as intended.
However, in case when client connections are configured not to use encryption, but broker connections are, the output of `(include "kafka.tlsEncryption" .)` still evaluates to `true`, which results in metric exporter trying to establish connection over TLS, which naturally fails and leads to CrashLoopBackOff in k8s.

With this change, the issue is resolved and the metric exporter uses TLS only if the client connections support it.

**Possible drawbacks**

No possible drawbacks discovered. The chart is made backward compatible and the original `(include "kafka.tlsEncryption" .)` helper template still follows the same logic as before, so will evaluate correctly in all places it is used.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md **(no new variables included)**
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

