### PR TITLE
[bitnami/etcd] Quote retention env variable values

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -25,4 +25,4 @@ name: etcd
 sources:
   - https://github.com/bitnami/bitnami-docker-etcd
   - https://coreos.com/etcd/
-version: 6.1.2
+version: 6.1.3

--- a/bitnami/etcd/templates/statefulset.yaml
+++ b/bitnami/etcd/templates/statefulset.yaml
@@ -154,11 +154,11 @@ spec:
               value: "{{ $etcdPeerProtocol }}://0.0.0.0:{{ .Values.service.peerPort }}"
             {{- if .Values.autoCompactionMode }}
             - name: ETCD_AUTO_COMPACTION_MODE
-              value: {{ .Values.autoCompactionMode }}
+              value: {{ .Values.autoCompactionMode | quote }}
             {{- end }}
             {{- if .Values.autoCompactionRetention }}
             - name: ETCD_AUTO_COMPACTION_RETENTION
-              value: {{ .Values.autoCompactionRetention }}
+              value: {{ .Values.autoCompactionRetention | quote }}
             {{- end }}
             {{- if .Values.maxProcs }}
             - name: GOMAXPROCS
@@ -354,7 +354,7 @@ spec:
         {{- end }}
         resources:
           requests:
-            storage: {{ .Values.persistence.size | quote }}        
+            storage: {{ .Values.persistence.size | quote }}
         {{- if .Values.persistence.selector }}
         selector: {{- include "common.tplvalues.render" ( dict "value" .Values.persistence.selector "context" $) | nindent 10 }}
         {{- end }}


### PR DESCRIPTION
Signed-off-by: Gorka Maiztegi <gmaiztegi@reviewpro.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

As the retention is a number, the value must be quoted to put it in the environment variables. 

**Benefits**

Bug fix, see the description.

**Possible drawbacks**

None that I can think of.

**Applicable issues**

Haven't seen any.

**Additional information**

None.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
