### PR TITLE
[bitnami/airflow] Apply securityContext & add resources on git containers

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -32,4 +32,4 @@ name: airflow
 sources:
   - https://github.com/bitnami/bitnami-docker-airflow
   - https://airflow.apache.org/
-version: 8.1.0
+version: 8.1.1

--- a/bitnami/airflow/README.md
+++ b/bitnami/airflow/README.md
@@ -321,6 +321,7 @@ The following tables lists the configurable parameters of the Airflow chart and 
 | `git.clone.extraEnvVarsCM`               | ConfigMap containing extra env vars                                                                               | `nil`                   |
 | `git.clone.extraEnvVarsSecret`           | Secret containing extra env vars (in case of sensitive data)                                                      | `nil`                   |
 | `git.clone.extraVolumeMounts`            | Array of extra volume mounts to be added (evaluated as template). Normally used with `extraVolumes`.              | `nil`                   |
+| `git.clone.resources`                    | The resources for the clone init container                                                                        | {}                      |
 | `git.dags.enabled`                       | Enable in order to download DAG files from git repository.                                                        | `false`                 |
 | `git.dags.repositories[0].branch`        | Branch from repository to checkout                                                                                | `nil`                   |
 | `git.dags.repositories[0].name`          | An unique identifier for repository, must be unique for each repository, by default: `[0].repository` in kebacase | `nil`                   |
@@ -342,6 +343,7 @@ The following tables lists the configurable parameters of the Airflow chart and 
 | `git.sync.extraEnvVarsCM`                | ConfigMap containing extra env vars                                                                               | `nil`                   |
 | `git.sync.extraEnvVarsSecret`            | Secret containing extra env vars (in case of sensitive data)                                                      | `nil`                   |
 | `git.sync.extraVolumeMounts`             | Array of extra volume mounts to be added (evaluated as template). Normally used with `extraVolumes`.              | `nil`                   |
+| `git.sync.resources`                     | The resources for the sync sidecar container                                                                      | {}                      |
 | `git.sync.interval`                      | Interval (in seconds) to pull the git repository containing the plugins and/or DAG files                          | `60`                    |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/bitnami/airflow/templates/_git_helpers.tpl
+++ b/bitnami/airflow/templates/_git_helpers.tpl
@@ -76,6 +76,12 @@ Returns the init container that will clone repositories files from a given list 
 - name: clone-repositories
   image: {{ include "git.image" . | quote }}
   imagePullPolicy: {{ .Values.git.image.pullPolicy | quote }}
+{{- if .Values.containerSecurityContext.enabled }}
+  securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 4 }}
+{{- end }}
+{{- if .Values.git.clone.resources}}
+  resources: {{- toYaml .Values.git.clone.resources | nindent 4 }}
+{{- end }}
 {{- if .Values.git.clone.command }}
   command: {{- include "common.tplvalues.render" (dict "value" .Values.git.clone.command "context" $) | nindent 4 }}
 {{- else }}
@@ -128,6 +134,12 @@ Returns the a container that will pull and sync repositories files from a given 
 - name: sync-repositories
   image: {{ include "git.image" . | quote }}
   imagePullPolicy: {{ .Values.git.image.pullPolicy | quote }}
+{{- if .Values.containerSecurityContext.enabled }}
+  securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 4 }}
+{{- end }}
+{{- if .Values.git.sync.resources}}
+  resources: {{- toYaml .Values.git.sync.resources | nindent 4 }}
+{{- end }}
 {{- if .Values.git.sync.command }}
   command: {{- include "common.tplvalues.render" (dict "value" .Values.git.sync.command "context" $) | nindent 4 }}
 {{- else }}

--- a/bitnami/airflow/values.yaml
+++ b/bitnami/airflow/values.yaml
@@ -602,6 +602,10 @@ git:
     ## Secret with extra environment variables
     ##
     extraEnvVarsSecret:
+    ## Clone init container resource requests and limits
+    ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+    ##
+    resources: {}
   sync:
     ## Interval in seconds to pull the git repository containing the plugins and/or DAG files
     ##
@@ -624,6 +628,10 @@ git:
     ## Secret with extra environment variables
     ##
     extraEnvVarsSecret:
+    ## Sync sidecar container resource requests and limits
+    ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+    ##
+    resources: {}
 
 ## LDAP configuration
 ##


### PR DESCRIPTION
**Description of the change**

Apply securityContext and add resources on git init & sidecar containers

**Benefits**

Ability to install the chart on constrained k8s cluster (no root images, explicit container resources)

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

None

**Checklist** 
- [ X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ X] Variables are documented in the README.md
- [ X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)