### PR TITLE
[bitnami/kube-prometheus] Update crds kube prometheus

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-prometheus
   - https://github.com/bitnami/bitnami-docker-alertmanager
   - https://github.com/prometheus-operator/kube-prometheus
-version: 4.1.1
+version: 4.1.2

--- a/bitnami/kube-prometheus/crds/crd-alertmanager-config.yaml
+++ b/bitnami/kube-prometheus/crds/crd-alertmanager-config.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.44.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.46.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -11,6 +11,8 @@ metadata:
 spec:
   group: monitoring.coreos.com
   names:
+    categories:
+      - prometheus-operator
     kind: AlertmanagerConfig
     listKind: AlertmanagerConfigList
     plural: alertmanagerconfigs
@@ -50,6 +52,7 @@ spec:
                           properties:
                             name:
                               description: Label to match.
+                              minLength: 1
                               type: string
                             regex:
                               description: Whether to match on equality (false) or regular-expression (true).
@@ -59,7 +62,6 @@ spec:
                               type: string
                           required:
                             - name
-                            - value
                           type: object
                         type: array
                       targetMatch:
@@ -69,6 +71,7 @@ spec:
                           properties:
                             name:
                               description: Label to match.
+                              minLength: 1
                               type: string
                             regex:
                               description: Whether to match on equality (false) or regular-expression (true).
@@ -78,7 +81,6 @@ spec:
                               type: string
                           required:
                             - name
-                            - value
                           type: object
                         type: array
                     type: object
@@ -94,9 +96,10 @@ spec:
                           description: EmailConfig configures notifications via Email.
                           properties:
                             authIdentity:
+                              description: The identity to use for authentication.
                               type: string
                             authPassword:
-                              description: SecretKeySelector selects a key of a Secret.
+                              description: The secret's key that contains the password to use for authentication. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
                               properties:
                                 key:
                                   description: The key of the secret to select from.  Must be a valid secret key.
@@ -111,7 +114,7 @@ spec:
                                 - key
                               type: object
                             authSecret:
-                              description: SecretKeySelector selects a key of a Secret.
+                              description: The secret's key that contains the CRAM-MD5 secret. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
                               properties:
                                 key:
                                   description: The key of the secret to select from.  Must be a valid secret key.
@@ -126,7 +129,7 @@ spec:
                                 - key
                               type: object
                             authUsername:
-                              description: SMTP authentication information.
+                              description: The username to use for authentication.
                               type: string
                             from:
                               description: The sender address.
@@ -138,6 +141,7 @@ spec:
                                 properties:
                                   key:
                                     description: Key of the tuple.
+                                    minLength: 1
                                     type: string
                                   value:
                                     description: Value of the tuple.
@@ -265,6 +269,7 @@ spec:
                         type: array
                       name:
                         description: Name of the receiver. Must be unique across all items from the list.
+                        minLength: 1
                         type: string
                       opsgenieConfigs:
                         description: List of OpsGenie configurations.
@@ -299,6 +304,7 @@ spec:
                                 properties:
                                   key:
                                     description: Key of the tuple.
+                                    minLength: 1
                                     type: string
                                   value:
                                     description: Value of the tuple.
@@ -469,7 +475,7 @@ spec:
                             responders:
                               description: List of responders responsible for notifications.
                               items:
-                                description: OpsGenieConfigResponder defines a responder to an incident. One of id, name or username has to be defined.
+                                description: OpsGenieConfigResponder defines a responder to an incident. One of `id`, `name` or `username` has to be defined.
                                 properties:
                                   id:
                                     description: ID of the responder.
@@ -479,10 +485,13 @@ spec:
                                     type: string
                                   type:
                                     description: Type of responder.
+                                    minLength: 1
                                     type: string
                                   username:
                                     description: Username of the responder.
                                     type: string
+                                required:
+                                  - type
                                 type: object
                               type: array
                             sendResolved:
@@ -523,6 +532,7 @@ spec:
                                 properties:
                                   key:
                                     description: Key of the tuple.
+                                    minLength: 1
                                     type: string
                                   value:
                                     description: Value of the tuple.
@@ -904,7 +914,7 @@ spec:
                               description: Notification title.
                               type: string
                             token:
-                              description: Your registered application’s API token, see https://pushover.net/apps
+                              description: The secret's key that contains the registered application’s API token, see https://pushover.net/apps. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
                               properties:
                                 key:
                                   description: The key of the secret to select from.  Must be a valid secret key.
@@ -925,7 +935,7 @@ spec:
                               description: A title for supplementary URL, otherwise just the URL is shown
                               type: string
                             userKey:
-                              description: The recipient user’s user key.
+                              description: The secret's key that contains the recipient user’s user key. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
                               properties:
                                 key:
                                   description: The key of the secret to select from.  Must be a valid secret key.
@@ -959,6 +969,7 @@ spec:
                                       okText:
                                         type: string
                                       text:
+                                        minLength: 1
                                         type: string
                                       title:
                                         type: string
