### PR TITLE
[bitnami/nginx] Add service account to nginx chart

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -25,4 +25,4 @@ name: nginx
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx
   - http://www.nginx.org
-version: 8.5.5
+version: 8.6.0

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -90,39 +90,42 @@ The following tables lists the configurable parameters of the NGINX chart and th
 
 ### NGINX deployment parameters
 
-| Parameter                   | Description                                                                               | Default                        |
-|-----------------------------|-------------------------------------------------------------------------------------------|--------------------------------|
-| `replicaCount`              | Number of NGINX replicas to deploy                                                        | `1`                            |
-| `strategyType`              | Deployment Strategy Type                                                                  | `RollingUpdate`                |
-| `podAffinityPreset`         | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                           |
-| `podAntiAffinityPreset`     | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                         |
-| `nodeAffinityPreset.type`   | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                           |
-| `nodeAffinityPreset.key`    | Node label key to match Ignored if `affinity` is set.                                     | `""`                           |
-| `nodeAffinityPreset.values` | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                           |
-| `affinity`                  | Affinity for pod assignment                                                               | `{}` (evaluated as a template) |
-| `nodeSelector`              | Node labels for pod assignment                                                            | `{}` (evaluated as a template) |
-| `tolerations`               | Tolerations for pod assignment                                                            | `[]` (evaluated as a template) |
-| `podLabels`                 | Additional labels for NGINX pods                                                          | `{}` (evaluated as a template) |
-| `podAnnotations`            | Annotations for NGINX pods                                                                | `{}` (evaluated as a template) |
-| `podSecurityContext`        | NGINX pods' Security Context                                                              | Check `values.yaml` file       |
-| `containerSecurityContext`  | NGINX containers' Security Context                                                        | Check `values.yaml` file       |
-| `containerPorts.http`       | Sets http port inside NGINX container                                                     | `8080`                         |
-| `containerPorts.https`      | Sets https port inside NGINX container                                                    | `nil`                          |
-| `resources.limits`          | The resources limits for the NGINX container                                              | `{}`                           |
-| `resources.requests`        | The requested resources for the NGINX container                                           | `{}`                           |
-| `livenessProbe`             | Liveness probe configuration for NGINX                                                    | Check `values.yaml` file       |
-| `readinessProbe`            | Readiness probe configuration for NGINX                                                   | Check `values.yaml` file       |
-| `customLivenessProbe`       | Override default liveness probe                                                           | `nil`                          |
-| `customReadinessProbe`      | Override default readiness probe                                                          | `nil`                          |
-| `autoscaling.enabled`       | Enable autoscaling for NGINX deployment                                                   | `false`                        |
-| `autoscaling.minReplicas`   | Minimum number of replicas to scale back                                                  | `nil`                          |
-| `autoscaling.maxReplicas`   | Maximum number of replicas to scale out                                                   | `nil`                          |
-| `autoscaling.targetCPU`     | Target CPU utilization percentage                                                         | `nil`                          |
-| `autoscaling.targetMemory`  | Target Memory utilization percentage                                                      | `nil`                          |
-| `extraVolumes`              | Array to add extra volumes                                                                | `[]` (evaluated as a template) |
-| `extraVolumeMounts`         | Array to add extra mount                                                                  | `[]` (evaluated as a template) |
-| `sidecars`                  | Attach additional containers to nginx pods                                                | `nil`                          |
-| `initContainers`            | Additional init containers (this value is evaluated as a template)                        | `[]`                           |
+| Parameter                    | Description                                                                                    | Default                                              |
+|------------------------------|------------------------------------------------------------------------------------------------|------------------------------------------------------|
+| `replicaCount`               | Number of NGINX replicas to deploy                                                             | `1`                                                  |
+| `strategyType`               | Deployment Strategy Type                                                                       | `RollingUpdate`                                      |
+| `podAffinityPreset`          | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`            | `""`                                                 |
+| `podAntiAffinityPreset`      | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `soft`                                               |
+| `nodeAffinityPreset.type`    | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`      | `""`                                                 |
+| `nodeAffinityPreset.key`     | Node label key to match Ignored if `affinity` is set.                                          | `""`                                                 |
+| `nodeAffinityPreset.values`  | Node label values to match. Ignored if `affinity` is set.                                      | `[]`                                                 |
+| `affinity`                   | Affinity for pod assignment                                                                    | `{}` (evaluated as a template)                       |
+| `nodeSelector`               | Node labels for pod assignment                                                                 | `{}` (evaluated as a template)                       |
+| `tolerations`                | Tolerations for pod assignment                                                                 | `[]` (evaluated as a template)                       |
+| `podLabels`                  | Additional labels for NGINX pods                                                               | `{}` (evaluated as a template)                       |
+| `podAnnotations`             | Annotations for NGINX pods                                                                     | `{}` (evaluated as a template)                       |
+| `podSecurityContext`         | NGINX pods' Security Context                                                                   | Check `values.yaml` file                             |
+| `containerSecurityContext`   | NGINX containers' Security Context                                                             | Check `values.yaml` file                             |
+| `containerPorts.http`        | Sets http port inside NGINX container                                                          | `8080`                                               |
+| `containerPorts.https`       | Sets https port inside NGINX container                                                         | `nil`                                                |
+| `resources.limits`           | The resources limits for the NGINX container                                                   | `{}`                                                 |
+| `resources.requests`         | The requested resources for the NGINX container                                                | `{}`                                                 |
+| `livenessProbe`              | Liveness probe configuration for NGINX                                                         | Check `values.yaml` file                             |
+| `readinessProbe`             | Readiness probe configuration for NGINX                                                        | Check `values.yaml` file                             |
+| `customLivenessProbe`        | Override default liveness probe                                                                | `nil`                                                |
+| `customReadinessProbe`       | Override default readiness probe                                                               | `nil`                                                |
+| `autoscaling.enabled`        | Enable autoscaling for NGINX deployment                                                        | `false`                                              |
+| `autoscaling.minReplicas`    | Minimum number of replicas to scale back                                                       | `nil`                                                |
+| `autoscaling.maxReplicas`    | Maximum number of replicas to scale out                                                        | `nil`                                                |
+| `autoscaling.targetCPU`      | Target CPU utilization percentage                                                              | `nil`                                                |
+| `autoscaling.targetMemory`   | Target Memory utilization percentage                                                           | `nil`                                                |
+| `extraVolumes`               | Array to add extra volumes                                                                     | `[]` (evaluated as a template)                       |
+| `extraVolumeMounts`          | Array to add extra mount                                                                       | `[]` (evaluated as a template)                       |
+| `sidecars`                   | Attach additional containers to nginx pods                                                     | `nil`                                                |
+| `initContainers`             | Additional init containers (this value is evaluated as a template)                             | `[]`                                                 |
+| `serviceAccount.create`      | Enable creation of ServiceAccount for nginx pod                                                | `false`                                              |
+| `serviceAccount.name`        | The name of the service account to use. If not set and `create` is `true`, a name is generated | Generated using the `common.names.fullname` template |
+| `serviceAccount.annotations` | Annotations for service account.                                                               | `{}`                                                 |
 
 ### Custom NGINX application parameters
 

