### PR TITLE
[bitnami/harbor] Update Harbor 2.2.0 and adapt Clair component

### DIFF
--- a/bitnami/harbor/Chart.lock
+++ b/bitnami/harbor/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.3.6
+  version: 10.3.12
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 12.7.6
+  version: 12.8.3
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.4.1
-digest: sha256:f9c6cd934dfb2141d1736642eabeef1db9991534693f8b68e92a723b9af2e483
-generated: "2021-02-24T13:33:25.589623838Z"
+digest: sha256:b16934d03ea440352c7f9d2d5a30db3dfb1134199b99eea50c66f304ba42e3df
+generated: "2021-03-11T16:19:38.227689858Z"

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Infrastructure
 apiVersion: v2
-appVersion: 2.1.3
+appVersion: 2.2.0
 dependencies:
   - condition: postgresql.enabled
     name: postgresql

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-harbor-registry
   - https://github.com/bitnami/bitnami-docker-harbor-registryctl
   - https://goharbor.io/
-version: 9.6.3
+version: 9.7.0

--- a/bitnami/harbor/README.md
+++ b/bitnami/harbor/README.md
@@ -524,7 +524,7 @@ The following tables list the configurable parameters of the Harbor chart and th
 | `clairAdapterImage.pullSecrets`      | Specify docker-registry secret names as an array                                                                                                                             | `[]` (does not add image pull secrets to deployed pods) |
 | `clairAdapterImage.debug`            | Specify if debug logs should be enabled                                                                                                                                      | `false`                                                 |
 | `clair.updateStrategy`               | The update strategy for deployments with persistent volumes: RollingUpdate or Recreate. Set it as Recreate when RWM for volumes isn't supported                              | `RollingUpdate`                                         |
-| `clair.enabled`                      | Enable Clair                                                                                                                                                                 | `true`                                                  |
+| `clair.enabled`                      | Enable Clair scanner. Add it as an additional interrogation service by following https://goharbor.io/docs/latest/administration/vulnerability-scanning/pluggable-scanners    | `false`                                                 |
 | `clair.replicas`                     | The replica count                                                                                                                                                            | `1`                                                     |
 | `clair.httpProxy`                    | The http proxy used to update vulnerabilities database from internet                                                                                                         | undefined                                               |
 | `clair.httpsProxy`                   | The https proxy used to update vulnerabilities database from internet                                                                                                        | undefined                                               |
@@ -873,6 +873,12 @@ Find more information about how to deal with common errors related to Bitnami’
 ## Upgrading
 
 > NOTE: In you are upgrading an installation that contains a high amount of data, it is recommended to disable the liveness/readiness probes as the migration can take a substantial amount of time.
+
+### To 9.7.0
+
+This new version of the chart bumps the version of Harbor to [`2.2.0`](https://github.com/goharbor/harbor/releases/tag/v2.2.0) which deprecates built-in Clair. If you still want to use Clair, you will need to set `clair.enabled` to `true` and Clair scanner and the Harbor adapter will be deployed. Follow [these steps](https://goharbor.io/docs/latest/administration/vulnerability-scanning/pluggable-scanners) to add it as an additional interrogation service for Harbor.
+
+Please note that Clair might be fully deprecated from this chart in following updates.
 
 ### To 9.0.0
 

--- a/bitnami/harbor/templates/NOTES.txt
+++ b/bitnami/harbor/templates/NOTES.txt
@@ -63,4 +63,13 @@
   {{- $passwordErrors = append $passwordErrors $redisPasswordValidationErrors -}}
 {{- end -}}
 
+{{- if .Values.clair.enabled -}}
+Clair scanner was deployed. Follow these steps to add it as an additional interrogation service for Harbor:
+https://goharbor.io/docs/latest/administration/vulnerability-scanning/pluggable-scanners
+
+  Endpoint: {{ include "harbor.clairAdapter.url" . | quote }}
+  Authorization: "None"
+  Options: "Use internal registry address"
+{{- end -}}
+
 {{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordErrors "context" $) -}}

--- a/bitnami/harbor/templates/NOTES.txt
+++ b/bitnami/harbor/templates/NOTES.txt
@@ -42,6 +42,17 @@
   echo Username: "admin"
   echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "harbor.core" . }}-envvars -o jsonpath="{.data.HARBOR_ADMIN_PASSWORD}" | base64 --decode)
 
+{{- if .Values.clair.enabled }}
+
+Clair scanner was deployed. Follow these steps to add it as an additional interrogation service for Harbor:
+https://goharbor.io/docs/latest/administration/vulnerability-scanning/pluggable-scanners
+
+  Endpoint: {{ include "harbor.clairAdapter.url" . | quote }}
+  Authorization: "None"
+  Options: "Use internal registry address"
+
+{{- end }}
+
 {{ include "harbor.validateValues" . }}
 {{ include "harbor.checkRollingTags" . }}
 
@@ -61,15 +72,6 @@
   {{- $requiredRedisPassword := dict "valueKey" "redis.password" "secret" $redisSecretName "field" "redis-password" -}}
   {{- $redisPasswordValidationErrors := include "common.validations.values.multiple.empty" (dict "required" (list $requiredRedisPassword) "context" $) -}}
   {{- $passwordErrors = append $passwordErrors $redisPasswordValidationErrors -}}
-{{- end -}}
-
-{{- if .Values.clair.enabled -}}
-Clair scanner was deployed. Follow these steps to add it as an additional interrogation service for Harbor:
-https://goharbor.io/docs/latest/administration/vulnerability-scanning/pluggable-scanners
-
-  Endpoint: {{ include "harbor.clairAdapter.url" . | quote }}
-  Authorization: "None"
-  Options: "Use internal registry address"
 {{- end -}}
 
 {{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordErrors "context" $) -}}

