### PR TITLE
[bitnami/memcached] add support for memcached to use its own SA

### DIFF
--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Infrastructure
 apiVersion: v2
-appVersion: 1.6.9
+appVersion: 1.7.0
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami

--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Infrastructure
 apiVersion: v2
-appVersion: 1.7.0
+appVersion: 1.6.9
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -22,4 +22,4 @@ name: memcached
 sources:
   - https://github.com/bitnami/bitnami-docker-memcached
   - http://memcached.org/
-version: 5.7.0
+version: 5.8.0

--- a/bitnami/memcached/README.md
+++ b/bitnami/memcached/README.md
@@ -110,6 +110,8 @@ The following tables lists the configurable parameters of the Memcached chart an
 | `nodeSelector`                           | Node labels for pod assignment                                                            | `{}` (evaluated as a template)                               |
 | `tolerations`                            | Tolerations for pod assignment                                                            | `[]` (evaluated as a template)                               |
 | `priorityClassName`                      | Controller priorityClassName                                                              | `nil`                                                        |
+| `serviceAccount.create` | Enable creation of ServiceAccount for memcached pods                                               | `true`                                                  |
+| `serviceAccount.name`   | The name of the service account to use. If not set and `create` is `true`, a name is generated | Generated using the `memcached.serviceAccountName` template |
 | `metrics.enabled`                        | Start a side-car prometheus exporter                                                      | `false`                                                      |
 | `metrics.image.registry`                 | Memcached exporter image registry                                                         | `docker.io`                                                  |
 | `metrics.image.repository`               | Memcached exporter image name                                                             | `bitnami/memcached-exporter`                                 |

--- a/bitnami/memcached/templates/_helpers.tpl
+++ b/bitnami/memcached/templates/_helpers.tpl
@@ -1,6 +1,15 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "memcached.fullname" -}}
+{{- include "common.names.fullname" . -}}
+{{- end -}}
+
+{{/*
 Return the proper Memcached image name
 */}}
 {{- define "memcached.image" -}}
@@ -71,5 +80,16 @@ memcached: replicaCount
 memcached: securityContext.readOnlyRootFilesystem
     Enabling authentication is not compatible with using a read-only filesystem.
     Please disable it (--set securityContext.readOnlyRootFilesystem=false)
+{{- end -}}
+{{- end -}}
+
+{{/*
+ Create the name of the service account to use
+ */}}
+{{- define "memcached.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "memcached.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}

--- a/bitnami/memcached/templates/deployment.yaml
+++ b/bitnami/memcached/templates/deployment.yaml
@@ -57,6 +57,7 @@ spec:
         fsGroup: {{ .Values.securityContext.fsGroup }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- end }}
+      serviceAccountName: {{ include "common.names.fullname" . }}
       containers:
         - name: memcached
           image: {{ template "memcached.image" . }}

--- a/bitnami/memcached/templates/deployment.yaml
+++ b/bitnami/memcached/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
         fsGroup: {{ .Values.securityContext.fsGroup }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- end }}
-      serviceAccountName: {{ include "common.names.fullname" . }}
+      serviceAccountName: {{ template "memcached.serviceAccountName" . }}
       containers:
         - name: memcached
           image: {{ template "memcached.image" . }}

--- a/bitnami/memcached/templates/serviceaccount.yaml
+++ b/bitnami/memcached/templates/serviceaccount.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "common.names.fullname" . }}
+  name: {{ template "memcached.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -10,3 +11,4 @@ metadata:
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
+{{- end }}

--- a/bitnami/memcached/templates/serviceaccount.yaml
+++ b/bitnami/memcached/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -208,6 +208,18 @@ tolerations: []
 ##
 # priorityClassName: ""
 
+## memcached pods ServiceAccount
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  ## Specifies whether a ServiceAccount should be created
+  ##
+  create: true
+  ## The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the memcached.serviceAccountName template
+  ##
+  # name:
+
 ## Persistence - used for dumping and restoring states between recreations
 ## Ref: https://github.com/memcached/memcached/wiki/WarmRestart
 ##


### PR DESCRIPTION
**Description of the change**

Add service account to memcached charts 
fixes #5811

**Benefits**

This is part of the best practices and is also a compliance thing for many of the certifications such as Fedramp.


**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #5811

**Additional information**

**dry-run output**
```
NAME: my-memcache
LAST DEPLOYED: Fri Mar 19 10:54:03 2021
NAMESPACE: mahesh
STATUS: pending-install
REVISION: 1
TEST SUITE: None
HOOKS:
MANIFEST:
---
# Source: memcached/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: my-memcache-memcached
  namespace: mahesh
  labels:
    app.kubernetes.io/name: memcached
    helm.sh/chart: memcached-5.7.0
    app.kubernetes.io/instance: my-memcache
    app.kubernetes.io/managed-by: Helm
---
# Source: memcached/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: my-memcache-memcached
  namespace: mahesh
  labels:
    app.kubernetes.io/name: memcached
    helm.sh/chart: memcached-5.7.0
    app.kubernetes.io/instance: my-memcache
    app.kubernetes.io/managed-by: Helm
  annotations:
spec:
  type: ClusterIP
  ports:
    - name: memcache
      port: 11211
      targetPort: memcache
      nodePort: null
  selector:
    app.kubernetes.io/name: memcached
    app.kubernetes.io/instance: my-memcache
---
# Source: memcached/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: my-memcache-memcached
  namespace: mahesh
  labels:
    app.kubernetes.io/name: memcached
    helm.sh/chart: memcached-5.7.0
    app.kubernetes.io/instance: my-memcache
    app.kubernetes.io/managed-by: Helm
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: memcached
      app.kubernetes.io/instance: my-memcache
  replicas: 1
  template:
    metadata:
      labels:
        app.kubernetes.io/name: memcached
        helm.sh/chart: memcached-5.7.0
        app.kubernetes.io/instance: my-memcache
        app.kubernetes.io/managed-by: Helm
    spec:

      affinity:
        podAffinity:

        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
            - podAffinityTerm:
                labelSelector:
                  matchLabels:
                    app.kubernetes.io/name: memcached
                    app.kubernetes.io/instance: my-memcache
                namespaces:
                  - "mahesh"
                topologyKey: kubernetes.io/hostname
              weight: 1
        nodeAffinity:

      securityContext:
        fsGroup: 1001
        runAsUser: 1001
      serviceAccountName: my-memcache-memcached
      containers:
        - name: memcached
          image: docker.io/bitnami/memcached:1.6.9-debian-10-r86
          imagePullPolicy: "IfNotPresent"
          args:
            - /run.sh
          env:
            - name: BITNAMI_DEBUG
              value: "false"
          ports:
            - name: memcache
              containerPort: 11211
          livenessProbe:
            tcpSocket:
              port: memcache
            initialDelaySeconds: 30
            timeoutSeconds: 5
            failureThreshold: 6
          readinessProbe:
            tcpSocket:
              port: memcache
            initialDelaySeconds: 5
            timeoutSeconds: 3
            periodSeconds: 5
          resources:
            limits: {}
            requests:
              cpu: 250m
              memory: 256Mi
          volumeMounts:
            - name: tmp
              mountPath: /tmp
          securityContext:
            readOnlyRootFilesystem: false
      volumes:
        - name: tmp
          emptyDir: {}

NOTES:
** Please be patient while the chart is being deployed **
```

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [ x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

