### PR TITLE
[bitnami/kafka] Only set ssl.client.auth to required when mTLS is used

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 12.9.1
+version: 12.9.2

--- a/bitnami/kafka/templates/NOTES.txt
+++ b/bitnami/kafka/templates/NOTES.txt
@@ -105,16 +105,39 @@ ssl.truststore.password={{ .Values.auth.jksPassword }}
 ssl.endpoint.identification.algorithm=
 {{- end }}
 EOF
+{{- else if (include "kafka.client.tlsEncryption" .) }}
+
+You need to configure your Kafka client to access using TLS authentication. To do so, you need to create the 'client.properties' configuration file by executing these command:
+
+cat > client.properties <<EOF
+security.protocol={{ $clientProtocol }}
+ssl.truststore.location=/tmp/kafka.truststore.jks
+{{- if eq .Values.auth.clientProtocol "mtls" }}
+ssl.keystore.location=/tmp/client.truststore.jks
+{{- end }}
+{{- if .Values.auth.jksPassword }}
+ssl.truststore.password={{ .Values.auth.jksPassword }}
+{{- end }}
+{{- if eq .Values.auth.tlsEndpointIdentificationAlgorithm "" }}
+ssl.endpoint.identification.algorithm=
+{{- end }}
+EOF
+
 {{- end }}
 
 To create a pod that you can use as a Kafka client run the following commands:
 
     kubectl run {{ $fullname }}-client --restart='Never' --image {{ template "kafka.image" . }} --namespace {{ $releaseNamespace }} --command -- sleep infinity
-    {{- if (include "kafka.client.saslAuthentication" .) }}
+    {{- if or (include "kafka.client.saslAuthentication" .) (include "kafka.client.tlsEncryption" .) }}
     kubectl cp --namespace {{ $releaseNamespace }} /path/to/client.properties {{ $fullname }}-client:/tmp/client.properties
+    {{- end }}
+    {{- if (include "kafka.client.saslAuthentication" .) }}
     kubectl cp --namespace {{ $releaseNamespace }} /path/to/kafka_jaas.conf {{ $fullname }}-client:/tmp/kafka_jaas.conf
-    {{- if eq .Values.auth.clientProtocol "sasl_tls" }}
+    {{- end }}
+    {{- if (include "kafka.client.tlsEncryption" .) }}
     kubectl cp --namespace {{ $releaseNamespace }} ./kafka.truststore.jks {{ $fullname }}-client:/tmp/kafka.truststore.jks
+    {{- if eq .Values.auth.clientProtocol "mtls" }}
+    kubectl cp --namespace {{ $releaseNamespace }} ./client.keystore.jks {{ $fullname }}-client:/tmp/client.truststore.jks
     {{- end }}
     {{- end }}
     kubectl exec --tty -i {{ $fullname }}-client --namespace {{ $releaseNamespace }} -- bash
@@ -124,13 +147,13 @@ To create a pod that you can use as a Kafka client run the following commands:
 
     PRODUCER:
         kafka-console-producer.sh \
-            {{ if (include "kafka.client.saslAuthentication" .) }}--producer.config /tmp/client.properties \{{ end }}
+            {{ if or (include "kafka.client.saslAuthentication" .) (include "kafka.client.tlsEncryption" .) }}--producer.config /tmp/client.properties \{{ end }}
             --broker-list {{ join "," $brokerList }} \
             --topic test
 
     CONSUMER:
         kafka-console-consumer.sh \
-            {{ if (include "kafka.client.saslAuthentication" .) }}--consumer.config /tmp/client.properties \{{ end }}
+            {{ if or (include "kafka.client.saslAuthentication" .) (include "kafka.client.tlsEncryption" .) }}--consumer.config /tmp/client.properties \{{ end }}
             --bootstrap-server {{ $fullname }}.{{ $releaseNamespace }}.svc.{{ $clusterDomain }}:{{ .Values.service.port }} \
             --topic test \
             --from-beginning

--- a/bitnami/kafka/templates/scripts-configmap.yaml
+++ b/bitnami/kafka/templates/scripts-configmap.yaml
@@ -114,11 +114,11 @@ data:
     {{- if and .Values.auth.jksTruststoreSecret .Values.auth.jksTruststore }}
     JKS_TRUSTSTORE="/truststore/{{ .Values.auth.jksTruststore }}"
     {{- else if .Values.auth.jksTruststoreSecret  }}
-    JKS_TRUSTSTORE="/truststore/kafka.trustore.jks"
+    JKS_TRUSTSTORE="/truststore/kafka.truststore.jks"
     {{- else if .Values.auth.jksTruststore  }}
     JKS_TRUSTSTORE="/certs/{{ .Values.auth.jksTruststore }}"
     {{- else }}
-    JKS_TRUSTSTORE="/certs/kafka.trustore.jks"
+    JKS_TRUSTSTORE="/certs/kafka.truststore.jks"
     {{- end }}
     
     {{- if .Values.auth.jksKeystoreSAN }}

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -246,6 +246,8 @@ spec:
             {{- if (include "kafka.tlsEncryption" .) }}
             - name: KAFKA_CFG_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM
               value: {{ .Values.auth.tlsEndpointIdentificationAlgorithm | quote }}
+            - name: KAFKA_CFG_TLS_CLIENT_AUTH
+              value: {{ ternary "required" "none" (eq .Values.auth.clientProtocol "mtls") | quote }}
             {{- if .Values.auth.jksPassword }}
             - name: KAFKA_CERTIFICATE_PASSWORD
               value: {{ .Values.auth.jksPassword | quote }}

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/kafka
-  tag: 2.7.0-debian-10-r35
+  tag: 2.7.0-debian-10-r64
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Thanks to [this contribution](https://github.com/bitnami/bitnami-docker-kafka/pull/142), now it's possible to use the environment variable **KAFKA_CFG_TLS_CLIENT_AUTH** to decide whether to set `ssl.client.auth` to `none`, `requested` or `required`.

This setting (`ssl.client.auth`) should only be set to `required` when `mtls` is set at `auth.clientProtocol`. This PR fixes this, and improves the NOTES to provide precise instructions to connect to the cluster using a client depending on the chosen protocol.

**Benefits**

`mTLS` and `tls` authentication  protocols are properly differentiated.

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/3755

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
