### PR TITLE
[bitnami/minio] MinIO Gateway for Azure: Use custom access/secret keys instead of reusing Azure credentials

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -25,4 +25,4 @@ name: minio
 sources:
   - https://github.com/bitnami/bitnami-docker-minio
   - https://min.io
-version: 6.5.0
+version: 6.6.0

--- a/bitnami/minio/README.md
+++ b/bitnami/minio/README.md
@@ -236,14 +236,16 @@ The following table lists the configurable parameters of the MinIO&reg; chart an
 | `gateway.enabled`                         | Use MinIO&reg; as Gateway for other storage systems                                 | `false`                                                      |
 | `gateway.type`                            | Gateway type. Supported types are: `azure`, `gcs`, `nas`, `s3`                      | `s3`                                                         |
 | `gateway.replicaCount`                    | Number of MinIO&reg; Gateway replicas                                               | `4`                                                          |
+| `gateway.auth.azure.accessKey`            | Access Key to access MinIO using Azure Gateway                                      | _random 10 character alphanumeric string_                    |
+| `gateway.auth.azure.secretKey`            | Secret Key to access MinIO using Azure Gateway                                      | _random 40 character alphanumeric string_                    |
 | `gateway.auth.azure.storageAccountName`   | Azure Storage Account Name to use to access Azure Blob Storage                      | `nil`                                                        |
 | `gateway.auth.azure.storageAccountKey`    | Azure Storage Account Key to use to access Azure Blob Storage                       | `nil`                                                        |
-| `gateway.auth.gcs.accessKey`              | Access Key to access MinIO using GCS Gateway                                        | `nil`                                                        |
-| `gateway.auth.gcs.secretKey`              | Secret Key to access MinIO using GCS Gateway                                        | `nil`                                                        |
+| `gateway.auth.gcs.accessKey`              | Access Key to access MinIO using GCS Gateway                                        | _random 10 character alphanumeric string_                    |
+| `gateway.auth.gcs.secretKey`              | Secret Key to access MinIO using GCS Gateway                                        | _random 40 character alphanumeric string_                    |
 | `gateway.auth.gcs.keyJSON`                | Service Account key to access GCS                                                   | `nil`                                                        |
 | `gateway.auth.gcs.projectID`              | GCP Project ID to use                                                               | `nil`                                                        |
-| `gateway.auth.nas.accessKey`              | Access Key to access MinIO using NAS Gateway                                        | `nil`                                                        |
-| `gateway.auth.nas.secretKey`              | Secret Key to access MinIO using NAS Gateway                                        | `nil`                                                        |
+| `gateway.auth.nas.accessKey`              | Access Key to access MinIO using NAS Gateway                                        | _random 10 character alphanumeric string_                    |
+| `gateway.auth.nas.secretKey`              | Secret Key to access MinIO using NAS Gateway                                        | _random 40 character alphanumeric string_                    |
 | `gateway.auth.s3.serviceEndpoint`         | AWS S3 endpoint                                                                     | `https://s3.amazonaws.com`                                   |
 | `gateway.auth.s3.accessKey`               | Access Key to use to access AWS S3                                                  | `nil`                                                        |
 | `gateway.auth.s3.secretKey`               | Secret Key to use to access AWS S3                                                  | `nil`                                                        |

--- a/bitnami/minio/templates/NOTES.txt
+++ b/bitnami/minio/templates/NOTES.txt
@@ -10,8 +10,8 @@ MinIO(R) can be accessed via port {{ .Values.service.port }} on the following DN
 
 To get your credentials run:
 
-   export ACCESS_KEY=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "minio.secretName" . }} -o jsonpath="{.data.{{ include "minio.secret.userKey" . }}}" | base64 --decode)
-   export SECRET_KEY=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "minio.secretName" . }} -o jsonpath="{.data.{{ include "minio.secret.passwordKey" . }}}" | base64 --decode)
+   export ACCESS_KEY=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "minio.secretName" . }} -o jsonpath="{.data.access-key}" | base64 --decode)
+   export SECRET_KEY=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "minio.secretName" . }} -o jsonpath="{.data.secret-key}" | base64 --decode)
 
 To connect to your MinIO(R) server using a client:
 
@@ -77,8 +77,8 @@ To access the MinIO(R) web UI:
 {{- $requiredPassword := list -}}
 {{- $secretName := include "minio.secretName" . -}}
 {{- if and (not .Values.existingSecret) (not .Values.forceNewKeys) -}}
