### PR TITLE
[bitnami/zookeeper] Add extra-list.yaml

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -21,4 +21,4 @@ name: zookeeper
 sources:
   - https://github.com/bitnami/bitnami-docker-zookeeper
   - https://zookeeper.apache.org/
-version: 6.4.0
+version: 6.5.0

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -61,6 +61,7 @@ The following tables lists the configurable parameters of the ZooKeeper chart an
 | `nameOverride`      | String to partially override common.names.fullname | `nil`                             |
 | `fullnameOverride`  | String to fully override common.names.fullname     | `nil`                             |
 | `clusterDomain`     | Default Kubernetes cluster domain                  | `cluster.local`                   |
+| `extraDeploy`       | Array of extra objects to deploy with the release  | `[]` (evaluated as a template)    |
 | `commonLabels`      | Labels to add to all deployed objects              | `{}`                              |
 | `commonAnnotations` | Annotations to add to all deployed objects         | `{}`                              |
 | `schedulerName`     | Kubernetes pod scheduler registry                  | `nil` (use the default-scheduler) |

--- a/bitnami/zookeeper/templates/extra-list.yaml
+++ b/bitnami/zookeeper/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -48,6 +48,10 @@ hostAliases: []
 ##
 clusterDomain: cluster.local
 
+## Extra objects to deploy (value evaluated as a template)
+##
+extraDeploy: []
+
 ## Add labels to all the deployed resources
 ##
 commonLabels: {}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

New version of tomcat chart proposes a flexible way to add extra objects in the chart. In a use case of mine, I need this as well in zookeeper, so I propose to port the same mechanism from tomcat chart to zookeeper.
There are some refactors we could do in zookeeper to make it align with latest practices in tomcat chart, theses will be for next PRs to come.  

**Benefits**

Align to latest practices

**Possible drawbacks**

None

**Applicable issues**

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.