### PR TITLE
[bitnami/mongodb] Added hidden node support

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 10.7.2
+version: 10.8.0

--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -219,32 +219,42 @@ The following tables lists the configurable parameters of the MongoDB&reg; chart
 
 ### Exposure parameters
 
-| Parameter                                         | Description                                                                                            | Default                        |
-|---------------------------------------------------|--------------------------------------------------------------------------------------------------------|--------------------------------|
-| `service.type`                                    | Kubernetes Service type                                                                                | `ClusterIP`                    |
-| `service.nameOverride`                            | MongoDB&reg; service name                                                                              | `{mongodb.fullname}-headless`  |
-| `service.port`                                    | MongoDB&reg; service port                                                                              | `27017`                        |
-| `service.portName`                                | MongoDB&reg; service port name                                                                         | `mongodb`                      |
-| `service.nodePort`                                | Port to bind to for NodePort and LoadBalancer service types                                            | `""`                           |
-| `service.clusterIP`                               | MongoDB&reg; service cluster IP                                                                        | `nil`                          |
-| `service.loadBalancerIP`                          | loadBalancerIP for MongoDB&reg; Service                                                                | `nil`                          |
-| `service.loadBalancerSourceRanges`                | Address(es) that are allowed when service is LoadBalancer                                              | `[]`                           |
-| `service.annotations`                             | Service annotations                                                                                    | `{}` (evaluated as a template) |
-| `externalAccess.enabled`                          | Enable Kubernetes external cluster access to MongoDB&reg; nodes                                        | `false`                        |
-| `externalAccess.autoDiscovery.enabled`            | Enable using an init container to auto-detect external IPs by querying the K8s API                     | `false`                        |
-| `externalAccess.autoDiscovery.image.registry`     | Init container auto-discovery image registry (kubectl)                                                 | `docker.io`                    |
-| `externalAccess.autoDiscovery.image.repository`   | Init container auto-discovery image name (kubectl)                                                     | `bitnami/kubectl`              |
-| `externalAccess.autoDiscovery.image.tag`          | Init container auto-discovery image tag (kubectl)                                                      | `{TAG_NAME}`                   |
-| `externalAccess.autoDiscovery.image.pullPolicy`   | Init container auto-discovery image pull policy (kubectl)                                              | `Always`                       |
-| `externalAccess.autoDiscovery.resources.limits`   | Init container auto-discovery resource limits                                                          | `{}`                           |
-| `externalAccess.autoDiscovery.resources.requests` | Init container auto-discovery resource requests                                                        | `{}`                           |
-| `externalAccess.service.type`                     | Kubernetes Service type for external access. It can be NodePort or LoadBalancer                        | `LoadBalancer`                 |
-| `externalAccess.service.port`                     | MongoDB&reg; port used for external access when service type is LoadBalancer                           | `27017`                        |
-| `externalAccess.service.loadBalancerIPs`          | Array of load balancer IPs for MongoDB&reg; nodes                                                      | `[]`                           |
-| `externalAccess.service.loadBalancerSourceRanges` | Address(es) that are allowed when service is LoadBalancer                                              | `[]`                           |
-| `externalAccess.service.domain`                   | Domain or external IP used to configure MongoDB&reg; advertised hostname when service type is NodePort | `nil`                          |
-| `externalAccess.service.nodePorts`                | Array of node ports used to configure MongoDB&reg; advertised hostname when service type is NodePort   | `[]`                           |
-| `externalAccess.service.annotations`              | Service annotations for external access                                                                | `{}`(evaluated as a template)  |
+| Parameter                                                | Description                                                                                            | Default                        |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------ |
+| `service.type`                                           | Kubernetes Service type                                                                                | `ClusterIP`                    |
+| `service.nameOverride`                                   | MongoDB&reg; service name                                                                              | `{mongodb.fullname}-headless`  |
+| `service.port`                                           | MongoDB&reg; service port                                                                              | `27017`                        |
+| `service.portName`                                       | MongoDB&reg; service port name                                                                         | `mongodb`                      |
+| `service.nodePort`                                       | Port to bind to for NodePort and LoadBalancer service types                                            | `""`                           |
+| `service.clusterIP`                                      | MongoDB&reg; service cluster IP                                                                        | `nil`                          |
+| `service.loadBalancerIP`                                 | loadBalancerIP for MongoDB&reg; Service                                                                | `nil`                          |
+| `service.loadBalancerSourceRanges`                       | Address(es) that are allowed when service is LoadBalancer                                              | `[]`                           |
+| `service.annotations`                                    | Service annotations                                                                                    | `{}` (evaluated as a template) |
+| `externalAccess.enabled`                                 | Enable Kubernetes external cluster access to MongoDB&reg; nodes                                        | `false`                        |
+| `externalAccess.autoDiscovery.enabled`                   | Enable using an init container to auto-detect external IPs by querying the K8s API                     | `false`                        |
+| `externalAccess.autoDiscovery.image.registry`            | Init container auto-discovery image registry (kubectl)                                                 | `docker.io`                    |
+| `externalAccess.autoDiscovery.image.repository`          | Init container auto-discovery image name (kubectl)                                                     | `bitnami/kubectl`              |
+| `externalAccess.autoDiscovery.image.tag`                 | Init container auto-discovery image tag (kubectl)                                                      | `{TAG_NAME}`                   |
+| `externalAccess.autoDiscovery.image.pullPolicy`          | Init container auto-discovery image pull policy (kubectl)                                              | `Always`                       |
+| `externalAccess.autoDiscovery.resources.limits`          | Init container auto-discovery resource limits                                                          | `{}`                           |
+| `externalAccess.autoDiscovery.resources.requests`        | Init container auto-discovery resource requests                                                        | `{}`                           |
+| `externalAccess.service.type`                            | Kubernetes Service type for external access. It can be NodePort or LoadBalancer                        | `LoadBalancer`                 |
+| `externalAccess.service.port`                            | MongoDB&reg; port used for external access when service type is LoadBalancer                           | `27017`                        |
+| `externalAccess.service.loadBalancerIPs`                 | Array of load balancer IPs for MongoDB&reg; nodes                                                      | `[]`                           |
+| `externalAccess.service.loadBalancerSourceRanges`        | Address(es) that are allowed when service is LoadBalancer                                              | `[]`                           |
+| `externalAccess.service.domain`                          | Domain or external IP used to configure MongoDB&reg; advertised hostname when service type is NodePort | `nil`                          |
+| `externalAccess.service.nodePorts`                       | Array of node ports used to configure MongoDB&reg; advertised hostname when service type is NodePort   | `[]`                           |
+| `externalAccess.service.annotations`                     | Service annotations for external access                                                                | `{}`(evaluated as a template)  |
+| `externalAccess.hidden.enabled`                          | Enable Kubernetes external cluster access to MongoDB&reg; hidden nodes                                 | `false`                        |
+| `externalAccess.hidden.service.type`                     | Kubernetes Service type for external access. It can be NodePort or LoadBalancer                        | `LoadBalancer`                 |
+| `externalAccess.hidden.service.port`                     | MongoDB&reg; port used for external access when service type is LoadBalancer                           | `27017`                        |
+| `externalAccess.hidden.service.loadBalancerIPs`          | Array of load balancer IPs for MongoDB&reg; nodes                                                      | `[]`                           |
+| `externalAccess.hidden.service.loadBalancerSourceRanges` | Address(es) that are allowed when service is LoadBalancer                                              | `[]`                           |
+| `externalAccess.hidden.service.domain`                   | Domain or external IP used to configure MongoDB&reg; advertised hostname when service type is NodePort | `nil`                          |
+| `externalAccess.hidden.service.nodePorts`                | Array of node ports used to configure MongoDB&reg; advertised hostname when service type is NodePort   | `[]`                           |
+| `externalAccess.hidden.service.annotations`              | Service annotations for external access                                                                | `{}`(evaluated as a template)  |
+
+
 
 ### Persistence parameters
 
