### PR TITLE
[bitnami/spring-cloud-dataflow] make upgrade possible without rabbitmq deployed

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -39,4 +39,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-spring-cloud-dataflow
   - https://github.com/bitnami/bitnami-docker-spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 2.8.0
+version: 2.8.1

--- a/bitnami/spring-cloud-dataflow/templates/NOTES.txt
+++ b/bitnami/spring-cloud-dataflow/templates/NOTES.txt
@@ -94,7 +94,7 @@ To access Spring Cloud Data Flow dashboard from outside the cluster execute the 
     {{- $requiredExternalDbPassword := dict "valueKey" "externalDatabase.password" "secret" $secretNameExternalDb "field" "mariadb-password" -}}
     {{- $passwordWarnings =  append $passwordWarnings $requiredExternalDbPassword -}}
   {{- end -}}
-  {{- if and (.Values.externalRabbitmq.enabled) (not .Values.rabbitmq.enabled) (not .Values.externalRabbitmq.existingPasswordSecret) -}}
+  {{- if and (.Values.externalRabbitmq.enabled) (.Values.rabbitmq.enabled) (not .Values.externalRabbitmq.existingPasswordSecret) -}}
     {{- $requiredExternalRabbitmqPassword := dict "valueKey" "externalRabbitmq.password" "secret" $secretNameExternalRabbitmq "field" "rabbitmq-password" -}}
     {{- $passwordWarnings =  append $passwordWarnings $requiredExternalRabbitmqPassword -}}
   {{- end -}}


### PR DESCRIPTION
Signed-off-by: Bruno Jost <bruno.jost@bedag.ch>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

fixes the bug: [[bitnami/spring-cloud-dataflow] make upgrade possible without rabbitmq deployed](https://github.com/bitnami/charts/issues/5781)

**Benefits**

Allow to do 'helm upgrade', even when there is no rabbitmq deployed.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #5781

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
