### PR TITLE
[bitnami/minio] Define the livenessProbe scheme value if tls.enabled, otherwise the c…

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -25,4 +25,4 @@ name: minio
 sources:
   - https://github.com/bitnami/bitnami-docker-minio
   - https://min.io
-version: 6.6.0
+version: 6.6.1

--- a/bitnami/minio/templates/distributed/statefulset.yaml
+++ b/bitnami/minio/templates/distributed/statefulset.yaml
@@ -195,6 +195,7 @@ spec:
             httpGet:
               path: /minio/health/live
               port: minio
+              scheme: {{ ternary "HTTPS" "HTTP" .Values.tls.enabled | quote }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}


### PR DESCRIPTION
**Description of the change**

The livenessProbe scheme is set per default to HTTP. 
If the tls at the container is enabled, the livenessProbe will fail, because it still tries HTTP requests. This change is to reflect the tls settings in the livenessProbe scheme to enalbe HTTPS if tls is used.

**Benefits**

A working livenessProbe without the need to use a customLivenessProbe.

**Additional information**

As workaround you can define customLivenessProbe, but I think the chart should be consistent and deliver a working application.
Additional clean PR as replacement for PR https://github.com/bitnami/charts/pull/5847

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
