### PR TITLE
[bitnami/nginx-ingress-controller] Allow users to enable or disable http/https service port

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -26,4 +26,4 @@ name: nginx-ingress-controller
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx-ingress-controller
   - https://github.com/kubernetes/ingress-nginx
-version: 7.4.9
+version: 7.5.0

--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -26,4 +26,4 @@ name: nginx-ingress-controller
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx-ingress-controller
   - https://github.com/kubernetes/ingress-nginx
-version: 7.5.0
+version: 7.4.10

--- a/bitnami/nginx-ingress-controller/README.md
+++ b/bitnami/nginx-ingress-controller/README.md
@@ -192,7 +192,7 @@ The following tables lists the configurable parameters of the Nginx Ingress Cont
 | `service.clusterIP`                | Controller Internal Cluster Service IP                                                                                                 | `""`           |
 | `service.omitClusterIP`            | To omit the `ClusterIP` from the controller service                                                                                    | `false`        |
 | `service.ports.http`               | Controller Service HTTP port                                                                                                           | `80`           |
-| `service.ports.https`              | Controller Service HTTPS port                                                                                                          | `""`           |
+| `service.ports.https`              | Controller Service HTTPS port                                                                                                          | `443`           |
 | `service.targetPorts.http`         | Map the controller service HTTP port                                                                                                   | `http`         |
 | `service.targetPorts.https`        | Map the controller service HTTPS port                                                                                                  | `https`        |
 | `service.externalTrafficPolicy`    | Enable client source IP preservation                                                                                                   | `Cluster`      |

--- a/bitnami/nginx-ingress-controller/templates/controller-service.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-service.yaml
@@ -41,6 +41,7 @@ spec:
   healthCheckNodePort: {{ .Values.service.healthCheckNodePort }}
   {{- end }}
   ports:
+    {{- if not (empty .Values.service.ports.http) }}
     - name: http
       port: {{ .Values.service.ports.http }}
       protocol: TCP
@@ -50,6 +51,8 @@ spec:
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    {{- end }}
+    {{- if not (empty .Values.service.ports.https) }}
     - name: https
       port: {{ .Values.service.ports.https }}
       protocol: TCP
@@ -59,6 +62,7 @@ spec:
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    {{- end }}
     {{- range $key, $value := .Values.tcp }}
     - name: {{ $key }}-tcp
       port: {{ $key }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Allow users to enable or disable http/https with an empty service port, just by leaving the port number blank.

The kubernetes/ingress-nginx already allows this by using two flags enableHttp and enableHttps
https://github.com/kubernetes/ingress-nginx/blob/master/charts/ingress-nginx/values.yaml#L370

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Turn on and off http/https as you like

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

None

<!-- Describe any known limitations with your change -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
