### PR TITLE
[bitnami/ghost] add "loadBalancerSourceRanges"

### DIFF
--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -33,4 +33,4 @@ name: ghost
 sources:
   - https://github.com/bitnami/bitnami-docker-ghost
   - http://www.ghost.org/
-version: 12.1.4
+version: 12.2.0

--- a/bitnami/ghost/README.md
+++ b/bitnami/ghost/README.md
@@ -159,7 +159,7 @@ The following table lists the configurable parameters of the Ghost chart and the
 | `service.nodePorts.http`          | Kubernetes http node port                                                            | `""`                           |
 | `service.externalTrafficPolicy`   | Enable client source IP preservation                                                 | `Cluster`                      |
 | `service.loadBalancerIP`          | LoadBalancerIP for the Ghost service                                                 | ``                             |
-| `service.loadBalancerSourceRanges`| define loadBalancerSourceRanges if the service type is `LoadBalancer`                | `[]`                          |
+| `service.loadBalancerSourceRanges`| define loadBalancerSourceRanges if the service type is `LoadBalancer`                | `[]`                           |
 | `service.annotations`             | Service annotations. Evaluated as a template                                         | `{}`                           |
 | `service.extraPorts`              | Service extra ports, normally used with the `sidecar` value. Evaluated as a template | `[]`                           |
 | `ingress.enabled`                 | Enable ingress controller resource                                                   | `false`                        |

--- a/bitnami/ghost/README.md
+++ b/bitnami/ghost/README.md
@@ -159,7 +159,7 @@ The following table lists the configurable parameters of the Ghost chart and the
 | `service.nodePorts.http`          | Kubernetes http node port                                                            | `""`                           |
 | `service.externalTrafficPolicy`   | Enable client source IP preservation                                                 | `Cluster`                      |
 | `service.loadBalancerIP`          | LoadBalancerIP for the Ghost service                                                 | ``                             |
-| `service.loadBalancerSourceRanges`| define loadBalancerSourceRanges if the service type is `LoadBalancer`                | `nil`                          |
+| `service.loadBalancerSourceRanges`| define loadBalancerSourceRanges if the service type is `LoadBalancer`                | `[]`                          |
 | `service.annotations`             | Service annotations. Evaluated as a template                                         | `{}`                           |
 | `service.extraPorts`              | Service extra ports, normally used with the `sidecar` value. Evaluated as a template | `[]`                           |
 | `ingress.enabled`                 | Enable ingress controller resource                                                   | `false`                        |

--- a/bitnami/ghost/README.md
+++ b/bitnami/ghost/README.md
@@ -152,29 +152,30 @@ The following table lists the configurable parameters of the Ghost chart and the
 
 ### Traffic Exposure Parameters
 
