### PR TITLE
bitnami/influxdb: Adding collectd listener option

### DIFF
--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -24,4 +24,4 @@ name: influxdb
 sources:
   - https://github.com/bitnami/bitnami-docker-influxdb
   - https://www.influxdata.com/products/influxdb-overview/
-version: 2.0.7
+version: 2.1.0

--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -24,4 +24,4 @@ name: influxdb
 sources:
   - https://github.com/bitnami/bitnami-docker-influxdb
   - https://www.influxdata.com/products/influxdb-overview/
-version: 2.0.6
+version: 2.0.7

--- a/bitnami/influxdb/README.md
+++ b/bitnami/influxdb/README.md
@@ -186,17 +186,16 @@ The following tables lists the configurable parameters of the InfluxDB<sup>TM</s
 
 ### InfluxDB Collectd<sup>TM</sup> parameters
 
-| Parameter                                | Description                                                                                                                  | Default                                                 |
-| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| `collectd.enabled`                       | InfluxDB Collectd<sup>TM</sup> service enable                                                                                | `false`                                                 |
-| `relay.service.type`                     | Kubernetes service type (`ClusterIP`, `NodePort` or `LoadBalancer`)                                                          | `ClusterIP`                                             |
-| `relay.service.port`                     | InfluxDB Collectd<sup>TM</sup> UDP port (should match with corresponding port in influxdb.conf)                              | `25826`                                                 |
-| `relay.service.nodePort`                 | Kubernetes HTTP node port                                                                                                    | `""`                                                    |
-| `relay.service.annotations`              | Annotations for InfluxDB Collectd<sup>TM</sup> service                                                                       | `{}`                                                    |
-| `relay.service.loadBalancerIP`           | loadBalancerIP if service type is `LoadBalancer`                                                                             | `nil`                                                   |
-| `relay.service.loadBalancerSourceRanges` | Address that are allowed when service is LoadBalancer                                                                        | `[]`                                                    |
-| `relay.service.clusterIP`                | Static clusterIP or None for headless services                                                                               | `nil`                                                   |
-
+| Parameter                                   | Description                                                                                                                  | Default                                                 |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `collectd.enabled`                          | InfluxDB Collectd<sup>TM</sup> service enable                                                                                | `false`                                                 |
+| `collectd.service.type`                     | Kubernetes service type (`ClusterIP`, `NodePort` or `LoadBalancer`)                                                          | `ClusterIP`                                             |
+| `collectd.service.port`                     | InfluxDB Collectd<sup>TM</sup> UDP port (should match with corresponding port in influxdb.conf)                              | `25826`                                                 |
+| `collectd.service.nodePort`                 | Kubernetes HTTP node port                                                                                                    | `""`                                                    |
+| `collectd.service.annotations`              | Annotations for InfluxDB Collectd<sup>TM</sup> service                                                                       | `{}`                                                    |
+| `collectd.service.loadBalancerIP`           | loadBalancerIP if service type is `LoadBalancer`                                                                             | `nil`                                                   |
+| `collectd.service.loadBalancerSourceRanges` | Address that are allowed when service is LoadBalancer                                                                        | `[]`                                                    |
+| `collectd.service.clusterIP`                | Static clusterIP or None for headless services                                                                               | `nil`                                                   |
 
 ### Exposing parameters
 

--- a/bitnami/influxdb/README.md
+++ b/bitnami/influxdb/README.md
@@ -184,6 +184,20 @@ The following tables lists the configurable parameters of the InfluxDB<sup>TM</s
 | `relay.service.loadBalancerSourceRanges` | Address that are allowed when service is LoadBalancer                                                                        | `[]`                                                    |
 | `relay.service.clusterIP`                | Static clusterIP or None for headless services                                                                               | `nil`                                                   |
 
+### InfluxDB Collectd<sup>TM</sup> parameters
+
+| Parameter                                | Description                                                                                                                  | Default                                                 |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `collectd.enabled`                       | InfluxDB Collectd<sup>TM</sup> service enable                                                                                | `false`                                                 |
+| `relay.service.type`                     | Kubernetes service type (`ClusterIP`, `NodePort` or `LoadBalancer`)                                                          | `ClusterIP`                                             |
+| `relay.service.port`                     | InfluxDB Collectd<sup>TM</sup> UDP port (should match with corresponding port in influxdb.conf)                              | `25826`                                                 |
+| `relay.service.nodePort`                 | Kubernetes HTTP node port                                                                                                    | `""`                                                    |
+| `relay.service.annotations`              | Annotations for InfluxDB Collectd<sup>TM</sup> service                                                                       | `{}`                                                    |
+| `relay.service.loadBalancerIP`           | loadBalancerIP if service type is `LoadBalancer`                                                                             | `nil`                                                   |
+| `relay.service.loadBalancerSourceRanges` | Address that are allowed when service is LoadBalancer                                                                        | `[]`                                                    |
+| `relay.service.clusterIP`                | Static clusterIP or None for headless services                                                                               | `nil`                                                   |
+
+
 ### Exposing parameters
 
 | Parameter                        | Description                                                   | Default                        |

