### PR TITLE
[bitnami/kafka] Ability to configure terminationGracePeriodSeconds

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Infrastructure
 apiVersion: v2
-appVersion: 2.7.0
+appVersion: 2.7.1
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -169,6 +169,7 @@ The following tables lists the configurable parameters of the Kafka chart and th
 | `command`                   | Override kafka container command                                                          | `['/scripts/setup.sh']`  (evaluated as a template) |
 | `args`                      | Override kafka container arguments                                                        | `[]` (evaluated as a template)                     |
 | `sidecars`                  | Attach additional sidecar containers to the Kafka pod                                     | `{}`                                               |
+| `terminationGracePeriodSeconds`                  | Seconds the pod needs to gracefully terminate                                      | `nil`                                               |
 
 ### Exposure parameters
 
@@ -569,7 +570,7 @@ extraDeploy:
       mongodb.properties: |-
         connection.uri=mongodb://root:password@mongodb-hostname:27017
         ...
-  - | 
+  - |
     apiVersion: v1
     kind: Service
     metadata:

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -85,6 +85,9 @@ spec:
       {{- if .Values.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -506,6 +506,10 @@ nodeSelector: {}
 ##
 tolerations: []
 
+## Seconds the pod needs to gracefully terminate
+#terminationGracePeriodSeconds: 30
+##
+
 ## Kafka pods' Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ##


### PR DESCRIPTION
Currently there is no way to pass terminationGracePeriodSeconds through the values file. For kafka a graceful shutdown is required for it to come back up properly during restarts.