### PR TITLE
bitnami/extern-dns

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -24,4 +24,4 @@ sources:
   - https://github.com/kubernetes-sigs/external-dns
   - https://github.com/bitnami/bitnami-docker-external-dns
   - https://github.com/kubernetes-sigs/external-dns
-version: 4.9.3
+version: 4.9.4

--- a/bitnami/external-dns/templates/_helpers.tpl
+++ b/bitnami/external-dns/templates/_helpers.tpl
@@ -186,14 +186,14 @@ Return the name of the Secret used to store the passwords
   {{- if .Values.alibabacloud.regionId }}
   "regionId": "{{ .Values.alibabacloud.regionId }}",
   {{- end}}
+  {{- if .Values.alibabacloud.vpcId }}
+  "vpcId": "{{ .Values.alibabacloud.vpcId }}",
+  {{- end}}
   {{- if .Values.alibabacloud.accessKeyId }}
   "accessKeyId": "{{ .Values.alibabacloud.accessKeyId }}",
   {{- end}}
   {{- if .Values.alibabacloud.accessKeySecret }}
-  "accessKeySecret": "{{ .Values.alibabacloud.accessKeySecret }}",
-  {{- end}}
-  {{- if .Values.alibabacloud.vpcId }}
-  "vpcId": "{{ .Values.alibabacloud.vpcId }}"
+  "accessKeySecret": "{{ .Values.alibabacloud.accessKeySecret }}"
   {{- end}}
 }
 {{ end }}

--- a/bitnami/external-dns/templates/_helpers.tpl
+++ b/bitnami/external-dns/templates/_helpers.tpl
@@ -190,7 +190,10 @@ Return the name of the Secret used to store the passwords
   "accessKeyId": "{{ .Values.alibabacloud.accessKeyId }}",
   {{- end}}
   {{- if .Values.alibabacloud.accessKeySecret }}
-  "accessKeySecret": "{{ .Values.alibabacloud.accessKeySecret }}"
+  "accessKeySecret": "{{ .Values.alibabacloud.accessKeySecret }}",
+  {{- end}}
+  {{- if .Values.alibabacloud.vpcId }}
+  "vpcId": "{{ .Values.alibabacloud.vpcId }}"
   {{- end}}
 }
 {{ end }}

--- a/bitnami/external-dns/values.yaml
+++ b/bitnami/external-dns/values.yaml
@@ -83,6 +83,7 @@ alibabacloud:
   accessKeyId: ""
   accessKeySecret: ""
   regionId: ""
+  vpcId: ""
 
   ## Use an existing secret with key "alibaba-cloud.json" defined.
   ## This ignores alibabacloud.accessKeyId, and alibabacloud.accessKeySecret


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

add "vpcId" to tpl of "external-dns.alibabacloud-credentials" in "external-dns" chart

**Benefits**

use it on alibaba cloud with private zone need it

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
