### PR TITLE
[bitnami/nginx] Add support for defining env vars in `cloneStaticSiteFromGit` containers

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -25,4 +25,4 @@ name: nginx
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx
   - http://www.nginx.org
-version: 8.6.0
+version: 8.7.0

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -140,6 +140,7 @@ The following tables lists the configurable parameters of the NGINX chart and th
 | `cloneStaticSiteFromGit.repository`        | GIT Repository to clone                                     | `nil`                                                   |
 | `cloneStaticSiteFromGit.branch`            | GIT revision to checkout                                    | `nil`                                                   |
 | `cloneStaticSiteFromGit.interval`          | Interval for sidecar container pull from the GIT repository | `60`                                                    |
+| `cloneStaticSiteFromGit.extraEnvVars`      | Extra environment variables to be set on GIT containers     | `[]`                                                    |
 | `serverBlock`                              | Custom NGINX server block                                   | `nil`                                                   |
 | `existingServerBlockConfigmap`             | Name of existing PVC with custom NGINX server block         | `nil`                                                   |
 | `staticSiteConfigmap`                      | Name of existing ConfigMap with the server static content   | `nil`                                                   |

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -67,6 +67,10 @@ spec:
           volumeMounts:
             - name: staticsite
               mountPath: /app
+          {{- if .Values.cloneStaticSiteFromGit.extraEnvVars }}
+          env:
+            {{- include "common.tplvalues.render" (dict "value" .Values.cloneStaticSiteFromGit.extraEnvVars "context" $) | nindent 12 }}
+          {{- end }}
       containers:
         - name: git-repo-syncer
           image: {{ include "nginx.cloneStaticSiteFromGit.image" . }}
@@ -82,6 +86,10 @@ spec:
           volumeMounts:
             - name: staticsite
               mountPath: /app
+          {{- if .Values.cloneStaticSiteFromGit.extraEnvVars }}
+          env:
+            {{- include "common.tplvalues.render" (dict "value" .Values.cloneStaticSiteFromGit.extraEnvVars "context" $) | nindent 12 }}
+          {{- end }}
       {{- else }}
       {{- with .Values.initContainers }}
       initContainers:

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -118,6 +118,14 @@ cloneStaticSiteFromGit:
   ##
   interval: 60
 
+  ## Additional environment variables to set for the in the containers that clone static site from git
+  ## E.g:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: BAR
+  ##
+  extraEnvVars: []
+
 ## Custom server block to be added to NGINX configuration
 ## PHP-FPM example server block:
 ## serverBlock: |-


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Add ability to set environment variables in the containers that clone static site from git via `cloneStaticSiteFromGit.extraEnvVars`. 

**Benefits**

This is helpful configuring git via environment variables (see https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables). For example, cloning a private git repository via ssh with something like:

```yaml
cloneStaticSiteFromGit:
  extraEnvVars:
    - name: GIT_SSH_COMMAND
      value: ssh -i /path/to/ssh/key
```

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