--- a/bitnami/influxdb/templates/service-collectd.yaml
+++ b/bitnami/influxdb/templates/service-collectd.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.collectd.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "common.names.fullname" . }}-collectd
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: influxdb
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.collectd.service.annotations .Values.commonAnnotations }}
+  annotations:
+  {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.collectd.service.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.collectd.service.annotations "context" $) | nindent 4 }}
+  {{- end }}
+  {{- end }}
+spec:
+  type: {{ .Values.collectd.service.type }}
+  {{- if and .Values.collectd.service.loadBalancerIP (eq .Values.collectd.service.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.collectd.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.collectd.service.type "LoadBalancer") .Values.collectd.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- with .Values.collectd.service.loadBalancerSourceRanges }}
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+  {{- if and (eq .Values.collectd.service.type "ClusterIP") .Values.collectd.service.clusterIP }}
+  clusterIP: {{ .Values.collectd.service.clusterIP }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.collectd.service.port }}
+      targetPort: {{ .Values.collectd.service.port }}
+      protocol: UDP
+      name: udp
+      {{- if (and (or (eq .Values.collectd.service.type "NodePort") (eq .Values.collectd.service.type "LoadBalancer")) (not (empty .Values.collectd.service.nodePort)))}}
+      nodePort: {{ .Values.collectd.service.nodePort }}
+      {{- else if eq .Values.collectd.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+  selector:
+    {{- include "common.labels.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: influxdb
+{{- end }}

--- a/bitnami/influxdb/values.yaml
+++ b/bitnami/influxdb/values.yaml
@@ -323,6 +323,38 @@ influxdb:
     ##
     annotations: {}
 
+collectd:
+  enabled: false
+  service:
+    ## Service type
+    ##
+    type: ClusterIP
+    ## InfluxDB(TM) collectd listener port
+    ## This requires corresponding configuration in influxdb.conf to enable
+    ## collectd block
+    ##
+    port: 25826
+    ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+    ##
+    nodePort: ""
+    ## Set the LoadBalancer service type to internal only.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    # loadBalancerIP:
+    ## Load Balancer sources
+    ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ##
+    # loadBalancerSourceRanges:
+    # - 10.10.10.0/24
+    ## Set the Cluster IP to use
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#choosing-your-own-ip-address
+    ##
+    # clusterIP: None
+    # annotations:
+    # Enable metallb annotations if you want to share the LB Ip between collectd and influx services
+    ##     metallb.universe.tf/allow-shared-ip: "true"
+
 ## InfluxDB Relay(TM) parameters
 ##
 relay:

--- a/bitnami/influxdb/values.yaml
+++ b/bitnami/influxdb/values.yaml
@@ -22,7 +22,7 @@ kubeVersion:
 image:
   registry: docker.io
   repository: bitnami/influxdb
-  tag: 2.0.4-debian-10-r29
+  tag: 2.0.4-debian-10-r36
 
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -814,7 +814,7 @@ backup:
       image:
         registry: docker.io
         repository: bitnami/google-cloud-sdk
-        tag: 0.331.0-debian-10-r5
+        tag: 0.332.0-debian-10-r5
 
         ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
         ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -839,7 +839,7 @@ backup:
       image:
         registry: docker.io
         repository: bitnami/azure-cli
-        tag: 2.20.0-debian-10-r12
+        tag: 2.20.0-debian-10-r18
 
         ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
         ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Add collectd as an additional service to influxdb chart. If you enable
this service, you must speciy the collectd listener port (default 25826)
along with corresponding configuration in influxdb.conf to enable collectd
listener.


**Description of the change**

InfluxDb is often used with collected listeners (to allow collectd service to push data to influx). Bitnami chart can be used to specify influxdb.conf with collectd section - however there is no option to specify the udp port (25826) to be exposed.

**Benefits**
InfluxDB can now ingest logs/data from collectd.


**Possible drawbacks**

Not that I know of

**Applicable issues**


**Additional information**

 I have only tested this on my local k8 setup with metallb. I have no way to test on any other setup

**Checklist** 
- [X ] Variables are documented in the README.md
- [X ] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
