### PR TITLE
[bitnami/harbor] Fix incorrect logic when disabling startupProbe

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-harbor-registry
   - https://github.com/bitnami/bitnami-docker-harbor-registryctl
   - https://goharbor.io/
-version: 9.4.5
+version: 9.4.6

--- a/bitnami/harbor/templates/core/core-dpl.yaml
+++ b/bitnami/harbor/templates/core/core-dpl.yaml
@@ -121,7 +121,7 @@ spec:
             timeoutSeconds: {{ .Values.core.startupProbe.timeoutSeconds }}
             successThreshold: {{ .Values.core.startupProbe.successThreshold }}
             failureThreshold: {{ .Values.core.startupProbe.failureThreshold }}
-          {{- else if .Values.core.startupProbe }}
+          {{- else if .Values.core.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.core.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           envFrom:


### PR DESCRIPTION


**Description of the change**

Fix what I think is just a typo in the handling of logic when disabling the startupProbe.  Without this fix, even setting the probe to disabled keeps the probe in place

**Benefits**

This allows for the chart to be used on older kubernetes versions, such as those shipped with Openshift 3.x

**Possible drawbacks**

None

**Additional information**

Tested this locally and everything seemed to work as expected

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
