### PR TITLE
[bitnami/harbor] Configure alternate domains for Notary Signer self-signed certificates

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-harbor-registry
   - https://github.com/bitnami/bitnami-docker-harbor-registryctl
   - https://goharbor.io/
-version: 9.5.0
+version: 9.5.1

--- a/bitnami/harbor/templates/ingress/ingress.yaml
+++ b/bitnami/harbor/templates/ingress/ingress.yaml
@@ -53,19 +53,6 @@ spec:
       hosts:
         - {{ .Values.ingress.hosts.core }}
       {{- end }}
-    {{- if .Values.notary.enabled }}
-    {{- if .Values.service.tls.notaryExistingSecret }}
-    - secretName: {{ .Values.service.tls.notaryExistingSecret | quote }}
-    {{- else if .Values.service.tls.existingSecret }}
-    - secretName: {{ .Values.service.tls.existingSecret | quote }}
-    {{- else }}
-    - secretName: {{ include "harbor.ingress" . | quote }}
-    {{- end }}
-      {{- if .Values.ingress.hosts.notary }}
-      hosts:
-        - {{ .Values.ingress.hosts.notary }}
-      {{- end }}
-    {{- end }}
   {{- end }}
   {{- if eq .Values.ingress.controller "ncp" }}
   backend: {{- include "common.ingress.backend" (dict "serviceName" (include "harbor.portal" .) "servicePort" "http" "context" $) | nindent 4 }}

--- a/bitnami/harbor/templates/notary/notary-secret.yaml
+++ b/bitnami/harbor/templates/notary/notary-secret.yaml
@@ -14,8 +14,9 @@ metadata:
 type: Opaque
 data:
   {{- if not .Values.notary.secretName }}
-  {{ $ca := genCA "harbor-notary-ca" 365 }}
-  {{ $cert := genSignedCert (include "harbor.notary-signer" .) nil nil 365 $ca }}
+  {{- $ca := genCA "harbor-notary-ca" 365 }}
+  {{- $altNames := list (printf "%s.%s.svc" (include "harbor.notary-signer" .) .Release.Namespace) (printf "%s.%s" (include "harbor.notary-signer" .) .Release.Namespace) (include "harbor.notary-signer" .) -}}
+  {{- $cert := genSignedCert (include "harbor.notary-signer" .) nil $altNames 365 $ca }}
   notary-signer-ca.crt: {{ $ca.Cert | b64enc | quote }}
   notary-signer.crt: {{ $cert.Cert | b64enc | quote }}
   notary-signer.key: {{ $cert.Key | b64enc | quote }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

When installing the chart relying on self-signed certificates generated by Helm, we find issues like the on below in the Notary Server container:

```
 x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0
```

Based on the solution proposed at https://github.com/helm/helm/issues/9046, I'm adding alternate domains to avoid this issue.

**Benefits**

No issues with self-signed certificates once these are configured to be trusted.

**Possible drawbacks**

None

**Applicable issues**

Related to https://github.com/bitnami/charts/issues/5551

**Additional information**

It also removes a duplicated TLS section in Ingress rules:

- Before

```console
$ kubectl get ingress harbor-ingress -o json | jq '.spec.tls[].hosts'
[
  "registry.juan.cluster"
]
[
  "notary.juan.cluster"
]
$ kubectl get ingress harbor-ingress-notary -o json | jq '.spec.tls[].hosts'
[
  "notary.juan.cluster"
]
```

- Now:

```console
$ kubectl get ingress harbor-ingress -o json | jq '.spec.tls[].hosts'
[
  "registry.juan.cluster"
]
$ kubectl get ingress harbor-ingress-notary -o json | jq '.spec.tls[].hosts'
[
  "notary.juan.cluster"
]
```

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

