### PR TITLE
[bitnami/redis-cluster] Fix podDisruptionBudget matching initJob

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -23,4 +23,4 @@ name: redis-cluster
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 4.3.3
+version: 4.3.4

--- a/bitnami/redis-cluster/templates/poddisruptionbudget.yaml
+++ b/bitnami/redis-cluster/templates/poddisruptionbudget.yaml
@@ -13,5 +13,7 @@ metadata:
 spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+    matchExpressions:
+      - {key: job-name, operator: NotIn, values: [{{ template "common.names.fullname" . }}-cluster-create]}
   {{- toYaml .Values.podDisruptionBudget | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
**Description of the change**

Adds a condition to the PDB selector to not match the initJob pod.

**Benefits**

PodDisruptionBudget will not match the initJob.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #5526

**Additional information**

Before the change:

```
> kubectl get pods
NAME                                                     READY   STATUS      RESTARTS   AGE
redis-cluster-0                                   1/1     Running     0          53s
redis-cluster-1                                   1/1     Running     0          53s
redis-cluster-2                                   1/1     Running     0          52s
redis-cluster-3                                   1/1     Running     0          52s
redis-cluster-4                                   1/1     Running     0          52s
redis-cluster-5                                   1/1     Running     0          52s
redis-cluster-cluster-create-wbfvt                0/1     Completed   0          52s

> kubectl get poddisruptionbudgets redis-cluster -o yaml
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      app.kubernetes.io/instance: redis-cluster
      app.kubernetes.io/name: redis-cluster
status:
  currentHealthy: 0
  desiredHealthy: 5
  disruptionsAllowed: 0
  expectedPods: 6
  observedGeneration: 1
```

After upgrading:
```
> helm upgrade redis-cluster ./bitnami/redis-cluster --set password=$REDIS_PASSWORD
> kubectl get pods
NAME                                           READY   STATUS      RESTARTS   AGE
redis-cluster-0                         1/1     Running     0          6m22s
redis-cluster-1                         1/1     Running     0          6m50s
redis-cluster-2                         1/1     Running     0          7m12s
redis-cluster-3                         1/1     Running     0          7m32s
redis-cluster-4                         1/1     Running     0          7m55s
redis-cluster-5                         1/1     Running     0          8m15s

> kubectl get poddisruptionbudgets redis-cluster -o yaml
spec:
  maxUnavailable: 1
  selector:
    matchExpressions:
    - key: job-name
      operator: NotIn
      values:
      - miruiz-redis-cluster-cluster-create
    matchLabels:
      app.kubernetes.io/instance: miruiz-redis-cluster
      app.kubernetes.io/name: redis-cluster
status:
  currentHealthy: 6
  desiredHealthy: 5
  disruptionsAllowed: 1
  expectedPods: 6
  observedGeneration: 2
```


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
