### PR TITLE
[bitnami/grafana-operator] Fix issue when serviceAccount field is empty

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -25,4 +25,4 @@ name: grafana-operator
 sources:
   - https://github.com/integr8ly/grafana-operator
   - https://github.com/bitnami/bitnami-docker-grafana-operator
-version: 0.6.2
+version: 0.6.3

--- a/bitnami/grafana-operator/templates/grafana.yaml
+++ b/bitnami/grafana-operator/templates/grafana.yaml
@@ -38,8 +38,10 @@ spec:
     {{- if .Values.commonAnnotations }}
     annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 6 }}
     {{- end }}
-  serviceAccount:
-    {{- include "common.images.pullSecrets" (dict "images" (list .Values.operator.image .Values.grafana.image .Values.grafanaPluginInit.image) "global" .Values.global) | nindent 4 }}
+  {{- $imagePullSecrets := include "common.images.pullSecrets" (dict "images" (list .Values.operator.image .Values.grafana.image .Values.grafanaPluginInit.image) "global" .Values.global) }}
+  {{- if not (empty ($imagePullSecrets)) }}
+  serviceAccount: {{- $imagePullSecrets | nindent 4 }}
+  {{- end }}
   deployment:
     labels: {{- include "common.labels.standard" . | nindent 6 }}
       {{- if .Values.commonLabels }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

We introduced a bug at https://github.com/bitnami/charts/pull/5869 since the error below appears when no pull secrets are indicated and `serviceAccount` is empty:

```
08:46:15  Error: Grafana.integreatly.org "t074611-grafana-grafana-operator-grafana" is invalid: spec.serviceAccount: Invalid value: "null": spec.serviceAccount in body must be of type object: "null"
```

**Benefits**

Fix bug

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)