### PR TITLE
[bitnami/keycloak] Fix password notes reading the secret

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 2.0.0
+version: 2.0.1

--- a/bitnami/keycloak/templates/NOTES.txt
+++ b/bitnami/keycloak/templates/NOTES.txt
@@ -48,7 +48,7 @@ To access Keycloak from outside the cluster execute the following commands:
 3. Access the Administration Console using the following credentials:
 
   echo Username: {{ .Values.auth.adminUser }}
-  echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ printf "%s-env-vars" (include "common.names.fullname" .) }} -o jsonpath="{.data.admin-password}" | base64 --decode)
+  echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "common.secrets.name" (dict "existingSecret" .Values.auth.existingSecret "context" $) }} -o jsonpath="{.data.admin-password}" | base64 --decode)
 {{- end }}
 {{- if .Values.metrics.enabled }}
 


### PR DESCRIPTION
**Description of the change**

Notes were using the wrong logic to obtain the secret name to show the password.

- Previous logic:
```console
$ helm install keycloak bitnami/keycloak
NAME: keycloak
LAST DEPLOYED: Fri Feb 12 08:31:09 2021
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
** Please be patient while the chart is being deployed **

Keycloak can be accessed through the following DNS name from within your cluster:

    keycloak.default.svc.cluster.local (port 80)

To access Keycloak from outside the cluster execute the following commands:

1. Get the Keycloak URL by running these commands:

  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
        You can watch its status by running 'kubectl get --namespace default svc -w keycloak'

    export SERVICE_PORT=$(kubectl get --namespace default -o jsonpath="{.spec.ports[0].port}" services keycloak)
    export SERVICE_IP=$(kubectl get svc --namespace default keycloak -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
    echo "http://${SERVICE_IP}:${SERVICE_PORT}/auth"

2. Access Keycloak using the obtained URL.
3. Access the Administration Console using the following credentials:

  echo Username: user
  echo Password: $(kubectl get secret --namespace default keycloak-env-vars -o jsonpath="{.data.admin-password}" | base64 --decode)

$ kubectl get secret --namespace default keycloak-env-vars -o jsonpath="{.data.admin-password}" | base64 --decode
Error from server (NotFound): secrets "keycloak-env-vars" not found

$ kubectl get secret | grep keycloak
keycloak                                                  Opaque                                3      38s
keycloak-postgresql                                       Opaque                                2      38s
keycloak-token-2hj2q                                      kubernetes.io/service-account-token   3      38s
```
there is not any secret named as `keycloak-env-vars`

- With the changes in this PR
```console
$ helm install keycloak2 .
NAME: keycloak2
LAST DEPLOYED: Fri Feb 12 08:33:14 2021
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
** Please be patient while the chart is being deployed **

Keycloak can be accessed through the following DNS name from within your cluster:

    keycloak2.default.svc.cluster.local (port 80)

To access Keycloak from outside the cluster execute the following commands:

1. Get the Keycloak URL by running these commands:

  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
        You can watch its status by running 'kubectl get --namespace default svc -w keycloak2'

    export SERVICE_PORT=$(kubectl get --namespace default -o jsonpath="{.spec.ports[0].port}" services keycloak2)
    export SERVICE_IP=$(kubectl get svc --namespace default keycloak2 -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
    echo "http://${SERVICE_IP}:${SERVICE_PORT}/auth"

2. Access Keycloak using the obtained URL.
3. Access the Administration Console using the following credentials:

  echo Username: user
  echo Password: $(kubectl get secret --namespace default keycloak2 -o jsonpath="{.data.admin-password}" | base64 --decode)

$ kubectl get secret --namespace default keycloak2 -o jsonpath="{.data.admin-password}" | base64 --decode
nBGSXZ57xn
```

**Applicable issues**

  - fixes #5464

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)