-  {{- $requiredAccessKey := dict "valueKey" "accessKey.password" "secret" $secretName "field" (include "minio.secret.userKey" .) -}}
-  {{- $requiredSecretKey := dict "valueKey" "secretKey.password" "secret" $secretName "field" (include "minio.secret.passwordKey" .) -}}
+  {{- $requiredAccessKey := dict "valueKey" "accessKey.password" "secret" $secretName "field" "access-key" -}}
+  {{- $requiredSecretKey := dict "valueKey" "secretKey.password" "secret" $secretName "field" "secret-key" -}}
   {{- $requiredPassword = append $requiredPassword $requiredAccessKey -}}
   {{- $requiredPassword = append $requiredPassword $requiredSecretKey -}}
 {{- end -}}

--- a/bitnami/minio/templates/_helpers.tpl
+++ b/bitnami/minio/templates/_helpers.tpl
@@ -30,23 +30,16 @@ Return the proper Docker Image Registry Secret Names
 {{- end -}}
 
 {{/*
-Get the credentials secret key to obtain the user
-*/}}
-{{- define "minio.secret.userKey" -}}
-{{- if or (not .Values.gateway.enabled) (eq .Values.gateway.type "nas") (eq .Values.gateway.type "gcs") (eq .Values.gateway.type "s3") -}}
-access-key
-{{- else if and .Values.gateway.enabled (eq .Values.gateway.type "azure") -}}
-azure-storage-account-name
-{{- end -}}
-{{- end -}}
-
-{{/*
 Get the user to use to access MinIO(R)
 */}}
 {{- define "minio.secret.userValue" -}}
 {{- if .Values.gateway.enabled }}
     {{- if eq .Values.gateway.type "azure" }}
-        {{- .Values.gateway.auth.azure.storageAccountName -}}
+        {{- if .Values.gateway.auth.azure.accessKey }}
+            {{- .Values.gateway.auth.azure.accessKey -}}
+        {{- else -}}
+            {{- randAlphaNum 10 -}}
+        {{- end -}}
     {{- else if eq .Values.gateway.type "gcs" }}
         {{- if .Values.gateway.auth.gcs.accessKey }}
             {{- .Values.gateway.auth.gcs.accessKey -}}
@@ -75,23 +68,16 @@ Get the user to use to access MinIO(R)
 {{- end -}}
 
 {{/*
-Get the credentials secret key to obtain the password
-*/}}
-{{- define "minio.secret.passwordKey" -}}
-{{- if or (not .Values.gateway.enabled) (eq .Values.gateway.type "nas") (eq .Values.gateway.type "gcs") (eq .Values.gateway.type "s3") -}}
-secret-key
-{{- else if and .Values.gateway.enabled (eq .Values.gateway.type "azure") -}}
-azure-storage-account-key
-{{- end -}}
-{{- end -}}
-
-{{/*
 Get the password to use to access MinIO(R)
 */}}
 {{- define "minio.secret.passwordValue" -}}
 {{- if .Values.gateway.enabled }}
     {{- if eq .Values.gateway.type "azure" }}
-        {{- .Values.gateway.auth.azure.storageAccountKey -}}
+        {{- if .Values.gateway.auth.azure.secretKey }}
+            {{- .Values.gateway.auth.azure.secretKey -}}
+        {{- else -}}
+            {{- randAlphaNum 40 -}}
+        {{- end -}}
     {{- else if eq .Values.gateway.type "gcs" }}
         {{- if .Values.gateway.auth.gcs.secretKey }}
             {{- .Values.gateway.auth.gcs.secretKey -}}

--- a/bitnami/minio/templates/distributed/statefulset.yaml
+++ b/bitnami/minio/templates/distributed/statefulset.yaml
@@ -142,23 +142,23 @@ spec:
               value: {{ ternary "yes" "no" .Values.forceNewKeys | quote }}
             {{- if .Values.useCredentialsFile }}
             - name: MINIO_ACCESS_KEY_FILE
-              value: {{ printf "/opt/bitnami/minio/secrets/%s" (include "minio.secret.userKey" .) | quote }}
+              value: "/opt/bitnami/minio/secrets/access-key"
             {{- else }}
             - name: MINIO_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "minio.secretName" . }}
-                  key: {{ include "minio.secret.userKey" . }}
+                  key: access-key
             {{- end }}
             {{- if .Values.useCredentialsFile }}
             - name: MINIO_SECRET_KEY_FILE
-              value: {{ printf "/opt/bitnami/minio/secrets/%s" (include "minio.secret.passwordKey" .) | quote }}
+              value: "/opt/bitnami/minio/secrets/secret-key"
             {{- else }}
             - name: MINIO_SECRET_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "minio.secretName" . }}
-                  key: {{ include "minio.secret.passwordKey" . }}
+                  key: secret-key
             {{- end }}
             - name: MINIO_SKIP_CLIENT
               value: {{ ternary "yes" "no" (empty .Values.defaultBuckets) | quote }}

