### PR TITLE
[bitnami/minio] Fix rendering of NOTES.txt

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -25,4 +25,4 @@ name: minio
 sources:
   - https://github.com/bitnami/bitnami-docker-minio
   - https://min.io
-version: 6.1.6
+version: 6.1.7

--- a/bitnami/minio/templates/NOTES.txt
+++ b/bitnami/minio/templates/NOTES.txt
@@ -19,7 +19,7 @@ To connect to your MinIO(R) server using a client:
      --env MINIO_SERVER_SECRET_KEY=$MINIO_SECRET_KEY \
      --env MINIO_SERVER_HOST={{ include "common.names.fullname" . }} \
      {{- if and (.Values.networkPolicy.enabled) (not .Values.networkPolicy.allowExternal) }}
-     --labels="{{ template "minio.name" . }}-client=true" \
+     --labels="{{ include "common.names.fullname" . }}-client=true" \
      {{- end }}
      --image {{ template "minio.clientImage" . }} -- admin info minio
 


### PR DESCRIPTION

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
NOTES.txt erroneously uses `template "minio.name"` instead of `include "common.names.fullname"`, which causes rendering to fail. This PR fixes it.
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
Fixes uses of the chart with network policies enabled and external access disabled.

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
