### PR TITLE
[bitnami/kafka] Fix provisioning template

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 12.12.1
+version: 12.12.2

--- a/bitnami/kafka/templates/kafka-provisioning.yaml
+++ b/bitnami/kafka/templates/kafka-provisioning.yaml
@@ -92,21 +92,21 @@ spec:
               mountPath: /certs
               readOnly: true
             {{- end }}
-          volumes:
-            {{- if or .Values.config .Values.existingConfigmap }}
-            - name: kafka-config
-              configMap:
-                name: {{ include "kafka.configmapName" . }}
-            {{- end }}
-            {{- if or .Values.log4j .Values.existingLog4jConfigMap }}
-            - name: log4j-config
-              configMap:
-                name: {{ include "kafka.log4j.configMapName" . }}
-            {{ end }}
-            {{- if (include "kafka.tlsEncryption" .) }}
-            - name: kafka-certificates
-              secret:
-                secretName: {{ include "kafka.tlsSecretName" . }}
-                defaultMode: 256
-            {{- end }}
+      volumes:
+        {{- if or .Values.config .Values.existingConfigmap }}
+        - name: kafka-config
+          configMap:
+            name: {{ include "kafka.configmapName" . }}
+        {{- end }}
+        {{- if or .Values.log4j .Values.existingLog4jConfigMap }}
+        - name: log4j-config
+          configMap:
+            name: {{ include "kafka.log4j.configMapName" . }}
+        {{ end }}
+        {{- if (include "kafka.tlsEncryption" .) }}
+        - name: kafka-certificates
+          secret:
+            secretName: {{ include "kafka.tlsSecretName" . }}
+            defaultMode: 256
+        {{- end }}
 {{- end }}


### PR DESCRIPTION
**Description of the change**

The `volumes:` section is wrongly indented so it appears as subobject of the container producing the following error when installing the chart with certain parameters:

```
... templates/kafka-provisioning.yaml: error validating "": error validating data: ValidationError(Job.spec.template.spec.containers[0]): unknown field "volumes" in io.k8s.api.core.v1.Container
```
With this PR `volumes:` is placed at the same level as `containers:`

**Applicable issues**

  - fixes #5882

**Additional information**

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)