### PR TITLE
[bitnami/postgresql] Don't put postgresql-postgres-password in secret when not needed

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -26,4 +26,4 @@ name: postgresql
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 10.3.7
+version: 10.3.8

--- a/bitnami/postgresql/templates/secrets.yaml
+++ b/bitnami/postgresql/templates/secrets.yaml
@@ -11,7 +11,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
+  {{- if not (eq (include "postgresql.username" .) "postgres")  }}
   postgresql-postgres-password: {{ include "postgresql.postgres.password" . | b64enc | quote }}
+  {{- end }}
   postgresql-password: {{ include "postgresql.password" . | b64enc | quote }}
   {{- if .Values.replication.enabled }}
   postgresql-replication-password: {{ include "postgresql.replication.password" . | b64enc | quote }}

--- a/bitnami/postgresql/templates/statefulset-readreplicas.yaml
+++ b/bitnami/postgresql/templates/statefulset-readreplicas.yaml
@@ -176,7 +176,7 @@ spec:
               value: {{ template "common.names.fullname" . }}
             - name: POSTGRES_MASTER_PORT_NUMBER
               value: {{ include "postgresql.port" . | quote }}
-            {{- if and (not (eq .Values.postgresqlUsername "postgres")) (or .Values.postgresqlPostgresPassword (include "postgresql.useExistingSecret" .)) }}
+            {{- if not (eq (include "postgresql.username" .) "postgres")  }}
             {{- if .Values.usePasswordFile }}
             - name: POSTGRES_POSTGRES_PASSWORD_FILE
               value: "/opt/bitnami/postgresql/secrets/postgresql-postgres-password"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
When only using the "postgres" user, the secret gets updated every helm upgrade with a
random string. When using with argocd (and maybe other gitops tools) there are always
changes until you put a dummy value into postgresqlPostgresPassword.

Use the same conditional as in statefulset.yaml:
~~~
{{- if not (eq (include "postgresql.username" .) "postgres")  }}
  # (..)
- name: POSTGRES_POSTGRES_PASSWORD
  valueFrom:
    secretKeyRef:
      name: {{ template "postgresql.secretName" . }}
      key: postgresql-postgres-password
{{- end }}
{{- end }}
~~~

**Benefits**

<!-- What benefits will be realized by the code change? -->
Accomplish idempotency when only using the "postgres" user.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
`-`

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
`-`

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
`-`

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
