### PR TITLE
[bitnami/rabbitmq] Improve handling of load-definitions

### DIFF
--- a/bitnami/rabbitmq/Chart.lock
+++ b/bitnami/rabbitmq/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.4.1
-digest: sha256:81be4c0ebd0a81952423b24268e82697231b8c07991ee60b23b950ff1db003a2
-generated: "2021-02-27T21:36:16.111066138Z"
+  version: 1.4.2
+digest: sha256:4e3ec38e0e27e9fc1defb2a13f67a0aa12374bf0b15f06a6c13b1b46df6bffeb
+generated: "2021-03-29T18:32:31.739607437Z"

--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -23,4 +23,4 @@ name: rabbitmq
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq
   - https://www.rabbitmq.com
-version: 8.11.4
+version: 8.11.5

--- a/bitnami/rabbitmq/README.md
+++ b/bitnami/rabbitmq/README.md
@@ -401,6 +401,8 @@ Then, specify the `load_definitions` property as an `extraConfiguration` pointin
 If needed, you can use `extraSecrets` to let the chart create the secret for you. This way, you don't need to manually create it before deploying a release. These secrets can also be templated to use supplied chart values. For example:
 
 ```yaml
+auth:
+  password: CHANGEME
 extraSecrets:
   load-definition:
     load_definition.json: |

--- a/bitnami/rabbitmq/templates/NOTES.txt
+++ b/bitnami/rabbitmq/templates/NOTES.txt
@@ -3,8 +3,10 @@
 
 Credentials:
 
+{{- if not .Values.loadDefinition.enabled }}
     echo "Username      : {{ .Values.auth.username }}"
     echo "Password      : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "rabbitmq.secretPasswordName" . }} -o jsonpath="{.data.rabbitmq-password}" | base64 --decode)"
+{{- end }}
     echo "ErLang Cookie : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "rabbitmq.secretErlangName" . }} -o jsonpath="{.data.rabbitmq-erlang-cookie}" | base64 --decode)"
 
 Note that the credentials are saved in persistent volume claims and will not be changed upon upgrade or reinstallation unless the persistent volume claim has been deleted. If this is not the first installation of this chart, the credentials may not be valid.
@@ -127,7 +129,7 @@ Then, open the obtained URL in a browser.
 {{- $requiredPassword := list -}}
 {{- $secretNameRabbitmq := include "rabbitmq.secretPasswordName" . -}}
 
-{{- if not .Values.auth.existingPasswordSecret -}}
+{{- if and (not .Values.auth.existingPasswordSecret) (not .Values.loadDefinition.enabled) -}}
   {{- $requiredRabbitmqPassword := dict "valueKey" "auth.password" "secret" $secretNameRabbitmq "field" "rabbitmq-password" -}}
   {{- $requiredPassword = append $requiredPassword $requiredRabbitmqPassword -}}
 {{- end -}}

--- a/bitnami/rabbitmq/templates/secrets.yaml
+++ b/bitnami/rabbitmq/templates/secrets.yaml
@@ -7,7 +7,7 @@ metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 type: Opaque
 data:
-  {{- if not .Values.auth.existingPasswordSecret }}
+  {{- if and (not .Values.auth.existingPasswordSecret) (not .Values.loadDefinition.enabled) }}
   {{- if .Values.auth.password }}
   rabbitmq-password: {{ .Values.auth.password | b64enc | quote }}
   {{- else }}

--- a/bitnami/rabbitmq/templates/statefulset.yaml
+++ b/bitnami/rabbitmq/templates/statefulset.yaml
@@ -166,6 +166,16 @@ spec:
                 secretKeyRef:
                   name: {{ template "rabbitmq.secretErlangName" . }}
                   key: rabbitmq-erlang-cookie
+            {{- if .Values.loadDefinition.enabled }}
+            - name: RABBITMQ_LOAD_DEFINITIONS
+              value: "yes"
+            - name: RABBITMQ_SECURE_PASSWORD
+              value: "no"
+            {{- else }}
+            - name: RABBITMQ_LOAD_DEFINITIONS
+              value: "no"
+            - name: RABBITMQ_SECURE_PASSWORD
+              value: "yes"
             - name: RABBITMQ_USERNAME
               value: {{ .Values.auth.username | quote }}
             - name: RABBITMQ_PASSWORD
@@ -173,6 +183,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "rabbitmq.secretPasswordName" . }}
                   key: rabbitmq-password
+            {{- end }}
             - name: RABBITMQ_PLUGINS
               value: {{ include "rabbitmq.plugins" . | quote }}
             {{- if .Values.communityPlugins }}

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/rabbitmq
-  tag: 3.8.14-debian-10-r0
+  tag: 3.8.14-debian-10-r24
 
   ## set to true if you would like to see extra information on logs
   ## It turns BASH and/or NAMI debugging in the image

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -198,10 +198,12 @@ extraContainerPorts: []
 ## To add more configuration, use `extraConfiguration` of `advancedConfiguration` instead
 ##
 configuration: |-
+  {{- if not .Values.loadDefinition.enabled -}}
   ## Username and password
   ##
   default_user = {{ .Values.auth.username }}
   default_pass = CHANGEME
+  {{- end }}
   ## Clustering
   ##
   cluster_formation.peer_discovery_backend  = rabbit_peer_discovery_k8s


### PR DESCRIPTION
**Description of the change**

- Improves the way password and load-definitions.
- Updates the RabbitMQ component.

This PR is based on #4374 by @msvticket. Thanks so much!

**Applicable issues**

  - fixes #4222
  - might help with #4033 #4351 #3783
  - closes #4374

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