@@ -261,16 +271,16 @@ The following tables lists the configurable parameters of the MongoDB&reg; chart
 
 ### RBAC parameters
 
-| Parameter                                                                                                                                                                                                                                                                         | Description                                             | Default                                         |
-|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|-------------------------------------------------|
-| `serviceAccount.create`                                                                                                                                                                                                                                                           | Enable creation of ServiceAccount for MongoDB&reg; pods | `true`                                          |
-| `serviceAccount.name`                                                                                                                                                                                                                                                             | Name of the created serviceAccount                      | Generated using the `mongodb.fullname` template |
-| `serviceAccount.annotations`                                                                                                                                                                                                                                                      | Additional Service Account annotations                  | `{}`                                            |
-| `rbac.create`                                                                                                                                                                                                                                                                     | Weather to create & use RBAC resources or not           | `false`                                         |
-| `podSecurityPolicy.create`                   | Whether to create & use PSP resource or not (Note: `rbac.create` needs to be `true`)                       | `false` |                                                    | |                                                    | |                                                         |                                                 |
-| `podSecurityPolicy.allowPrivilegeEscalation`                                                                                                                                                                                                                                      | Enable privilege escalation                             | `false`                                         |
-| `podSecurityPolicy.privileged`                                                                                                                                                                                                                                                    | Allow privileged                                        | `false`                                         |
-| `podSecurityPolicy.spec`                     | The PSP Spec (See https://kubernetes.io/docs/concepts/policy/pod-security-policy/), takes precedence       | `{}`    |                                                    | |                                                    | |                                                         |                                                 |
+| Parameter                                    | Description                                                                                          | Default                                         |
+| -------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `serviceAccount.create`                      | Enable creation of ServiceAccount for MongoDB&reg; pods                                              | `true`                                          |
+| `serviceAccount.name`                        | Name of the created serviceAccount                                                                   | Generated using the `mongodb.fullname` template |
+| `serviceAccount.annotations`                 | Additional Service Account annotations                                                               | `{}`                                            |
+| `rbac.create`                                | Weather to create & use RBAC resources or not                                                        | `false`                                         |
+| `podSecurityPolicy.create`                   | Whether to create & use PSP resource or not (Note: `rbac.create` needs to be `true`)                 | `false`                                         |
+| `podSecurityPolicy.allowPrivilegeEscalation` | Enable privilege escalation                                                                          | `false`                                         |
+| `podSecurityPolicy.privileged`               | Allow privileged                                                                                     | `false`                                         |
+| `podSecurityPolicy.spec`                     | The PSP Spec (See https://kubernetes.io/docs/concepts/policy/pod-security-policy/), takes precedence | `{}`                                            |
 
 ### Volume Permissions parameters
 
@@ -329,6 +339,57 @@ The following tables lists the configurable parameters of the MongoDB&reg; chart
 | `arbiter.extraVolumeMounts`         | Optionally specify extra list of additional volumeMounts for the Arbiter container(s)             | `{}`                                  |
 | `arbiter.extraVolumes`              | Optionally specify extra list of additional volumes to the Arbiter statefulset                    | `{}`                                  |
 | `arbiter.service.nameOverride`      | The arbiter service name                                                                          | `{mongodb.fullname}-arbiter-headless` |
+
+### Hidden Node parameters
+
+| Parameter                                                | Description                                                                                                          | Default                                                 |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `hidden.enabled`                                         | Enable deploying the hidden nodes                                                                                    | `false`                                                 |
+| `hidden.hostAliases`                                     | Add deployment host aliases                                                                                          | `[]`                                                    |
+| `hidden.configuration`                                   | Hidden node configuration file to be used                                                                            | `{}`                                                    |
+| `hidden.existingConfigmap`                               | Name of existing ConfigMap with Hidden node configuration                                                            | `nil`                                                   |
+| `hidden.command`                                         | Override default container command (useful when using custom images)                                                 | `nil`                                                   |
+| `hidden.args`                                            | Override default container args (useful when using custom images)                                                    | `nil`                                                   |
+| `hidden.extraFlags`                                      | Hidden node additional command line flags                                                                            | `[]`                                                    |
+| `hidden.extraEnvVars`                                    | Extra environment variables to add to Hidden node pods                                                               | `[]`                                                    |
+| `hidden.extraEnvVarsCM`                                  | Name of existing ConfigMap containing extra env vars                                                                 | `nil`                                                   |
+| `hidden.extraEnvVarsSecret`                              | Name of existing Secret containing extra env vars (in case of sensitive data)                                        | `nil`                                                   |
+| `hidden.replicaCount`                                    | Number of hidden nodes (only when `architecture=replicaset`)                                                         | `2`                                                     |
+| `hidden.labels`                                          | Annotations to be added to the hidden node statefulset                                                               | `{}` (evaluated as a template)                          |
+| `hidden.annotations`                                     | Additional labels to be added to thehidden node statefulset                                                          | `{}` (evaluated as a template)                          |
+| `hidden.podManagementPolicy`                             | Pod management policy for hidden node                                                                                | `OrderedReady`                                          |
+| `hidden.strategyType`                                    | StrategyType for hidden node statefulset                                                                             | `RollingUpdate`                                         |
+| `hidden.podLabels`                                       | Hidden node pod labels                                                                                               | `{}` (evaluated as a template)                          |
+| `hidden.podAnnotations`                                  | Hidden node Pod annotations                                                                                          | `{}` (evaluated as a template)                          |
+| `hidden.priorityClassName`                               | Name of the existing priority class to be used by hidden node pod(s)                                                 | `""`                                                    |
+| `hidden.podAffinityPreset`                               | Hidden node Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                      | `""`                                                    |
+| `hidden.podAntiAffinityPreset`                           | Hidden node Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                 | `soft`                                                  |
+| `hidden.nodeAffinityPreset.type`                         | Hidden Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                     | `""`                                                    |
+| `hidden.nodeAffinityPreset.key`                          | Hidden Node label key to match Ignored if `affinity` is set.                                                         | `""`                                                    |
+| `hidden.nodeAffinityPreset.values`                       | Hidden Node label values to match. Ignored if `affinity` is set.                                                     | `[]`                                                    |
+| `hidden.affinity`                                        | Hidden node Affinity for pod assignment                                                                              | `{}` (evaluated as a template)                          |
+| `hidden.nodeSelector`                                    | Hidden node Node labels for pod assignment                                                                           | `{}` (evaluated as a template)                          |
+| `hidden.tolerations`                                     | Hidden node Tolerations for pod assignment                                                                           | `[]` (evaluated as a template)                          |
+| `hidden.resources.limits`                                | The resources limits for hidden node containers                                                                      | `{}`                                                    |
+| `hidden.resources.requests`                              | The requested resources for hidden node containers                                                                   | `{}`                                                    |
+| `hidden.livenessProbe`                                   | Liveness probe configuration for hidden node                                                                         | Check `values.yaml` file                                |
+| `hidden.readinessProbe`                                  | Readiness probe configuration for hidden node                                                                        | Check `values.yaml` file                                |
+| `hidden.customLivenessProbe`                             | Override default liveness probe for hidden node containers                                                           | `nil`                                                   |
+| `hidden.customReadinessProbe`                            | Override default readiness probe for hidden node containers                                                          | `nil`                                                   |
+| `hidden.pdb.create`                                      | Enable/disable a Pod Disruption Budget creation for hidden node pod(s)                                               | `false`                                                 |
+| `hidden.pdb.minAvailable`                                | Minimum number/percentage of hidden node pods that should remain scheduled                                           | `1`                                                     |
+| `hidden.pdb.maxUnavailable`                              | Maximum number/percentage of hidden node pods that may be made unavailable                                           | `nil`                                                   |
+| `initContainers`                                        | Add additional init containers for the hidden node pod(s)                                                            | `{}` (evaluated as a template)                          |
+| `hidden.sidecars`                                        | Add additional sidecar containers for the hidden node pod(s)                                                         | `{}` (evaluated as a template)                          |
+| `hidden.extraVolumeMounts`                               | Optionally specify extra list of additional volumeMounts for the hidden node container(s)                            | `{}`                                                    |
+| `hidden.extraVolumes`                                    | Optionally specify extra list of additional volumes to the hidden node statefulset                                   | `{}`                                                    |
+| `hidden.persistence.enabled`                             | Enable hidden node data persistence using PVC                                                                        | `true`                                                  |
+| `hidden.persistence.storageClass`                        | PVC Storage Class for hidden node data volume                                                                        | `nil`                                                   |
+| `hidden.persistence.accessMode`                          | PVC Access Mode for hidden node data volume                                                                          | `ReadWriteOnce`                                         |
+| `hidden.persistence.size`                                | PVC Storage Request for hidden node data volume                                                                      | `8Gi`                                                   |
+| `hidden.persistence.mountPath`                           | Path to mount the volume at                                                                                          | `/bitnami/mongodb`                                      |
+| `hidden.persistence.subPath`                             | Subdirectory of the volume to mount at                                                                               | `""`                                                    |
+| `hidden.persistence.volumeClaimTemplates.selector`       | A label query over volumes to consider for binding (e.g. when using local volumes)                                   | ``                                                      |
 
 ### Metrics parameters
 

--- a/bitnami/mongodb/templates/_helpers.tpl
+++ b/bitnami/mongodb/templates/_helpers.tpl
@@ -225,6 +225,35 @@ Return true if a configmap object should be created for MongoDB(R) Arbiter
 {{- end -}}
 
 {{/*
+Return true if the Hidden should be deployed
+*/}}
+{{- define "mongodb.hidden.enabled" -}}
+{{- if and (eq .Values.architecture "replicaset") .Values.hidden.enabled }}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the configmap with the MongoDB(R) configuration for the Hidden
+*/}}
+{{- define "mongodb.hidden.configmapName" -}}
+{{- if .Values.hidden.existingConfigmap -}}
+    {{- printf "%s" (tpl .Values.hidden.existingConfigmap $) -}}
+{{- else -}}
+    {{- printf "%s-hidden" (include "mongodb.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if a configmap object should be created for MongoDB(R) Hidden
+*/}}
+{{- define "mongodb.hidden.createConfigmap" -}}
+{{- if and  (include "mongodb.hidden.enabled" .) .Values.hidden.enabled .Values.hidden.configuration (not .Values.hidden.existingConfigmap) }}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Compile all warnings into a single message, and call fail.
 */}}
 {{- define "mongodb.validateValues" -}}

