### PR TITLE
[bitnami/aspnet-core] Change default repo branch from master to main

### DIFF
--- a/bitnami/aspnet-core/Chart.yaml
+++ b/bitnami/aspnet-core/Chart.yaml
@@ -22,4 +22,4 @@ name: aspnet-core
 sources:
   - https://github.com/bitnami/bitnami-docker-aspnet-core
   - https://dotnet.microsoft.com/apps/aspnet
-version: 1.2.4
+version: 1.2.5

--- a/bitnami/aspnet-core/README.md
+++ b/bitnami/aspnet-core/README.md
@@ -134,7 +134,7 @@ The following tables lists the configurable parameters of the ASP.NET Core chart
 | `appFromExternalRepo.clone.image.pullPolicy`      | GIT image pull policy                                                          | `IfNotPresent`                                                     |
 | `appFromExternalRepo.clone.image.pullSecrets`     | Specify docker-registry secret names as an array                               | `[]` (does not add image pull secrets to deployed pods)            |
 | `appFromExternalRepo.clone.repository`            | GIT Repository to clone                                                        | `https://github.com/dotnet/AspNetCore.Docs.git`                    |
-| `appFromExternalRepo.clone.revision`              | GIT revision to checkout                                                       | `master`                                                           |
+| `appFromExternalRepo.clone.revision`              | GIT revision to checkout                                                       | `main`                                                             |
 | `appFromExternalRepo.publish.image.registry`      | .NET SDK image registry                                                        | `docker.io`                                                        |
 | `appFromExternalRepo.publish.image.repository`    | .NET SDK Image name                                                            | `bitnami/git`                                                      |
 | `appFromExternalRepo.publish.image.tag`           | .NET SDK Image tag                                                             | `{TAG_NAME}`                                                       |
@@ -259,7 +259,7 @@ For example, you can deploy a sample [Kestrel server](https://docs.microsoft.com
 ```console
 appFromExternalRepo.enabled=true
 appFromExternalRepo.clone.repository=https://github.com/dotnet/AspNetCore.Docs.git
-appFromExternalRepo.clone.branch=master
+appFromExternalRepo.clone.branch=main
 appFromExternalRepo.publish.aspnetcore/fundamentals/servers/kestrel/samples/3.x/KestrelSample
 appFromExternalRepo.startCommand[0]=dotnet
 appFromExternalRepo.startCommand[1]=KestrelSample.dll

--- a/bitnami/aspnet-core/README.md
+++ b/bitnami/aspnet-core/README.md
@@ -259,7 +259,7 @@ For example, you can deploy a sample [Kestrel server](https://docs.microsoft.com
 ```console
 appFromExternalRepo.enabled=true
 appFromExternalRepo.clone.repository=https://github.com/dotnet/AspNetCore.Docs.git
-appFromExternalRepo.clone.branch=main
+appFromExternalRepo.clone.revision=main
 appFromExternalRepo.publish.aspnetcore/fundamentals/servers/kestrel/samples/3.x/KestrelSample
 appFromExternalRepo.startCommand[0]=dotnet
 appFromExternalRepo.startCommand[1]=KestrelSample.dll

--- a/bitnami/aspnet-core/values.yaml
+++ b/bitnami/aspnet-core/values.yaml
@@ -79,7 +79,7 @@ appFromExternalRepo:
     repository: https://github.com/dotnet/AspNetCore.Docs.git
     ## Git revision to checkout
     ##
-    revision: master
+    revision: main
   publish:
     ## Bitnami .NET SDK image version
     ## ref: https://hub.docker.com/r/bitnami/dotnet-sdk/tags/


### PR DESCRIPTION
**Description of the change**

Currently, this Helm Chart is not working because the branch name in the cloned repository has changed from `master` to `main`, see https://github.com/dotnet/AspNetCore.Docs/pull/21737.

This PR updates the default value to `main`.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
