### PR TITLE
[bitnami/kibana] Fix helm test

### DIFF
--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -25,4 +25,4 @@ name: kibana
 sources:
   - https://github.com/bitnami/bitnami-docker-kibana
   - https://www.elastic.co/products/kibana
-version: 7.2.3
+version: 7.2.4

--- a/bitnami/kibana/templates/_helpers.tpl
+++ b/bitnami/kibana/templates/_helpers.tpl
@@ -143,5 +143,4 @@ Check if there are rolling tags in the images
 */}}
 {{- define "kibana.checkRollingTags" -}}
 {{- include "common.warnings.rollingTag" .Values.image }}
-{{- include "common.warnings.rollingTag" .Values.volumePermissions.image }}
 {{- end -}}

--- a/bitnami/kibana/templates/tests/test-connection.yaml
+++ b/bitnami/kibana/templates/tests/test-connection.yaml
@@ -1,15 +1,17 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ include "common.names.fullname" . }}-test-connection"
+  name: {{ printf "%s-test-connection" (include "common.names.fullname" .) }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app: test-connection
   annotations:
     "helm.sh/hook": test-success
 spec:
   containers:
-    - name: wget
-      image: bitnami/minideb
-      command: ['wget']
-      args: ['{{ include "common.names.fullname" . }}:{{ .Values.service.port }}']
+    - name: test-connection
+      image: bitnami/bitnami-shell
+      command:
+        - curl
+      args:
+        - {{ include "common.names.fullname" . }}:{{ .Values.service.port }}
   restartPolicy: Never


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Fixes the "test-connection" chart test by substituting `minideb` with `bitnami-shell` and `wget` with `curl`

**Benefits**

You can run `helm test RELEASE_NAME` and it works.

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/5801

**Additional information**

N/A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

