### PR TITLE
[bitnami/mongodb] Fix portname variable refrence

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 10.9.0
+version: 10.9.1

--- a/bitnami/mongodb/templates/hidden/external-access-svc.yaml
+++ b/bitnami/mongodb/templates/hidden/external-access-svc.yaml
@@ -30,7 +30,7 @@ spec:
   {{- end }}
   publishNotReadyAddresses: true
   ports:
-    - name: {{ $root.Values.service.hidden.portName }}
+    - name: {{ $root.Values.service.portName }}
       port: {{ $root.Values.externalAccess.hidden.service.port }}
       {{- if not (empty $root.Values.externalAccess.hidden.service.nodePorts) }}
       nodePort: {{ index $root.Values.externalAccess.hidden.service.nodePorts $i }}


### PR DESCRIPTION


**Description of the change**

- Fix portName variable for hidden node external service

**Additional information**

https://github.com/bitnami/charts/pull/5505

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
