### PR TITLE
[bitnami/thanos] Add receive to query dns discovery

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 3.8.4
+version: 3.8.5

--- a/bitnami/thanos/templates/query/deployment.yaml
+++ b/bitnami/thanos/templates/query/deployment.yaml
@@ -85,6 +85,9 @@ spec:
             {{- if and .Values.ruler.enabled $query.dnsDiscovery.enabled }}
             - --store=dnssrv+_grpc._tcp.{{ include "common.names.fullname" . }}-ruler.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
             {{- end }}
+            {{- if and .Values.receive.enabled $query.dnsDiscovery.enabled }}
+            - --store=dnssrv+_grpc._tcp.{{ include "common.names.fullname" . }}-receive.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
+            {{- end }}
             {{- range $query.stores }}
             - --store={{ . }}
             {{- end }}


### PR DESCRIPTION
**Description of the change**

Add a default dns discovery entry in _query_ for _receive_ service 
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

_Receive_ In-memory chunks can be queried 

**Possible drawbacks**


**Applicable issues**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
