### PR TITLE
[bitnami/harbor] Use notary secret for notary ingress

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-harbor-registry
   - https://github.com/bitnami/bitnami-docker-harbor-registryctl
   - https://goharbor.io/
-version: 9.8.1
+version: 9.8.2

--- a/bitnami/harbor/templates/ingress/ingress.yaml
+++ b/bitnami/harbor/templates/ingress/ingress.yaml
@@ -122,7 +122,7 @@ spec:
     {{- else if .Values.service.tls.existingSecret }}
     - secretName: {{ .Values.service.tls.existingSecret }}
     {{- else }}
-    - secretName: {{ include "harbor.ingress" . }}
+    - secretName: {{ include "harbor.ingress-notary" . }}
     {{- end }}
       {{- if .Values.ingress.hosts.notary }}
       hosts:

--- a/bitnami/harbor/templates/ingress/secret.yaml
+++ b/bitnami/harbor/templates/ingress/secret.yaml
@@ -1,10 +1,28 @@
 {{- if eq (include "harbor.autoGenCertForIngress" .) "true" }}
 {{- $ca := genCA "harbor-ca" 365 }}
-{{- $cert := genSignedCert .Values.ingress.hosts.core nil (list .Values.ingress.hosts.core .Values.ingress.hosts.notary) 365 $ca }}
+{{- $cert := genSignedCert .Values.ingress.hosts.core nil (list .Values.ingress.hosts.core ) 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "harbor.ingress" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $cert.Cert | b64enc | quote }}
+  tls.key: {{ $cert.Key | b64enc | quote }}
+  ca.crt: {{ $ca.Cert | b64enc | quote }}
+---
+{{- $cert := genSignedCert .Values.ingress.hosts.notary nil (list .Values.ingress.hosts.notary) 365 $ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "harbor.ingress-notary" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

Forces the Notary Ingress TLS secret to be stored in a separate secret than the Harbor Ingress TLS secret. When they both use the same secret, you would have to use a wildcard cert for this to work. 

**Benefits**

Allows both Harbor and Notary Ingress endpoints to have their own secrets which allows them to present valid TLS certs to clients.

**Possible drawbacks**

No known limitations

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #5770 

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
