### PR TITLE
[bitnami/charts/discourse] Add selector option to pvc

### DIFF
--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-discourse
   - https://github.com/spinnaker
   - https://www.discourse.org/
-version: 2.2.1
+version: 2.2.2

--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-discourse
   - https://github.com/spinnaker
   - https://www.discourse.org/
-version: 2.2.2
+version: 2.3.0

--- a/bitnami/discourse/README.md
+++ b/bitnami/discourse/README.md
@@ -82,6 +82,7 @@ The following table lists the configurable parameters of the Discourse chart and
 | `persistence.existingClaim`  | Name of an existing PVC to reuse                                                          | `nil`                                                   |
 | `persistence.accessMode`     | PVC Access Mode (RWO, ROX, RWX)                                                           | `ReadWriteOnce`                                         |
 | `persistence.size`           | Size of the PVC to request                                                                | `10Gi`                                                  |
+| `persistence.selector`       | Selector to match an existing Persistent Volume (this value is evaluated as a template)   | `{}`                                                    |
 | `updateStrategy`             | Update strategy of deployment                                                             | `{type: "RollingUpdate"}`                               |
 | `podAnnotations`             | Additional pod annotations                                                                | `{}`                                                    |
 | `podLabels`                  | Additional pod labels                                                                     | `{}` (evaluated as a template)                          |

--- a/bitnami/discourse/templates/pvc.yaml
+++ b/bitnami/discourse/templates/pvc.yaml
@@ -18,6 +18,6 @@ spec:
       storage: {{ .Values.persistence.size | quote }}
   {{ include "discourse.storageClass" . }}
   {{- if .Values.persistence.selector }}
-  selector: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.selector "context" $) | nindent 10 }}
+  selector: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.selector "context" $) | nindent 4 }}
   {{- end -}}
 {{- end }}

--- a/bitnami/discourse/templates/pvc.yaml
+++ b/bitnami/discourse/templates/pvc.yaml
@@ -17,4 +17,7 @@ spec:
     requests:
       storage: {{ .Values.persistence.size | quote }}
   {{ include "discourse.storageClass" . }}
+  {{- if .Values.persistence.selector }}
+  selector: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.selector "context" $) | nindent 10 }}
+  {{- end -}}
 {{- end }}

--- a/bitnami/discourse/values.yaml
+++ b/bitnami/discourse/values.yaml
@@ -323,8 +323,13 @@ persistence:
   ## If you want to reuse an existing claim, you can pass the name of the PVC using
   ## the existingClaim variable
   # existingClaim: your-claim
-  accessMode: ReadWriteOnce
+  accessMode: ReadWriteMany
   size: 10Gi
+  ## selector can be used to match an existing PersistentVolume
+  ## selector:
+  ##   matchLabels:
+  ##     app: my-app
+  selector: {}  
 
 ## Kubernetes configuration
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer or ClusterIP

--- a/bitnami/discourse/values.yaml
+++ b/bitnami/discourse/values.yaml
@@ -329,7 +329,7 @@ persistence:
   ## selector:
   ##   matchLabels:
   ##     app: my-app
-  selector: {}  
+  selector: {}
 
 ## Kubernetes configuration
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer or ClusterIP

--- a/bitnami/discourse/values.yaml
+++ b/bitnami/discourse/values.yaml
@@ -323,7 +323,7 @@ persistence:
   ## If you want to reuse an existing claim, you can pass the name of the PVC using
   ## the existingClaim variable
   # existingClaim: your-claim
-  accessMode: ReadWriteMany
+  accessMode: ReadWriteOnce
   size: 10Gi
   ## selector can be used to match an existing PersistentVolume
   ## selector:


### PR DESCRIPTION

**Description of the change**

This change adds a selector to the PCV so that user can use label matching to select the PV
Also updated the accessMode to ReadWriteMany as it being used by discourse and sidekiq  pods.

**Benefits**

User can target the right PV in a kube that has many PVs

**Possible drawbacks**

If the user does not have a storage provider that supports ReadWriteMany, they will need to create two PVC, one for discourse and one for sidekiq

**Applicable issues**

  - fixes #5454

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ X ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ X ] Variables are documented in the README.md
- [ X ] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
