### PR TITLE
[bitnami/kafka] Add support for custom command/args on provisioning job

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 12.12.2
+version: 12.13.0

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -135,16 +135,6 @@ The following tables lists the configurable parameters of the Kafka chart and th
 | `initContainers`                          | Add extra init containers                                                                                                                            | `[]`                                                    |
 | `podManagementPolicy`                     | Management Policy for Kafka StatefulSet (either Parallel or OrderedReady)                                                                            | `Parallel`                                              |
 
-### Kafka provisioning parameters
-
-| Parameter                    | Description                                                           | Default                  |
-|------------------------------|-----------------------------------------------------------------------|--------------------------|
-| `provisioning.enabled`       | Enable kafka provisioning Job                                         | `false`                  |
-| `provisioning.image`         | Kafka provisioning Job image                                          | `Check values.yaml file` |
-| `provisioning.resources`     | Kafka provisioning Job resources                                      | `Check values.yaml file` |
-| `provisioning.topics`        | Kafka provisioning topics                                             | `[]`                     |
-| `provisioning.schedulerName` | Name of the k8s scheduler (other than default) for kafka provisioning | `nil`                    |
-
 ### Statefulset parameters
 
 | Parameter                   | Description                                                                               | Default                                            |
@@ -299,6 +289,18 @@ The following tables lists the configurable parameters of the Kafka chart and th
 | `metrics.serviceMonitor.interval`      | Interval at which metrics should be scraped                                                                                      | `nil`                                                   |
 | `metrics.serviceMonitor.scrapeTimeout` | Timeout after which the scrape is ended                                                                                          | `nil` (Prometheus Operator default value)               |
 | `metrics.serviceMonitor.selector`      | ServiceMonitor selector labels                                                                                                   | `nil` (Prometheus Operator default value)               |
+
+### Kafka provisioning parameters
+
+| Parameter                    | Description                                                           | Default                        |
+|------------------------------|-----------------------------------------------------------------------|--------------------------------|
+| `provisioning.enabled`       | Enable kafka provisioning Job                                         | `false`                        |
+| `provisioning.image`         | Kafka provisioning Job image                                          | `Check values.yaml file`       |
+| `provisioning.resources`     | Kafka provisioning Job resources                                      | `Check values.yaml file`       |
+| `provisioning.topics`        | Kafka provisioning topics                                             | `[]`                           |
+| `provisioning.schedulerName` | Name of the k8s scheduler (other than default) for kafka provisioning | `nil`                          |
+| `provisioning.command`       | Override provisioning container command                               | `[]` (evaluated as a template) |
+| `provisioning.args`          | Override provisioning container arguments                             | `[]` (evaluated as a template) |
 
 ### Zookeeper chart parameters
 

--- a/bitnami/kafka/templates/kafka-provisioning.yaml
+++ b/bitnami/kafka/templates/kafka-provisioning.yaml
@@ -50,14 +50,20 @@ spec:
           image: {{ include "kafka.provisioning.image" . }}
           imagePullPolicy: {{ .Values.provisioning.image.pullPolicy | quote }}
           command:
+            {{- if .Values.provisioning.command }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.provisioning.command "context" $) | nindent 12 }}
+            {{- else }}
             - /bin/bash
-            - -c
-            - >-
-              set -e;
-            {{- $bootstrapServer := printf "%s:%d" (include "kafka.fullname" .) (.Values.service.port | int64) }}
-            {{- range $topic := .Values.provisioning.topics }}
-              echo "Ensure topic '{{ $topic.name }}' exists";
-
+            {{- end }}
+          args:
+            {{- if .Values.provisioning.args }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.provisioning.args "context" $) | nindent 12 }}
+            {{- else }}
+            - -ec
+            - |
+              {{- $bootstrapServer := printf "%s:%d" (include "kafka.fullname" .) (.Values.service.port | int64) }}
+              {{- range $topic := .Values.provisioning.topics }}
+              echo "Ensure topic '{{ $topic.name }}' exists"
               /opt/bitnami/kafka/bin/kafka-topics.sh \
                 --create \
                 --if-not-exists \
@@ -67,9 +73,10 @@ spec:
                 {{- range $name, $value := $topic.config }}
                 --config {{ $name }}={{ $value }} \
                 {{- end }}
-                --topic {{ $topic.name }};
+                --topic {{ $topic.name }}
+              {{- end }}
+              echo "Provisioning succeeded"
             {{- end }}
-              echo "Provisioning succeeded";
           env:
             - name: BITNAMI_DEBUG
               value: {{ ternary "true" "false" .Values.provisioning.image.debug | quote }}

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -215,7 +215,7 @@ zookeeperConnectionTimeoutMs: 6000
 ##
 command:
   - /scripts/setup.sh
-args:
+args: []
 
 ## All the parameters from the configuration file can be overwritten by using environment variables with this format: KAFKA_CFG_{KEY}
 ## ref: https://github.com/bitnami/bitnami-docker-kafka#configuration
@@ -878,6 +878,11 @@ provisioning:
     requests: {}
     #   cpu: 250m
     #   memory: 256Mi
+
+  ## Command and args for running the container (set to default if not set). Use array form
+  ##
+  command: []
+  args: []
 
   topics: []
   # - name: topic-name


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR adds support for custom command/args on provisioning job.

**Benefits**

- Flexibility

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/5835

**Additional information**

N/A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
