### PR TITLE
[bitnami/minio] Use v2 endpoint to scrap metrics and make it customizable

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -25,4 +25,4 @@ name: minio
 sources:
   - https://github.com/bitnami/bitnami-docker-minio
   - https://min.io
-version: 6.6.1
+version: 6.7.0

--- a/bitnami/minio/README.md
+++ b/bitnami/minio/README.md
@@ -221,6 +221,7 @@ The following table lists the configurable parameters of the MinIO&reg; chart an
 |-------------------------------------------|-------------------------------------------------------------------------------------|--------------------------------------------------------------|
 | `metrics.prometheusAuthType`              | Authentication mode for Prometheus (`jwt` or `public`)                              | `public`                                                     |
 | `metrics.serviceMonitor.enabled`          | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator        | `false`                                                      |
+| `metrics.serviceMonitor.path`             | HTTP path to scrape for metrics                                                     | `/minio/v2/metrics/cluster`                                  |
 | `metrics.serviceMonitor.namespace`        | Namespace which Prometheus is running in                                            | `nil`                                                        |
 | `metrics.serviceMonitor.interval`         | Interval at which metrics should be scraped                                         | `30s`                                                        |
 | `metrics.serviceMonitor.scrapeTimeout`    | Specify the timeout after which the scrape is ended                                 | `nil`                                                        |
@@ -303,13 +304,13 @@ statefulset.drivesPerNode=2
 
 ### Prometheus exporter
 
-MinIO&reg; exports Prometheus metrics at `/minio/prometheus/metrics`. To allow Prometheus collecting your MinIO&reg; metrics, modify the `values.yaml` adding the corresponding annotations:
+MinIO&reg; exports Prometheus metrics at `/minio/v2/metrics/cluster`. To allow Prometheus collecting your MinIO&reg; metrics, modify the `values.yaml` adding the corresponding annotations:
 
 ```diff
 - podAnnotations: {}
 + podAnnotations:
 +   prometheus.io/scrape: "true"
-+   prometheus.io/path: "/minio/prometheus/metrics"
++   prometheus.io/path: "/minio/v2/metrics/cluster"
 +   prometheus.io/port: "9000"
 ```
 

--- a/bitnami/minio/templates/servicemonitor.yaml
+++ b/bitnami/minio/templates/servicemonitor.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   endpoints:
     - port: minio
-      path: /minio/prometheus/metrics
+      path: {{ .Values.metrics.serviceMonitor.path }}
       {{- if .Values.metrics.serviceMonitor.interval }}
       interval: {{ .Values.metrics.serviceMonitor.interval }}
       {{- end }}

--- a/bitnami/minio/values.yaml
+++ b/bitnami/minio/values.yaml
@@ -610,6 +610,9 @@ metrics:
     ## Specify the namespace in which the serviceMonitor resource will be created
     ##
     # namespace: ""
+    ## HTTP path to scrape for metrics
+    ##
+    path: /minio/v2/metrics/cluster
     ## Specify the interval at which metrics should be scraped
     ##
     interval: 30s


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>


**Description of the change**

As explained at the [MinIO docs](https://docs.min.io/docs/how-to-monitor-minio-using-prometheus.html), the recommended endpoint to scrap metrics from is `/minio/v2/metrics/cluster`.

The chart is currently using an equivalent legacy endpoint, that will be deprecated at some point.

**Benefits**

- Flexibility

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
