### PR TITLE
[bitnami/thanos] Add ingress to ruler

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 3.12.0
+version: 3.13.0

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -488,6 +488,21 @@ The following tables lists the configurable parameters of the Thanos chart and t
 | `ruler.pdb.create`                            | Enable/disable a Pod Disruption Budget creation                                                              | `false`                        |
 | `ruler.pdb.minAvailable`                      | Minimum number/percentage of pods that should remain scheduled                                               | `1`                            |
 | `ruler.pdb.maxUnavailable`                    | Maximum number/percentage of pods that may be made unavailable                                               | `nil`                          |
+| `ruler.ingress.enabled`                       | Enable ingress controller resource                                                                           | `false`                        |
+| `ruler.ingress.apiVersion`                    | Force Ingress API version (automatically detected if not set)                                                | ``                             |
+| `ruler.ingress.path`                          | Ingress path                                                                                                 | `/`                            |
+| `ruler.ingress.pathType`                      | Ingress path type                                                                                            | `ImplementationSpecific`       |
+| `ruler.ingress.certManager`                   | Add annotations for cert-manager                                                                             | `false`                        |
+| `ruler.ingress.hostname`                      | Default host for the ingress resource                                                                        | `thanos-bucketweb.local`       |
+| `ruler.ingress.annotations`                   | Ingress annotations                                                                                          | `[]`                           |
+| `ruler.ingress.tls`                           | Create ingress TLS section                                                                                   | `false`                        |
+| `ruler.ingress.extraHosts[0].name`            | Additional hostnames to be covered                                                                           | `nil`                          |
+| `ruler.ingress.extraHosts[0].path`            | Additional hostnames to be covered                                                                           | `nil`                          |
+| `ruler.ingress.extraTls[0].hosts[0]`          | TLS configuration for additional hostnames to be covered                                                     | `nil`                          |
+| `ruler.ingress.extraTls[0].secretName`        | TLS configuration for additional hostnames to be covered                                                     | `nil`                          |
+| `ruler.ingress.secrets[0].name`               | TLS Secret Name                                                                                              | `nil`                          |
+| `ruler.ingress.secrets[0].certificate`        | TLS Secret Certificate                                                                                       | `nil`                          |
+| `ruler.ingress.secrets[0].key`                | TLS Secret Key                                                                                               | `nil`                          |
 
 ### Thanos Receive parameters
 

--- a/bitnami/thanos/templates/ruler/ingress.yaml
+++ b/bitnami/thanos/templates/ruler/ingress.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.ruler.ingress.enabled -}}
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
+kind: Ingress
+metadata:
+  name: {{ include "common.names.fullname" . }}-ruler
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  annotations:
+    {{- if .Values.ruler.ingress.certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- range $key, $value := .Values.ruler.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- if .Values.ruler.ingress.hostname }}
+    - host: {{ .Values.ruler.ingress.hostname }}
+      http:
+        paths:
+          - path: {{ .Values.ruler.ingress.path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.ruler.ingress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" .) "ruler") "servicePort" "http" "context" $)  | nindent 14 }}
+    {{- end }}
+    {{- range .Values.ruler.ingress.extraHosts }}
+    - host: {{ .name }}
+      http:
+        paths:
+          - path: {{ default "/" .path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
+            pathType: {{ default "ImplementationSpecific" .pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" $) "ruler") "servicePort" "http" "context" $) | nindent 14 }}
+    {{- end }}
+  {{- if or .Values.ruler.ingress.tls .Values.ruler.ingress.extraTls .Values.ruler.ingress.hosts }}
+  tls:
+    {{- if or .Values.ruler.ingress.secrets .Values.ruler.ingress.tls }}
+    - hosts:
+        - {{ .Values.ruler.ingress.hostname }}
+      secretName: {{ printf "%s-tls" .Values.ruler.ingress.hostname }}
+    {{- end }}
+    {{- if .Values.ruler.ingress.extraTls }}
+    {{- toYaml .Values.ruler.ingress.extraTls | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -1784,6 +1784,71 @@ ruler:
     ##
     # maxUnavailable: 1
 
+  ## Configure the ingress resource that allows you to access Thanos Ruler
+  ## ref: http://kubernetes.io/docs/user-guide/ingress/
+  ##
+  ingress:
+    ## Set to true to enable ingress record generation
+    ##
+    enabled: false
+
+    ## Set this to true in order to add the corresponding annotations for cert-manager
+    ##
+    certManager: false
+
+    ## When the ingress is enabled, a host pointing to this will be created
+    ##
+    hostname: thanos-ruler.local
+
+    ## Ingress annotations done as key:value pairs
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+    ##
+    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+    ##
+    annotations: {}
+
+    ## The list of additional hostnames to be covered with this ingress record.
+    ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+    # extraHosts:
+    # - name: thanos.local
+    #   path: /
+    #   pathType: ImplementationSpecific
+
+    ## The tls configuration for additional hostnames to be covered with this ingress record.
+    ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+    # extraTls:
+    # - hosts:
+    #     - thanos.local
+    #   secretName: thanos.local-tls
+
+    ## If you're providing your own certificates, please use this to add the certificates as secrets
+    ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+    ## -----BEGIN RSA PRIVATE KEY-----
+    ##
+    ## name should line up with a tlsSecret set further up
+    ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+    ##
+    ## It is also possible to create and manage the certificates outside of this helm chart
+    ## Please see README.md for more information
+    ##
+    secrets: []
+    # - name: thanos.local-tls
+    #   key:
+    #   certificate:
+
+    ## Override API Version (automatically detected if not set)
+    ##
+    apiVersion:
+
+    ## Ingress Path
+    ##
+    path: /
+
+    ## Ingress Path type
+    ##
+    pathType: ImplementationSpecific
+
 ## Thanos Receive parameters
 ##
 receive:


### PR DESCRIPTION
**Description of the change**

Add ingress support for ruler component.

**Benefits**

Ruler UI can be joined through ingress. 

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

None

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
