### PR TITLE
[bitname/keycloak] Support existingSecret for externalDatabase use

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 2.3.0
+version: 2.4.0

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -272,6 +272,7 @@ The following tables lists the configurable parameters of the Keycloak chart and
 | `externalDatabase.user`          | PostgreSQL username (when using an external db)                              | `bn_keycloak`      |
 | `externalDatabase.password`      | Password for the above username (when using an external db)                  | `""`               |
 | `externalDatabase.database`      | Name of the existing database (when using an external db)                    | `bitnami_keycloak` |
+| `externalDatabase.existingSecret`| Use an existing secret file with the external PostgreSQL credentials         | `nil`              |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/keycloak/templates/configmap-env-vars.yaml
+++ b/bitnami/keycloak/templates/configmap-env-vars.yaml
@@ -15,13 +15,15 @@ data:
   KEYCLOAK_CREATE_ADMIN_USER: {{ ternary "true" "false" .Values.auth.createAdminUser | quote }}
   KEYCLOAK_ADMIN_USER: {{ .Values.auth.adminUser | quote }}
   KEYCLOAK_MANAGEMENT_USER: {{ .Values.auth.managementUser | quote }}
+  KEYCLOAK_HTTP_PORT: {{ .Values.containerPorts.http | quote }}
+  KEYCLOAK_PROXY_ADDRESS_FORWARDING: {{ ternary "true" "false" .Values.proxyAddressForwarding | quote }}
+  KEYCLOAK_ENABLE_STATISTICS: {{ ternary "true" "false" .Values.metrics.enabled | quote }}
+  {{- if (not .Values.externalDatabase.existingSecret) }}
   KEYCLOAK_DATABASE_HOST: {{ include "keycloak.databaseHost" . | quote }}
   KEYCLOAK_DATABASE_PORT: {{ include "keycloak.databasePort" . }}
   KEYCLOAK_DATABASE_NAME: {{ include "keycloak.databaseName" . | quote }}
   KEYCLOAK_DATABASE_USER: {{ include "keycloak.databaseUser" . | quote }}
-  KEYCLOAK_HTTP_PORT: {{ .Values.containerPorts.http | quote }}
-  KEYCLOAK_PROXY_ADDRESS_FORWARDING: {{ ternary "true" "false" .Values.proxyAddressForwarding | quote }}
-  KEYCLOAK_ENABLE_STATISTICS: {{ ternary "true" "false" .Values.metrics.enabled | quote }}
+  {{- end }}
   {{- if .Values.serviceDiscovery.enabled }}
   KEYCLOAK_JGROUPS_DISCOVERY_PROTOCOL: {{ .Values.serviceDiscovery.protocol | quote }}
   KEYCLOAK_JGROUPS_DISCOVERY_PROPERTIES: {{ (tpl (join "," .Values.serviceDiscovery.properties) $) | quote }}

--- a/bitnami/keycloak/templates/secrets.yaml
+++ b/bitnami/keycloak/templates/secrets.yaml
@@ -24,7 +24,9 @@ data:
   {{- else }}
   management-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
+  {{- if (not .Values.externalDatabase.existingSecret) }}
   database-password: {{ include "keycloak.databaseEncryptedPassword" . }}
+  {{- end }}
   {{- if .Values.auth.tls.enabled }}
   {{- if .Values.auth.tls.keystorePassword }}
   tls-keystore-password: {{ .Values.auth.tls.keystorePassword | b64enc | quote }}

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -150,6 +150,7 @@ spec:
                   name: {{ $globalSecretName }}
                   key: {{ include "common.secrets.key" (dict "existingSecret" .Values.auth.existingSecret "key" "management-password") }}
                 {{- end }}
+            {{- if (not .Values.externalDatabase.existingSecret) }}
             - name: KEYCLOAK_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -160,6 +161,7 @@ spec:
                   name: {{ $globalSecretName }}
                   key: {{ include "common.secrets.key" (dict "existingSecret" .Values.auth.existingSecret "key" "database-password") }}
                 {{- end }}
+            {{- end }}
             {{- if .Values.auth.tls.enabled }}
             {{- if or .Values.auth.tls.keystorePassword .Values.auth.existingSecretPerPassword }}
             - name: KEYCLOAK_TLS_KEYSTORE_PASSWORD
@@ -203,6 +205,10 @@ spec:
             {{- if .Values.extraEnvVarsSecret }}
             - secretRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
+            {{- end }}
+            {{- if and .Values.externalDatabase.existingSecret (not .Values.postgresql.enabled) }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.externalDatabase.existingSecret "context" $) }}
             {{- end }}
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -729,6 +729,17 @@ externalDatabase:
   ## Database name
   ##
   database: bitnami_keycloak
+  ## An already existing secret containing credentials info
+  ##
+  # existingSecret: mySecret
+  #
+  ## e.g.
+  ## data:
+  ##   KEYCLOAK_DATABASE_PASSWORD: xxx
+  ##   KEYCLOAK_DATABASE_HOST: xxx
+  ##   KEYCLOAK_DATABASE_PORT: xxx
+  ##   KEYCLOAK_DATABASE_NAME: xxx
+  ##   KEYCLOAK_DATABASE_USER: xxx
 
 ## Configuration for keycloak-config-cli
 ## ref: https://github.com/adorsys/keycloak-config-cli


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Add the possibility to specify an existing secret for the external database configuration.

**Benefits**

The current release of the chart _only_ supports externally setting the password. In my belief using an external database almost always means that creation of database and installing of the keycloak chart are separate workflows. The operator creating the database will store the credentials to the database in one location. Therefore splitting it up like in the current release of the chart is some overhead work.

**Possible drawbacks**

Complexity of the chart of course. Other than that none, since the chart will keep its backwards compatibility.

**Applicable issues**

#5834 

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
