### PR TITLE
[bitnami/postgresql] Fix postgresql.conf generation from values

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -26,4 +26,4 @@ name: postgresql
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 10.3.13
+version: 10.3.14

--- a/bitnami/postgresql/templates/configmap.yaml
+++ b/bitnami/postgresql/templates/configmap.yaml
@@ -15,7 +15,11 @@ data:
 {{- else if .Values.postgresqlConfiguration }}
   postgresql.conf: |
 {{- range $key, $value := default dict .Values.postgresqlConfiguration }}
-    {{ $key | snakecase }}={{ $value }}
+    {{- if kindIs "string" $value }}
+    {{ $key | snakecase }} = '{{ $value }}'
+    {{- else }}
+    {{ $key | snakecase }} = {{ $value }}
+    {{- end }}
 {{- end }}
 {{- end }}
 {{- if (.Files.Glob "files/pg_hba.conf") }}

--- a/bitnami/postgresql/templates/extended-config-configmap.yaml
+++ b/bitnami/postgresql/templates/extended-config-configmap.yaml
@@ -16,7 +16,11 @@ data:
 {{ with .Values.postgresqlExtendedConf }}
   override.conf: |
 {{- range $key, $value := . }}
-    {{ $key | snakecase }}={{ $value }}
+    {{- if kindIs "string" $value }}
+    {{ $key | snakecase }} = '{{ $value }}'
+    {{- else }}
+    {{ $key | snakecase }} = {{ $value }}
+    {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Currently the postgresql chart will fail if postgresqlConfiguration contains strings, since those strings are not contained 
in the configuration file.

```yaml
postgresql:
  postgresqlConfiguration:
    listenAddresses: '*'
```
-> results in:

listen_addresses: *

This can be fixed with this PR.
I've already tested this change on my cluster.
