### PR TITLE
[bitnami/redis] mount /tmp as emptyDir

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -25,4 +25,4 @@ name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 12.7.5
+version: 12.7.6

--- a/bitnami/redis/templates/redis-master-statefulset.yaml
+++ b/bitnami/redis/templates/redis-master-statefulset.yaml
@@ -188,6 +188,8 @@ spec:
               mountPath: /opt/bitnami/redis/mounted-etc
             - name: redis-tmp-conf
               mountPath: /opt/bitnami/redis/etc/
+            - name: tmp
+              mountPath: /tmp
             {{- if .Values.tls.enabled }}
             - name: redis-certificates
               mountPath: /opt/bitnami/redis/certs
@@ -325,6 +327,8 @@ spec:
             path: /sys
         {{- end }}
         - name: redis-tmp-conf
+          emptyDir: {}
+        - name: tmp
           emptyDir: {}
         {{- if .Values.tls.enabled }}
         - name: redis-certificates

--- a/bitnami/redis/templates/redis-node-statefulset.yaml
+++ b/bitnami/redis/templates/redis-node-statefulset.yaml
@@ -208,6 +208,8 @@ spec:
               mountPath: /opt/bitnami/redis/mounted-etc
             - name: redis-tmp-conf
               mountPath: /opt/bitnami/redis/etc
+            - name: tmp
+              mountPath: /tmp
             {{- if .Values.tls.enabled }}
             - name: redis-certificates
               mountPath: /opt/bitnami/redis/certs
@@ -438,6 +440,8 @@ spec:
         - name: sentinel-tmp-conf
           emptyDir: {}
         - name: redis-tmp-conf
+          emptyDir: {}
+        - name: tmp
           emptyDir: {}
     {{- if .Values.tls.enabled }}
         - name: redis-certificates


### PR DESCRIPTION
**Description of the change**

mount /tmp as emptyDir. 

Default image (bitnami redis) uses heredoc as seen [here](https://github.com/bitnami/bitnami-docker-redis/blob/master/6.0/debian-10/rootfs/opt/bitnami/scripts/redis/run.sh#L23). 

heredoc creates a temp file in the `/tmp` directory. Thus, `/tmp` has to be exempted implicitly in order to support read only root filesystem.

**Benefits**
Support read only root filesystem. 

**Applicable issues**
  - fixes #5600

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.

