### PR TITLE
[bitnami/thanos] Fix extraHosts fullnameOverride nil pointer

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 3.9.0
+version: 3.9.1

--- a/bitnami/thanos/templates/bucketweb/ingress.yaml
+++ b/bitnami/thanos/templates/bucketweb/ingress.yaml
@@ -31,7 +31,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" .) "bucketweb") "servicePort" "http" "context" $) | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" $) "bucketweb") "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
   {{- if or .Values.bucketweb.ingress.tls .Values.bucketweb.ingress.extraTls .Values.bucketweb.ingress.hosts }}
   tls:

--- a/bitnami/thanos/templates/query-frontend/ingress.yaml
+++ b/bitnami/thanos/templates/query-frontend/ingress.yaml
@@ -31,7 +31,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" .) "query-frontend") "servicePort" "http" "context" $) | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" $) "query-frontend") "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
   {{- if or .Values.queryFrontend.ingress.tls .Values.queryFrontend.ingress.extraTls .Values.queryFrontend.ingress.hosts }}
   tls:

--- a/bitnami/thanos/templates/query/ingress-grpc.yaml
+++ b/bitnami/thanos/templates/query/ingress-grpc.yaml
@@ -32,7 +32,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s" (include "common.names.fullname" .) "query") "servicePort" "grpc" "context" $) | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s" (include "common.names.fullname" $) "query") "servicePort" "grpc" "context" $) | nindent 14 }}
     {{- end }}
   {{- if or $query.ingress.grpc.tls $query.ingress.grpc.extraTls $query.ingress.grpc.hosts }}
   tls:

--- a/bitnami/thanos/templates/query/ingress.yaml
+++ b/bitnami/thanos/templates/query/ingress.yaml
@@ -32,7 +32,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" .) "query") "servicePort" "http" "context" $) | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" $) "query") "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
   {{- if or $query.ingress.tls $query.ingress.extraTls $query.ingress.hosts }}
   tls:

--- a/bitnami/thanos/templates/receive/ingress.yaml
+++ b/bitnami/thanos/templates/receive/ingress.yaml
@@ -39,7 +39,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" .) "receive") "servicePort" "http" "context" $) | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" $) "receive") "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
   {{- if or .Values.receive.ingress.tls .Values.receive.ingress.extraTls .Values.receive.ingress.hosts }}
   tls:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
When using extraHosts on any ingress, you get the error:
```
Error: template: thanos/templates/query-frontend/ingress.yaml:34:96: executing "thanos/templates/query-frontend/ingress.yaml" at <include "common.names.fullname" .>: error calling include: template: thanos/charts/common/templates/_names.tpl:22:14: executing "common.names.fullname" at <.Values.fullnameOverride>: nil pointer evaluating interface {}.fullnameOverride
```
This PR will fix the usage of extraHosts variable on Thanos.
<!-- Describe the scope of your change - i.e. what the change does. -->


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
