### PR TITLE
[bitnami/apache] Add extra-list.yaml & extra initContainers & sidecars

### DIFF
--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -26,4 +26,4 @@ name: apache
 sources:
   - https://github.com/bitnami/bitnami-docker-apache
   - https://httpd.apache.org
-version: 8.2.3
+version: 8.3.0

--- a/bitnami/apache/README.md
+++ b/bitnami/apache/README.md
@@ -133,6 +133,8 @@ The following tables lists the configurable parameters of the Apache chart and t
 | `extraVolumes`                   | Array to add extra volumes                                                                | `[]` (evaluated as a template)                               |
 | `extraVolumeMounts`              | Array to add extra mount                                                                  | `[]` (evaluated as a template)                               |
 | `extraEnvVars`                   | Array to add extra environment variables                                                  | `[]` (evaluated as a template)                               |
+| `initContainers`                 | Add additional init containers to the Apache pods                                         | `{}` (evaluated as a template)                               |
+| `sidecars`                       | Add additional sidecar containers to the Apache pods                                      | `{}` (evaluated as a template)                               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/apache/README.md
+++ b/bitnami/apache/README.md
@@ -47,15 +47,26 @@ $ helm delete my-release
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
+### Global parameters
+
+| Parameter                 | Description                                     | Default                                                 |
+|---------------------------|-------------------------------------------------|---------------------------------------------------------|
+| `global.imageRegistry`    | Global Docker image registry                    | `nil`                                                   |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
+
+### Common parameters
+
+| Parameter           | Description                                                          | Default                        |
+|---------------------|----------------------------------------------------------------------|--------------------------------|
+| `extraDeploy`       | Array of extra objects to deploy with the release                    | `[]` (evaluated as a template) |
+| `kubeVersion`       | Force target Kubernetes version (using Helm capabilities if not set) | `nil`                          |
+
 ## Parameters
 
 The following tables lists the configurable parameters of the Apache chart and their default values.
 
 | Parameter                        | Description                                                                               | Default                                                      |
 |----------------------------------|-------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `global.imageRegistry`           | Global Docker image registry                                                              | `nil`                                                        |
-| `global.imagePullSecrets`        | Global Docker registry secret names as an array                                           | `[]` (does not add image pull secrets to deployed pods)      |
-| `kubeVersion`                    | Force target Kubernetes version (using Helm capabilities if not set)                      | `nil`                                                        |
 | `image.registry`                 | Apache Docker image registry                                                              | `docker.io`                                                  |
 | `image.repository`               | Apache Docker image name                                                                  | `bitnami/apache`                                             |
 | `image.tag`                      | Apache Docker image tag                                                                   | `{TAG_NAME}`                                                 |

--- a/bitnami/apache/templates/deployment.yaml
+++ b/bitnami/apache/templates/deployment.yaml
@@ -40,8 +40,9 @@ spec:
       {{- if .Values.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
       {{- end }}
-      {{- if .Values.cloneHtdocsFromGit.enabled }}
+      {{- if or .Values.initContainers .Values.cloneHtdocsFromGit.enabled }}
       initContainers:
+        {{- if .Values.cloneHtdocsFromGit.enabled }}
         - name: git-clone-repository
           image: {{ include "git.image" . }}
           imagePullPolicy: {{ .Values.git.pullPolicy | quote }}
@@ -54,7 +55,13 @@ spec:
           volumeMounts:
             - name: htdocs
               mountPath: /app
+        {{- end }}
+        {{- if .Values.initContainers }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+        {{- end }}
+      {{- end }}
       containers:
+        {{- if .Values.cloneHtdocsFromGit.enabled }}
         - name: git-repo-syncer
           image: {{ include "git.image" . }}
           imagePullPolicy: {{ .Values.git.pullPolicy | quote }}
@@ -70,9 +77,7 @@ spec:
           volumeMounts:
             - name: htdocs
               mountPath: /app
-      {{- else }}
-      containers:
-      {{- end }}
+        {{- end }}
         - name: apache
           image: {{ include "apache.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
@@ -152,6 +157,9 @@ spec:
           {{- if .Values.metrics.resources }}
           resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
           {{- end }}
+        {{- end }}
+        {{- if .Values.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) | nindent 8 }}
         {{- end }}
       volumes:
         {{- if (include "apache.useHtdocs" .) }}

--- a/bitnami/apache/templates/extra-list.yaml
+++ b/bitnami/apache/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -308,6 +308,30 @@ extraVolumeMounts: []
 ##
 extraEnvVars: []
 
+## Add init containers to the Apache pods.
+## Example:
+## initContainers:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+initContainers: {}
+
+## Add sidecars to the Apache pods.
+## Example:
+## sidecars:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+sidecars: {}
+
 ## Service parameters
 ##
 service:

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -34,6 +34,10 @@ image:
   ##
   debug: false
 
+## Extra objects to deploy (value evaluated as a template)
+##
+extraDeploy: []
+
 ## Bitnami Git image version
 ## ref: https://hub.docker.com/r/bitnami/git/tags/
 ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

New version of tomcat chart proposes a flexible way to add extra objects in the chart and extra initContainers & sidecars in the pod. In a use case of mine, I need this as well in apache, so I propose to port the same mechanism from tomcat chart to apache.

**Benefits**

Align to latest practices

**Possible drawbacks**

None

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
