### PR TITLE
[bitnami/kubewatch] Fix readme resources

### DIFF
--- a/bitnami/kubewatch/Chart.yaml
+++ b/bitnami/kubewatch/Chart.yaml
@@ -28,4 +28,4 @@ name: kubewatch
 sources:
   - https://github.com/bitnami/bitnami-docker-kubewatch
   - https://github.com/bitnami-labs/kubewatch
-version: 3.1.3
+version: 3.1.4

--- a/bitnami/kubewatch/README.md
+++ b/bitnami/kubewatch/README.md
@@ -98,15 +98,22 @@ The following tables lists the configurable parameters of the Kubewatch chart an
 | `smtp.auth.secret`                       | Secret for CRAM-MD5 auth mech                                        | `""`                                                    |
 | `smtp.requireTLS`                        | Force STARTTLS                                                       | `false`                                                 |
 | `namespaceToWatch`                       | namespace to watch, leave it empty for watching all                  | `""`                                                    |
-| `resourcesToWatch`                       | list of resources which kubewatch should watch and notify slack      | `{pod: true, deployment: true}`                         |
-| `resourcesToWatch.pod`                   | watch changes to Pods                                                | `true`                                                  |
+| `resourcesToWatch`                       | Map of resources which kubewatch should watch and notify the handler | `{po: true, deployment: true}`                          |
+| `resourcesToWatch.clusterrole`           | watch changes to Cluster roles                                       | `false`                                                 |
+| `resourcesToWatch.configmap`             | watch changes to Configmaps                                          | `false`                                                 |
 | `resourcesToWatch.deployment`            | watch changes to Deployments                                         | `true`                                                  |
-| `resourcesToWatch.replicationcontroller` | watch changes to ReplicationControllers                              | `false`                                                 |
-| `resourcesToWatch.replicaset`            | watch changes to ReplicaSets                                         | `false`                                                 |
-| `resourcesToWatch.daemonset`             | watch changes to DaemonSets                                          | `false`                                                 |
-| `resourcesToWatch.services`              | watch changes to Services                                            | `false`                                                 |
+| `resourcesToWatch.ds`                    | watch changes to Daemonsets                                          | `false`                                                 |
+| `resourcesToWatch.ing`                   | watch changes to Ingress                                             | `false`                                                 |
 | `resourcesToWatch.job`                   | watch changes to Jobs                                                | `false`                                                 |
-| `resourcesToWatch.persistentvolume`      | watch changes to PersistentVolumes                                   | `false`                                                 |
+| `resourcesToWatch.node`                  | watch changes to Nodes                                               | `false`                                                 |
+| `resourcesToWatch.ns`                    | watch changes to Namespaces                                          | `false`                                                 |
+| `resourcesToWatch.po`                    | watch changes to Pods                                                | `true`                                                  |
+| `resourcesToWatch.pv`                    | watch changes to PersistentVolumes                                   | `false`                                                 |
+| `resourcesToWatch.rc`                    | watch changes to ReplicationControllers                              | `false`                                                 |
+| `resourcesToWatch.rs`                    | watch changes to ReplicaSets                                         | `false`                                                 |
+| `resourcesToWatch.sa`                    | watch changes to Service Accounts                                    | `false`                                                 |
+| `resourcesToWatch.secret`                | watch changes to Secrets                                             | `false`                                                 |
+| `resourcesToWatch.svc`                   | watch changes to Services                                            | `false`                                                 |
 | `command`                                | Override default container command (useful when using custom images) | `nil`                                                   |
 | `args`                                   | Override default container args (useful when using custom images)    | `nil`                                                   |
 | `extraEnvVars`                           | Extra environment variables to be set on Kubewatch container         | `{}`                                                    |
@@ -134,6 +141,7 @@ The following tables lists the configurable parameters of the Kubewatch chart an
 | `affinity`                  | Affinity for pod assignment                                                               | `{}` (evaluated as a template) |
 | `nodeSelector`              | Node labels for pod assignment                                                            | `{}` (evaluated as a template) |
 | `tolerations`               | Tolerations for pod assignment                                                            | `[]` (evaluated as a template) |
+| `priorityClassName`         | Controller priorityClassName                                                              | `nil`                          |
 | `podLabels`                 | Extra labels for Kubewatch pods                                                           | `{}`                           |
 | `podAnnotations`            | Annotations for Kubewatch pods                                                            | `{}`                           |
 | `extraVolumeMounts`         | Optionally specify extra list of additional volumeMounts for Kubewatch container(s)       | `[]`                           |

--- a/bitnami/kubewatch/values.yaml
+++ b/bitnami/kubewatch/values.yaml
@@ -100,13 +100,13 @@ namespaceToWatch: ""
 # Resources to watch
 resourcesToWatch:
   deployment: true
-  replicationcontroller: false
-  replicaset: false
-  daemonset: false
-  services: false
-  pod: true
+  ds: false
   job: false
-  persistentvolume: false
+  po: true
+  pv: false
+  rc: false
+  rs: false
+  svc: false
 
 ## Command and args for running the container (set to default if not set). Use array form
 ##
@@ -240,6 +240,11 @@ nodeSelector: {}
 ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
 tolerations: []
+
+## Pod priority
+## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+##
+# priorityClassName: ""
 
 ## Pod extra labels
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/


### PR DESCRIPTION
**Description of the change**

Based on the kubewatch code:
https://github.com/bitnami-labs/kubewatch/blob/master/config/config.go#L50
Seems like there's a mismatch between the helm chart documentation and the
binary.

This commit performs the sync.
- Fix the documentation to match the kubewatch code
- Modify the values.yaml file to use the correct resource option names

**Benefits**

Updated documentation. 
Addresses https://github.com/bitnami/charts/issues/5729

**Possible drawbacks**

Can't think of any.

**Applicable issues**

Can't think of any. 

**Additional information**

None.

**Checklist** 
- [x] Bumped the helm chart version
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)



