### PR TITLE
[Bitnami/minio] Update README.md

### DIFF
--- a/bitnami/minio/README.md
+++ b/bitnami/minio/README.md
@@ -301,13 +301,13 @@ statefulset.drivesPerNode=2
 
 ### Prometheus exporter
 
-MinIO&reg; exports Prometheus metrics at `/minio/prometheus/metrics`. To allow Prometheus collecting your MinIO&reg; metrics, modify the `values.yaml` adding the corresponding annotations:
+MinIO&reg; exports Prometheus metrics at `/minio/v2/metrics/cluster`. To allow Prometheus collecting your MinIO&reg; metrics, modify the `values.yaml` adding the corresponding annotations:
 
 ```diff
 - podAnnotations: {}
 + podAnnotations:
 +   prometheus.io/scrape: "true"
-+   prometheus.io/path: "/minio/prometheus/metrics"
++   prometheus.io/path: "/minio/v2/metrics/cluster"
 +   prometheus.io/port: "9000"
 ```
 


### PR DESCRIPTION
**Description of the change**

prometheus endpoint is changed to /minio/v2/metrics/cluster

I didn't update the version because it is not that important.

https://docs.min.io/docs/minio-monitoring-guide.html

Not sure if we should update the one in service monitor. It seems like it will cause a breaking change
