### PR TITLE
[bitnami/solr] Fix exporter's flag to connect to Zookeeper

### DIFF
--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -27,4 +27,4 @@ name: solr
 sources:
   - https://github.com/bitnami/bitnami-docker-solr
   - https://lucene.apache.org/solr/
-version: 0.2.3
+version: 0.2.4

--- a/bitnami/solr/templates/NOTES.txt
+++ b/bitnami/solr/templates/NOTES.txt
@@ -58,7 +58,7 @@ To connect to your Solr from outside the cluster execute the following commands:
 
   * Internally, within the kubernetes cluster on:
 
-{{ include "solr.exporter-name" . }}.{{ .Release.Name }}.svc.{{ .Values.clusterDomain }}:{{ .Values.exporter.port }}/solr
+{{ include "solr.exporter-name" . }}.{{ .Release.Name }}.svc.{{ .Values.clusterDomain }}:{{ .Values.exporter.port }}/metrics
 
 {{- end }}
 

--- a/bitnami/solr/templates/exporter-deployment.yaml
+++ b/bitnami/solr/templates/exporter-deployment.yaml
@@ -79,7 +79,7 @@ spec:
             - "-p"
             - {{ .Values.exporter.port | quote }}
             - "-z"
-            - "{{ include "solr.zookeeper.host" . }}:{{ .Values.zookeeper.port }}/solr"
+            - "{{ include "solr.zookeeper.host" . }}/solr"
             - "-n"
             - {{ .Values.exporter.threads | quote }}
             - "-f"


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Fixes the default flags passed to the exporter since the one used for Zookeeper was wrong. The `"solr.zookeeper.host"` marco already includes the Zookeeper port, so it's not necessary to append it again. 

**Benefits**

Users can properly expose metrics.

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/5789

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

