### PR TITLE
[bitnami/spring-cloud-dataflow] Fix skipper volume references

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -39,4 +39,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-spring-cloud-dataflow
   - https://github.com/bitnami/bitnami-docker-spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 2.7.2
+version: 2.7.3

--- a/bitnami/spring-cloud-dataflow/templates/skipper/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/deployment.yaml
@@ -175,8 +175,8 @@ spec:
               mountPath: /etc/secrets/rabbitmq
               readOnly: true
             {{- end }}
-            {{- if .Values.server.extraVolumeMounts }}
-            {{- toYaml .Values.server.extraVolumeMounts | nindent 12 }}
+            {{- if .Values.skipper.extraVolumeMounts }}
+            {{- toYaml .Values.skipper.extraVolumeMounts | nindent 12 }}
             {{- end }}
         {{- if .Values.skipper.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.skipper.sidecars "context" $) | nindent 8 }}
@@ -202,7 +202,7 @@ spec:
             name: {{ include "scdf.fullname" . }}-scripts
             defaultMode: 0755
         {{- end }}
-        {{- if .Values.server.extraVolumes }}
-          {{- toYaml .Values.server.extraVolumes | nindent 8 }}
+        {{- if .Values.skipper.extraVolumes }}
+          {{- toYaml .Values.skipper.extraVolumes | nindent 8 }}
         {{- end }}
 {{- end }}


### PR DESCRIPTION
**Description of the change**

This PR fixes skipper `extraVolumes` and `extraVolumeMounts`, which are improperly pointing at the server section.

**Benefits**

Skipper volumes work as expected.

**Possible drawbacks**

None that I can think of.

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
