### PR TITLE
[bitnami/mysql] Fix *.pdb.enabled parameters

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -25,4 +25,4 @@ name: mysql
 sources:
   - https://github.com/bitnami/bitnami-docker-mysql
   - https://mysql.com
-version: 8.3.0
+version: 8.3.1

--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -142,7 +142,7 @@ The following table lists the configurable parameters of the MySQL chart and the
 | `primary.service.nodePort`                   | MySQL Primary K8s service node port                                                                             | `nil`                          |
 | `primary.service.loadBalancerIP`             | MySQL Primary loadBalancerIP if service type is `LoadBalancer`                                                  | `nil`                          |
 | `primary.service.loadBalancerSourceRanges`   | Address that are allowed when MySQL Primary service is LoadBalancer                                             | `[]`                           |
-| `primary.pdb.create`                         | Enable/disable a Pod Disruption Budget creation for MySQL primary pods                                          | `false`                        |
+| `primary.pdb.enabled`                        | Enable/disable a Pod Disruption Budget creation for MySQL primary pods                                          | `false`                        |
 | `primary.pdb.minAvailable`                   | Minimum number/percentage of MySQL primary pods that should remain scheduled                                    | `1`                            |
 | `primary.pdb.maxUnavailable`                 | Maximum number/percentage of MySQL primary pods that may be made unavailable                                    | `nil`                          |
 
@@ -197,7 +197,7 @@ The following table lists the configurable parameters of the MySQL chart and the
 | `secondary.service.nodePort`                   | MySQL secondary K8s service node port                                                                               | `nil`                          |
 | `secondary.service.loadBalancerIP`             | MySQL secondary loadBalancerIP if service type is `LoadBalancer`                                                    | `nil`                          |
 | `secondary.service.loadBalancerSourceRanges`   | Address that are allowed when MySQL secondary service is LoadBalancer                                               | `[]`                           |
-| `secondary.pdb.create`                         | Enable/disable a Pod Disruption Budget creation for MySQL secondary pods                                            | `false`                        |
+| `secondary.pdb.enabled`                        | Enable/disable a Pod Disruption Budget creation for MySQL secondary pods                                            | `false`                        |
 | `secondary.pdb.minAvailable`                   | Minimum number/percentage of MySQL secondary pods that should remain scheduled                                      | `1`                            |
 | `secondary.pdb.maxUnavailable`                 | Maximum number/percentage of MySQL secondary pods that may be made unavailable                                      | `nil`                          |
 

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -395,7 +395,7 @@ primary:
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   ##
   pdb:
-    create: false
+    enabled: false
     ## Min number of pods that must still be available after the eviction
     ##
     minAvailable: 1
@@ -682,7 +682,7 @@ secondary:
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   ##
   pdb:
-    create: false
+    enabled: false
     ## Min number of pods that must still be available after the eviction
     ##
     minAvailable: 1


### PR DESCRIPTION
**Description of the change**

The PR fixes the `*.pdb.enabled` parameters. The templates are using `enabled` but values and readme specify `create`.

https://github.com/bitnami/charts/blob/782282306b2ff68131bb4cbcff7f7f68cf4af0d4/bitnami/mysql/templates/primary/pdb.yaml#L1
https://github.com/bitnami/charts/blob/782282306b2ff68131bb4cbcff7f7f68cf4af0d4/bitnami/mysql/templates/secondary/pdb.yaml#L1

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #5398

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)