### PR TITLE
[bitnami/kafka] Fix `long` value for `log.flush.scheduler.interval.ms`

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 12.9.3
+version: 12.9.4

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -85,7 +85,7 @@ The following tables lists the configurable parameters of the Kafka chart and th
 | `heapOpts`                                | Kafka's Java Heap size                                                                                                                               | `-Xmx1024m -Xms1024m`                                   |
 | `deleteTopicEnable`                       | Switch to enable topic deletion or not                                                                                                               | `false`                                                 |
 | `autoCreateTopicsEnable`                  | Switch to enable auto creation of topics. Enabling auto creation of topics not recommended for production or similar environments                    | `false`                                                 |
-| `logFlushIntervalMessages`                | The number of messages to accept before forcing a flush of data to disk                                                                              | `10000`                                                 |
+| `logFlushIntervalMessages`                | The number of messages to accept before forcing a flush of data to disk                                                                              | `_10000`                                                 |
 | `logFlushIntervalMs`                      | The maximum amount of time a message can sit in a log before we force a flush                                                                        | `1000`                                                  |
 | `logRetentionBytes`                       | A size-based retention policy for logs                                                                                                               | `_1073741824`                                           |
 | `logRetentionCheckIntervalMs`             | The interval at which log segments are checked to see if they can be deleted                                                                         | `300000`                                                |
@@ -376,8 +376,8 @@ kubectl create secret generic kafka-jks --from-file=./kafka.truststore.jks --fro
 As an alternative to manually create the secret before installing the chart, you can put your JKS files inside the chart folder `files/jks`, an a secret including them will be generated. Please note this alternative requires to have the chart downloaded locally, so you will have to clone this repository or fetch the chart before installing it.
 
 If, for some reason (like using Cert-Manager) you can not use the default JKS secret scheme, you can use the additional parameters:
- - `auth.jksTruststoreSecret` to define additional secret, where the `kafka.truststore.jks` is being kept. The truststore password **must** be the same as in `auth.jksPassword` 
- - `auth.jksTruststore` to overwrite the default value of the truststore key (`kafka.truststore.jks`). 
+ - `auth.jksTruststoreSecret` to define additional secret, where the `kafka.truststore.jks` is being kept. The truststore password **must** be the same as in `auth.jksPassword`
+ - `auth.jksTruststore` to overwrite the default value of the truststore key (`kafka.truststore.jks`).
  - `auth.jksKeystoreSAN` if you want to use a SAN certificate for your brokers. Setting this parameter would mean that the chart expects a existing key in the `auth.jksSecret` with the `auth.jksKeystoreSAN`-value and use this as a keystore for **all** brokers
 > **Note**: The truststore/keystore from above **must** be protected with the same password as in `auth.jksPassword`
 

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -268,7 +268,7 @@ spec:
             - name: KAFKA_HEAP_OPTS
               value: {{ .Values.heapOpts | quote }}
             - name: KAFKA_CFG_LOG_FLUSH_INTERVAL_MESSAGES
-              value: {{ .Values.logFlushIntervalMessages | quote }}
+              value: {{ .Values.logFlushIntervalMessages | replace "_" "" | quote }}
             - name: KAFKA_CFG_LOG_FLUSH_INTERVAL_MS
               value: {{ .Values.logFlushIntervalMs | quote }}
             - name: KAFKA_CFG_LOG_RETENTION_BYTES

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -128,7 +128,7 @@ autoCreateTopicsEnable: true
 
 ## The number of messages to accept before forcing a flush of data to disk.
 ##
-logFlushIntervalMessages: 10000
+logFlushIntervalMessages: _10000
 
 ## The maximum amount of time a message can sit in a log before we force a flush.
 ##


### PR DESCRIPTION

**Description of the change**

Fix for `long` value for `log.flush.scheduler.interval.ms`. See #5578


**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)