### PR TITLE
[bitnami/kube-prometheus] Fix alertmanager ingress extraTls

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-prometheus
   - https://github.com/bitnami/bitnami-docker-alertmanager
   - https://github.com/prometheus-operator/kube-prometheus
-version: 4.0.0
+version: 4.0.1

--- a/bitnami/kube-prometheus/templates/alertmanager/ingress.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/ingress.yaml
@@ -44,8 +44,8 @@ spec:
         - {{ .Values.alertmanager.ingress.hostname }}
       secretName: {{ printf "%s-tls" .Values.alertmanager.ingress.hostname }}
     {{- end }}
-    {{- if .Values.prometheus.ingress.extraTls }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.prometheus.ingress.extraTls "context" $ ) | nindent 4 }}
+    {{- if .Values.alertmanager.ingress.extraTls }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.alertmanager.ingress.extraTls "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
**Description of the change**

Fix regression introduced by #5338.

Current workaround is to have a definition of `prometheus.ingress.extraTls` in your `values.yaml`.

**Benefits**

Allow extra TLS definition for Alertmanager and minor fix for `extraTls` block.

**Possible drawbacks**

**Applicable issues**

  - fixes #

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
