### PR TITLE
[bitnami/thanos] fix query TLS client in a modular way (#5437)

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 3.8.5
+version: 3.8.6

--- a/bitnami/thanos/templates/query/deployment.yaml
+++ b/bitnami/thanos/templates/query/deployment.yaml
@@ -100,9 +100,15 @@ spec:
             {{- end }}
             {{- if or $query.grpcTLS.client.secure $query.grpcTLS.client.existingSecret }}
             - --grpc-client-tls-secure
+            {{- if or $query.grpcTLS.client.cert $query.grpcTLS.client.existingSecret }}
             - --grpc-client-tls-cert=/tls/client/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpcTLS.client.existingSecret "key" "tls-cert") }}
+            {{- end }}
+            {{- if or $query.grpcTLS.client.key $query.grpcTLS.client.existingSecret }}
             - --grpc-client-tls-key=/tls/client/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpcTLS.client.existingSecret "key" "tls-key") }}
+            {{- end }}
+            {{- if or $query.grpcTLS.client.ca $query.grpcTLS.client.existingSecret }}
             - --grpc-client-tls-ca=/tls/client/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpcTLS.client.existingSecret "key" "ca-cert") }}
+            {{- end }}
             {{- end }}
             {{- if $query.grpcTLS.client.servername }}
             - --grpc-client-server-name={{$query.grpcTLS.client.servername}}

--- a/bitnami/thanos/templates/query/deployment.yaml
+++ b/bitnami/thanos/templates/query/deployment.yaml
@@ -94,7 +94,9 @@ spec:
             {{- if or $query.grpcTLS.server.secure $query.grpcTLS.server.existingSecret }}
             - --grpc-server-tls-cert=/tls/server/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpcTLS.server.existingSecret "key" "tls-cert") }}
             - --grpc-server-tls-key=/tls/server/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpcTLS.server.existingSecret "key" "tls-key") }}
+            {{- if or $query.grpcTLS.server.ca $query.grpcTLS.client.existingSecret }}
             - --grpc-server-tls-client-ca=/tls/server/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpcTLS.server.existingSecret "key" "ca-cert") }}
+            {{- end }}
             {{- end }}
             {{- if or $query.grpcTLS.client.secure $query.grpcTLS.client.existingSecret }}
             - --grpc-client-tls-secure

--- a/bitnami/thanos/templates/query/tls-server-secret.yaml
+++ b/bitnami/thanos/templates/query/tls-server-secret.yaml
@@ -10,5 +10,7 @@ type: Opaque
 data:
   tls-cert: {{ $query.grpcTLS.server.cert | b64enc | quote }}
   tls-key: {{ $query.grpcTLS.server.key | b64enc | quote }}
+{{- if $query.grpcTLS.server.ca }}
   ca-cert : {{ $query.grpcTLS.server.ca | b64enc | quote }}
+{{- end }}
 {{ end }}


### PR DESCRIPTION
**Description of the change**

Restore TLS client config in a modular way as implemented in PR https://github.com/bitnami/charts/pull/3989 (issue https://github.com/bitnami/charts/issues/3988).

**Benefits**

As explained on #3988 this would enable the usage of multiple ingresses as target stores if they are all under the same CA.

**Possible drawbacks**

It does not break compatibility as the user is still able to specify all CA, Cert and Key for its TLS client. This only makes it so it is modular enough for the user to only pass the information needed to its use-case.

**Applicable issues**

  - fixes #5437

**Checklist*
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)