### PR TITLE
[bitnami/kube-prometheus] Add possibility to pull images without giving registry name

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-prometheus
   - https://github.com/bitnami/bitnami-docker-alertmanager
   - https://github.com/prometheus-operator/kube-prometheus
-version: 4.1.1
+version: 4.1.2

--- a/bitnami/kube-prometheus/templates/_helpers.tpl
+++ b/bitnami/kube-prometheus/templates/_helpers.tpl
@@ -138,7 +138,7 @@ Return the proper Prometheus Operator image name
 Return the proper Prometheus Operator Reloader image name
 */}}
 {{- define "kube-prometheus.prometheusConfigReloader.image" -}}
-{{- if and .Values.operator.prometheusConfigReloader.image.registry (and .Values.operator.prometheusConfigReloader.image.repository .Values.operator.prometheusConfigReloader.image.tag) }}
+{{- if and .Values.operator.prometheusConfigReloader.image.repository .Values.operator.prometheusConfigReloader.image.tag }}
 {{- include "common.images.image" (dict "imageRoot" .Values.operator.prometheusConfigReloader.image "global" .Values.global) }}
 {{- else -}}
 {{- include "kube-prometheus.image" . -}}


### PR DESCRIPTION
**Description of the change**

Add possibility to pull images prometheusConfigReload Image without giving specific registry in Values.yaml file but by setting default registry on host. See #5582 

**Benefits**

We can use non default prometheusConfigReload if we omit `.Values.operator.prometheusConfigReloader.image.registry`

**Possible drawbacks**

We cannot use default behavior for prometheusConfigReload by omitting `.Values.operator.prometheusConfigReloader.image.registry`, we need to omit imageName or imageTag.

**Applicable issues**

  - fixes #5584 

**Additional information**

None

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
