### PR TITLE
[bitnami/keycloak] HTTPS between the ingress and the pods

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 1.4.3
+version: 2.1.0

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -179,6 +179,7 @@ The following tables lists the configurable parameters of the Keycloak chart and
 | `ingress.secrets[0].name`          | TLS Secret Name                                                                   | `nil`                          |
 | `ingress.secrets[0].certificate`   | TLS Secret Certificate                                                            | `nil`                          |
 | `ingress.secrets[0].key`           | TLS Secret Key                                                                    | `nil`                          |
+| `ingress.servicePort`              | Service port to be used                                                           | `http`                          |
 | `networkPolicy.enabled`            | Enable the default NetworkPolicy policy                                           | `false`                        |
 | `networkPolicy.allowExternal`      | Don't require client label for connections                                        | `true`                         |
 | `networkPolicy.additionalRules`    | Additional NetworkPolicy rules                                                    | `{}` (evaluated as a template) |

--- a/bitnami/keycloak/templates/ingress.yaml
+++ b/bitnami/keycloak/templates/ingress.yaml
@@ -31,7 +31,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" .Values.ingress.servicePort "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
     - host: {{ .name }}
@@ -41,7 +41,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" .Values.ingress.servicePort "context" $) | nindent 14 }}
     {{- end }}
   {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
   tls:

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -533,6 +533,10 @@ ingress:
   ##
   secrets: []
 
+  ## The service port to be used by this ingress.
+  ## Default is http. Alternative is https.
+  servicePort: http
+
 ## Network Policy configuration
 ## ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Allow the ingress to talk the pods via HTTPS port.

**Benefits**

Not plain HTTP between the Ingress and the Keycloak pods.
It is relevant in contexts without NetworkPolicies.

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
