### PR TITLE
[bitnami/kubewatch] Add events to empty api groups

### DIFF
--- a/bitnami/kubewatch/Chart.yaml
+++ b/bitnami/kubewatch/Chart.yaml
@@ -28,4 +28,4 @@ name: kubewatch
 sources:
   - https://github.com/bitnami/bitnami-docker-kubewatch
   - https://github.com/bitnami-labs/kubewatch
-version: 3.1.2
+version: 3.1.3

--- a/bitnami/kubewatch/templates/clusterrole.yaml
+++ b/bitnami/kubewatch/templates/clusterrole.yaml
@@ -15,14 +15,15 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - pods
-      - namespaces
-      - services
-      - deployments
-      - replicationcontrollers
-      - replicasets
       - daemonsets
+      - deployments
+      - events
+      - namespaces
       - persistentvolumes
+      - pods
+      - replicasets
+      - replicationcontrollers
+      - services
     verbs:
       - list
       - watch


### PR DESCRIPTION

**Description of the change**
Add `events` to the "" api groups, as well as alphabetically sort the list.

**Benefits**

- fixes https://github.com/bitnami/charts/issues/5410

I'm not aware of any limitations this causes

**Additional information**

Testing was done locally: 
```
$ helm dependency build kubewatch
$ helm package kubewatch
$ helm upgrade -i kubewatch ~/sources/charts-1/bitnami/kubewatch-3.1.3.tgz -f ~/tmp/kubewatch.yaml
```

Where the values file was something like this:
```
rbac:
  create: true
slack:
  enabled: false
image:
  registry: 'myregistry.io'
  repository: 'kubewatch'
  tag: '1.0.0'
  pullSecrets:
  - myPullSecret
```

I've manually verified in the kubewatch pod logs that the error isn't showing up.

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