--- a/bitnami/nginx/templates/_helpers.tpl
+++ b/bitnami/nginx/templates/_helpers.tpl
@@ -112,3 +112,14 @@ nginx: missing-extra-volume-mounts
     the extraVolumeMounts value
 {{- end -}}
 {{- end -}}
+
+{{/*
+ Create the name of the service account to use
+ */}}
+{{- define "nginx.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "common.names.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       {{- end }}
     spec:
       {{- include "nginx.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ template "nginx.serviceAccountName" . }}
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/nginx/templates/serviceaccount.yaml
+++ b/bitnami/nginx/templates/serviceaccount.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "nginx.serviceAccountName" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.serviceAccount.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.serviceAccount.annotations "context" $) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -300,6 +300,22 @@ extraVolumes: []
 ##
 extraVolumeMounts: []
 
+## Pods Service Account
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  ## Specifies whether a ServiceAccount should be created
+  ##
+  create: false
+  ## The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the `common.names.fullname` template
+  # name:
+
+  ## Annotations for service account. Evaluated as a template.
+  ## Only used if `create` is `true`.
+  ##
+  annotations: {}
+
 ## NGINX Service properties
 ##
 service:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Add the ability to create and name a service account for the nginx Deployment. This is based on how the `nginx-ingress-controller` configures the service account.

**Benefits**

This is a common feature across a lot of Bitnami charts, which allows setting `serviceAccount.create` and `serviceAccount.name` values to configure creating a new service account for nginx and what the name should be.

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
