### PR TITLE
[bitnami/kafka] Fix Zookeeper with SASL-auth in combination with client/interbroker mTLS

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 12.9.0
+version: 12.9.1

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -222,6 +222,16 @@ spec:
                   name: {{ include "kafka.jaasSecretName" . }}
                   key: client-passwords
             {{- end }}
+            {{- if (include "kafka.interBroker.saslAuthentication" .) }}
+            - name: KAFKA_INTER_BROKER_USER
+              value: {{ .Values.auth.jaas.interBrokerUser | quote }}
+            - name: KAFKA_INTER_BROKER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kafka.jaasSecretName" . }}
+                  key: inter-broker-password
+            {{- end }}
+            {{- end }}
             {{- if .Values.auth.jaas.zookeeperUser }}
             - name: KAFKA_ZOOKEEPER_PROTOCOL
               value: "SASL"
@@ -232,16 +242,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "kafka.jaasSecretName" . }}
                   key: zookeeper-password
-            {{- end }}
-            {{- if (include "kafka.interBroker.saslAuthentication" .) }}
-            - name: KAFKA_INTER_BROKER_USER
-              value: {{ .Values.auth.jaas.interBrokerUser | quote }}
-            - name: KAFKA_INTER_BROKER_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "kafka.jaasSecretName" . }}
-                  key: inter-broker-password
-            {{- end }}
             {{- end }}
             {{- if (include "kafka.tlsEncryption" .) }}
             - name: KAFKA_CFG_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM


### PR DESCRIPTION
**Description of the change**

The combination of Zookeeper-Auth with jaas and client/interbroker with mTLS is not possible at this moment 

**Benefits**

Fix the problem from the description

**Possible drawbacks**

**Applicable issues**

  - fixes #5523

**Additional information**

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
