### PR TITLE
[bitnami/kafka] Always include serviceAccountName on statefulset

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 12.11.0
+version: 12.11.1

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -227,11 +227,11 @@ The following tables lists the configurable parameters of the Kafka chart and th
 
 ### RBAC parameters
 
-| Parameter               | Description                                      | Default                                       |
-|-------------------------|--------------------------------------------------|-----------------------------------------------|
-| `serviceAccount.create` | Enable creation of ServiceAccount for Kafka pods | `true`                                        |
-| `serviceAccount.name`   | Name of the created serviceAccount               | Generated using the `kafka.fullname` template |
-| `rbac.create`           | Weather to create & use RBAC resources or not    | `false`                                       |
+| Parameter               | Description                                                                                    | Default                                                 |
+|-------------------------|------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `serviceAccount.create` | Enable creation of ServiceAccount for Kafka pods                                               | `true`                                                  |
+| `serviceAccount.name`   | The name of the service account to use. If not set and `create` is `true`, a name is generated | Generated using the `kafka.serviceAccountName` template |
+| `rbac.create`           | Whether to create & use RBAC resources or not                                                  | `false`                                                 |
 
 ### Volume Permissions parameters
 

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -88,9 +88,7 @@ spec:
       {{- if .Values.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
-      {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ template "kafka.serviceAccountName" . }}
-      {{- end }}
       {{- if or (and .Values.volumePermissions.enabled .Values.persistence.enabled) (and .Values.externalAccess.enabled .Values.externalAccess.autoDiscovery.enabled) .Values.initContainers }}
       initContainers:
         {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -776,7 +776,7 @@ serviceAccount:
   ##
   create: true
   ## The name of the ServiceAccount to use.
-  ## If not set and create is true, a name is generated using the fluentd.fullname template
+  ## If not set and create is true, a name is generated using the kafka.serviceAccountName template
   ##
   # name:
 


### PR DESCRIPTION
**Description of the change**

The serviceAccountName is always included on the statefulset

**Benefits**

This fixes a bug where users could not specify an existing service account name to use via the following values:
```yaml
serviceAccount:
  create: false
  name: useThisName
```

**Possible drawbacks**

No known limitations

**Applicable issues**

No applicable issues

**Additional information**

This change brings the kafka chart in line with other bitnami charts with respect to specifying the service account, like the following:
https://github.com/bitnami/charts/blob/master/bitnami/cassandra/templates/statefulset.yaml#L47
https://github.com/bitnami/charts/blob/master/bitnami/zookeeper/templates/statefulset.yaml#L46

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
