### PR TITLE
[bitnami/postgresql-ha] Fix usePasswordFile readiness and liveness Probe

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -27,4 +27,4 @@ name: postgresql-ha
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 6.5.2
+version: 6.5.3

--- a/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
@@ -280,8 +280,8 @@ spec:
           livenessProbe:
             exec:
               command:
-                - sh
-                - -c
+                - bash
+                - -ec
                 - '{{ include "postgresql-ha.pgpassword" . }} psql -w -U {{ include "postgresql-ha.postgresqlUsername" . | quote }} -d {{ (include "postgresql-ha.postgresqlDatabase" .) | quote }}  -h 127.0.0.1 -c "SELECT 1"'
             initialDelaySeconds: {{ .Values.postgresql.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.postgresql.livenessProbe.periodSeconds }}
@@ -295,8 +295,8 @@ spec:
           readinessProbe:
             exec:
               command:
-                - sh
-                - -c
+                - bash
+                - -ec
                 - '{{ include "postgresql-ha.pgpassword" . }} psql -w -U {{ include "postgresql-ha.postgresqlUsername" . | quote }} -d {{ (include "postgresql-ha.postgresqlDatabase" .) | quote }}  -h 127.0.0.1 -c "SELECT 1"'
             initialDelaySeconds: {{ .Values.postgresql.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.postgresql.readinessProbe.periodSeconds }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Readiness and Liveness probe were failing because of using `PGPASSWORD=$(<$POSTGRES_PASSWORD_FILE)` in an `sh` command.

This PR changes the Readiness and Liveness from `sh -c` to `bash -ec` which supports the Syntax.

An alternative solution would be using `cat` to set PGPASSWORD:
```
PGPASSWORD=$(cat $POSTGRES_PASSWORD_FILE)
```

For more information please check https://stackoverflow.com/questions/7427262/how-to-read-a-file-into-a-variable-in-shell

Testing outcome:

```sh
#Current command
> kubectl exec -it miruiz-postgresql-postgresql-ha-postgresql-0 -- sh -c 'export POSTGRES_PASSWORD_FILE=/opt/bitnami/postgresql/secrets/postgresql-password; PGPASSWORD=$(<$POSTGRES_PASSWORD_FILE); echo $PGPASSWORD'


```
```bash
#Using sh and cat
> kubectl exec -it miruiz-postgresql-postgresql-ha-postgresql-0 -- sh -c 'export POSTGRES_PASSWORD_FILE=/opt/bitnami/postgresql/secrets/postgresql-password; PGPASSWORD=$(cat $POSTGRES_PASSWORD_FILE); echo $PGPASSWORD' 
2zYHlc2uJ5
```

```bash
#Current command but using bash
> kubectl exec -it miruiz-postgresql-postgresql-ha-postgresql-0 -- bash -ec 'export POSTGRES_PASSWORD_FILE=/opt/bitnami/postgresql/secrets/postgresql-password; PGPASSWORD=$(<$POSTGRES_PASSWORD_FILE); echo $PGPASSWORD'
2zYHlc2uJ5
```

After applying the fix, pods are up and running:
```
postgresql-postgresql-ha-pgpool-567857d9b-n7nm6   1/1     Running   0          5m18s
postgresql-postgresql-ha-postgresql-0             1/1     Running   0          5m18s
postgresql-postgresql-ha-postgresql-1             1/1     Running   1          5m18s
```


**Benefits**

Readiness and liveness probe are fixed when using usePasswordFile.

**Possible drawbacks**

None known.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #4833

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
