### PR TITLE
[bitnami/mariadb-galera] Remove percona keyword from mariadb-galera

### DIFF
--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-mariadb-galera
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 5.6.4
+version: 5.6.5

--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -19,7 +19,6 @@ keywords:
   - sql
   - prometheus
   - galera
-  - percona
 maintainers:
   - email: containers@bitnami.com
     name: Bitnami


### PR DESCRIPTION
Why  do you use in keyword percona, but this chart install mariadb software?
