### PR TITLE
[bitnami/nats] fix: Quote string values in config file

### DIFF
--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -24,4 +24,4 @@ name: nats
 sources:
   - https://github.com/bitnami/bitnami-docker-nats
   - https://nats.io/
-version: 6.2.2
+version: 6.2.3

--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Infrastructure
 apiVersion: v2
-appVersion: 2.1.9
+appVersion: 2.2.0
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami

--- a/bitnami/nats/templates/NOTES.txt
+++ b/bitnami/nats/templates/NOTES.txt
@@ -28,8 +28,8 @@ NATS can be accessed via port {{ .Values.client.service.port }} on the following
 
 To get the authentication credentials, run:
 
-    export NATS_USER=$(kubectl get cm --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} -o jsonpath='{.data.*}' | grep -m 1 user | awk '{print $2}')
-    export NATS_PASS=$(kubectl get cm --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} -o jsonpath='{.data.*}' | grep -m 1 password | awk '{print $2}')
+    export NATS_USER=$(kubectl get cm --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} -o jsonpath='{.data.*}' | grep -m 1 user | awk '{print $2}' | tr -d '"')
+    export NATS_PASS=$(kubectl get cm --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} -o jsonpath='{.data.*}' | grep -m 1 password | awk '{print $2}' | tr -d '"')
     echo -e "Client credentials:\n\tUser: $NATS_USER\n\tPassword: $NATS_PASS"
 
 {{- end }}

--- a/bitnami/nats/templates/configmap.yaml
+++ b/bitnami/nats/templates/configmap.yaml
@@ -21,10 +21,10 @@ data:
     {{- if .Values.auth.enabled }}
     authorization {
       {{- if .Values.auth.user }}
-      user: {{ .Values.auth.user }}
-      password: {{ $authPwd }}
+      user: {{ .Values.auth.user | quote }}
+      password: {{ $authPwd | quote }}
       {{- else if .Values.auth.token }}
-      token: {{ .Values.auth.token }}
+      token: {{ .Values.auth.token | quote }}
       {{- end }}
       timeout:  1
     }
@@ -61,10 +61,10 @@ data:
       {{- if .Values.clusterAuth.enabled }}
       authorization {
         {{- if .Values.clusterAuth.user }}
-        user: {{ .Values.clusterAuth.user }}
-        password: {{ $clusterAuthPwd }}
+        user: {{ .Values.clusterAuth.user | quote }}
+        password: {{ $clusterAuthPwd | quote }}
         {{- else if .Values.clusterAuth.token }}
-        token: {{ .Values.clusterAuth.token }}
+        token: {{ .Values.clusterAuth.token | quote }}
         {{- end }}
         timeout:  1
       }

--- a/bitnami/nats/values.yaml
+++ b/bitnami/nats/values.yaml
@@ -13,7 +13,7 @@
 image:
   registry: docker.io
   repository: bitnami/nats
-  tag: 2.1.9-debian-10-r119
+  tag: 2.2.0-debian-10-r0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -520,7 +520,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/nats-exporter
-    tag: 0.7.0-debian-10-r10
+    tag: 0.7.0-debian-10-r19
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Signed-off-by: joancafom <jcarmona@vmware.com>

**Description of the change**

When the configuration file for nats holds strings starting with numeric values, the server is unable to parse the information and the pod fails to start:

```
$ helm install --set clusterAuth.password=1234test alpha bitnami/nats

$ kubectl get pods
NAME           READY   STATUS   RESTARTS   AGE
alpha-nats-0   0/1     Error    0          2s

$ kubectl logs alpha-nats-0
nats-server: Parse error on line 29: 'Expected a map value terminator "," or a map terminator "}", but got 'e' instead.'
```

This is an error we have faced in the upcoming version of the application `2.2.0`, but does not seem to fail with the current one. However, this is a known issue and the recommended way of storing such values in the configuration file is by quoting them.

See ref: https://github.com/nats-io/nats-server/issues/716#issuecomment-406679679

This PR implements this recommendation and prevents the chart from failing when supplying strings beginning with numbers.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

The server can interpret all string values correctly and does not fail-exit on start up.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
