### PR TITLE
[bitnami/spring-cloud-dataflow] Add more options for Pometheus Proxy

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.lock
+++ b/bitnami/spring-cloud-dataflow/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 1.4.1
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 9.3.4
+  version: 9.3.5
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
-  version: 8.11.2
+  version: 8.11.3
 - name: kafka
   repository: https://charts.bitnami.com/bitnami
-  version: 12.9.5
-digest: sha256:34f2312eb4fb40f47fd140771efa52914a739f9049ec214f20bfcd9d19547608
-generated: "2021-03-04T02:22:15.749764419Z"
+  version: 12.11.1
+digest: sha256:4704eb5697ccacaf418385efc937b0f5cacafc59cb3966c9883237ec11c010c4
+generated: "2021-03-17T00:31:31.6493933-04:00"

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -39,4 +39,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-spring-cloud-dataflow
   - https://github.com/bitnami/bitnami-docker-spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 2.8.0
+version: 2.9.0

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -250,15 +250,26 @@ The following tables lists the configurable parameters of the Spring Cloud Data 
 | `metrics.image.tag`                    | Prometheus Rsocket Proxy image tag                                                                     | `{TAG_NAME}`                                            |
 | `metrics.image.pullPolicy`             | Prometheus Rsocket Proxy image pull policy                                                             | `IfNotPresent`                                          |
 | `metrics.image.pullSecrets`            | Specify docker-registry secret names as an array                                                       | `[]` (does not add image pull secrets to deployed pods) |
