### PR TITLE
[bitnami/influxdb] Fix typo in ingress.yaml

### DIFF
--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -24,4 +24,4 @@ name: influxdb
 sources:
   - https://github.com/bitnami/bitnami-docker-influxdb
   - https://www.influxdata.com/products/influxdb-overview/
-version: 2.0.4
+version: 2.0.5

--- a/bitnami/influxdb/templates/ingress.yaml
+++ b/bitnami/influxdb/templates/ingress.yaml
@@ -34,7 +34,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
             {{- end }}
-            {{- $relayServiceName := printf "%s-%s" (include "common.names.fullname" .) "relay" -}}
+            {{- $relayServiceName := printf "%s-%s" (include "common.names.fullname" .) "relay" }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" $relayServiceName  "servicePort" "http" "context" $)  | nindent 14 }}
           {{- end }}
           - path: {{ default "/*" .Values.ingress.path }}


### PR DESCRIPTION
**Description of the change**

```
$ helm template --set-string architecture=high-availability --set-string ingress.enabled=true . --debug -s templates/ingress.yaml
```

The ingress.yaml template is not well indented when rendered with the parameters above.

**Applicable issues**

  - fixes #5691

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)