### PR TITLE
[bitnami/grafana-operator] Added support for configmaps in global rbac role.

### DIFF
--- a/bitnami/grafana-operator/Chart.lock
+++ b/bitnami/grafana-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.4.1
-digest: sha256:81be4c0ebd0a81952423b24268e82697231b8c07991ee60b23b950ff1db003a2
-generated: "2021-03-13T22:13:18.668656012Z"
+  version: 1.4.2
+digest: sha256:4e3ec38e0e27e9fc1defb2a13f67a0aa12374bf0b15f06a6c13b1b46df6bffeb
+generated: "2021-03-29T07:14:44.363641087Z"

--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -25,4 +25,4 @@ name: grafana-operator
 sources:
   - https://github.com/integr8ly/grafana-operator
   - https://github.com/bitnami/bitnami-docker-grafana-operator
-version: 0.6.3
+version: 0.6.4

--- a/bitnami/grafana-operator/templates/rbac.yaml
+++ b/bitnami/grafana-operator/templates/rbac.yaml
@@ -140,6 +140,7 @@ rules:
     resources:
       - grafanadashboards
       - grafanadashboards/status
+      - configmaps
     verbs: ['get', 'list', 'update', 'watch']
   - apiGroups:
       - ""

--- a/bitnami/grafana-operator/values.yaml
+++ b/bitnami/grafana-operator/values.yaml
@@ -53,7 +53,7 @@ operator:
   image:
     registry: docker.io
     repository: bitnami/grafana-operator
-    tag: 3.9.0-debian-10-r28
+    tag: 3.9.0-debian-10-r43
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## Ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -204,7 +204,7 @@ grafana:
   image:
     registry: docker.io
     repository: bitnami/grafana
-    tag: 7.4.3-debian-10-r17
+    tag: 7.5.1-debian-10-r2
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -463,7 +463,7 @@ grafanaPluginInit:
   image:
     registry: docker.io
     repository: bitnami/grafana
-    tag: 7.4.3-debian-10-r17
+    tag: 7.5.1-debian-10-r2
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION
support for examples like this -> https://github.com/integr8ly/grafana-operator/blob/master/deploy/examples/dashboards/DashboardFromConfigMap.yaml

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

* Added support for dashboards from configmaps.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

* being able to reference a configmap inside a dashboard resource cluster wide.

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