+| `metrics.replicaCount`                 | Number of Prometheus Rsocket Proxy replicas to deploy                                                  | `1`                                                     |
 | `metrics.resources.limits`             | The resources limits for the Prometheus Rsocket Proxy container                                        | `{}`                                                    |
 | `metrics.resources.requests`           | The requested resources for the Prometheus Rsocket Proxy container                                     | `{}`                                                    |
 | `metrics.kafka.service.httpPort`       | Prometheus Rsocket Proxy HTTP port                                                                     | `8080`                                                  |
 | `metrics.kafka.service.rsocketPort`    | Prometheus Rsocket Proxy Rsocket port                                                                  | `8080`                                                  |
 | `metrics.kafka.service.annotations`    | Annotations for Prometheus Rsocket Proxy service                                                       | `Check values.yaml file`                                |
 | `metrics.serviceMonitor.enabled`       | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`) | `false`                                                 |
-| `metrics.serviceMonitor.namespace`     | Namespace in which Prometheus is running                                                               | `nil`                                                   |
+| `metrics.serviceMonitor.namespace`     | Namespace in which ServiceMonitor is created if different from release                                 | `nil`                                                   |
+| `metrics.serviceMonitor.extraLabels`   | Labels to add to ServiceMonitor                                                                        | `{}`                                                    |
 | `metrics.serviceMonitor.interval`      | Interval at which metrics should be scraped.                                                           | `nil` (Prometheus Operator default value)               |
 | `metrics.serviceMonitor.scrapeTimeout` | Timeout after which the scrape is ended                                                                | `nil` (Prometheus Operator default value)               |
+| `metrics.pdb.create`                   | Enable/disable a Pod Disruption Budget creation                                                        | `false`                                                 |
+| `metrics.pdb.minAvailable`             | Minimum number/percentage of pods that should remain scheduled                                         | `1`                                                     |
+| `metrics.pdb.maxUnavailable`           | Maximum number/percentage of pods that may be made unavailable                                         | `nil`                                                   |
+| `metrics.autoscaling.enabled`          | Enable autoscaling for Prometheus Rsocket Proxy                                                        | `false`                                                 |
+| `metrics.autoscaling.minReplicas`      | Minimum number of Prometheus Rsocket Proxy replicas                                                    | `nil`                                                   |
+| `metrics.autoscaling.maxReplicas`      | Maximum number of Prometheus Rsocket Proxy replicas                                                    | `nil`                                                   |
+| `metrics.autoscaling.targetCPU`        | Target CPU utilization percentage                                                                      | `nil`                                                   |
+| `metrics.autoscaling.targetMemory`     | Target Memory utilization percentage                                                                   | `nil`                                                   |
+
 
 ### Init Container parameters
 

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/deployment.yaml
@@ -13,6 +13,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  replicas: {{ .Values.metrics.replicaCount }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: prometheus-proxy

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/hpa.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/hpa.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.metrics.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "scdf.fullname" . }}-prometheus-proxy
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: prometheus-proxy
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+    kind: Deployment
+    name: {{ include "scdf.fullname" . }}-prometheus-proxy
+  minReplicas: {{ .Values.metrics.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.metrics.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.metrics.autoscaling.targetCPU }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.metrics.autoscaling.targetCPU }}
+    {{- end }}
+    {{- if .Values.metrics.autoscaling.targetMemory }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.metrics.autoscaling.targetMemory  }}
+    {{- end }}
+{{- end }}

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/pdb.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/pdb.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.metrics.pdb.create }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "scdf.fullname" . }}-prometheus-proxy
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: prometheus-proxy
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.metrics.pdb.minAvailable }}
+  minAvailable: {{ .Values.metrics.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.metrics.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.metrics.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: prometheus-proxy
+{{- end }}

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/servicemonitor-metrics.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/servicemonitor-metrics.yaml
@@ -3,15 +3,15 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "scdf.fullname" . }}-prometheus-proxy
-  {{- if .Values.metrics.serviceMonitor.namespace }}
-  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
-  {{- end }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: prometheus-proxy
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  namespace: {{ .Release.Namespace }}
+    {{- if .Values.metrics.serviceMonitor.extraLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.extraLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace | default .Release.Namespace }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -838,6 +838,11 @@ metrics:
     # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
     limits: {}
     requests: {}
+
+  ## Number of Dataflow Prometheus Rsocket Proxy replicas to deploy.
+  ##
+  replicaCount: 1
+
   service:
     ## Prometheus Rsocket Proxy HTTP port
     ##
@@ -855,7 +860,11 @@ metrics:
   ##
   serviceMonitor:
     enabled: false
-    ## Namespace in which Prometheus is running
+    ## Labels to add to ServiceMonitor, in case prometheus operator is configured with serviceMonitorSelector
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+    ##
+    extraLabels: {}
+    ## Namespace in which ServiceMonitor is created if different from release
     ##
     # namespace: monitoring
     ## Interval at which metrics should be scraped.
@@ -866,6 +875,27 @@ metrics:
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
     ##
     # scrapeTimeout: 10s
+
+  ## Prometheus Rsocket Proxy Pod Disruption Budget configuration
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  ##
+  pdb:
+    create: false
+    ## Min number of pods that must still be available after the eviction
+    ##
+    minAvailable: 1
+    ## Max number of pods that can be unavailable after the eviction
+    ##
+    # maxUnavailable: 1
+
+  ## Prometheus Rsocket Proxy Autoscaling parameters.
+  ##
+  autoscaling:
+    enabled: false
+    # minReplicas: 1
+    # maxReplicas: 11
+    # targetCPU: 50
+    # targetMemory: 50
 
 ##
 ## MariaDB chart configuration


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

- Added Prometheus Rsocket Proxy deployment replica count
- Extra labels for ServiceMonitor, in case [Prometheus](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#prometheusspec) is configured with serviceMonitorSelector
- PDB / HPA for Prometheus Rsocket Proxy
- Fix duplicate namespace in ServiceMonitor

**Benefits**

- Allow the ServiceMonitor to be picked up by Prometheus configured with serviceMonitorSelector
- Allow HA / autoscaling of Prometheus Rsocket Proxy

**Possible drawbacks**



**Applicable issues**

ServiceMonitor won't be picked up by Prometheus if specific label is required.
Prometheus Rsocket Proxy has no option to be deployed in HA

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
