### PR TITLE
[bitnami/postgresql-ha] Shortened pgpool backend hostnames

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -27,4 +27,4 @@ name: postgresql-ha
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 7.0.0
+version: 7.1.0

--- a/bitnami/postgresql-ha/templates/_helpers.tpl
+++ b/bitnami/postgresql-ha/templates/_helpers.tpl
@@ -580,9 +580,7 @@ Compile all warnings into a single message, and call fail.
 {{- define "postgresql-ha.validateValues.nodesHostnames" -}}
 {{- $postgresqlFullname := include "postgresql-ha.postgresql" . }}
 {{- $postgresqlHeadlessServiceName := printf "%s-headless" (include "postgresql-ha.postgresql" .) }}
-{{- $releaseNamespace := .Release.Namespace }}
-{{- $clusterDomain:= .Values.clusterDomain }}
-{{- $nodeHostname := printf "%s-00.%s.%s.svc.%s:1234" $postgresqlFullname $postgresqlHeadlessServiceName $releaseNamespace $clusterDomain }}
+{{- $nodeHostname := printf "%s-00.%s:1234" $postgresqlFullname $postgresqlHeadlessServiceName }}
 {{- if gt (len $nodeHostname) 128 -}}
 postgresql-ha: Nodes hostnames
     PostgreSQL nodes hostnames ({{ $nodeHostname }}) exceeds the characters limit for Pgpool: 128.

--- a/bitnami/postgresql-ha/templates/_helpers.tpl
+++ b/bitnami/postgresql-ha/templates/_helpers.tpl
@@ -580,7 +580,7 @@ Compile all warnings into a single message, and call fail.
 {{- define "postgresql-ha.validateValues.nodesHostnames" -}}
 {{- $postgresqlFullname := include "postgresql-ha.postgresql" . }}
 {{- $postgresqlHeadlessServiceName := printf "%s-headless" (include "postgresql-ha.postgresql" .) }}
-{{- $nodeHostname := printf "%s-00.%s:1234" $postgresqlFullname $postgresqlHeadlessServiceName }}
+{{- $nodeHostname := printf "%s-00.%s" $postgresqlFullname $postgresqlHeadlessServiceName }}
 {{- if gt (len $nodeHostname) 128 -}}
 postgresql-ha: Nodes hostnames
     PostgreSQL nodes hostnames ({{ $nodeHostname }}) exceeds the characters limit for Pgpool: 128.

--- a/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
@@ -96,7 +96,6 @@ spec:
       {{- $postgresqlReplicaCount := int .Values.postgresql.replicaCount }}
       {{- $postgresqlFullname := include "postgresql-ha.postgresql" . }}
       {{- $postgresqlHeadlessServiceName := printf "%s-headless" (include "postgresql-ha.postgresql" .) }}
-      {{- $clusterDomain:= .Values.clusterDomain }}
       containers:
         - name: pgpool
           image: {{ include "postgresql-ha.pgpoolImage" . }}
@@ -128,12 +127,8 @@ spec:
                   name: {{ include "postgresql-ha.pgpoolCustomUsersSecretName" . }}
                   key: passwords
             {{- end }}
-            - name: PGPOOL_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
             - name: PGPOOL_BACKEND_NODES
-              value: {{range $e, $i := until $postgresqlReplicaCount }}{{ $i }}:{{ $postgresqlFullname }}-{{ $i }}.{{ $postgresqlHeadlessServiceName }}.$(PGPOOL_NAMESPACE).svc.{{ $clusterDomain }}:5432,{{ end }}
+              value: {{range $e, $i := until $postgresqlReplicaCount }}{{ $i }}:{{ $postgresqlFullname }}-{{ $i }}.{{ $postgresqlHeadlessServiceName }}:5432,{{ end }}
             - name: PGPOOL_SR_CHECK_USER
               value: {{ (include "postgresql-ha.postgresqlRepmgrUsername" .) | quote }}
             {{- if .Values.postgresql.usePasswordFile }}


### PR DESCRIPTION
**Description of the change**
Shorten the hostnames used by pgpool by omitting the namespace and cluster domain.

**Benefits**
It will be possible to use longer release names.

**Possible drawbacks**
Short hostnames might not be supported by all DNS plugins. However, other charts use short hosts too. For example: e.g. [redis-cluster](https://github.com/bitnami/charts/blob/master/bitnami/redis-cluster/templates/redis-statefulset.yaml#L128).

**Applicable issues**
  - fixes #4923

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)