@@ -970,8 +981,10 @@ spec:
                                   style:
                                     type: string
                                   text:
+                                    minLength: 1
                                     type: string
                                   type:
+                                    minLength: 1
                                     type: string
                                   url:
                                     type: string
@@ -1014,8 +1027,10 @@ spec:
                                   short:
                                     type: boolean
                                   title:
+                                    minLength: 1
                                     type: string
                                   value:
+                                    minLength: 1
                                     type: string
                                 required:
                                   - title
@@ -1210,7 +1225,7 @@ spec:
                           description: VictorOpsConfig configures notifications via VictorOps. See https://prometheus.io/docs/alerting/latest/configuration/#victorops_config
                           properties:
                             apiKey:
-                              description: The API key to use when talking to the VictorOps API.
+                              description: The secret's key that contains the API key to use when talking to the VictorOps API. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
                               properties:
                                 key:
                                   description: The key of the secret to select from.  Must be a valid secret key.
@@ -1234,6 +1249,7 @@ spec:
                                 properties:
                                   key:
                                     description: Key of the tuple.
+                                    minLength: 1
                                     type: string
                                   value:
                                     description: Value of the tuple.
@@ -1410,8 +1426,6 @@ spec:
                             stateMessage:
                               description: Contains long explanation of the alerted problem.
                               type: string
-                          required:
-                            - routingKey
                           type: object
                         type: array
                       webhookConfigs:
@@ -1569,8 +1583,9 @@ spec:
                                   type: object
                               type: object
                             maxAlerts:
-                              description: Maximum number of alerts to be sent per webhook message.
+                              description: Maximum number of alerts to be sent per webhook message. When 0, all alerts are included.
                               format: int32
+                              minimum: 0
                               type: integer
                             sendResolved:
                               description: Whether or not to notify about resolved alerts.
@@ -1793,7 +1808,7 @@ spec:
                     type: object
                   type: array
                 route:
-                  description: The Alertmanager route definition for alerts matching the resource’s namespace. It will be added to the generated Alertmanager configuration as a first-level route.
+                  description: The Alertmanager route definition for alerts matching the resource’s namespace. If present, it will be added to the generated Alertmanager configuration as a first-level route.
                   properties:
                     continue:
                       description: Boolean indicating whether an alert should continue matching subsequent sibling nodes. It will always be overridden to true for the first-level route by the Prometheus operator.
@@ -1816,6 +1831,7 @@ spec:
                         properties:
                           name:
                             description: Label to match.
+                            minLength: 1
                             type: string
                           regex:
                             description: Whether to match on equality (false) or regular-expression (true).
@@ -1825,11 +1841,10 @@ spec:
                             type: string
                         required:
                           - name
-                          - value
                         type: object
                       type: array
                     receiver:
-                      description: Name of the receiver for this route. If present, it should be listed in the `receivers` field. The field can be omitted only for nested routes otherwise it is mandatory.
+                      description: Name of the receiver for this route. If not empty, it should be listed in the `receivers` field.
                       type: string
                     repeatInterval:
                       description: How long to wait before repeating the last notification. Must match the regular expression `[0-9]+(ms|s|m|h)` (milliseconds seconds minutes hours).

--- a/bitnami/kube-prometheus/crds/crd-alertmanager.yaml
+++ b/bitnami/kube-prometheus/crds/crd-alertmanager.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.44.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.46.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -11,6 +11,8 @@ metadata:
 spec:
   group: monitoring.coreos.com
   names:
+    categories:
+      - prometheus-operator
     kind: Alertmanager
     listKind: AlertmanagerList
     plural: alertmanagers

--- a/bitnami/kube-prometheus/crds/crd-podmonitor.yaml
+++ b/bitnami/kube-prometheus/crds/crd-podmonitor.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.44.0/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.46.0/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -11,6 +11,8 @@ metadata:
 spec:
   group: monitoring.coreos.com
   names:
+    categories:
+      - prometheus-operator
     kind: PodMonitor
     listKind: PodMonitorList
     plural: podmonitors

--- a/bitnami/kube-prometheus/crds/crd-probes.yaml
+++ b/bitnami/kube-prometheus/crds/crd-probes.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.44.0/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.46.0/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -11,6 +11,8 @@ metadata:
 spec:
   group: monitoring.coreos.com
   names:
+    categories:
+      - prometheus-operator
     kind: Probe
     listKind: ProbeList
     plural: probes
@@ -148,6 +150,37 @@ spec:
                             type: string
                           description: Labels assigned to all metrics scraped from the targets.
                           type: object
