### PR TITLE
[bitnami/influxdb] Add sessionaffinity capability

### DIFF
--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -24,4 +24,4 @@ name: influxdb
 sources:
   - https://github.com/bitnami/bitnami-docker-influxdb
   - https://www.influxdata.com/products/influxdb-overview/
-version: 2.1.0
+version: 2.2.0

--- a/bitnami/influxdb/README.md
+++ b/bitnami/influxdb/README.md
@@ -144,6 +144,8 @@ The following tables lists the configurable parameters of the InfluxDB<sup>TM</s
 | `influxdb.service.loadBalancerIP`           | loadBalancerIP if service type is `LoadBalancer`                                                                                                                                                                                                                     | `nil`                                                   |
 | `influxdb.service.loadBalancerSourceRanges` | Address that are allowed when service is LoadBalancer                                                                                                                                                                                                                | `[]`                                                    |
 | `influxdb.service.clusterIP`                | Static clusterIP or None for headless services                                                                                                                                                                                                                       | `nil`                                                   |
+| `influxdb.service.sessionAffinity`          | Session affinity for the InfluxDB<sup>TM</sup> service                                                                                                                                                                                                               | `nil`                                                   |
+| `influxdb.service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                                                                                                                                                                                                          | `{}`                                                    |
 
 ### InfluxDB Relay<sup>TM</sup> parameters
 
@@ -377,6 +379,8 @@ The high availability install a statefulset with N InfluxDB<sup>TM</sup> servers
       |                                   ▲
       └───────────────────────────────────┘
 ```
+
+When using the high-availability architecture, it is recommended to configure sticky sessions using `--set influxdb.service.sessionAffinity="ClientIP"` or configuring the IngressController accordingly.
 
 ### Configure the way how to expose InfluxDB<sup>TM</sup>
 

--- a/bitnami/influxdb/templates/NOTES.txt
+++ b/bitnami/influxdb/templates/NOTES.txt
@@ -137,7 +137,7 @@ To connect to your database from outside the cluster execute the following comma
 
 {{- end }}
 
-{{- if and (eq .Values.architecture "high-availability") (not .Values.influxdb.service.sessionAffinity) (not .Values.influxdb.ingress.enabled) }}
+{{- if and (eq .Values.architecture "high-availability") (not .Values.influxdb.service.sessionAffinity) (not .Values.ingress.enabled) }}
   NOTE: When using "high-availability" it is recommended to configure 'influxdb.service.sessionAffinity' to prevent client connections from switching pods when connecting to InfluxDB.
         When using an IngressController, it is necessary to configure it with affinity/session stickiness settings.
 {{- end }}

--- a/bitnami/influxdb/templates/NOTES.txt
+++ b/bitnami/influxdb/templates/NOTES.txt
@@ -139,8 +139,7 @@ To connect to your database from outside the cluster execute the following comma
 
 {{- if and (eq .Values.architecture "high-availability") (not .Values.influxdb.service.sessionAffinity) (not .Values.ingress.enabled) }}
 
-NOTE: When using "high-availability" it is recommended to configure 'influxdb.service.sessionAffinity' to prevent client connections from switching pods when connecting to InfluxDB.
-      When using an IngressController, it is necessary to configure it with affinity/session stickiness settings.
+NOTE: When using "high-availability" it is recommended to configure 'influxdb.service.sessionAffinity' to prevent client connections from switching pods when connecting to InfluxDB UI.
 {{- end }}
 
 {{- include "influxdb.validateValues" . }}

--- a/bitnami/influxdb/templates/NOTES.txt
+++ b/bitnami/influxdb/templates/NOTES.txt
@@ -137,6 +137,11 @@ To connect to your database from outside the cluster execute the following comma
 
 {{- end }}
 
+{{- if and (eq .Values.architecture "high-availability") (not .Values.influxdb.service.sessionAffinity) (not .Values.influxdb.ingress.enabled) }}
+  NOTE: When using "high-availability" it is recommended to configure 'influxdb.service.sessionAffinity' to prevent client connections from switching pods when connecting to InfluxDB.
+        When using an IngressController, it is necessary to configure it with affinity/session stickiness settings.
+{{- end }}
+
 {{- include "influxdb.validateValues" . }}
 
 {{- include "common.warnings.rollingTag" .Values.image }}

--- a/bitnami/influxdb/templates/NOTES.txt
+++ b/bitnami/influxdb/templates/NOTES.txt
@@ -138,8 +138,9 @@ To connect to your database from outside the cluster execute the following comma
 {{- end }}
 
 {{- if and (eq .Values.architecture "high-availability") (not .Values.influxdb.service.sessionAffinity) (not .Values.ingress.enabled) }}
-  NOTE: When using "high-availability" it is recommended to configure 'influxdb.service.sessionAffinity' to prevent client connections from switching pods when connecting to InfluxDB.
-        When using an IngressController, it is necessary to configure it with affinity/session stickiness settings.
+
+NOTE: When using "high-availability" it is recommended to configure 'influxdb.service.sessionAffinity' to prevent client connections from switching pods when connecting to InfluxDB.
+      When using an IngressController, it is necessary to configure it with affinity/session stickiness settings.
 {{- end }}
 
 {{- include "influxdb.validateValues" . }}

