### PR TITLE
bitnami/mysql: add `externalTrafficPolicy` to service type `LoadBalancer`

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -25,4 +25,4 @@ name: mysql
 sources:
   - https://github.com/bitnami/bitnami-docker-mysql
   - https://mysql.com
-version: 8.3.1
+version: 8.4.1

--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -25,4 +25,4 @@ name: mysql
 sources:
   - https://github.com/bitnami/bitnami-docker-mysql
   - https://mysql.com
-version: 8.4.1
+version: 8.4.0

--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -141,6 +141,7 @@ The following table lists the configurable parameters of the MySQL chart and the
 | `primary.service.port`                       | MySQL Primary K8s service port                                                                                  | `3306`                         |
 | `primary.service.nodePort`                   | MySQL Primary K8s service node port                                                                             | `nil`                          |
 | `primary.service.loadBalancerIP`             | MySQL Primary loadBalancerIP if service type is `LoadBalancer`                                                  | `nil`                          |
+| `primary.service.externalTrafficPolicy`      | Enable client source IP preservation                                                                            | `Cluster`                      |
 | `primary.service.loadBalancerSourceRanges`   | Address that are allowed when MySQL Primary service is LoadBalancer                                             | `[]`                           |
 | `primary.pdb.enabled`                        | Enable/disable a Pod Disruption Budget creation for MySQL primary pods                                          | `false`                        |
 | `primary.pdb.minAvailable`                   | Minimum number/percentage of MySQL primary pods that should remain scheduled                                    | `1`                            |
@@ -196,6 +197,7 @@ The following table lists the configurable parameters of the MySQL chart and the
 | `secondary.service.port`                       | MySQL secondary K8s service port                                                                                    | `3306`                         |
 | `secondary.service.nodePort`                   | MySQL secondary K8s service node port                                                                               | `nil`                          |
 | `secondary.service.loadBalancerIP`             | MySQL secondary loadBalancerIP if service type is `LoadBalancer`                                                    | `nil`                          |
+| `secondary.service.externalTrafficPolicy`      | Enable client source IP preservation                                                                                | `Cluster`                      |
 | `secondary.service.loadBalancerSourceRanges`   | Address that are allowed when MySQL secondary service is LoadBalancer                                               | `[]`                           |
 | `secondary.pdb.enabled`                        | Enable/disable a Pod Disruption Budget creation for MySQL secondary pods                                            | `false`                        |
 | `secondary.pdb.minAvailable`                   | Minimum number/percentage of MySQL secondary pods that should remain scheduled                                      | `1`                            |

--- a/bitnami/mysql/templates/primary/svc.yaml
+++ b/bitnami/mysql/templates/primary/svc.yaml
@@ -22,6 +22,7 @@ spec:
   {{- end }}
   {{- if and .Values.primary.service.loadBalancerIP (eq .Values.primary.service.type "LoadBalancer") }}
   loadBalancerIP: {{ .Values.primary.service.loadBalancerIP }}
+  externalTrafficPolicy: {{ .Values.primary.service.externalTrafficPolicy | quote }}
   {{- end }}
   {{- if and (eq .Values.primary.service.type "LoadBalancer") .Values.primary.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{- toYaml .Values.primary.service.loadBalancerSourceRanges | nindent 4 }}

--- a/bitnami/mysql/templates/secondary/svc.yaml
+++ b/bitnami/mysql/templates/secondary/svc.yaml
@@ -23,6 +23,7 @@ spec:
   {{- end }}
   {{- if and .Values.secondary.service.loadBalancerIP (eq .Values.secondary.service.type "LoadBalancer") }}
   loadBalancerIP: {{ .Values.secondary.service.loadBalancerIP }}
+  externalTrafficPolicy: {{ .Values.secondary.service.externalTrafficPolicy | quote }}
   {{- end }}
   {{- if and (eq .Values.secondary.service.type "LoadBalancer") .Values.secondary.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{- toYaml .Values.secondary.service.loadBalancerSourceRanges | nindent 4 }}

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -671,6 +671,10 @@ secondary:
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
     ##
     loadBalancerIP: ""
+    ## Enable client source IP preservation
+    ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+    ##
+    externalTrafficPolicy: Cluster
     ## Load Balancer sources
     ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## E.g.

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -380,6 +380,10 @@ primary:
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
     ##
     loadBalancerIP: ""
+    ## Enable client source IP preservation
+    ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+    ##
+    externalTrafficPolicy: Cluster
     ## Load Balancer sources
     ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## E.g.


### PR DESCRIPTION
**Description of the change**
PR adds an option to configure `externalTrafficPolicy` to service type `LoadBalancer` in mysql chart to preserve Client IP. Additionally, while running MySQL on Azure AKS cluster with an internal  LoadBalancer and default `externalTrafficPolicy`: `Cluster`, mysql instance gets health probes from AKS LoadBalancer and drops them as aborted connections, this fills up error logs and reserves unnecessary connections in mysql. Setting `externalTrafficPolicy`: `Local` eliminates this issue. 


**Benefits**
* `externalTrafficPolicy` is configurable to preserve `ClientIP`
* avoid issues with internal load balancers on AKS clusters 


**Possible drawbacks**
not known 

**Applicable issues**
no 

**Additional information**
no 

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

