### PR TITLE
[bitnami/contour] Add ingressclasses to RBAC

### DIFF
--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/bitnami-docker-contour
   - https://projectcontour.io
-version: 4.2.0
+version: 4.2.1

--- a/bitnami/contour/templates/contour/rbac.yaml
+++ b/bitnami/contour/templates/contour/rbac.yaml
@@ -58,6 +58,14 @@ rules:
   - apiGroups:
       - networking.k8s.io
     resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
       - ingresses
     verbs:
       - get


### PR DESCRIPTION
The original change in contour happened here: https://github.com/projectcontour/contour/pull/3266/files

I have very limited experience with helm charts, and this is the first time I've heard of RBAC so please review this PR accordingly.

**Description of the change**

Added  `incgressclasses` to RBAC.

**Benefits**

This chart is broken otherwise.

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