-| Parameter                        | Description                                                                          | Default                        |
-|----------------------------------|--------------------------------------------------------------------------------------|--------------------------------|
-| `service.type`                   | Kubernetes Service type                                                              | `LoadBalancer`                 |
-| `service.port`                   | Service HTTP port                                                                    | `80`                           |
-| `service.nodePorts.http`         | Kubernetes http node port                                                            | `""`                           |
-| `service.externalTrafficPolicy`  | Enable client source IP preservation                                                 | `Cluster`                      |
-| `service.loadBalancerIP`         | LoadBalancerIP for the Ghost service                                                 | ``                             |
-| `service.annotations`            | Service annotations. Evaluated as a template                                         | `{}`                           |
-| `service.extraPorts`             | Service extra ports, normally used with the `sidecar` value. Evaluated as a template | `[]`                           |
-| `ingress.enabled`                | Enable ingress controller resource                                                   | `false`                        |
-| `ingress.certManager`            | Add annotations for cert-manager                                                     | `false`                        |
-| `ingress.hostname`               | Default host for the ingress resource                                                | `ghost.local`                  |
-| `ingress.path`                   | Default path for the ingress resource                                                | `/`                            |
-| `ingress.tls`                    | Create TLS Secret                                                                    | `false`                        |
-| `ingress.annotations`            | Ingress annotations                                                                  | `[]` (evaluated as a template) |
-| `ingress.extraHosts[0].name`     | Additional hostnames to be covered                                                   | `nil`                          |
-| `ingress.extraHosts[0].path`     | Additional hostnames to be covered                                                   | `nil`                          |
-| `ingress.extraPaths`             | Additional arbitrary path/backend objects                                            | `nil`                          |
-| `ingress.extraTls[0].hosts[0]`   | TLS configuration for additional hostnames to be covered                             | `nil`                          |
-| `ingress.extraTls[0].secretName` | TLS configuration for additional hostnames to be covered                             | `nil`                          |
-| `ingress.secrets[0].name`        | TLS Secret Name                                                                      | `nil`                          |
-| `ingress.secrets[0].certificate` | TLS Secret Certificate                                                               | `nil`                          |
-| `ingress.secrets[0].key`         | TLS Secret Key                                                                       | `nil`                          |
+| Parameter                         | Description                                                                          | Default                        |
+|-----------------------------------|--------------------------------------------------------------------------------------|--------------------------------|
+| `service.type`                    | Kubernetes Service type                                                              | `LoadBalancer`                 |
+| `service.port`                    | Service HTTP port                                                                    | `80`                           |
+| `service.nodePorts.http`          | Kubernetes http node port                                                            | `""`                           |
+| `service.externalTrafficPolicy`   | Enable client source IP preservation                                                 | `Cluster`                      |
+| `service.loadBalancerIP`          | LoadBalancerIP for the Ghost service                                                 | ``                             |
+| `service.loadBalancerSourceRanges`| define loadBalancerSourceRanges if the service type is `LoadBalancer`                | `nil`                          |
+| `service.annotations`             | Service annotations. Evaluated as a template                                         | `{}`                           |
+| `service.extraPorts`              | Service extra ports, normally used with the `sidecar` value. Evaluated as a template | `[]`                           |
+| `ingress.enabled`                 | Enable ingress controller resource                                                   | `false`                        |
+| `ingress.certManager`             | Add annotations for cert-manager                                                     | `false`                        |
+| `ingress.hostname`                | Default host for the ingress resource                                                | `ghost.local`                  |
+| `ingress.path`                    | Default path for the ingress resource                                                | `/`                            |
+| `ingress.tls`                     | Create TLS Secret                                                                    | `false`                        |
+| `ingress.annotations`             | Ingress annotations                                                                  | `[]` (evaluated as a template) |
+| `ingress.extraHosts[0].name`      | Additional hostnames to be covered                                                   | `nil`                          |
+| `ingress.extraHosts[0].path`      | Additional hostnames to be covered                                                   | `nil`                          |
+| `ingress.extraPaths`              | Additional arbitrary path/backend objects                                            | `nil`                          |
+| `ingress.extraTls[0].hosts[0]`    | TLS configuration for additional hostnames to be covered                             | `nil`                          |
+| `ingress.extraTls[0].secretName`  | TLS configuration for additional hostnames to be covered                             | `nil`                          |
+| `ingress.secrets[0].name`         | TLS Secret Name                                                                      | `nil`                          |
+| `ingress.secrets[0].certificate`  | TLS Secret Certificate                                                               | `nil`                          |
+| `ingress.secrets[0].key`          | TLS Secret Key                                                                       | `nil`                          |
 
 ### Database parameters
 

--- a/bitnami/ghost/templates/svc.yaml
+++ b/bitnami/ghost/templates/svc.yaml
@@ -22,6 +22,9 @@ spec:
   {{- if eq .Values.service.type "LoadBalancer" }}
   loadBalancerIP: {{ default "" .Values.service.loadBalancerIP | quote }}
   {{- end }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
   ports:
     - name: http
       port: {{ .Values.service.port }}

--- a/bitnami/ghost/values.yaml
+++ b/bitnami/ghost/values.yaml
@@ -265,6 +265,9 @@ service:
   ##
   loadBalancerIP:
 
+  # loadBalancerSourceRanges:
+  # - 10.10.10.0/24
+
   ## nodePorts:
   ##   http: <to set explicitly, choose port between 30000-32767>
   ##


### PR DESCRIPTION
**Description of the change**

The change adds a possibility to use `loadBalancerSourceRanges` for the service definition.

**Benefits**

So, anyone is able to define `loadBalancerSourceRanges` from `values.yaml`

**Possible drawbacks**

-

**Applicable issues**

-

**Additional information**

-

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
