### PR TITLE
[bitnami/kafka] Flexible tls config

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 12.7.6
+version: 12.8.0

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -113,6 +113,9 @@ The following tables lists the configurable parameters of the Kafka chart and th
 | `auth.saslMechanisms`                     | SASL mechanisms when either `auth.interBrokerProtocol` or `auth.clientProtocol` are `sasl`. Allowed types: `plain`, `scram-sha-256`, `scram-sha-512` | `plain,scram-sha-256,scram-sha-512`                     |
 | `auth.saslInterBrokerMechanism`           | SASL mechanism to use as inter broker protocol, it must be included at `auth.saslMechanisms`                                                         | `plain`                                                 |
 | `auth.jksSecret`                          | Name of the existing secret containing the truststore and one keystore per Kafka broker you have in the cluster                                      | `nil`                                                   |
+| `auth.jksKeystoreSAN`                          | The secret key from the jksSecret containing the keystore with a SAN certificate.                                      | `nil`                                                   |
+| `auth.jksTruststoreSecret`                          | Name of the existing secret containing your truststore if truststore not existing or different from the one in the jksSecret.                                      | `nil`                                                   |
+| `auth.jksTruststore`                          | The secret key from the jksSecret or jksTruststoreSecret if truststore key different from the default                                      | `nil`                                                   |
 | `auth.jksPassword`                        | Password to access the JKS files when they are password-protected                                                                                    | `nil`                                                   |
 | `auth.tlsEndpointIdentificationAlgorithm` | The endpoint identification algorithm to validate server hostname using server certificate                                                           | `https`                                                 |
 | `auth.jaas.interBrokerUser`               | Kafka inter broker communication user for SASL authentication                                                                                        | `admin`                                                 |
@@ -354,7 +357,7 @@ If you enabled SASL authentication on any listener, you can set the SASL credent
 - `auth.jaas.interBrokerUser`/`auth.jaas.interBrokerPassword`:  when enabling SASL authentication for inter-broker communications.
 - `auth.jaas.zookeeperUser`/`auth.jaas.zookeeperPassword`: In the case that the Zookeeper chart is deployed with SASL authentication enabled.
 
-In order to configure TLS authentication/encryption, you **must** create a secret containing the Java Key Stores (JKS) files: the truststore (`kafka.truststore.jks`) and one keystore (`kafka.keystore.jks`) per Kafka broker you have in the cluster. Then, you need pass the secret name with the `--auth.jksSecret` parameter when deploying the chart.
+In order to configure TLS authentication/encryption, you **can** create a secret containing the Java Key Stores (JKS) files: the truststore (`kafka.truststore.jks`) and one keystore (`kafka.keystore.jks`) per Kafka broker you have in the cluster. Then, you need pass the secret name with the `--auth.jksSecret` parameter when deploying the chart.
 
 > **Note**: If the JKS files are password protected (recommended), you will need to provide the password to get access to the keystores. To do so, use the `auth.jksPassword` parameter to provide your password.
 