--- a/bitnami/minio/templates/gateway/deployment.yaml
+++ b/bitnami/minio/templates/gateway/deployment.yaml
@@ -94,7 +94,18 @@ spec:
             {{- end }}
             {{- end }}
           env:
-            {{- if and (eq .Values.gateway.type "gcs") .Values.gateway.auth.gcs.keyJSON }}
+            {{- if eq .Values.gateway.type "azure" }}
+            - name: AZURE_STORAGE_ACCOUNT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "minio.secretName" . }}
+                  key: azure-storage-account-name
+            - name: AZURE_STORAGE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "minio.secretName" . }}
+                  key: azure-storage-account-key
+            {{- else if and (eq .Values.gateway.type "gcs") .Values.gateway.auth.gcs.keyJSON }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: "/opt/bitnami/minio/secrets/key.json"
             {{- end }}
@@ -102,12 +113,14 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "minio.secretName" . }}
-                  key: {{ include "minio.secret.userKey" . }}
+                  key: access-key
             - name: MINIO_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "minio.secretName" . }}
-                  key: {{ include "minio.secret.passwordKey" . }}
+                  key: secret-key
+            - name: MINIO_PROMETHEUS_AUTH_TYPE
+              value: {{ .Values.metrics.prometheusAuthType | quote }}
             {{- if .Values.extraEnv }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnv "context" $) | nindent 12 }}
             {{- end }}

--- a/bitnami/minio/templates/secrets.yaml
+++ b/bitnami/minio/templates/secrets.yaml
@@ -13,9 +13,12 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{ include "minio.secret.userKey" . }}: {{ include "minio.secret.userValue" . | b64enc | quote }}
-  {{ include "minio.secret.passwordKey" . }}: {{ include "minio.secret.passwordValue" . | b64enc | quote }}
-  {{- if and (eq .Values.gateway.type "gcs") .Values.gateway.auth.gcs.keyJSON }}
-  key.json: {{ .Values.gateway.auth.gcs.keyJSON | toString | b64enc }}
+  access-key: {{ include "minio.secret.userValue" . | b64enc | quote }}
+  secret-key: {{ include "minio.secret.passwordValue" . | b64enc | quote }}
+  {{- if eq .Values.gateway.type "azure" }}
+  azure-storage-account-name: {{ .Values.gateway.auth.azure.storageAccountName | toString | b64enc | quote }}
+  azure-storage-account-key: {{ .Values.gateway.auth.azure.storageAccountKey | toString | b64enc | quote }}
+  {{- else if and (eq .Values.gateway.type "gcs") .Values.gateway.auth.gcs.keyJSON | quote }}
+  key.json: {{ .Values.gateway.auth.gcs.keyJSON | toString | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/bitnami/minio/templates/standalone/deployment.yaml
+++ b/bitnami/minio/templates/standalone/deployment.yaml
@@ -104,23 +104,23 @@ spec:
               value: {{ ternary "yes" "no" .Values.forceNewKeys | quote }}
             {{- if .Values.useCredentialsFile }}
             - name: MINIO_ACCESS_KEY_FILE
-              value: {{ printf "/opt/bitnami/minio/secrets/%s" (include "minio.secret.userKey" .) | quote }}
+              value: "/opt/bitnami/minio/secrets/access-key"
             {{- else }}
             - name: MINIO_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "minio.secretName" . }}
-                  key: {{ include "minio.secret.userKey" . }}
+                  key: access-key
             {{- end }}
             {{- if .Values.useCredentialsFile }}
             - name: MINIO_SECRET_KEY_FILE
-              value: {{ printf "/opt/bitnami/minio/secrets/%s" (include "minio.secret.passwordKey" .) | quote }}
+              value: "/opt/bitnami/minio/secrets/secret-key"
             {{- else }}
             - name: MINIO_SECRET_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "minio.secretName" . }}
-                  key: {{ include "minio.secret.passwordKey" . }}
+                  key: secret-key
             {{- end }}
             {{- if .Values.defaultBuckets }}
             - name: MINIO_DEFAULT_BUCKETS

--- a/bitnami/minio/values.yaml
+++ b/bitnami/minio/values.yaml
@@ -654,6 +654,8 @@ gateway:
     ## Ignored unless type=azure
     ##
     azure:
+      accessKey: ""
+      secretKey: ""
       storageAccountName: ""
       storageAccountKey: ""
     ## Authentication configuration for GCS


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

As described at MinIO Gateway for Azure docs: 

- https://docs.min.io/docs/minio-gateway-for-azure

It's possible to use custom  access/secret keys to provide users access the MinIO UI instead of reusing Azure credentials. This is a safer setup.

**Benefits**

Security

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

Change suggested by @maxisam 

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
