### PR TITLE
[bitnami/*] Use common macro to define RBAC apiVersion

### DIFF
--- a/bitnami/airflow/Chart.lock
+++ b/bitnami/airflow/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.9
+  version: 1.4.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.3.1
+  version: 10.3.4
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 12.7.4
-digest: sha256:a7565f6f0ac972a9ecccd1ba229c7e9baab855366093bb53ec0d6edd8d3c25f6
-generated: "2021-02-12T14:38:03.588226208Z"
+digest: sha256:c1151926252fef8ecdd46baf7cf7abb93477cb73429d268c60f5327f52f1f134
+generated: "2021-02-22T16:15:23.926298+01:00"

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -32,4 +32,4 @@ name: airflow
 sources:
   - https://github.com/bitnami/bitnami-docker-airflow
   - https://airflow.apache.org/
-version: 8.0.4
+version: 8.0.5

--- a/bitnami/airflow/templates/rbac/role.yaml
+++ b/bitnami/airflow/templates/rbac/role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ include "common.names.fullname" . }}

--- a/bitnami/airflow/templates/rbac/rolebinding.yaml
+++ b/bitnami/airflow/templates/rbac/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ include "common.names.fullname" . }}

--- a/bitnami/contour/Chart.lock
+++ b/bitnami/contour/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.8
-digest: sha256:c200bbfd8c6fa776c41f1a335bc17906d858dfe975e90bad6fb7050c1e594ece
-generated: "2021-02-09T16:36:03.363636468Z"
+  version: 1.4.0
+digest: sha256:f8634e5c0ac4598321ccb7148b2d2495c1c4d5e503219a632a4dd145cd81e56a
+generated: "2021-02-22T16:15:46.748438+01:00"

--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/bitnami-docker-contour
   - https://projectcontour.io
-version: 4.1.2
+version: 4.1.3

--- a/bitnami/contour/templates/certgen/rbac.yaml
+++ b/bitnami/contour/templates/certgen/rbac.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.rbac.create .Values.contour.enabled (include "contour.contour-certgen.enabled" .) }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ include "common.names.fullname" .}}-contour-certgen
@@ -19,7 +19,7 @@ rules:
       - create
       - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ include "common.names.fullname" .}}-contour-certgen

--- a/bitnami/contour/templates/contour/rbac.yaml
+++ b/bitnami/contour/templates/contour/rbac.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.rbac.create .Values.contour.enabled }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname" .}}-contour
@@ -105,7 +105,7 @@ rules:
       - get
       - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "common.names.fullname" .}}-contour

--- a/bitnami/elasticsearch/Chart.lock
+++ b/bitnami/elasticsearch/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.7
+  version: 1.4.0
 - name: kibana
   repository: https://charts.bitnami.com/bitnami
-  version: 7.2.1
-digest: sha256:e30fcb4d06d47393ae38c24cf8be125b51c6c8656f7b9069bb6cb532f651e738
-generated: "2021-01-27T23:37:55.770200361Z"
+  version: 7.2.2
+digest: sha256:1647597061986d92192b6da8c3872a39cd3bd08a4c7a904c0ce6e58742913858
+generated: "2021-02-22T16:16:52.525546+01:00"

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/bitnami-docker-elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 14.2.1
+version: 14.2.2

--- a/bitnami/elasticsearch/templates/role.yaml
+++ b/bitnami/elasticsearch/templates/role.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.curator.enabled .Values.curator.rbac.enabled }}
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ include "elasticsearch.curator.name" . }}
   labels: {{- include "elasticsearch.labels" . | nindent 4 }}

--- a/bitnami/elasticsearch/templates/rolebinding.yaml
+++ b/bitnami/elasticsearch/templates/rolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.curator.enabled .Values.curator.rbac.enabled }}
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ include "elasticsearch.curator.name" . }}
   labels: {{- include "elasticsearch.labels" . | nindent 4 }}

--- a/bitnami/external-dns/Chart.lock
+++ b/bitnami/external-dns/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.9
-digest: sha256:de03bcd37a85979dadc44edf9094170791b0eb5004c9901b74c61c3a5c5f3af7
-generated: "2021-02-13T12:03:17.028544858Z"
+  version: 1.4.0
+digest: sha256:f8634e5c0ac4598321ccb7148b2d2495c1c4d5e503219a632a4dd145cd81e56a
+generated: "2021-02-22T16:17:07.495694+01:00"

--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -24,4 +24,4 @@ sources:
   - https://github.com/kubernetes-sigs/external-dns
   - https://github.com/bitnami/bitnami-docker-external-dns
   - https://github.com/kubernetes-sigs/external-dns
-version: 4.8.2
+version: 4.8.3

--- a/bitnami/external-dns/templates/psp-clusterrole.yaml
+++ b/bitnami/external-dns/templates/psp-clusterrole.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.pspEnabled }}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ template "external-dns.fullname" . }}-psp
   labels: {{ include "external-dns.labels" . | nindent 4 }}

--- a/bitnami/external-dns/templates/psp-clusterrolebinding.yaml
+++ b/bitnami/external-dns/templates/psp-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "external-dns.fullname" . }}-psp

--- a/bitnami/fluentd/Chart.lock
+++ b/bitnami/fluentd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.9
-digest: sha256:de03bcd37a85979dadc44edf9094170791b0eb5004c9901b74c61c3a5c5f3af7
-generated: "2021-02-19T03:43:09.014685896Z"
+  version: 1.4.0
+digest: sha256:f8634e5c0ac4598321ccb7148b2d2495c1c4d5e503219a632a4dd145cd81e56a
+generated: "2021-02-22T16:18:08.24355+01:00"

--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -25,4 +25,4 @@ name: fluentd
 sources:
   - https://github.com/bitnami/bitnami-docker-fluentd
   - https://www.fluentd.org/
-version: 3.6.1
+version: 3.6.2

--- a/bitnami/fluentd/templates/forwarder-clusterrole.yaml
+++ b/bitnami/fluentd/templates/forwarder-clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.forwarder.enabled .Values.forwarder.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ include "fluentd.fullname" . }}

--- a/bitnami/fluentd/templates/forwarder-clusterrolebinding.yaml
+++ b/bitnami/fluentd/templates/forwarder-clusterrolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.forwarder.enabled .Values.forwarder.rbac.create }}
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ include "fluentd.fullname" . }}
   labels: {{- include "fluentd.labels" . | nindent 4 }}

--- a/bitnami/grafana-operator/Chart.lock
+++ b/bitnami/grafana-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.9
-digest: sha256:de03bcd37a85979dadc44edf9094170791b0eb5004c9901b74c61c3a5c5f3af7
-generated: "2021-02-12T12:28:21.370527719Z"
+  version: 1.4.0
+digest: sha256:f8634e5c0ac4598321ccb7148b2d2495c1c4d5e503219a632a4dd145cd81e56a
+generated: "2021-02-22T16:18:40.070472+01:00"

--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -25,4 +25,4 @@ name: grafana-operator
 sources:
   - https://github.com/integr8ly/grafana-operator
   - https://github.com/bitnami/bitnami-docker-grafana-operator
-version: 0.3.1
+version: 0.3.2

--- a/bitnami/grafana-operator/templates/rbac.yaml
+++ b/bitnami/grafana-operator/templates/rbac.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.operator.rbac.create .Values.operator.enabled }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ include "common.names.fullname" . }}
@@ -103,7 +103,7 @@ rules:
       - deletecollection
       - watch
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ include "common.names.fullname" . }}
@@ -123,7 +123,7 @@ subjects:
     name: {{ include "grafana-operator.serviceAccountName" . }}
 {{- if or .Values.operator.args.scanAllNamespaces  .Values.operator.args.scanNamespaces}}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname" . }}
@@ -147,7 +147,7 @@ rules:
       - namespaces
     verbs: ['get', 'list', 'watch']
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "common.names.fullname" . }}

--- a/bitnami/kafka/Chart.lock
+++ b/bitnami/kafka/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.7
+  version: 1.4.0
 - name: zookeeper
   repository: https://charts.bitnami.com/bitnami
-  version: 6.3.4
-digest: sha256:6fde11f1696cd4498a395b0daa6646ee8525fd9d69e77793d0bd1fd87ebf2688
-generated: "2021-01-27T17:19:07.071672111Z"
+  version: 6.5.0
+digest: sha256:298d4e293fee59519211b0f7558cfcce959547d20f4e7dd010e6eecaf5b94c83
+generated: "2021-02-22T16:18:57.505169+01:00"

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 12.9.2
+version: 12.9.3

--- a/bitnami/kafka/templates/role.yaml
+++ b/bitnami/kafka/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ template "kafka.fullname" . }}

--- a/bitnami/kafka/templates/rolebinding.yaml
+++ b/bitnami/kafka/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.serviceAccount.create .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ template "kafka.fullname" . }}

--- a/bitnami/keycloak/Chart.lock
+++ b/bitnami/keycloak/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.9
+  version: 1.4.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.3.2
-digest: sha256:e0886456f388da85d22d1118b87e67978c0d0871d04e2be0e75749f8eae3c825
-generated: "2021-02-16T09:38:16.593121979Z"
+  version: 10.3.4
+digest: sha256:981837c59f73600f3f3b688ddf10c7912df1573dd8de1afb177eff91606821bd
+generated: "2021-02-22T16:19:18.943582+01:00"

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 2.2.0
+version: 2.2.1

--- a/bitnami/keycloak/templates/role.yaml
+++ b/bitnami/keycloak/templates/role.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.serviceAccount.create .Values.rbac.create }}
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ template "keycloak.fullname" . }}
   namespace: {{ .Release.Namespace }}

--- a/bitnami/keycloak/templates/rolebinding.yaml
+++ b/bitnami/keycloak/templates/rolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.serviceAccount.create .Values.rbac.create }}
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ template "keycloak.fullname" . }}
   namespace: {{ .Release.Namespace }}

--- a/bitnami/kiam/Chart.lock
+++ b/bitnami/kiam/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.9
-digest: sha256:de03bcd37a85979dadc44edf9094170791b0eb5004c9901b74c61c3a5c5f3af7
-generated: "2021-02-18T19:47:51.164543484Z"
+  version: 1.4.0
+digest: sha256:f8634e5c0ac4598321ccb7148b2d2495c1c4d5e503219a632a4dd145cd81e56a
+generated: "2021-02-22T16:19:41.865739+01:00"

--- a/bitnami/kiam/Chart.yaml
+++ b/bitnami/kiam/Chart.yaml
@@ -23,4 +23,4 @@ name: kiam
 sources:
   - https://github.com/bitnami/bitnami-docker-kiam
   - https://github.com/uswitch/kiam
-version: 0.3.1
+version: 0.3.2

--- a/bitnami/kiam/templates/agent/agent-psp-clusterrole.yaml
+++ b/bitnami/kiam/templates/agent/agent-psp-clusterrole.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.agent.enabled .Values.agent.podSecurityPolicy.create }}
 {{- if .Values.rbac.create }}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: agent

--- a/bitnami/kiam/templates/agent/agent-psp-clusterrolebinding.yaml
+++ b/bitnami/kiam/templates/agent/agent-psp-clusterrolebinding.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.agent.enabled .Values.agent.podSecurityPolicy.create }}
 {{- if .Values.rbac.create }}
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: agent

--- a/bitnami/kiam/templates/server/server-psp-clusterrole.yaml
+++ b/bitnami/kiam/templates/server/server-psp-clusterrole.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.server.enabled .Values.server.podSecurityPolicy.create }}
 {{- if .Values.rbac.create }}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: server

--- a/bitnami/kiam/templates/server/server-psp-clusterrolebinding.yaml
+++ b/bitnami/kiam/templates/server/server-psp-clusterrolebinding.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.server.enabled .Values.server.podSecurityPolicy.create }}
 {{- if .Values.rbac.create }}
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: server

--- a/bitnami/kiam/templates/server/server-read-clusterrole.yaml
+++ b/bitnami/kiam/templates/server/server-read-clusterrole.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.server.enabled }}
 {{- if .Values.rbac.create }}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: server

--- a/bitnami/kiam/templates/server/server-read-clusterrolebinding.yaml
+++ b/bitnami/kiam/templates/server/server-read-clusterrolebinding.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.server.enabled }}
 {{- if .Values.rbac.create }}
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: server

--- a/bitnami/kiam/templates/server/server-write-clusterrole.yaml
+++ b/bitnami/kiam/templates/server/server-write-clusterrole.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.server.enabled }}
 {{- if .Values.rbac.create }}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: server

--- a/bitnami/kiam/templates/server/server-write-clusterrolebinding.yaml
+++ b/bitnami/kiam/templates/server/server-write-clusterrolebinding.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.server.enabled }}
 {{- if .Values.rbac.create }}
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: server

--- a/bitnami/kong/Chart.lock
+++ b/bitnami/kong/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.2.8
+  version: 10.3.4
 - name: cassandra
   repository: https://charts.bitnami.com/bitnami
   version: 7.3.2
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.9
-digest: sha256:0f086f92ef314ecb592f09ec4102144b25929613066095c2455ef3dfdde5601a
-generated: "2021-02-11T01:27:01.514072942Z"
+  version: 1.4.0
+digest: sha256:3dea53f342112a1c90ac396e8c9d83c24eba2d03432cf244cd43078380ada6d1
+generated: "2021-02-22T16:20:06.867067+01:00"

--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -34,4 +34,4 @@ name: kong
 sources:
   - https://github.com/bitnami/bitnami-docker-kong
   - https://konghq.com/
-version: 3.4.1
+version: 3.4.2

--- a/bitnami/kong/templates/ingress-controller-rbac.yaml
+++ b/bitnami/kong/templates/ingress-controller-rbac.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.ingressController.rbac.create .Values.ingressController.enabled }}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ include "common.names.fullname" . }}
@@ -44,7 +44,7 @@ rules:
     verbs:
       - get
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ template "common.names.fullname" . }}
@@ -66,7 +66,7 @@ subjects:
     name: {{ template "kong.serviceAccount" . }}
     namespace: {{ .Release.Namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
@@ -148,7 +148,7 @@ rules:
       - list
       - watch
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "common.names.fullname" . }}

--- a/bitnami/kong/templates/kong-prometheus-role.yaml
+++ b/bitnami/kong/templates/kong-prometheus-role.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled .Values.metrics.serviceMonitor.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ template "common.names.fullname" . }}-prometheus

--- a/bitnami/kong/templates/kong-prometheus-rolebinding.yaml
+++ b/bitnami/kong/templates/kong-prometheus-rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled .Values.metrics.serviceMonitor.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ template "common.names.fullname" . }}-prometheus

--- a/bitnami/kube-prometheus/Chart.lock
+++ b/bitnami/kube-prometheus/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.7
+  version: 1.4.0
 - name: node-exporter
   repository: https://charts.bitnami.com/bitnami
-  version: 2.2.0
+  version: 2.2.2
 - name: kube-state-metrics
   repository: https://charts.bitnami.com/bitnami
-  version: 1.2.0
-digest: sha256:042e3104259560b5a5a3548a84f4ff92a7e5cd6ee88350613493b6b9affcfc59
-generated: "2021-02-01T15:16:06.848546756Z"
+  version: 1.2.1
+digest: sha256:1914db1e186db703c8c46a34c00ed1480af93f991d78e1e39d1cfa7fa9e0185b
+generated: "2021-02-22T16:20:41.476218+01:00"

--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-prometheus
   - https://github.com/bitnami/bitnami-docker-alertmanager
   - https://github.com/prometheus-operator/kube-prometheus
-version: 4.0.1
+version: 4.0.2

--- a/bitnami/kube-prometheus/templates/alertmanager/psp-clusterrole.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/psp-clusterrole.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.alertmanager.enabled .Values.rbac.create .Values.rbac.pspEnabled }}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ template "kube-prometheus.alertmanager.fullname" . }}-psp
   labels: {{- include "kube-prometheus.alertmanager.labels" . | nindent 4 }}

--- a/bitnami/kube-prometheus/templates/alertmanager/psp-clusterrolebinding.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/psp-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.alertmanager.enabled .Values.rbac.create .Values.rbac.pspEnabled }}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "kube-prometheus.alertmanager.fullname" . }}-psp

--- a/bitnami/kube-prometheus/templates/prometheus-operator/clusterrole.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.operator.enabled .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ template "kube-prometheus.operator.fullname" . }}

--- a/bitnami/kube-prometheus/templates/prometheus-operator/clusterrolebinding.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.operator.enabled .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "kube-prometheus.operator.fullname" . }}

--- a/bitnami/kube-prometheus/templates/prometheus-operator/psp-clusterrole.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/psp-clusterrole.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.operator.enabled .Values.rbac.create .Values.rbac.pspEnabled }}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ template "kube-prometheus.operator.fullname" . }}-psp
   labels: {{- include "kube-prometheus.operator.labels" . | nindent 4 }}

--- a/bitnami/kube-prometheus/templates/prometheus-operator/psp-clusterrolebinding.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/psp-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.operator.enabled .Values.rbac.create .Values.rbac.pspEnabled }}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "kube-prometheus.operator.fullname" . }}-psp

--- a/bitnami/kube-prometheus/templates/prometheus/clusterrole.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.prometheus.enabled .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ template "kube-prometheus.prometheus.fullname" . }}

--- a/bitnami/kube-prometheus/templates/prometheus/clusterrolebinding.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.prometheus.enabled .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "kube-prometheus.prometheus.fullname" . }}

--- a/bitnami/kube-prometheus/templates/prometheus/psp-clusterrole.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/psp-clusterrole.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.prometheus.enabled .Values.rbac.create .Values.rbac.pspEnabled }}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ template "kube-prometheus.prometheus.fullname" . }}-psp
   labels: {{- include "kube-prometheus.prometheus.labels" . | nindent 4 }}

--- a/bitnami/kube-prometheus/templates/prometheus/psp-clusterrolebinding.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/psp-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.prometheus.enabled .Values.rbac.create .Values.rbac.pspEnabled }}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "kube-prometheus.prometheus.fullname" . }}-psp

--- a/bitnami/kube-state-metrics/Chart.lock
+++ b/bitnami/kube-state-metrics/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.8
-digest: sha256:c200bbfd8c6fa776c41f1a335bc17906d858dfe975e90bad6fb7050c1e594ece
-generated: "2021-02-08T15:22:49.261652514Z"
+  version: 1.4.0
+digest: sha256:f8634e5c0ac4598321ccb7148b2d2495c1c4d5e503219a632a4dd145cd81e56a
+generated: "2021-02-22T16:21:39.623319+01:00"

--- a/bitnami/kube-state-metrics/Chart.yaml
+++ b/bitnami/kube-state-metrics/Chart.yaml
@@ -23,4 +23,4 @@ name: kube-state-metrics
 sources:
   - https://github.com/bitnami/bitnami-docker-kube-state-metrics
   - https://github.com/kubernetes/kube-state-metrics
-version: 1.2.1
+version: 1.2.2

--- a/bitnami/kube-state-metrics/templates/clusterrole.yaml
+++ b/bitnami/kube-state-metrics/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ template "common.names.fullname" . }}

--- a/bitnami/kube-state-metrics/templates/clusterrolebinding.yaml
+++ b/bitnami/kube-state-metrics/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "common.names.fullname" . }}

--- a/bitnami/kube-state-metrics/templates/psp-clusterrole.yaml
+++ b/bitnami/kube-state-metrics/templates/psp-clusterrole.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.rbac.create .Values.rbac.pspEnabled }}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ template "common.names.fullname" . }}-psp
   labels: {{- include "common.labels.standard" . | nindent 4 }}

--- a/bitnami/kube-state-metrics/templates/psp-clusterrolebinding.yaml
+++ b/bitnami/kube-state-metrics/templates/psp-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.rbac.create .Values.rbac.pspEnabled }}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "common.names.fullname" . }}-psp

--- a/bitnami/kubernetes-event-exporter/Chart.lock
+++ b/bitnami/kubernetes-event-exporter/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.7
-digest: sha256:8d8e2b6a63a344d8bd0153181d5b3345d14b04094d339736a9199e3fb907fb19
-generated: "2021-01-24T19:08:21.187433643Z"
+  version: 1.4.0
+digest: sha256:f8634e5c0ac4598321ccb7148b2d2495c1c4d5e503219a632a4dd145cd81e56a
+generated: "2021-02-22T16:22:41.128224+01:00"

--- a/bitnami/kubernetes-event-exporter/Chart.yaml
+++ b/bitnami/kubernetes-event-exporter/Chart.yaml
@@ -26,4 +26,4 @@ name: kubernetes-event-exporter
 sources:
   - https://github.com/bitnami/bitnami-docker-kubernetes-event-exporter
   - https://github.com/opsgenie/kubernetes-event-exporter
-version: 1.1.0
+version: 1.1.1

--- a/bitnami/kubernetes-event-exporter/templates/rbac.yaml
+++ b/bitnami/kubernetes-event-exporter/templates/rbac.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "common.names.fullname" . }}

--- a/bitnami/kubewatch/Chart.lock
+++ b/bitnami/kubewatch/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.8
-digest: sha256:c200bbfd8c6fa776c41f1a335bc17906d858dfe975e90bad6fb7050c1e594ece
-generated: "2021-02-07T20:31:23.561722403Z"
+  version: 1.4.0
+digest: sha256:f8634e5c0ac4598321ccb7148b2d2495c1c4d5e503219a632a4dd145cd81e56a
+generated: "2021-02-22T16:23:12.917813+01:00"

--- a/bitnami/kubewatch/Chart.yaml
+++ b/bitnami/kubewatch/Chart.yaml
@@ -28,4 +28,4 @@ name: kubewatch
 sources:
   - https://github.com/bitnami/bitnami-docker-kubewatch
   - https://github.com/bitnami-labs/kubewatch
-version: 3.1.1
+version: 3.1.2

--- a/bitnami/kubewatch/templates/clusterrole.yaml
+++ b/bitnami/kubewatch/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname" . }}

--- a/bitnami/kubewatch/templates/clusterrolebinding.yaml
+++ b/bitnami/kubewatch/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.serviceAccount.create .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "common.names.fullname" . }}

--- a/bitnami/mariadb-galera/Chart.lock
+++ b/bitnami/mariadb-galera/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.8
-digest: sha256:c200bbfd8c6fa776c41f1a335bc17906d858dfe975e90bad6fb7050c1e594ece
-generated: "2021-02-08T10:08:51.18503042Z"
+  version: 1.4.0
+digest: sha256:f8634e5c0ac4598321ccb7148b2d2495c1c4d5e503219a632a4dd145cd81e56a
+generated: "2021-02-22T16:23:57.711242+01:00"

--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -28,4 +28,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-mariadb-galera
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 5.6.0
+version: 5.6.1

--- a/bitnami/mariadb-galera/templates/role.yaml
+++ b/bitnami/mariadb-galera/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.serviceAccount.create .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ template "common.names.fullname" . }}

--- a/bitnami/mariadb-galera/templates/rolebinding.yaml
+++ b/bitnami/mariadb-galera/templates/rolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.serviceAccount.create .Values.rbac.create }}
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ template "common.names.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}

--- a/bitnami/mariadb/Chart.lock
+++ b/bitnami/mariadb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.8
-digest: sha256:c200bbfd8c6fa776c41f1a335bc17906d858dfe975e90bad6fb7050c1e594ece
-generated: "2021-02-06T09:59:56.37410134Z"
+  version: 1.4.0
+digest: sha256:f8634e5c0ac4598321ccb7148b2d2495c1c4d5e503219a632a4dd145cd81e56a
+generated: "2021-02-22T16:23:35.857706+01:00"

--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -26,4 +26,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-mariadb
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 9.3.2
+version: 9.3.3

--- a/bitnami/mariadb/templates/role.yaml
+++ b/bitnami/mariadb/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.serviceAccount.create  .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ include "common.names.fullname" . }}

--- a/bitnami/mariadb/templates/rolebinding.yaml
+++ b/bitnami/mariadb/templates/rolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.serviceAccount.create .Values.rbac.create }}
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ include "common.names.fullname" . }}
   namespace: {{ .Release.Namespace }}

--- a/bitnami/metallb/Chart.lock
+++ b/bitnami/metallb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.9
-digest: sha256:de03bcd37a85979dadc44edf9094170791b0eb5004c9901b74c61c3a5c5f3af7
-generated: "2021-02-19T17:10:02.266025103Z"
+  version: 1.4.0
+digest: sha256:f8634e5c0ac4598321ccb7148b2d2495c1c4d5e503219a632a4dd145cd81e56a
+generated: "2021-02-22T16:24:15.665508+01:00"

--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/metallb/metallb
   - https://github.com/bitnami/bitnami-docker-metallb
   - https://metallb.universe.tf
-version: 2.3.1
+version: 2.3.2

--- a/bitnami/metallb/templates/controller/rbac.yaml
+++ b/bitnami/metallb/templates/controller/rbac.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.rbac.create .Values.controller.rbac.create -}}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname" . }}-controller
@@ -45,7 +45,7 @@ rules:
       - use
 ---
 ## Role bindings
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "common.names.fullname" . }}-controller

--- a/bitnami/metallb/templates/rbac.yaml
+++ b/bitnami/metallb/templates/rbac.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.rbac.create (or .Values.controller.rbac.create .Values.speaker.rbac.create ) -}}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ include "common.names.fullname" . }}-config-watcher
@@ -21,7 +21,7 @@ rules:
       - list
       - watch
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ include "common.names.fullname" . }}-config-watcher

--- a/bitnami/metallb/templates/speaker/rbac.yaml
+++ b/bitnami/metallb/templates/speaker/rbac.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.rbac.create .Values.speaker.rbac.create -}}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname" . }}-speaker
@@ -39,7 +39,7 @@ rules:
     verbs:
       - use
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ include "common.names.fullname" . }}-pod-lister
@@ -59,7 +59,7 @@ rules:
     verbs:
       - list
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "common.names.fullname" . }}-speaker
@@ -80,7 +80,7 @@ roleRef:
   kind: ClusterRole
   name: {{ include "common.names.fullname" . }}-speaker
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ include "common.names.fullname" . }}-pod-lister

--- a/bitnami/metrics-server/Chart.lock
+++ b/bitnami/metrics-server/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.8
-digest: sha256:c200bbfd8c6fa776c41f1a335bc17906d858dfe975e90bad6fb7050c1e594ece
-generated: "2021-02-05T21:46:30.666128932Z"
+  version: 1.4.0
+digest: sha256:f8634e5c0ac4598321ccb7148b2d2495c1c4d5e503219a632a4dd145cd81e56a
+generated: "2021-02-22T16:25:06.901298+01:00"

--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -23,4 +23,4 @@ name: metrics-server
 sources:
   - https://github.com/bitnami/bitnami-docker-metrics-server
   - https://github.com/kubernetes-incubator/metrics-server
-version: 5.5.1
+version: 5.5.2

--- a/bitnami/metrics-server/templates/auth-delegator-crb.yaml
+++ b/bitnami/metrics-server/templates/auth-delegator-crb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ printf "%s:system:auth-delegator" (include "common.names.fullname" .) }}

--- a/bitnami/metrics-server/templates/cluster-role.yaml
+++ b/bitnami/metrics-server/templates/cluster-role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ printf "system:%s" (include "common.names.fullname" .) }}
@@ -23,7 +23,7 @@ rules:
       - get
       - create
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}

--- a/bitnami/metrics-server/templates/metrics-server-crb.yaml
+++ b/bitnami/metrics-server/templates/metrics-server-crb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: system:{{ template "common.names.fullname" . }}

--- a/bitnami/metrics-server/templates/role-binding.yaml
+++ b/bitnami/metrics-server/templates/role-binding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ printf "%s-auth-reader" (include "common.names.fullname" .) }}

--- a/bitnami/mongodb/Chart.lock
+++ b/bitnami/mongodb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.9
-digest: sha256:de03bcd37a85979dadc44edf9094170791b0eb5004c9901b74c61c3a5c5f3af7
-generated: "2021-02-10T08:45:39.119601262Z"
+  version: 1.4.0
+digest: sha256:f8634e5c0ac4598321ccb7148b2d2495c1c4d5e503219a632a4dd145cd81e56a
+generated: "2021-02-22T16:25:23.987004+01:00"

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 10.7.0
+version: 10.7.1

--- a/bitnami/mongodb/templates/role.yaml
+++ b/bitnami/mongodb/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ include "mongodb.fullname" . }}

--- a/bitnami/mongodb/templates/rolebinding.yaml
+++ b/bitnami/mongodb/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.serviceAccount.create .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ include "mongodb.fullname" . }}

--- a/bitnami/mysql/Chart.lock
+++ b/bitnami/mysql/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.9
-digest: sha256:de03bcd37a85979dadc44edf9094170791b0eb5004c9901b74c61c3a5c5f3af7
-generated: "2021-02-17T15:39:26.825735479Z"
+  version: 1.4.0
+digest: sha256:f8634e5c0ac4598321ccb7148b2d2495c1c4d5e503219a632a4dd145cd81e56a
+generated: "2021-02-22T16:25:41.610357+01:00"

--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -25,4 +25,4 @@ name: mysql
 sources:
   - https://github.com/bitnami/bitnami-docker-mysql
   - https://mysql.com
-version: 8.4.2
+version: 8.4.3

--- a/bitnami/mysql/templates/role.yaml
+++ b/bitnami/mysql/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.serviceAccount.create  .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ include "common.names.fullname" . }}

--- a/bitnami/mysql/templates/rolebinding.yaml
+++ b/bitnami/mysql/templates/rolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.serviceAccount.create .Values.rbac.create }}
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ include "common.names.fullname" . }}
   namespace: {{ .Release.Namespace }}

--- a/bitnami/nginx-ingress-controller/Chart.lock
+++ b/bitnami/nginx-ingress-controller/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.9
-digest: sha256:de03bcd37a85979dadc44edf9094170791b0eb5004c9901b74c61c3a5c5f3af7
-generated: "2021-02-17T01:33:24.637413597Z"
+  version: 1.4.0
+digest: sha256:f8634e5c0ac4598321ccb7148b2d2495c1c4d5e503219a632a4dd145cd81e56a
+generated: "2021-02-22T16:25:52.425637+01:00"

--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -26,4 +26,4 @@ name: nginx-ingress-controller
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx-ingress-controller
   - https://github.com/kubernetes/ingress-nginx
-version: 7.4.4
+version: 7.4.5

--- a/bitnami/nginx-ingress-controller/templates/clusterrole.yaml
+++ b/bitnami/nginx-ingress-controller/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.rbac.create (not .Values.scope.enabled) -}}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname" . }}

--- a/bitnami/nginx-ingress-controller/templates/clusterrolebinding.yaml
+++ b/bitnami/nginx-ingress-controller/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.rbac.create (not .Values.scope.enabled) -}}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "common.names.fullname" . }}

--- a/bitnami/nginx-ingress-controller/templates/role.yaml
+++ b/bitnami/nginx-ingress-controller/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ template "common.names.fullname" . }}

--- a/bitnami/nginx-ingress-controller/templates/rolebinding.yaml
+++ b/bitnami/nginx-ingress-controller/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ template "common.names.fullname" . }}

--- a/bitnami/node-exporter/Chart.lock
+++ b/bitnami/node-exporter/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.9
-digest: sha256:de03bcd37a85979dadc44edf9094170791b0eb5004c9901b74c61c3a5c5f3af7
-generated: "2021-02-13T21:23:44.528045212Z"
+  version: 1.4.0
+digest: sha256:f8634e5c0ac4598321ccb7148b2d2495c1c4d5e503219a632a4dd145cd81e56a
+generated: "2021-02-22T16:26:23.798122+01:00"

--- a/bitnami/node-exporter/Chart.yaml
+++ b/bitnami/node-exporter/Chart.yaml
@@ -24,4 +24,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-node-exporter
   - https://github.com/prometheus/node_exporter
   - https://prometheus.io/
-version: 2.2.2
+version: 2.2.3

--- a/bitnami/node-exporter/templates/psp-clusterrole.yaml
+++ b/bitnami/node-exporter/templates/psp-clusterrole.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.rbac.create .Values.rbac.pspEnabled }}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ template "common.names.fullname" . }}-psp
   labels: {{- include "common.labels.standard" . | nindent 4 }}

--- a/bitnami/node-exporter/templates/psp-clusterrolebinding.yaml
+++ b/bitnami/node-exporter/templates/psp-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.rbac.create .Values.rbac.pspEnabled }}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "common.names.fullname" . }}-psp

--- a/bitnami/postgresql/Chart.lock
+++ b/bitnami/postgresql/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.9
-digest: sha256:b55689c2a6ccb0ae039cc129e66528e988d78cc566ec304704b4f2bc83b85e8f
-generated: "2021-02-11T21:30:58.224548294Z"
+  version: 1.4.0
+digest: sha256:af8a0894ca6f099e57ebfe9ce25a50d9e7548aeaa53b69d051ecc1681d6d77bb
+generated: "2021-02-22T16:26:47.159006+01:00"

--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -26,4 +26,4 @@ name: postgresql
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 10.3.4
+version: 10.3.5

--- a/bitnami/postgresql/templates/role.yaml
+++ b/bitnami/postgresql/templates/role.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create }}
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ template "common.names.fullname" . }}
   labels:

--- a/bitnami/postgresql/templates/rolebinding.yaml
+++ b/bitnami/postgresql/templates/rolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create }}
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ template "common.names.fullname" . }}
   labels:

--- a/bitnami/rabbitmq/Chart.lock
+++ b/bitnami/rabbitmq/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.9
-digest: sha256:de03bcd37a85979dadc44edf9094170791b0eb5004c9901b74c61c3a5c5f3af7
-generated: "2021-02-17T02:54:33.6730115Z"
+  version: 1.4.0
+digest: sha256:f8634e5c0ac4598321ccb7148b2d2495c1c4d5e503219a632a4dd145cd81e56a
+generated: "2021-02-22T16:27:04.769848+01:00"

--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -23,4 +23,4 @@ name: rabbitmq
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq
   - https://www.rabbitmq.com
-version: 8.10.1
+version: 8.10.2

--- a/bitnami/rabbitmq/templates/role.yaml
+++ b/bitnami/rabbitmq/templates/role.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create }}
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ template "rabbitmq.fullname" . }}-endpoint-reader
   namespace: {{ .Release.Namespace | quote }}

--- a/bitnami/rabbitmq/templates/rolebinding.yaml
+++ b/bitnami/rabbitmq/templates/rolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.serviceAccount.create .Values.rbac.create }}
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ template "rabbitmq.fullname" . }}-endpoint-reader
   namespace: {{ .Release.Namespace | quote }}

--- a/bitnami/redis-cluster/Chart.lock
+++ b/bitnami/redis-cluster/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.9
-digest: sha256:de03bcd37a85979dadc44edf9094170791b0eb5004c9901b74c61c3a5c5f3af7
-generated: "2021-02-20T17:45:42.764531165Z"
+  version: 1.4.0
+digest: sha256:f8634e5c0ac4598321ccb7148b2d2495c1c4d5e503219a632a4dd145cd81e56a
+generated: "2021-02-22T16:28:18.161707+01:00"

--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -23,4 +23,4 @@ name: redis-cluster
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 4.3.2
+version: 4.3.3

--- a/bitnami/redis-cluster/templates/redis-role.yaml
+++ b/bitnami/redis-cluster/templates/redis-role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ template "common.names.fullname" . }}

--- a/bitnami/redis-cluster/templates/redis-rolebinding.yaml
+++ b/bitnami/redis-cluster/templates/redis-rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ template "common.names.fullname" . }}

--- a/bitnami/redis/Chart.lock
+++ b/bitnami/redis/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.8
-digest: sha256:c200bbfd8c6fa776c41f1a335bc17906d858dfe975e90bad6fb7050c1e594ece
-generated: "2021-02-05T12:46:05.731372675Z"
+  version: 1.4.0
+digest: sha256:f8634e5c0ac4598321ccb7148b2d2495c1c4d5e503219a632a4dd145cd81e56a
+generated: "2021-02-22T16:28:00.608364+01:00"

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -25,4 +25,4 @@ name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 12.7.4
+version: 12.7.5

--- a/bitnami/redis/templates/redis-role.yaml
+++ b/bitnami/redis/templates/redis-role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ template "redis.fullname" . }}

--- a/bitnami/redis/templates/redis-rolebinding.yaml
+++ b/bitnami/redis/templates/redis-rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ template "redis.fullname" . }}

--- a/bitnami/spring-cloud-dataflow/Chart.lock
+++ b/bitnami/spring-cloud-dataflow/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.7
+  version: 1.4.0
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 9.3.0
+  version: 9.3.2
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
-  version: 8.9.1
+  version: 8.10.1
 - name: kafka
   repository: https://charts.bitnami.com/bitnami
-  version: 12.7.3
-digest: sha256:6035bde7e15d66cd622a5e78c59a4c17a64b1c6eff52586e7157c7f77ffa9ec9
-generated: "2021-01-31T21:18:39.59319141Z"
+  version: 12.9.2
+digest: sha256:656c2d234796803a5438d0104b420f420bfd339b8d21f20ab1db8a6124910270
+generated: "2021-02-22T16:28:34.33007+01:00"

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -39,4 +39,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-spring-cloud-dataflow
   - https://github.com/bitnami/bitnami-docker-spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 2.7.3
+version: 2.7.4

--- a/bitnami/spring-cloud-dataflow/templates/role.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/role.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create }}
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ include "scdf.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}

--- a/bitnami/spring-cloud-dataflow/templates/rolebinding.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/rolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create }}
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ include "scdf.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}

--- a/bitnami/thanos/Chart.lock
+++ b/bitnami/thanos/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.9
+  version: 1.4.0
 - name: minio
   repository: https://charts.bitnami.com/bitnami
-  version: 6.1.8
-digest: sha256:c749203d3880a0cf63638f9b8fb661f93803de45930a28833d8ea7d5b720d218
-generated: "2021-02-16T11:40:39.8237848+01:00"
+  version: 6.1.10
+digest: sha256:ab7aff2f4bc4c2c0b8b428791501a86366f460ee7c6b1bc15b3dac620e1caa99
+generated: "2021-02-22T16:28:54.219682+01:00"

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 3.11.2
+version: 3.11.3

--- a/bitnami/thanos/templates/query-frontend/psp-clusterrole.yaml
+++ b/bitnami/thanos/templates/query-frontend/psp-clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.queryFrontend.enabled .Values.queryFrontend.pspEnabled .Values.queryFrontend.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname" . }}-query-frontend

--- a/bitnami/thanos/templates/query-frontend/psp-clusterrolebinding.yaml
+++ b/bitnami/thanos/templates/query-frontend/psp-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.queryFrontend.enabled .Values.queryFrontend.pspEnabled .Values.queryFrontend.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "common.names.fullname" . }}-query-frontend

--- a/bitnami/thanos/templates/query/psp-clusterrole.yaml
+++ b/bitnami/thanos/templates/query/psp-clusterrole.yaml
@@ -1,6 +1,6 @@
 {{- $query := (include "thanos.query.values" . | fromYaml) -}}
 {{- if and $query.enabled $query.pspEnabled $query.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname" . }}-query

--- a/bitnami/thanos/templates/query/psp-clusterrolebinding.yaml
+++ b/bitnami/thanos/templates/query/psp-clusterrolebinding.yaml
@@ -1,6 +1,6 @@
 {{- $query := (include "thanos.query.values" . | fromYaml) -}}
 {{- if and $query.enabled $query.pspEnabled $query.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "common.names.fullname" . }}-query

--- a/bitnami/wavefront/Chart.lock
+++ b/bitnami/wavefront/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.3.9
+  version: 1.4.0
 - name: kube-state-metrics
   repository: https://charts.bitnami.com/bitnami
   version: 1.2.1
-digest: sha256:43b5b0cb2b07c0de75f0e274546ddc8c1c30373431b0cb0ea23e2b974c6dbea0
-generated: "2021-02-19T03:40:32.506687575Z"
+digest: sha256:9d726f1c3e245f24c42277139013eab7379286e715541dadac939d65be9e9740
+generated: "2021-02-22T16:29:07.713776+01:00"

--- a/bitnami/wavefront/Chart.yaml
+++ b/bitnami/wavefront/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-wavefront-proxy
   - https://github.com/wavefrontHQ/wavefront-collector-for-kubernetes
   - https://github.com/wavefrontHQ/wavefront-proxy
-version: 1.2.1
+version: 1.2.2

--- a/bitnami/wavefront/templates/collector-cluster-role.yaml
+++ b/bitnami/wavefront/templates/collector-cluster-role.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.rbac.create .Values.collector.enabled }}
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}

--- a/bitnami/wavefront/templates/collector-clusterrolebinding.yaml
+++ b/bitnami/wavefront/templates/collector-clusterrolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.rbac.create .Values.collector.enabled }}
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: collector

--- a/bitnami/wavefront/templates/project-pacific-rolebinding.yaml
+++ b/bitnami/wavefront/templates/project-pacific-rolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.projectPacific.enabled }}
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   {{- if .Values.commonLabels }}
   labels: {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/template/CHART_NAME/templates/clusterrolebinding.yaml
+++ b/template/CHART_NAME/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: %%COMPONENT_NAME%%


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR adapts the charts to use the macro that allows defining the `apiVersion` for RBAC resources introduced at https://github.com/bitnami/charts/pull/5583

**Benefits**

Standardize the way to define the RBAC apiVersion in the manifests.

**Possible drawbacks**

None

**Applicable issues**

- fixes https://github.com/bitnami/charts/issues/5577

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