@@ -367,6 +370,12 @@ kubectl create secret generic kafka-jks --from-file=./kafka.truststore.jks --fro
 > **Note**: the command above assumes you already created the trustore and keystores files. This [script](https://raw.githubusercontent.com/confluentinc/confluent-platform-security-tools/master/kafka-generate-ssl.sh) can help you with the JKS files generation.
 
 As an alternative to manually create the secret before installing the chart, you can put your JKS files inside the chart folder `files/jks`, an a secret including them will be generated. Please note this alternative requires to have the chart downloaded locally, so you will have to clone this repository or fetch the chart before installing it.
+
+If, for some reason (like using Cert-Manager) you can not use the default JKS secret scheme, you can use the additional parameters:
+ - `auth.jksTruststoreSecret` to define additional secret, where the `kafka.truststore.jks` is being kept. The truststore password **must** be the same as in `auth.jksPassword` 
+ - `auth.jksTruststore` to overwrite the default value of the truststore key (`kafka.truststore.jks`). 
+ - `auth.jksKeystoreSAN` if you want to use a SAN certificate for your brokers. Setting this parameter would mean that the chart expects a existing key in the `auth.jksSecret` with the `auth.jksKeystoreSAN`-value and use this as a keystore for **all** brokers
+> **Note**: The truststore/keystore from above **must** be protected with the same password as in `auth.jksPassword`
 
 You can deploy the chart with authentication using the following parameters:
 

--- a/bitnami/kafka/templates/scripts-configmap.yaml
+++ b/bitnami/kafka/templates/scripts-configmap.yaml
@@ -109,12 +109,28 @@ data:
     export KAFKA_CFG_ADVERTISED_LISTENERS="INTERNAL://${MY_POD_NAME}.{{ $fullname }}-headless.{{ $releaseNamespace }}.svc.{{ $clusterDomain }}:{{ $interBrokerPort }},CLIENT://${MY_POD_NAME}.{{ $fullname }}-headless.{{ $releaseNamespace }}.svc.{{ $clusterDomain }}:{{ $clientPort }},EXTERNAL://${EXTERNAL_ACCESS_IP}:${EXTERNAL_ACCESS_PORT}"
     {{- end }}
     {{- end }}
-
     {{- if (include "kafka.tlsEncryption" .) }}
-    if [[ -f "/certs/kafka.truststore.jks" ]] && [[ -f "/certs/kafka-${ID}.keystore.jks" ]]; then
+    
+    {{- if and .Values.auth.jksTruststoreSecret .Values.auth.jksTruststore }}
+    JKS_TRUSTSTORE="/truststore/{{ .Values.auth.jksTruststore }}"
+    {{- else if .Values.auth.jksTruststoreSecret  }}
+    JKS_TRUSTSTORE="/truststore/kafka.trustore.jks"
+    {{- else if .Values.auth.jksTruststore  }}
+    JKS_TRUSTSTORE="/certs/{{ .Values.auth.jksTruststore }}"
+    {{- else }}
+    JKS_TRUSTSTORE="/certs/kafka.trustore.jks"
+    {{- end }}
+    
+    {{- if .Values.auth.jksKeystoreSAN }}
+    JKS_KEYSTORE="/certs/{{ .Values.auth.jksKeystoreSAN }}"
+    {{- else }}
+    JKS_KEYSTORE="/certs/kafka-${ID}.keystore.jks"
+    {{- end }}
+
+    if [[ -f "${JKS_TRUSTSTORE}" ]] && [[ -f "${JKS_KEYSTORE}" ]]; then
         mkdir -p /opt/bitnami/kafka/config/certs
-        cp "/certs/kafka.truststore.jks" "/opt/bitnami/kafka/config/certs/kafka.truststore.jks"
-        cp "/certs/kafka-${ID}.keystore.jks" "/opt/bitnami/kafka/config/certs/kafka.keystore.jks"
+        cp "${JKS_TRUSTSTORE}" "/opt/bitnami/kafka/config/certs/kafka.truststore.jks"
+        cp "${JKS_KEYSTORE}" "/opt/bitnami/kafka/config/certs/kafka.keystore.jks"
     else
         echo "Couldn't find the expected Java Key Stores (JKS) files! They are mandatory when encryption via TLS is enabled."
         exit 1

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -370,6 +370,11 @@ spec:
             - name: kafka-certificates
               mountPath: /certs
               readOnly: true
+            {{- if  .Values.auth.jksTruststoreSecret }}
+            - name: kafka-truststore
+              mountPath: /truststore
+              readOnly: true
+            {{- end }}
             {{- end }}
             {{- if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
@@ -430,6 +435,12 @@ spec:
           secret:
             secretName: {{ include "kafka.jksSecretName" . }}
             defaultMode: 256
+        {{- if .Values.auth.jksTruststoreSecret }}
+        - name: kafka-truststore
+          secret:
+            secretName: {{ .Values.auth.jksTruststoreSecret }}
+            defaultMode: 256
+        {{- end }}
         {{- end }}
         {{- if .Values.extraVolumes }}
         {{- toYaml .Values.extraVolumes | nindent 8 }}

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -275,6 +275,22 @@ auth:
   ##
   # jksSecret:
 
+  ## The secret key from the jksSecret containing the keystore with a SAN certificate. The SAN certificate in it should be
+  ## issued with Subject Alternative Names for all headless services. Example for 3 Broker:
+  ##  - kafka-0.kafka-headless.kafka.svc.cluster.local
+  ##  - kafka-1.kafka-headless.kafka.svc.cluster.local
+  ##  - kafka-2.kafka-headless.kafka.svc.cluster.local
+  ##
+  # jksKeystoreSAN:
+
+  ## Name of the existing secret containing your truststore if truststore not existing or different from the one in the jksSecret.
+  ##
+  # jksTruststoreSecret:
+
+  ## The secret key from the jksSecret or jksTruststoreSecret if truststore key different from the default (kafka.truststore.jks)
+  ##
+  # jksTruststore:
+
   ## Password to access the JKS files when they are password-protected.
   ##
   # jksPassword:


### PR DESCRIPTION
**Description of the change**

Flexible JKS configuration. 
In my company we are using cert-manager to automate certificate management. The cert-manager creates a secret, which is completely different, than the one forced by the kafka-helm-chart. 

We need to be able to change the default JKS secret and key mappings.

**Benefits**

This is helpful for anyone who is using already some kind of cert-management or even using a different scheme for creating the certs.

**Possible drawbacks**

Don't see any

**Applicable issues**

**Additional information**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