--- a/bitnami/influxdb/templates/influxdb/service.yaml
+++ b/bitnami/influxdb/templates/influxdb/service.yaml
@@ -31,6 +31,12 @@ spec:
   {{- if and (eq .Values.influxdb.service.type "ClusterIP") .Values.influxdb.service.clusterIP }}
   clusterIP: {{ .Values.influxdb.service.clusterIP }}
   {{- end }}
+  {{- if .Values.influxdb.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.influxdb.service.sessionAffinity }}
+  {{- if .Values.influxdb.service.sessionAffinityConfig }}
+  sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.influxdb.service.sessionAffinityConfig "context" $) | nindent 4 }}
+  {{- end }}
+  {{- end }}
   ports:
     - port: {{ .Values.influxdb.service.port }}
       targetPort: http

--- a/bitnami/influxdb/values.yaml
+++ b/bitnami/influxdb/values.yaml
@@ -325,12 +325,12 @@ influxdb:
 
     ## Set the service SessionAffinity for session stickiness
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#proxy-mode-userspace
-    #sessionAffinity: ClientIP
+    # sessionAffinity: ClientIP
 
     ## Customize the SessionAffinity configuration. The default value for sessionAffinityConfig.clientIP.timeoutSeconds is 10800 (3 hours)
-    sessionAffinityConfig:
-      clientIP:
-        timeoutSeconds: 300
+    # sessionAffinityConfig:
+    #   clientIP:
+    #     timeoutSeconds: 300
 
 collectd:
   enabled: false

--- a/bitnami/influxdb/values.yaml
+++ b/bitnami/influxdb/values.yaml
@@ -328,9 +328,9 @@ influxdb:
     #sessionAffinity: ClientIP
 
     ## Customize the SessionAffinity configuration. The default value for sessionAffinityConfig.clientIP.timeoutSeconds is 10800 (3 hours)
-    #sessionAffinityConfig:
-    #  clientIP:
-    #    timeoutSeconds: 300
+    sessionAffinityConfig:
+      clientIP:
+        timeoutSeconds: 300
 
 collectd:
   enabled: false

--- a/bitnami/influxdb/values.yaml
+++ b/bitnami/influxdb/values.yaml
@@ -323,6 +323,15 @@ influxdb:
     ##
     annotations: {}
 
+    ## Set the service SessionAffinity for session stickiness
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#proxy-mode-userspace
+    #sessionAffinity: ClientIP
+
+    ## Customize the SessionAffinity configuration. The default value for sessionAffinityConfig.clientIP.timeoutSeconds is 10800 (3 hours)
+    #sessionAffinityConfig:
+    #  clientIP:
+    #    timeoutSeconds: 300
+
 collectd:
   enabled: false
   service:


### PR DESCRIPTION
**Description of the change**

Adds `service.sessionAffinity` to the InfluxDb chart

**Benefits**

Adds session stickiness, fixing an issue caused by the Kubernetes service balancing an already connected session to a different pod where the connection doesn't exist.

**Possible drawbacks**

None known.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #5866

**Additional information**
```
> helm template bitnami/influxdb
...
# Source: influxdb/templates/influxdb/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: influx-influxdb
  labels:
    app.kubernetes.io/name: influxdb
    helm.sh/chart: influxdb-2.2.0
    app.kubernetes.io/instance: influx
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: influxdb
spec:
  type: ClusterIP
  sessionAffinity: ClientIP
  sessionAffinityConfig:
    clientIP:
      timeoutSeconds: 300
  ports:
    - port: 8086
      targetPort: http
      protocol: TCP
      name: http
      nodePort: null
    - port: 8088
      targetPort: rpc
      protocol: TCP
      name: rpc
      nodePort: null
  selector:
    app.kubernetes.io/name: influxdb
    app.kubernetes.io/instance: influx
    app.kubernetes.io/component: influxdb
...
```
```
> helm install
NAME: influx
LAST DEPLOYED: Thu Mar 25 11:05:17 2021
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
** Please be patient while the chart is being deployed **


InfluxDB(TM) can be accessed through following DNS names from within your cluster:
    InfluxDB Relay(TM) (write operations): influx-influxdb-relay.default.svc.cluster.local (port 9096)
    InfluxDB(TM) servers (read operations):  influx-influxdb.default.svc.cluster.local (port 8086)

To connect to your database run the following commands:

    (write operations):

    kubectl run influx-influxdb-client --rm --tty -i --restart='Never' --namespace default  \
        --image docker.io/bitnami/influxdb:2.0.4-debian-10-r36 \
        --command -- influx -host influx-influxdb-relay -port 9096

    (read operations):

    kubectl run influx-influxdb-client --rm --tty -i --restart='Never' --namespace default  \
        --image docker.io/bitnami/influxdb:2.0.4-debian-10-r36 \
        --command -- influx -host influx-influxdb -port 8086

To connect to your database from outside the cluster execute the following commands:

  (write operations):

    kubectl port-forward svc/influx-influxdb-relay 9096:9096 & influx -host 127.0.0.1 -port 9096

  (read operations):

    kubectl port-forward svc/influx-influxdb 8086:8086 & influx -host 127.0.0.1 -port 8086

NOTE: When using "high-availability" it is recommended to configure 'influxdb.service.sessionAffinity' to prevent client connections from switching pods when connecting to InfluxDB.
```
**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
