### PR TITLE
[bitnami/common] Add RBAC/CRD apiVersion support for versions 1.22+

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: Infrastructure
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 1.3.9
+appVersion: 1.4.0
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://github.com/bitnami/charts/tree/master/bitnami/common
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -20,4 +20,4 @@ sources:
   - https://github.com/bitnami/charts
   - http://www.bitnami.com/
 type: library
-version: 1.3.9
+version: 1.4.0

--- a/bitnami/common/README.md
+++ b/bitnami/common/README.md
@@ -56,6 +56,8 @@ The following table lists the helpers available in the library which are scoped 
 | `common.capabilities.deployment.apiVersion`  | Return the appropriate apiVersion for deployment.                                              | `.` Chart context |
 | `common.capabilities.statefulset.apiVersion` | Return the appropriate apiVersion for statefulset.                                             | `.` Chart context |
 | `common.capabilities.ingress.apiVersion`     | Return the appropriate apiVersion for ingress.                                                 | `.` Chart context |
+| `common.capabilities.rbac.apiVersion`        | Return the appropriate apiVersion for RBAC resources.                                          | `.` Chart context |
+| `common.capabilities.crd.apiVersion`         | Return the appropriate apiVersion for CRDs.                                                    | `.` Chart context |
 | `common.capabilities.supportsHelmVersion`    | Returns true if the used Helm version is 3.3+                                                  | `.` Chart context |
 
 ### Errors

--- a/bitnami/common/templates/_capabilities.tpl
+++ b/bitnami/common/templates/_capabilities.tpl
@@ -64,7 +64,7 @@ Return the appropriate apiVersion for ingress.
 Return the appropriate apiVersion for RBAC resources.
 */}}
 {{- define "common.capabilities.rbac.apiVersion" -}}
-{{- if semverCompare "<1.22-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- if semverCompare "<1.17-0" (include "common.capabilities.kubeVersion" .) -}}
 {{- print "rbac.authorization.k8s.io/v1beta1" -}}
 {{- else -}}
 {{- print "rbac.authorization.k8s.io/v1" -}}
@@ -75,7 +75,7 @@ Return the appropriate apiVersion for RBAC resources.
 Return the appropriate apiVersion for CRDs.
 */}}
 {{- define "common.capabilities.crd.apiVersion" -}}
-{{- if semverCompare "<1.22-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- if semverCompare "<1.19-0" (include "common.capabilities.kubeVersion" .) -}}
 {{- print "apiextensions.k8s.io/v1beta1" -}}
 {{- else -}}
 {{- print "apiextensions.k8s.io/v1" -}}

--- a/bitnami/common/templates/_capabilities.tpl
+++ b/bitnami/common/templates/_capabilities.tpl
@@ -61,6 +61,28 @@ Return the appropriate apiVersion for ingress.
 {{- end -}}
 
 {{/*
+Return the appropriate apiVersion for RBAC resources.
+*/}}
+{{- define "common.capabilities.rbac.apiVersion" -}}
+{{- if semverCompare "<1.21-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "rbac.authorization.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "rbac.authorization.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for CRDs.
+*/}}
+{{- define "common.capabilities.crd.apiVersion" -}}
+{{- if semverCompare "<1.21-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "apiextensions.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "apiextensions.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Returns true if the used Helm version is 3.3+.
 A way to check the used Helm version was not introduced until version 3.3.0 with .Capabilities.HelmVersion, which contains an additional "{}}"  structure.
 This check is introduced as a regexMatch instead of {{ if .Capabilities.HelmVersion }} because checking for the key HelmVersion in <3.3 results in a "interface not found" error.

--- a/bitnami/common/templates/_capabilities.tpl
+++ b/bitnami/common/templates/_capabilities.tpl
@@ -64,7 +64,7 @@ Return the appropriate apiVersion for ingress.
 Return the appropriate apiVersion for RBAC resources.
 */}}
 {{- define "common.capabilities.rbac.apiVersion" -}}
-{{- if semverCompare "<1.21-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- if semverCompare "<1.22-0" (include "common.capabilities.kubeVersion" .) -}}
 {{- print "rbac.authorization.k8s.io/v1beta1" -}}
 {{- else -}}
 {{- print "rbac.authorization.k8s.io/v1" -}}
@@ -75,7 +75,7 @@ Return the appropriate apiVersion for RBAC resources.
 Return the appropriate apiVersion for CRDs.
 */}}
 {{- define "common.capabilities.crd.apiVersion" -}}
-{{- if semverCompare "<1.21-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- if semverCompare "<1.22-0" (include "common.capabilities.kubeVersion" .) -}}
 {{- print "apiextensions.k8s.io/v1beta1" -}}
 {{- else -}}
 {{- print "apiextensions.k8s.io/v1" -}}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

There are two main removed API versions included in Kubernetes v1.22 (see https://kubernetes.io/docs/reference/using-api/deprecation-guide/):
 
- CRDs: `apiextensions.k8s.io/v1beta1` removed in favor of `apiextensions.k8s.io/v1` (was deprecated in v1.19). **It requires several changes in the manifests.**
- RBAC: `rbac.authorization.k8s.io/v1beta1` removed in favor of `rbac.authorization.k8s.io/v1` (was deprecated in v1.17, see https://pkg.go.dev/k8s.io/api/rbac/v1beta1).

This PR adds new macros to `bitnami/common` to distinguish between versions: 

**Benefits**

Compatibility with different K8s versions.

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/5577

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

