### PR TITLE
[bitnami/harbor] add permitted registry types for harbor 2.2

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-harbor-registry
   - https://github.com/bitnami/bitnami-docker-harbor-registryctl
   - https://goharbor.io/
-version: 9.8.0
+version: 9.8.1

--- a/bitnami/harbor/templates/core/core-cm-envvars.yaml
+++ b/bitnami/harbor/templates/core/core-cm-envvars.yaml
@@ -40,7 +40,7 @@ data:
   PORTAL_URL: {{ include "harbor.portal.url" . | quote }}
   REGISTRY_CONTROLLER_URL: {{ include "harbor.registryCtl.url" . | quote }}
   REGISTRY_CREDENTIAL_USERNAME: {{ .Values.registry.credentials.username | quote }}
-  PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE: "docker-hub,harbor"
+  PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE: "docker-hub,harbor,aws-ecr,azure-acr,quay,google-gcr"
   {{- if .Values.core.uaaSecretName }}
   UAA_CA_ROOT: "/etc/core/ca/auth-ca.crt"
   {{- end }}


### PR DESCRIPTION
Enhance the proxy cache to support Google Container Registry(GCR), Elastic Container Registry(ECR), Azure Container Registry(Azure), Quay.io.