### PR TITLE
[bitnami/cassandra] Add default service account

### DIFF
--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -23,5 +23,4 @@ name: cassandra
 sources:
   - https://github.com/bitnami/bitnami-docker-cassandra
   - http://cassandra.apache.org
-
-version: 7.4.0
+version: 7.4.1

--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -23,4 +23,4 @@ name: cassandra
 sources:
   - https://github.com/bitnami/bitnami-docker-cassandra
   - http://cassandra.apache.org
-version: 7.4.1
+version: 7.5.0

--- a/bitnami/cassandra/README.md
+++ b/bitnami/cassandra/README.md
@@ -148,6 +148,13 @@ The following table lists the configurable parameters of the Cassandra chart and
 | `metrics.containerPorts.http`        | HTTP Port on the Host and Container                                                       | `8080`                         |
 | `metrics.containerPorts.jmx`         | JMX Port on the Host and Container                                                        | `5555`                         |
 
+### RBAC parameters
+
+| Parameter                    | Description                                                | Default                                           |
+|------------------------------|------------------------------------------------------------|---------------------------------------------------|
+| `serviceAccount.create`      | Enable the creation of a ServiceAccount for Cassandra pods | `true`                                            |
+| `serviceAccount.name`        | Name of the created ServiceAccount                         | Generated using the `cassandra.fullname` template |
+| `serviceAccount.annotations` | Annotations for Cassandra Service Account                  | `{}` (evaluated as a template)                    |
 
 ### Exposure parameters
 

--- a/bitnami/cassandra/templates/_helpers.tpl
+++ b/bitnami/cassandra/templates/_helpers.tpl
@@ -29,6 +29,17 @@ Return the proper Docker Image Registry Secret Names
 {{- end -}}
 
 {{/*
+Create the name of the service account to use
+*/}}
+{{- define "cassandra.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "common.names.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the list of Cassandra seed nodes
 */}}
 {{- define "cassandra.seeds" -}}

--- a/bitnami/cassandra/templates/serviceaccount.yaml
+++ b/bitnami/cassandra/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "cassandra.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.serviceAccount.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.serviceAccount.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/bitnami/cassandra/templates/statefulset.yaml
+++ b/bitnami/cassandra/templates/statefulset.yaml
@@ -44,6 +44,7 @@ spec:
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ template "cassandra.serviceAccountName" . }}
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- else }}

--- a/bitnami/cassandra/values.yaml
+++ b/bitnami/cassandra/values.yaml
@@ -54,6 +54,21 @@ commonAnnotations: {}
 ##
 commonLabels: {}
 
+## Cassandra pods ServiceAccount
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  ## Specifies whether a ServiceAccount should be created
+  ##
+  create: true
+  ## The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the cassandra.fullname template
+  ##
+  # name:
+  ## Annotations to add to the service account (evaluated as a template)
+  ##
+  annotations: {}
+
 ## Cassandra container ports to open
 ## If hostNetwork true: the hostPort is set identical to the containerPort
 ##


### PR DESCRIPTION
**Description of the change**

Create a service account by default to be used by the statefulset

**Benefits**

This allows users of the helm chart to create RBAC resources as needed for their cluster by linking them to the service account that is created.

**Possible drawbacks**

No known limitations

**Applicable issues**

None

**Additional information**

Moving forward, any users of this helm chart who may have created RBAC resources for the default service account to run cassandra in their cluster will instead need to link them to the service account that is created by the chart.

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