--- a/bitnami/mongodb/templates/hidden/configmap.yml
+++ b/bitnami/mongodb/templates/hidden/configmap.yml
@@ -1,0 +1,12 @@
+{{- if (include "mongodb.hidden.createConfigmap" .) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mongodb.fullname" . }}-hidden
+  namespace: {{ include "mongodb.namespace" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: hidden
+data:
+  mongodb.conf: |-
+    {{- include "common.tplvalues.render" (dict "value" .Values.hidden.configuration "context" $) | nindent 4 }}
+{{- end }}

--- a/bitnami/mongodb/templates/hidden/external-access-svc.yaml
+++ b/bitnami/mongodb/templates/hidden/external-access-svc.yaml
@@ -1,0 +1,46 @@
+{{- if and (include "mongodb.hidden.enabled" .) .Values.externalAccess.hidden.enabled }}
+{{- $fullName := include "mongodb.fullname" . }}
+{{- $replicaCount := .Values.hidden.replicaCount | int }}
+{{- $root := . }}
+
+{{- range $i, $e := until $replicaCount }}
+{{- $targetPod := printf "%s-hidden-%d" (printf "%s" $fullName) $i }}
+{{- $_ := set $ "targetPod" $targetPod }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-hidden-{{ $i }}-external
+  namespace: {{ include "mongodb.namespace" $ }}
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
+    app.kubernetes.io/component: hidden
+    pod: {{ $targetPod }}
+  {{- if $root.Values.externalAccess.hidden.service.annotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $root.Values.externalAccess.hidden.service.annotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ $root.Values.externalAccess.hidden.service.type }}
+  {{- if eq $root.Values.externalAccess.hidden.service.type "LoadBalancer" }}
+  {{- if not (empty $root.Values.externalAccess.hidden.service.loadBalancerIPs) }}
+  loadBalancerIP: {{ index $root.Values.externalAccess.hidden.service.loadBalancerIPs $i }}
+  {{- end }}
+  {{- if $root.Values.externalAccess.hidden.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml $root.Values.externalAccess.hidden.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  {{- end }}
+  publishNotReadyAddresses: true
+  ports:
+    - name: {{ $root.Values.service.hidden.portName }}
+      port: {{ $root.Values.externalAccess.hidden.service.port }}
+      {{- if not (empty $root.Values.externalAccess.hidden.service.nodePorts) }}
+      nodePort: {{ index $root.Values.externalAccess.hidden.service.nodePorts $i }}
+      {{- else }}
+      nodePort: null
+      {{- end }}
+      targetPort: mongodb
+  selector: {{- include "common.labels.matchLabels" $ | nindent 4 }}
+    app.kubernetes.io/component: hidden
+    statefulset.kubernetes.io/pod-name: {{ $targetPod }}
+---
+{{- end }}
+{{- end }}

--- a/bitnami/mongodb/templates/hidden/headless-svc.yaml
+++ b/bitnami/mongodb/templates/hidden/headless-svc.yaml
@@ -1,0 +1,22 @@
+{{- if (include "mongodb.hidden.enabled" .) }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mongodb.fullname" . }}-hidden-headless
+  namespace: {{ include "mongodb.namespace" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: hidden
+  {{- if .Values.service.annotations }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: {{ .Values.service.portName }}
+      port: {{ .Values.service.port }}
+      targetPort: mongodb
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: hidden
+{{- end }}

--- a/bitnami/mongodb/templates/hidden/pdb.yaml
+++ b/bitnami/mongodb/templates/hidden/pdb.yaml
@@ -1,0 +1,19 @@
+{{- if and (include "mongodb.hidden.enabled" .) .Values.hidden.pdb.create }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "mongodb.fullname" . }}-hidden
+  namespace: {{ include "mongodb.namespace" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: hidden
+spec:
+  {{- if .Values.hidden.pdb.minAvailable }}
+  minAvailable: {{ .Values.hidden.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.hidden.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.hidden.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: hidden
+{{- end }}

--- a/bitnami/mongodb/templates/hidden/statefulset.yaml
+++ b/bitnami/mongodb/templates/hidden/statefulset.yaml
@@ -1,0 +1,480 @@
+{{- if (include "mongodb.hidden.enabled" .) }}
+{{- $replicaCount := int .Values.hidden.replicaCount }}
+{{- $loadBalancerIPListLength := len .Values.externalAccess.hidden.service.loadBalancerIPs }}
+{{- if not (and .Values.externalAccess.hidden.enabled (not .Values.externalAccess.autoDiscovery.enabled) (not (eq $replicaCount $loadBalancerIPListLength )) (eq .Values.externalAccess.hidden.service.type "LoadBalancer")) }}
+apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
+kind: StatefulSet
+metadata:
+  name: {{ include "mongodb.fullname" . }}-hidden
+  namespace: {{ include "mongodb.namespace" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: hidden
+    {{- if .Values.hidden.labels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.hidden.labels "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.hidden.annotations }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.hidden.annotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  serviceName: {{ include "mongodb.fullname" . }}-hidden-headless
+  podManagementPolicy: {{ .Values.hidden.podManagementPolicy }}
+  replicas: {{ .Values.hidden.replicaCount }}
+  updateStrategy:
+    type: {{ .Values.hidden.strategyType }}
+    {{- if (eq "OnDelete" .Values.hidden.strategyType) }}
+    rollingUpdate: null
+    {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: hidden
+  template:
+    metadata:
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        app.kubernetes.io/component: hidden
+        {{- if .Values.hidden.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.hidden.podLabels "context" $) | nindent 8 }}
+        {{- end }}
+      {{- if or (include "mongodb.hidden.createConfigmap" .) .Values.hidden.podAnnotations }}
+      annotations:
+        {{- if (include "mongodb.hidden.createConfigmap" .) }}
+        checksum/configuration: {{ include (print $.Template.BasePath "/hidden/configmap.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.hidden.podAnnotations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.hidden.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
+      {{- end }}
+    spec:
+      {{- include "mongodb.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.schedulerName }}
+      schedulerName: "{{ .Values.schedulerName }}"
+      {{- end }}
+      serviceAccountName: {{ template "mongodb.serviceAccountName" . }}
+      {{- if .Values.hidden.affinity }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.hidden.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.hidden.podAffinityPreset "component" "" "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.hidden.podAntiAffinityPreset "component" "" "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.hidden.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      {{- if .Values.hidden.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.hidden.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.hidden.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.hidden.tolerations "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.hidden.priorityClassName }}
+      priorityClassName: {{ .Values.hidden.priorityClassName }}
+      {{- end }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if or .Values.hidden.initContainers (and .Values.volumePermissions.enabled .Values.hidden.persistence.enabled) (and .Values.externalAccess.hidden.enabled .Values.externalAccess.autoDiscovery.enabled) .Values.tls.enabled }}
+      initContainers:
+        {{- if .Values.hidden.initContainers }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.hidden.initContainers "context" $) | nindent 8 }}
+        {{- end }}
+        {{- if and .Values.volumePermissions.enabled .Values.hidden.persistence.enabled }}
+        - name: volume-permissions
+          image: {{ include "mongodb.volumePermissions.image" . }}
+          imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
+          command:
+            - /bin/bash
+            - -ec
+          args:
+            - |
+              mkdir -p {{ .Values.hidden.persistence.mountPath }}{{- if .Values.hidden.persistence.subPath }}/{{ .Values.hidden.persistence.subPath }}{{- end }}
+              {{- if and .Values.podSecurityContext.enabled .Values.containerSecurityContext.enabled }}
+              chown -R "{{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }}" "{{ .Values.hidden.persistence.mountPath }}{{- if .Values.hidden.persistence.subPath }}/{{ .Values.hidden.persistence.subPath }}{{- end }}"
+              {{- end }}
+          {{- if eq ( toString ( .Values.volumePermissions.securityContext.runAsUser )) "auto" }}
+          securityContext: {{- omit .Values.volumePermissions.securityContext "runAsUser" | toYaml | nindent 12 }}
+          {{- else }}
+          securityContext: {{- .Values.volumePermissions.securityContext | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.volumePermissions.resources }}
+          resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: datadir
+              mountPath: {{ .Values.hidden.persistence.mountPath }}
+        {{- end }}
+        {{- if .Values.tls.enabled }}
+        - name: generate-tls-certs
+          image: {{ include "mongodb.tls.image" . }}
+          imagePullPolicy: {{ .Values.tls.image.pullPolicy | quote }}
+          env:
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+          - name: certs-volume
+            mountPath: /certs/CAs
+          - name: certs
+            mountPath: /certs
+          command:
+            - sh
+            - "-c"
+            - |
+              /bin/bash <<'EOF'
+              my_hostname=$(hostname)
+              svc=$(echo -n "$my_hostname" | sed s/-[0-9]*$//)-headless
+              cp /certs/CAs/* /certs/
+              cat >/certs/openssl.cnf <<EOL
+              [req]
+              req_extensions = v3_req
+              distinguished_name = req_distinguished_name
+              [req_distinguished_name]
+              [ v3_req ]
+              basicConstraints = CA:FALSE
+              keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+              subjectAltName = @alt_names
+              [alt_names]
+              DNS.1 = $svc
+              DNS.2 = $my_hostname
+              DNS.3 = $my_hostname.$svc.$MY_POD_NAMESPACE.svc.cluster.local
+              DNS.4 = localhost
+              DNS.5 = 127.0.0.1
+              {{- if .Values.externalAccess.hidden.service.loadBalancerIPs }}
+              {{- range $key, $val := .Values.externalAccess.hidden.service.loadBalancerIPs }}
+              IP.{{ $key }} = {{ $val | quote }}
+              {{- end }}
+              {{- end }}
+              EOL
+
+              export RANDFILE=/certs/.rnd && openssl genrsa -out /certs/mongo.key 2048
+              #Create the client/server certificate
+              openssl req -new -key /certs/mongo.key -out /certs/mongo.csr -subj "/C=US/O=My Organisations/OU=IT/CN=$my_hostname" -config /certs/openssl.cnf
+              #Signing the server certificate with the CA cert and key
+              openssl x509 -req -in /certs/mongo.csr -CA /certs/mongodb-ca-cert -CAkey /certs/mongodb-ca-key -CAcreateserial -out /certs/mongo.crt -days 3650 -extensions v3_req -extfile /certs/openssl.cnf
+              rm /certs/mongo.csr
+              #Concatenate to a pem file for use as the client PEM file which can be used for both member and client authentication.
+              cat /certs/mongo.crt /certs/mongo.key > /certs/mongodb.pem
+              cd /certs/
+              shopt -s extglob
+              rm -rf !(mongodb-ca-cert|mongodb.pem|CAs|openssl.cnf)
+              EOF
+        {{- end }}
+        {{- if and .Values.externalAccess.hidden.enabled .Values.externalAccess.autoDiscovery.enabled (eq .Values.externalAccess.hidden.service.type "LoadBalancer") }}
+        - name: auto-discovery
+          image: {{ include "mongodb.externalAccess.autoDiscovery.image" . }}
+          imagePullPolicy: {{ .Values.externalAccess.autoDiscovery.image.pullPolicy | quote }}
+          command:
+            - /scripts/auto-discovery.sh
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: SHARED_FILE
+              value: "/shared/info.txt"
+          {{- if .Values.externalAccess.autoDiscovery.resources }}
+          resources: {{- toYaml .Values.externalAccess.autoDiscovery.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
+            - name: scripts
+              mountPath: /scripts/auto-discovery.sh
+              subPath: auto-discovery.sh
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: mongodb
+          image: {{ include "mongodb.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.hidden.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.hidden.command "context" $) | nindent 12 }}
+          {{- else }}
+          command:
+            - /scripts/setup-hidden.sh
+          {{- end }}
+          {{- if .Values.hidden.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.hidden.args "context" $) | nindent 12 }}
+          {{- end }}
+          env:
+            - name: BITNAMI_DEBUG
+              value: {{ ternary "true" "false" .Values.image.debug | quote }}
+            {{- if and .Values.externalAccess.hidden.enabled .Values.externalAccess.autoDiscovery.enabled (eq .Values.externalAccess.hidden.service.type "LoadBalancer") }}
+            - name: SHARED_FILE
+              value: "/shared/info.txt"
+            {{- end }}
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: K8S_SERVICE_NAME
+              value: "{{ include "mongodb.fullname" . }}-headless"
+            - name: MONGODB_REPLICA_SET_MODE
+              value: "hidden"
+            - name: MONGODB_INITIAL_PRIMARY_HOST
+              value: "{{ include "mongodb.fullname" . }}-0.$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.{{ .Values.clusterDomain }}"
+            - name: MONGODB_REPLICA_SET_NAME
+              value: {{ .Values.replicaSetName | quote }}
+            {{- if and .Values.replicaSetHostnames (not .Values.externalAccess.hidden.enabled) }}
+            - name: MONGODB_ADVERTISED_HOSTNAME
+              value: "$(MY_POD_NAME).$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.{{ .Values.clusterDomain }}"
+            {{- end }}
+            {{- if .Values.auth.username }}
+            - name: MONGODB_USERNAME
+              value: {{ .Values.auth.username | quote }}
+            {{- end }}
+            {{- if .Values.auth.database }}
+            - name: MONGODB_DATABASE
+              value: {{ .Values.auth.database | quote }}
+            {{- end }}
+            {{- if .Values.auth.enabled }}
+            {{- if and .Values.auth.username .Values.auth.database }}
+            - name: MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mongodb.secretName" . }}
+                  key: mongodb-password
+            {{- end }}
+            - name: MONGODB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mongodb.secretName" . }}
+                  key: mongodb-root-password
+            - name: MONGODB_REPLICA_SET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mongodb.secretName" . }}
+                  key: mongodb-replica-set-key
+            {{- end }}
+            - name: ALLOW_EMPTY_PASSWORD
+              value: {{ ternary "no" "yes" .Values.auth.enabled | quote }}
+            - name: MONGODB_SYSTEM_LOG_VERBOSITY
+              value: {{ .Values.systemLogVerbosity | quote }}
+            - name: MONGODB_DISABLE_SYSTEM_LOG
+              value: {{ ternary "yes" "no" .Values.disableSystemLog | quote }}
+            - name: MONGODB_ENABLE_IPV6
+              value: {{ ternary "yes" "no" .Values.enableIPv6 | quote }}
+            - name: MONGODB_ENABLE_DIRECTORY_PER_DB
+              value: {{ ternary "yes" "no" .Values.directoryPerDB | quote }}
+            {{- if .Values.tls.enabled }}
+            - name: MONGODB_EXTRA_FLAGS
+              value: --tlsMode=requireTLS --tlsCertificateKeyFile=/certs/mongodb.pem --tlsCAFile=/certs/mongodb-ca-cert
+            {{- end }}
+            {{- if .Values.hidden.extraFlags }}
+            - name: MONGODB_EXTRA_FLAGS
+              value: {{ .Values.hidden.extraFlags | join " " | quote }}
+            {{- end }}
+            {{- if .Values.tls.enabled }}
+            - name: MONGODB_CLIENT_EXTRA_FLAGS
+              value: --tls --tlsCertificateKeyFile=/certs/mongodb.pem --tlsCAFile=/certs/mongodb-ca-cert
+            {{- end }}
+            {{- if .Values.hidden.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.hidden.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+          {{- if or .Values.hidden.extraEnvVarsCM .Values.hidden.extraEnvVarsSecret }}
+          envFrom:
+            {{- if .Values.hidden.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ tpl .Values.hidden.extraEnvVarsCM . | quote }}
+            {{- end }}
+            {{- if .Values.hidden.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ tpl .Values.hidden.extraEnvVarsSecret . | quote }}
+            {{- end }}
+          {{- end }}
+          ports:
+            - containerPort: 27017
+              name: mongodb
+          {{- if .Values.hidden.livenessProbe.enabled }}
+          livenessProbe:
+            exec:
+              command:
+                - mongo
+              {{- if .Values.tls.enabled }}
+                - --tls
+                - --tlsCertificateKeyFile=/certs/mongodb.pem
+                - --tlsCAFile=/certs/mongodb-ca-cert
+              {{- end }}
+                - --eval
+                - "db.adminCommand('ping')"
+            initialDelaySeconds: {{ .Values.hidden.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.hidden.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.hidden.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.hidden.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.hidden.livenessProbe.failureThreshold }}
+          {{- else if .Values.hidden.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.hidden.customLivenessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.hidden.readinessProbe.enabled }}
+          readinessProbe:
+            exec:
+              command:
+                - mongo
+              {{- if .Values.tls.enabled }}
+                - --tls
+                - --tlsCertificateKeyFile=/certs/mongodb.pem
+                - --tlsCAFile=/certs/mongodb-ca-cert
+              {{- end }}
+                - --eval
+                - "db.adminCommand('ping')"
+            initialDelaySeconds: {{ .Values.hidden.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.hidden.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.hidden.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.hidden.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.hidden.readinessProbe.failureThreshold }}
+          {{- else if .Values.hidden.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.hidden.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.hidden.resources }}
+          resources: {{- toYaml .Values.hidden.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: datadir
+              mountPath: {{ .Values.hidden.persistence.mountPath }}
+              subPath: {{ .Values.hidden.persistence.subPath }}
+            {{- if or .Values.initdbScriptsConfigMap .Values.initdbScripts }}
+            - name: custom-init-scripts
+              mountPath: /docker-entrypoint-initdb.d
+            {{- end }}
+            {{- if or .Values.hidden.configuration .Values.hidden.existingConfigmap }}
+            - name: config
+              mountPath: /opt/bitnami/mongodb/conf/mongodb.conf
+              subPath: mongodb.conf
+            {{- end }}
+            - name: scripts
+              mountPath: /scripts/setup-hidden.sh
+              subPath: setup-hidden.sh
+            {{- if and .Values.externalAccess.hidden.enabled .Values.externalAccess.autoDiscovery.enabled (eq .Values.externalAccess.hidden.service.type "LoadBalancer") }}
+            - name: shared
+              mountPath: /shared
+            {{- end }}
+            {{- if .Values.tls.enabled }}
+            - name: certs
+              mountPath: /certs
+            {{- end }}
+            {{- if .Values.hidden.extraVolumeMounts }}
+            {{- toYaml .Values.hidden.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+        {{- if .Values.metrics.enabled }}
+        - name: metrics
+          image: {{ template "mongodb.metrics.image" . }}
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          command:
+            - /bin/bash
+            - -ec
+          args:
+            - |
+              /bin/mongodb_exporter --mongodb.uri "{{ include "mongodb.mongodb_exporter.uri" . }}" {{ .Values.metrics.extraFlags }}
+          env:
+          {{- if .Values.auth.enabled }}
+          - name: MONGODB_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "mongodb.secretName" . }}
+                key: mongodb-root-password
+          {{- end }}
+          volumeMounts:
+          {{- if .Values.tls.enabled }}
+          - name: certs
+            mountPath: /certs
+          {{- end }}
+          ports:
+            - name: metrics
+              containerPort: 9216
+          {{- if .Values.metrics.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: metrics
+            initialDelaySeconds: {{ .Values.metrics.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.metrics.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.metrics.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.metrics.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.metrics.livenessProbe.successThreshold }}
+          {{- end }}
+          {{- if .Values.metrics.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: metrics
+            initialDelaySeconds: {{ .Values.metrics.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.metrics.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.metrics.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.metrics.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.metrics.readinessProbe.successThreshold }}
+          {{- end }}
+          {{- if .Values.metrics.resources }}
+          resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
+          {{- end }}
+        {{- end }}
+        {{- if .Values.hidden.sidecars }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.hidden.sidecars "context" $) | nindent 8 }}
+        {{- end }}
+      volumes:
+        {{- if or .Values.initdbScriptsConfigMap .Values.initdbScripts }}
+        - name: custom-init-scripts
+          configMap:
+            name: {{ template "mongodb.initdbScriptsCM" . }}
+        {{- end }}
+        {{- if or .Values.hidden.configuration .Values.hidden.existingConfigmap }}
+        - name: config
+          configMap:
+            name: {{ include "mongodb.hidden.configmapName" . }}
+        {{- end }}
+        {{- if and .Values.externalAccess.hidden.enabled .Values.externalAccess.autoDiscovery.enabled (eq .Values.externalAccess.hidden.service.type "LoadBalancer") }}
+        - name: shared
+          emptyDir: {}
+        {{- end }}
+        - name: scripts
+          configMap:
+            name: {{ include "mongodb.fullname" . }}-scripts
+            defaultMode: 0755
+        {{- if .Values.hidden.extraVolumes }}
+        {{- toYaml .Values.hidden.extraVolumes | nindent 8 }}
+        {{- end }}
+        {{- if .Values.tls.enabled }}
+        - name: certs
+          emptyDir: {}
+        - name: certs-volume
+          secret:
+            secretName: {{ template "mongodb.caSecretName" . }}
+            items:
+            - key: mongodb-ca-cert
+              path: mongodb-ca-cert
+              mode: 511
+            - key: mongodb-ca-key
+              path: mongodb-ca-key
+              mode: 511
+        {{- end }}
+  {{- if not .Values.hidden.persistence.enabled }}
+        - name: datadir
+          emptyDir: {}
+  {{- else }}
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        {{- if .Values.hidden.persistence.annotations }}
+        annotations: {{- include "common.tplvalues.render" (dict "value" .Values.hidden.persistence.annotations "context" $) | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+        {{- range .Values.hidden.persistence.accessModes }}
+          - {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.hidden.persistence.size | quote }}
+        {{- if .Values.hidden.persistence.volumeClaimTemplates.selector }}
+        selector: {{- include "common.tplvalues.render" (dict "value" .Values.hidden.persistence.volumeClaimTemplates.selector "context" $) | nindent 10 }}
+        {{- end }}
+        {{ include "common.storage.class" (dict "persistence" .Values.hidden.persistence "global" .Values.global) }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/bitnami/mongodb/templates/replicaset/scripts-configmap.yaml
+++ b/bitnami/mongodb/templates/replicaset/scripts-configmap.yaml
@@ -85,4 +85,30 @@ data:
     fi
 
     exec /opt/bitnami/scripts/mongodb/entrypoint.sh /opt/bitnami/scripts/mongodb/run.sh
+  setup-hidden.sh: |-
+    #!/bin/bash
+
+    {{- if .Values.externalAccess.hidden.enabled }}
+    {{- if eq .Values.externalAccess.hidden.service.type "LoadBalancer" }}
+    {{- if .Values.externalAccess.autoDiscovery.enabled }}
+    export MONGODB_ADVERTISED_HOSTNAME="$(<${SHARED_FILE})"
+    {{- else }}
+    ID="${MY_POD_NAME#"{{ $fullname }}-hidden-"}"
+    export MONGODB_ADVERTISED_HOSTNAME=$(echo '{{ .Values.externalAccess.hidden.service.loadBalancerIPs }}' | tr -d '[]' | cut -d ' ' -f "$(($ID + 1))")
+    {{- end }}
+    {{- else if eq .Values.externalAccess.hidden.service.type "NodePort" }}
+    {{- if .Values.externalAccess.hidden.service.domain }}
+    export MONGODB_ADVERTISED_HOSTNAME={{ .Values.externalAccess.hidden.service.domain }}
+    {{- else }}
+    export MONGODB_ADVERTISED_HOSTNAME=$(curl -s https://ipinfo.io/ip)
+    {{- end }}
+    {{- end }}
+    {{- end }}
+    echo "Advertised Hostname: $MONGODB_ADVERTISED_HOSTNAME"
+    echo "Configuring node as a hidden node"
+    export MONGODB_REPLICA_SET_MODE="hidden"
+    export MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD="$MONGODB_ROOT_PASSWORD"
+    export MONGODB_INITIAL_PRIMARY_PORT_NUMBER="$MONGODB_PORT_NUMBER"
+    export MONGODB_ROOT_PASSWORD="" MONGODB_USERNAME="" MONGODB_DATABASE="" MONGODB_PASSWORD=""
+    exec /opt/bitnami/scripts/mongodb/entrypoint.sh /opt/bitnami/scripts/mongodb/run.sh
 {{- end }}

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -603,6 +603,50 @@ externalAccess:
     ## Provide any additional annotations which may be required. Evaluated as a template
     ##
     annotations: {}
+  ## External Access to MongoDB(R) Hidden nodes configuration
+  ##
+  hidden:
+    ## Enable Kubernetes external cluster access to MongoDB(R) nodes
+    ##
+    enabled: false
+    ## Parameters to configure K8s service(s) used to externally access MongoDB(R)
+    ## A new service per broker will be created
+    ##
+    service:
+      ## Service type. Allowed values: LoadBalancer or NodePort
+      ##
+      type: LoadBalancer
+      ## Port used when service type is LoadBalancer
+      ##
+      port: 27017
+      ## Array of load balancer IPs for each MongoDB(R) node. Length must be the same as replicaCount
+      ## Example:
+      ## loadBalancerIPs:
+      ##   - X.X.X.X
+      ##   - Y.Y.Y.Y
+      ##
+      loadBalancerIPs: []
+      ## Load Balancer sources
+      ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+      ## Example:
+      ## loadBalancerSourceRanges:
+      ## - 10.10.10.0/24
+      ##
+      loadBalancerSourceRanges: []
+      ## Array of node ports used for each MongoDB(R) nodes. Length must be the same as replicaCount
+      ## Example:
+      ## nodePorts:
+      ##   - 30001
+      ##   - 30002
+      ##
+      nodePorts: []
+      ## When service type is NodePort, you can specify the domain used for MongoDB(R) advertised hostnames.
+      ## If not specified, the container will try to get the kubernetes node external IP
+      ##
+      # domain: mydomain.com
+      ## Provide any additional annotations which may be required. Evaluated as a template
+      ##
+      annotations: {}
 
 ##
 ## MongoDB(R) Arbiter parameters.
@@ -1104,3 +1148,267 @@ metrics:
     ##       summary: High request latency
     ##
     rules: {}
+
+##
+## MongoDB(R) Hidden node parameters.
+##
+hidden:
+  ## Enable deploying the MongoDB(R) Hidden Node
+  ##   https://docs.mongodb.com/manual/tutorial/configure-a-hidden-replica-set-member/
+  ##
+  enabled: false
+
+  ## MongoDB(R) configuration file for Hidden nodes. For documentation of all options, see:
+  ##   http://docs.mongodb.org/manual/reference/configuration-options/
+  ##
+  configuration: ""
+
+  ## ConfigMap with MongoDB(R) configuration for Hidden nodes
+  ## NOTE: When it's set the hidden.configuration parameter is ignored
+  ##
+  # existingConfigmap:
+
+  ## Command and args for running the container (set to default if not set). Use array form
+  ##
+  # command:
+  # args:
+
+  ## Additional command line flags
+  ## Example:
+  ## extraFlags:
+  ##  - "--wiredTigerCacheSizeGB=2"
+  ##
+  extraFlags: []
+
+  ## Additional environment variables to set
+  ## E.g:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: BAR
+  ##
+  extraEnvVars: []
+
+  ## ConfigMap with extra environment variables
+  ##
+  # extraEnvVarsCM:
+
+  ## Secret with extra environment variables
+  ##
+  # extraEnvVarsSecret:
+
+  ## Annotations to be added to the MongoDB(R) Hidden statefulset. Evaluated as a template.
+  ##
+  annotations: {}
+
+  ## Additional labels to be added to the MongoDB(R) Hidden statefulset. Evaluated as a template.
+  ##
+  labels: {}
+
+  ## Number of MongoDB(R) Hidden replicas to deploy.
+  ## Ignored when mongodb.architecture=standalone
+  ##
+  replicaCount: 1
+
+  ## StrategyType for MongoDB(R) Hidden statefulset
+  ## It can be set to RollingUpdate or Recreate by default.
+  ##
+  strategyType: RollingUpdate
+
+  ## MongoDB(R) Hidden should be initialized one by one when building the replicaset for the first time.
+  ##
+  podManagementPolicy: OrderedReady
+
+  ## Pod affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAffinityPreset: ""
+
+  ## Pod anti-affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ## Allowed values: soft, hard
+  ##
+  podAntiAffinityPreset: soft
+
+  ## Node affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ## Allowed values: soft, hard
+  ##
+  nodeAffinityPreset:
+    ## Node affinity type
+    ## Allowed values: soft, hard
+    ##
+    type: ""
+    ## Node label key to match
+    ## E.g.
+    ## key: "kubernetes.io/e2e-az-name"
+    ##
+    key: ""
+    ## Node label values to match
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+
+  ## Affinity for pod assignment. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
+  ##
+  affinity: {}
+
+  ## Node labels for pod assignment. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Tolerations for pod assignment. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## Labels for MongoDB(R) Hidden pods. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  ##
+  podLabels: {}
+
+  ## Annotations for MongoDB(R) Hidden pods. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+
+  ## MongoDB(R) Hidden pods' priority.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  ##
+  # priorityClassName: ""
+
+  ## MongoDB(R) Hidden containers' resource requests and limits.
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+    requests: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  ## MongoDB(R) Hidden pods' liveness and readiness probes. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+
+  ## Custom Liveness probes for MongoDB(R) Hidden pods.
+  ## Ignored when livenessProbe.enabled=true
+  ##
+  customLivenessProbe: {}
+
+  ## Custom Rediness probes MongoDB(R) Hidden pods
+  ## Ignored when readinessProbe.enabled=true
+  ##
+  customReadinessProbe: {}
+
+  ## Add init containers to the MongoDB(R) Hidden pods.
+  ## Example:
+  ## initContainers:
+  ##   - name: your-image-name
+  ##     image: your-image
+  ##     imagePullPolicy: Always
+  ##     ports:
+  ##       - name: portname
+  ##         containerPort: 1234
+  ##
+  initContainers: {}
+
+  ## Add sidecars to the MongoDB(R) Hidden pods.
+  ## Example:
+  ## sidecars:
+  ##   - name: your-image-name
+  ##     image: your-image
+  ##     imagePullPolicy: Always
+  ##     ports:
+  ##       - name: portname
+  ##         containerPort: 1234
+  ##
+  sidecars: {}
+
+  ## extraVolumes and extraVolumeMounts allows you to mount other volumes on MongoDB(R) Hidden pods
+  ## Examples:
+  ## extraVolumeMounts:
+  ##   - name: extras
+  ##     mountPath: /usr/share/extras
+  ##     readOnly: true
+  ## extraVolumes:
+  ##   - name: extras
+  ##     emptyDir: {}
+  ##
+  extraVolumeMounts: []
+  extraVolumes: []
+
+  ## MongoDB(R) Hidden Pod Disruption Budget configuration
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  ##
+  pdb:
+    create: false
+    ## Min number of pods that must still be available after the eviction
+    ##
+    minAvailable: 1
+    ## Max number of pods that can be unavailable after the eviction
+    ##
+    # maxUnavailable: 1
+
+  ## Enable persistence using Persistent Volume Claims
+  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  ##
+  persistence:
+    enabled: true
+    ## PV Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ## set, choosing the default provisioner.
+    ##
+    # storageClass: "-"
+    ## PV Access Mode
+    ##
+    accessModes:
+      - ReadWriteOnce
+    ## PVC size
+    ##
+    size: 8Gi
+    ## PVC annotations
+    ##
+    annotations: {}
+    ## The path the volume will be mounted at, useful when using different
+    ## MongoDB(R) images.
+    ##
+    mountPath: /bitnami/mongodb
+    ## The subdirectory of the volume to mount to, useful in dev environments
+    ## and one PV for multiple services.
+    ##
+    subPath: ""
+    ## Fine tuning for volumeClaimTemplates
+    ##
+    volumeClaimTemplates:
+      ## A label query over volumes to consider for binding (e.g. when using local volumes)
+      ## See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#labelselector-v1-meta for more details
+      ##
+      selector:


### PR DESCRIPTION
**Description of the change**

Added Hidden replica node support

**Benefits**

These nodes can be used for several things like - 
- Analytical Queries
- Backup

**Possible drawbacks**

Backwards compatibile, so no obvious issues beyond the minor increase in complexity

**Applicable issues**

  - fixes #4051

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