--- a/bitnami/harbor/templates/core/core-cm-envvars.yaml
+++ b/bitnami/harbor/templates/core/core-cm-envvars.yaml
@@ -28,14 +28,6 @@ data:
   CORE_LOCAL_URL: "{{ ternary "https://127.0.0.1:8443" "http://127.0.0.1:8080" .Values.internalTLS.enabled }}"
   CFG_EXPIRATION: "5"
   ADMIRAL_URL: "NA"
-  WITH_CLAIR: {{ .Values.clair.enabled | quote }}
-  CLAIR_DB_HOST: {{ include "harbor.database.host" . | quote }}
-  CLAIR_DB_PORT: {{ include "harbor.database.port" . | quote }}
-  CLAIR_DB_USERNAME: {{ include "harbor.database.clairUsername" . | quote }}
-  CLAIR_DB: {{ include "harbor.database.clairDatabase" . | quote }}
-  CLAIR_DB_SSLMODE: {{ include "harbor.database.sslmode" . | quote }}
-  CLAIR_URL: {{ printf "http://%s:6060" (include "harbor.clair" .) | quote }}
-  CLAIR_ADAPTER_URL: {{ include "harbor.clairAdapter.url" . | quote }}
   WITH_TRIVY: {{ .Values.trivy.enabled | quote }}
   TRIVY_ADAPTER_URL: {{ include "harbor.trivy.url" . | quote }}
   REGISTRY_STORAGE_PROVIDER_NAME: {{ .Values.persistence.imageChartStorage.type | quote }}

--- a/bitnami/harbor/templates/core/core-secret-envvars.yaml
+++ b/bitnami/harbor/templates/core/core-secret-envvars.yaml
@@ -29,6 +29,3 @@ data:
   HARBOR_ADMIN_PASSWORD: {{ required "A Harbor Admin Password is required!" .Values.harborAdminPassword }}
   {{- end }}
   POSTGRESQL_PASSWORD: {{ template "harbor.database.encryptedPassword" . }}
-  {{- if .Values.clair.enabled }}
-  CLAIR_DB_PASSWORD: {{ template "harbor.database.encryptedClairPassword" . }}
-  {{- end }}

--- a/bitnami/harbor/values.yaml
+++ b/bitnami/harbor/values.yaml
@@ -14,7 +14,7 @@
 coreImage:
   registry: docker.io
   repository: bitnami/harbor-core
-  tag: 2.1.3-debian-10-r38
+  tag: 2.2.0-debian-10-r11
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -38,7 +38,7 @@ coreImage:
 portalImage:
   registry: docker.io
   repository: bitnami/harbor-portal
-  tag: 2.1.3-debian-10-r39
+  tag: 2.2.0-debian-10-r0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -63,7 +63,7 @@ portalImage:
 jobserviceImage:
   registry: docker.io
   repository: bitnami/harbor-jobservice
-  tag: 2.2.0-debian-10-r0
+  tag: 2.2.0-debian-10-r14
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -87,7 +87,7 @@ jobserviceImage:
 chartMuseumImage:
   registry: docker.io
   repository: bitnami/chartmuseum
-  tag: 0.13.0-debian-10-r19
+  tag: 0.13.0-debian-10-r33
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -111,7 +111,7 @@ chartMuseumImage:
 registryImage:
   registry: docker.io
   repository: bitnami/harbor-registry
-  tag: 2.1.3-debian-10-r40
+  tag: 2.2.0-debian-10-r13
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -135,7 +135,7 @@ registryImage:
 registryctlImage:
   registry: docker.io
   repository: bitnami/harbor-registryctl
-  tag: 2.1.3-debian-10-r39
+  tag: 2.2.0-debian-10-r13
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -159,7 +159,7 @@ registryctlImage:
 trivyImage:
   registry: docker.io
   repository: bitnami/harbor-adapter-trivy
-  tag: 2.1.3-debian-10-r38
+  tag: 2.2.0-debian-10-r13
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -183,7 +183,7 @@ trivyImage:
 clairImage:
   registry: docker.io
   repository: bitnami/harbor-clair
-  tag: 2.1.3-debian-10-r39
+  tag: 2.2.0-debian-10-r0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -208,7 +208,7 @@ clairImage:
 clairAdapterImage:
   registry: docker.io
   repository: bitnami/harbor-adapter-clair
-  tag: 2.1.3-debian-10-r38
+  tag: 2.2.0-debian-10-r0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -232,7 +232,7 @@ clairAdapterImage:
 notaryServerImage:
   registry: docker.io
   repository: bitnami/harbor-notary-server
-  tag: 2.1.3-debian-10-r39
+  tag: 2.2.0-debian-10-r10
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -256,7 +256,7 @@ notaryServerImage:
 notarySignerImage:
   registry: docker.io
   repository: bitnami/harbor-notary-signer
-  tag: 2.1.3-debian-10-r40
+  tag: 2.2.0-debian-10-r10
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -280,7 +280,7 @@ notarySignerImage:
 nginxImage:
   registry: docker.io
   repository: bitnami/nginx
-  tag: 1.19.7-debian-10-r7
+  tag: 1.19.8-debian-10-r1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/harbor/values.yaml
+++ b/bitnami/harbor/values.yaml
@@ -1837,7 +1837,7 @@ chartmuseum:
 ## Clair parameters
 ##
 clair:
-  enabled: true
+  enabled: false
 
   replicas: 1
 


### PR DESCRIPTION
**Description of the change**

- Updates the Harbor components to `2.2.0`.
- Adapts Clair component that has been deprecated. We will keep the option to deploy the service and add it manually as an additional interrogation service.

**Possible drawbacks**

If users are configuring Clair with Habor, they will need to add it again.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)