### PR TITLE
[bitnami/kubewatch] Add missing resources to rbac api group

### DIFF
--- a/bitnami/kubewatch/Chart.yaml
+++ b/bitnami/kubewatch/Chart.yaml
@@ -28,4 +28,4 @@ name: kubewatch
 sources:
   - https://github.com/bitnami/bitnami-docker-kubewatch
   - https://github.com/bitnami-labs/kubewatch
-version: 3.1.3
+version: 3.1.4

--- a/bitnami/kubewatch/templates/clusterrole.yaml
+++ b/bitnami/kubewatch/templates/clusterrole.yaml
@@ -15,14 +15,17 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - configmaps
       - daemonsets
       - deployments
       - events
       - namespaces
+      - nodes
       - persistentvolumes
       - pods
       - replicasets
       - replicationcontrollers
+      - secrets
       - services
     verbs:
       - list


### PR DESCRIPTION
**Description of the change**

Adding configmaps, nodes and secrets to RBAC "" API group.

**Benefits**

When running with a custom image, we get permission errors, as you can see in the attached issue.

**Possible drawbacks**

There's still a missing resource (clusterrole), but that's for another api group which I couldn't figure how to add. 

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/5730

**Additional information**

Testing was done using the following values.yaml file: 
```
rbac:
  create: true
slack:
  enabled: false
image:
  registry: 'myregistry.io'
  repository: 'kubewatch'
  tag: '1.0.0'
  pullSecrets:
  - myPullSecret
resourcesToWatch:
  clusterrole: false  # cluster role
  configmap: true     # configmap
  deployment: true    # deployment
  ds: true            # daemon set
  ing: true           # ingress
  job: true           # job
  node: true          # node
  ns: false           # namespace
  po: true            # pods
  pv: true            # persistent volume
  rc: true            # replication controller
  rs: true            # replica set
  sa: true            # service account
  secret: true        # secret
  svc: true           # services
```
Then, I verified in the pod's logs that no errors show up. 

Got the cluster role and verified that is has the needed permissions: 
```
$ kubectl get ClusterRole kubewatch -n monitoring  -o yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  annotations:
    meta.helm.sh/release-name: kubewatch
    meta.helm.sh/release-namespace: monitoring
  creationTimestamp: "2021-03-07T11:22:26Z"
  labels:
    app.kubernetes.io/instance: kubewatch
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: kubewatch
    helm.sh/chart: kubewatch-3.1.4
  name: kubewatch
  resourceVersion: "63450509"
  selfLink: /apis/rbac.authorization.k8s.io/v1/clusterroles/kubewatch
  uid: 2653a6e9-215b-40a8-a436-a876cfa9acfd
rules:
- apiGroups:
  - ""
  resources:
  - configmaps
  - daemonsets
  - deployments
  - events
  - namespaces
  - nodes
  - persistentvolumes
  - pods
  - replicasets
  - replicationcontrollers
  - secrets
  - services
  verbs:
  - list
  - watch
  - get
- apiGroups:
  - apps
  resources:
  - daemonsets
  - deployments
  - deployments/scale
  - replicasets
  - replicasets/scale
  - statefulsets
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - extensions
  resources:
  - daemonsets
  - deployments
  - deployments/scale
  - replicasets
  - replicasets/scale
  - replicationcontrollers/scale
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - batch
  resources:
  - cronjobs
  - jobs
  verbs:
  - get
  - list
  - watch
```

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
