### PR TITLE
[bitnami/kube-prometheus] Add secret thanos tls

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-prometheus
   - https://github.com/bitnami/bitnami-docker-alertmanager
   - https://github.com/prometheus-operator/kube-prometheus
-version: 4.0.0
+version: 4.1.0

--- a/bitnami/kube-prometheus/README.md
+++ b/bitnami/kube-prometheus/README.md
@@ -274,8 +274,13 @@ The following table lists the configurable parameters of the kube-prometheus cha
 | `prometheus.thanos.ingress.annotations`                           | Ingress annotations                                                                                     | `[]`                                                                                                                                    |
 | `prometheus.thanos.ingress.hosts[0].name`                         | Hostname to your Prometheus installation                                                                | `thanos.prometheus.local`                                                                                                                      |
 | `prometheus.thanos.ingress.hosts[0].path`                         | Path within the url structure                                                                           | `/`                                                                                                                                     |
-| `prometheus.thanos.ingress.tls[0].hosts[0]`                       | TLS hosts                                                                                               | `thanos.prometheus.local`                                                                                                                      |
-| `prometheus.thanos.ingress.tls[0].secretName`                     | TLS Secret (certificates)                                                                               | `prometheus.local-tls`                                                                                                                  |
+| `prometheus.thanos.ingress.secrets[0].hosts[0]` | TLS configuration for hostnames | `nil` |
+| `prometheus.thanos.ingress.secrets[0].name` | TLS Secret Name | `nil` |
+| `prometheus.thanos.ingress.secrets[0].cert` | TLS Secret Certificate | `nil` |
+| `prometheus.thanos.ingress.secrets[0].key` | TLS Secret Key | `nil` |
+| `prometheus.thanos.ingress.secrets[0].ca` | TLS Secret CA Certificate | `nil` |
+| `prometheus.thanos.ingress.extraTls[0].hosts[0]` | TLS configuration for additional hostnames to be covered | `nil` |
+| `prometheus.thanos.ingress.extraTls[0].secretName` | TLS configuration for additional hostnames to be covered | `nil` |
 | `prometheus.serviceMonitor.enabled`                        | Creates a ServiceMonitor to monitor Prometheus itself                                                   | `true`                                                                                                                                  |
 
 ### Alertmanager Parameters

--- a/bitnami/kube-prometheus/templates/prometheus/thanos-ingress.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/thanos-ingress.yaml
@@ -25,8 +25,19 @@ spec:
           {{- end }}
           backend: {{- include "common.ingress.backend" (dict "serviceName" (include "kube-prometheus.thanos.fullname" $) "servicePort" "grpc" "context" $) | nindent 14 }}
     {{- end }}
-  {{- if .Values.prometheus.thanos.ingress.tls }}
+  {{- if or .Values.prometheus.thanos.ingress.secrets .Values.prometheus.thanos.ingress.extraTls }}
   tls:
-{{ toYaml .Values.prometheus.thanos.ingress.tls | indent 4 }}
+    {{- if .Values.prometheus.thanos.ingress.secrets }}
+    {{- range .Values.prometheus.thanos.ingress.secrets }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .name }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.prometheus.thanos.ingress.extraTls }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.prometheus.thanos.ingress.extraTls "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- end }}
 {{- end -}}

--- a/bitnami/kube-prometheus/templates/prometheus/thanos-tls-secrets.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/thanos-tls-secrets.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.prometheus.enabled .Values.prometheus.thanos.create .Values.prometheus.thanos.ingress.enabled }}
+{{- range .Values.prometheus.thanos.ingress.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  namespace: {{ $.Release.Namespace }}
+  labels: {{- include "kube-prometheus.prometheus.labels" $ | nindent 4 }}
+    app.kubernetes.io/subcomponent: thanos
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .cert | b64enc | quote }}
+  tls.key: {{ .key | b64enc | quote }}
+  {{- if .ca }}
+  ca.crt: {{ .ca | b64enc | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/bitnami/kube-prometheus/values.yaml
+++ b/bitnami/kube-prometheus/values.yaml
@@ -919,7 +919,7 @@ prometheus:
       ##
       annotations: {}
       #  kubernetes.io/ingress.class: nginx
-      #  nginx.ingress.kubernetes.io/backend-protocol: "GRPCS"
+      #  nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
 
       ## The list of hostnames to be covered with this ingress record.
       ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
@@ -928,14 +928,32 @@ prometheus:
         - name: thanos.prometheus.local
           path: /
 
-      ## The tls configuration for the ingress
+      ## If you're providing your own certificates, please use this to add the certificates as secrets
+      ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+      ## -----BEGIN RSA PRIVATE KEY-----
+      ##
+      ## name should line up with a tlsSecret set further up
+      ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+      ##
+      ## It is also possible to create and manage the certificates outside of this helm chart
+      ## Please see README.md for more information
+      ##
+      secrets: []
+      ## - hosts:
+      ##     - thanos.prometheus.local
+      ##   name: thanos.prometheus.local-tls
+      ##   cert:
+      ##   key:
+      ##   ca:
+      ##
+
+      ## The tls configuration for additional hostnames to be covered with this ingress record.
       ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
-      ## tls:
+      ## extraTls:
       ## - hosts:
       ##     - thanos.prometheus.local
       ##   secretName: thanos.prometheus.local-tls
       ##
-      tls: {}
 
 ## Configuration for alertmanager
 ## ref: https://prometheus.io/docs/alerting/alertmanager/


### PR DESCRIPTION
**Description of the change**

Add support for thanos secret tls on ingress

**Benefits**

Create automatically secret tls

**Possible drawbacks**

**Applicable issues**

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
