### PR TITLE
bitnami/thanos - Thanos Receive fixes

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 3.8.3
+version: 3.8.4

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -517,6 +517,8 @@ The following tables lists the configurable parameters of the Thanos chart and t
 | `receive.service.http.nodePort`                 | Service HTTP node port                                                                                         | `nil`                                   |
 | `receive.service.grpc.port`                     | Service GRPC port                                                                                              | `10901`                                 |
 | `receive.service.grpc.nodePort`                 | Service GRPC node port                                                                                         | `nil`                                   |
+| `receive.service.remoteWrite.port`              | Service remote write port                                                                                      | `19291`                                 |
+| `receive.service.remoteWrite.nodePort`          | Service remote write node port                                                                                 | `nil`                                   |
 | `receive.service.loadBalancerIP`                | loadBalancerIP if service type is `LoadBalancer`                                                               | `nil`                                   |
 | `receive.service.loadBalancerSourceRanges`      | Address that are allowed when service is LoadBalancer                                                          | `[]`                                    |
 | `receive.service.annotations`                   | Annotations for Thanos Receive service                                                                         | `{}`                                    |

--- a/bitnami/thanos/templates/receive/configmap.yaml
+++ b/bitnami/thanos/templates/receive/configmap.yaml
@@ -6,6 +6,6 @@ metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: receive
 data:
-  hashrings.json: |
-    {{ .Values.receive.config  | toJson | nindent 4 }}
+  hashrings.json: |-
+    {{- include "common.tplvalues.render" (dict "value" .Values.receive.config  "context" $) | nindent 4 }}
 {{ end }}

--- a/bitnami/thanos/templates/receive/service.yaml
+++ b/bitnami/thanos/templates/receive/service.yaml
@@ -38,6 +38,15 @@ spec:
       {{- else if eq .Values.receive.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    - port: {{ .Values.receive.service.remoteWrite.port }}
+      targetPort: remote-write
+      protocol: TCP
+      name: remote-write
+      {{- if (and (or (eq .Values.receive.service.type "NodePort") (eq .Values.receive.service.type "LoadBalancer")) .Values.receive.service.remoteWrite.nodePort) }}
+      nodePort: {{ .Values.receive.service.remoteWrite.nodePort }}
+      {{- else if eq .Values.receive.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
   selector: 
     {{- if .Values.receive.service.labelSelectorsOverride }}
     {{- include "common.tplvalues.render" (dict "value" .Values.ruler.service.labelSelectorsOverride "context" $) | nindent 4 }}

--- a/bitnami/thanos/templates/receive/statefulset.yaml
+++ b/bitnami/thanos/templates/receive/statefulset.yaml
@@ -79,6 +79,9 @@ spec:
             - --tsdb.retention=15d
             - --receive.local-endpoint=127.0.0.1:10901
             - --receive.hashrings-file=/var/lib/thanos-receive/hashrings.json
+            {{- if .Values.receive.extraFlags }}
+            {{- .Values.receive.extraFlags | toYaml | nindent 12 }}
+            {{- end }}
           env:
           - name: NAME
             valueFrom:

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -1954,6 +1954,12 @@ receive:
       ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
       ##
       # nodePort:
+    remoteWrite:
+      port: 19291
+      ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+      ##
+      # nodePort:
     ## Set the LoadBalancer service type to internal only.
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
     ##


### PR DESCRIPTION
**Description of the change**

Thanos Receive fixes
- hashring config now rendered
- `extraFlags` is now being utilized
- missing remote write port was added to the service

**Benefits**

Thanos Receive is now usable

**Additional information**

There are still unimplemented/missing parts for Thanos Receive

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)