### PR TITLE
[bitnami/postgresql-ha] Improve explanation about initdbScripts

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -27,4 +27,4 @@ name: postgresql-ha
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 6.6.2
+version: 6.6.3

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -434,9 +434,13 @@ In addition to this option, you can also set an external ConfigMap with all the 
 
 The [Bitnami PostgreSQL with Repmgr](https://github.com/bitnami/bitnami-docker-postgresql-repmgr) image allows you to use your custom scripts to initialize a fresh instance. You can specify custom scripts using the `initdbScripts` parameter as dict so they can be consumed as a ConfigMap.
 
-In addition to this option, you can also set an external ConfigMap with all the initialization scripts. This is done by setting the `postgresql.initdbScriptsCM` parameter. Note that this will override the two previous option. If your initialization scripts contain sensitive information such as credentials or passwords, you can use the `initdbScriptsSecret` parameter.
+In addition to this option, you can also set an external ConfigMap with all the initialization scripts. This is done by setting the `initdbScriptsCM` parameter. Note that this will override the two previous options. If your initialization scripts contain sensitive information such as credentials or passwords, you can use the `initdbScriptsSecret` parameter.
 
-The allowed extensions are `.sh`, `.sql` and `.sql.gz`.
+The above parameters (`initdbScripts`, `initdbScriptsCM`, and `initdbScriptsSecret`) are supported in both StatefulSet by prepending `postgresql` or `pgpool` to the parameter, depending on the use case (see above parameters table).
+
+The allowed extensions are `.sh`, `.sql` and `.sql.gz` in the `postgresql` container. Only `.sh` in the case of the `pgpool` one.
+
++info: https://github.com/bitnami/bitnami-docker-postgresql#initializing-a-new-instance and https://github.com/bitnami/bitnami-docker-pgpool#initializing-with-custom-scripts
 
 ### Use of global variables
 

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -438,7 +438,7 @@ In addition to this option, you can also set an external ConfigMap with all the 
 
 The above parameters (`initdbScripts`, `initdbScriptsCM`, and `initdbScriptsSecret`) are supported in both StatefulSet by prepending `postgresql` or `pgpool` to the parameter, depending on the use case (see above parameters table).
 
-The allowed extensions are `.sh`, `.sql` and `.sql.gz` in the `postgresql` container. Only `.sh` in the case of the `pgpool` one.
+The allowed extensions are `.sh`, `.sql` and `.sql.gz` in the **postgresql** container while only `.sh` in the case of the **pgpool** one.
 
 +info: https://github.com/bitnami/bitnami-docker-postgresql#initializing-a-new-instance and https://github.com/bitnami/bitnami-docker-pgpool#initializing-with-custom-scripts
 

--- a/bitnami/postgresql-ha/values.yaml
+++ b/bitnami/postgresql-ha/values.yaml
@@ -499,6 +499,8 @@ postgresql:
 
   ## initdb scripts
   ## Specify dictionary of scripts to be run at first boot
+  ## The allowed extensions are `.sh`, `.sql` and `.sql.gz`
+  ## ref: https://github.com/bitnami/charts/tree/master/bitnami/postgresql-ha#initialize-a-fresh-instance
   ##
   # initdbScripts:
   #   my_init_script.sh: |
@@ -820,6 +822,8 @@ pgpool:
 
   ## initdb scripts
   ## Specify dictionary of scripts to be run every time Pgpool container is initialized
+  ## The allowed extension is `.sh`
+  ## ref: https://github.com/bitnami/charts/tree/master/bitnami/postgresql-ha#initialize-a-fresh-instance
   ##
   # initdbScripts:
   #   my_init_script.sh: |


### PR DESCRIPTION
**Description of the change**

Improve explanation about initdbScripts (both in README and comments in the values.yaml), focusing on the different StatefulSets where it can be applied and the supported extensions.

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)