### PR TITLE
[bitnami/es] Improve notes and values regarding custom params and kernel settings

### DIFF
--- a/bitnami/elasticsearch/Chart.lock
+++ b/bitnami/elasticsearch/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.4.1
 - name: kibana
   repository: https://charts.bitnami.com/bitnami
-  version: 7.2.2
-digest: sha256:6d624726d3de49ae6e50b679c4c4f11cf19c8b1d57a1f9acc4a1dd2802d09f37
-generated: "2021-02-26T18:04:58.293911595Z"
+  version: 7.2.3
+digest: sha256:a6f8ca3855a642b63d1660bc1d5a05b31d7cdb47df84930202ef6e1ce4be05b4
+generated: "2021-03-16T11:15:37.719180782Z"

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/bitnami-docker-elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 14.5.0
+version: 14.5.1

--- a/bitnami/elasticsearch/templates/NOTES.txt
+++ b/bitnami/elasticsearch/templates/NOTES.txt
@@ -35,8 +35,16 @@
     As an alternative, you can specify "sysctlImage.enabled=true" to use a
     privileged initContainer to change those settings in the Kernel:
 
-      helm upgrade {{ .Release.Name }} bitnami/elasticsearch \
-        --set sysctlImage.enabled=true
+      helm upgrade {{ .Release.Name }} bitnami/elasticsearch --set sysctlImage.enabled=true
+
+    Note that this requires the ability to run privileged containers, which is likely not
+    the case on many secure clusters. To cover this use case, you can also set some parameters
+    in the config file to customize the default settings:
+
+      https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-store.html
+      https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html
+
+    For that, you can place the desired parameters by using the "config" block present in the values.yaml
 
 {{- else if .Values.sysctlImage.enabled }}
 

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -19,7 +19,7 @@ global:
 image:
   registry: docker.io
   repository: bitnami/elasticsearch
-  tag: 7.10.2-debian-10-r40
+  tag: 7.10.2-debian-10-r56
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -847,7 +847,7 @@ curator:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch-curator
-    tag: 5.8.3-debian-10-r72
+    tag: 5.8.3-debian-10-r89
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -1073,7 +1073,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch-exporter
-    tag: 1.1.0-debian-10-r368
+    tag: 1.1.0-debian-10-r385
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -125,6 +125,11 @@ name: elastic
 # snapshotRepoPath:
 
 ## Customize elasticsearch configuration
+## See below example:
+## config:
+##   node:
+##     store:
+##       allow_mmap: false
 ## ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html
 ##
 # config:


### PR DESCRIPTION
**Description of the change**

Improve documentation (installation notes and _values.yaml_ comments) regarding custom parameters and kernel settings.

**Benefits**

With the changes in the bitnami/elasticsearch image users should be able to deploy ES in a non-privileged cluster without modifying the kernel settings but using some specific parameters in the ES config file (_elasticsearch.yml_) via the `config:` block present in the _values.yaml_

**Applicable issues**

  - fixes #5641

**Additional information**

Pending changes in the container image ⚠️ 

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)