### PR TITLE
[bitnami/etcd] Service: Fix clientPortNameOverride and peerPortNameOverride

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -25,4 +25,4 @@ name: etcd
 sources:
   - https://github.com/bitnami/bitnami-docker-etcd
   - https://coreos.com/etcd/
-version: 6.1.0
+version: 6.1.1

--- a/bitnami/etcd/templates/svc.yaml
+++ b/bitnami/etcd/templates/svc.yaml
@@ -26,7 +26,7 @@ spec:
   externalIPs: {{- toYaml .Values.service.externalIPs | nindent 4 }}
   {{- end }}
   ports:
-    - name: {{ default "client" .Values.auth.client.clientPortNameOverride | quote }}
+    - name: {{ default "client" .Values.service.clientPortNameOverride | quote }}
       port: {{ .Values.service.port  }}
       targetPort: client
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.clientPort)) }}
@@ -34,7 +34,7 @@ spec:
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
-    - name: {{ default "peer" .Values.auth.client.clientPortNameOverride | quote }}
+    - name: {{ default "peer" .Values.service.peerPortNameOverride | quote }}
       port: {{ .Values.service.peerPort  }}
       targetPort: peer
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.peerPort)) }}


### PR DESCRIPTION
It seems recent refactor broke it.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
