### PR TITLE
[bitnami/dokuwiki] fix: align scrape_uri port to apache

### DIFF
--- a/bitnami/dokuwiki/Chart.yaml
+++ b/bitnami/dokuwiki/Chart.yaml
@@ -24,4 +24,4 @@ name: dokuwiki
 sources:
   - https://github.com/bitnami/bitnami-docker-dokuwiki
   - http://www.dokuwiki.org/
-version: 11.1.3
+version: 11.1.4

--- a/bitnami/dokuwiki/templates/deployment.yaml
+++ b/bitnami/dokuwiki/templates/deployment.yaml
@@ -231,7 +231,7 @@ spec:
         - name: metrics
           image: {{ template "dokuwiki.metrics.image" . }}
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
-          command: [ '/bin/apache_exporter', '--scrape_uri', 'http://status.localhost:80/server-status/?auto']
+          command: [ '/bin/apache_exporter', '--scrape_uri', 'http://status.localhost:8080/server-status/?auto']
           ports:
           - name: metrics
             containerPort: 9117


### PR DESCRIPTION
**Description of the change**

fixes scraping

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