+                        relabelingConfigs:
+                          description: "RelabelConfigs to apply to samples before ingestion. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
+                          items:
+                            description: "RelabelConfig allows dynamic rewriting of the label set, being applied to samples before ingestion. It defines `<metric_relabel_configs>`-section of Prometheus configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs"
+                            properties:
+                              action:
+                                description: Action to perform based on regex matching. Default is 'replace'
+                                type: string
+                              modulus:
+                                description: Modulus to take of the hash of the source label values.
+                                format: int64
+                                type: integer
+                              regex:
+                                description: Regular expression against which the extracted value is matched. Default is '(.*)'
+                                type: string
+                              replacement:
+                                description: Replacement value against which a regex replace is performed if the regular expression matches. Regex capture groups are available. Default is '$1'
+                                type: string
+                              separator:
+                                description: Separator placed between concatenated source label values. default is ';'.
+                                type: string
+                              sourceLabels:
+                                description: The source labels select values from existing labels. Their content is concatenated using the configured separator and matched against the configured regular expression for the replace, keep, and drop actions.
+                                items:
+                                  type: string
+                                type: array
+                              targetLabel:
+                                description: Label to which the resulting value is written in a replace action. It is mandatory for replace actions. Regex capture groups are available.
+                                type: string
+                            type: object
+                          type: array
                         static:
                           description: Targets is a list of URLs to probe using the configured prober.
                           items:

--- a/bitnami/kube-prometheus/crds/crd-prometheus.yaml
+++ b/bitnami/kube-prometheus/crds/crd-prometheus.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.44.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.46.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -11,6 +11,8 @@ metadata:
 spec:
   group: monitoring.coreos.com
   names:
+    categories:
+      - prometheus-operator
     kind: Prometheus
     listKind: PrometheusList
     plural: prometheuses
@@ -2258,7 +2260,7 @@ spec:
                       type: string
                   type: object
                 podMonitorNamespaceSelector:
-                  description: Namespaces to be selected for PodMonitor discovery. If nil, only check own namespace.
+                  description: Namespace's labels to match for PodMonitor discovery. If nil, only check own namespace.
                   properties:
                     matchExpressions:
                       description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -2639,6 +2641,11 @@ spec:
                       bearerTokenFile:
                         description: File to read bearer token for remote write.
                         type: string
+                      headers:
+                        additionalProperties:
+                          type: string
+                        description: Custom HTTP headers to be sent along with each remote write request. Be aware that headers that are set by Prometheus itself can't be overwritten. Only valid in Prometheus versions 2.25.0 and newer.
+                        type: object
                       name:
                         description: The name of the remote write queue, must be unique if specified. The name is used in metrics and logging in order to differentiate queues. Only valid in Prometheus versions 2.15.0 and newer.
                         type: string
@@ -2849,7 +2856,7 @@ spec:
                   description: Time duration Prometheus shall retain data for. Default is '24h', and must match the regular expression `[0-9]+(ms|s|m|h|d|w|y)` (milliseconds seconds minutes hours days weeks years).
                   type: string
                 retentionSize:
-                  description: Maximum amount of disk space used by blocks.
+                  description: "Maximum amount of disk space used by blocks. Supported units: B, KB, MB, GB, TB, PB, EB. Ex: `512MB`."
                   type: string
                 routePrefix:
                   description: The route prefix Prometheus registers HTTP handlers for. This is useful, if using ExternalURL and a proxy is rewriting HTTP routes of a request, and the actual ExternalURL is still true, but the server serves requests under a different route prefix. For example for use with `kubectl proxy`.
@@ -3019,7 +3026,7 @@ spec:
                   description: ServiceAccountName is the name of the ServiceAccount to use to run the Prometheus Pods.
                   type: string
                 serviceMonitorNamespaceSelector:
-                  description: Namespaces to be selected for ServiceMonitor discovery. If nil, only check own namespace.
+                  description: Namespace's labels to match for ServiceMonitor discovery. If nil, only check own namespace.
                   properties:
                     matchExpressions:
                       description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -3456,6 +3463,9 @@ spec:
                       required:
                         - key
                       type: object
+                    tracingConfigFile:
+                      description: TracingConfig specifies the path of the tracing configuration file. When used alongside with TracingConfig, TracingConfigFile takes precedence.
+                      type: string
                     version:
                       description: Version describes the version of Thanos to use.
                       type: string

--- a/bitnami/kube-prometheus/crds/crd-prometheusrules.yaml
+++ b/bitnami/kube-prometheus/crds/crd-prometheusrules.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.44.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.46.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/bitnami/kube-prometheus/crds/crd-servicemonitor.yaml
+++ b/bitnami/kube-prometheus/crds/crd-servicemonitor.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.44.0/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.46.0/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/bitnami/kube-prometheus/crds/crd-thanosrulers.yaml
+++ b/bitnami/kube-prometheus/crds/crd-thanosrulers.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.44.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.46.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -11,6 +11,8 @@ metadata:
 spec:
   group: monitoring.coreos.com
   names:
+    categories:
+      - prometheus-operator
     kind: ThanosRuler
     listKind: ThanosRulerList
     plural: thanosrulers


### PR DESCRIPTION
**Description of the change**

Update crds to prometheus-operator 0.46.0

**Benefits**

Add relabelingConfigs to ProbeTargetStaticConfig (provided by 0.46.0)

**Possible drawbacks**

None

**Applicable issues**

https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.46.0

**Additional information**

None

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
