### PR TITLE
Zookeeper TLS liveness/readiness probes fail when using auto signed certs

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -21,4 +21,4 @@ name: zookeeper
 sources:
   - https://github.com/bitnami/bitnami-docker-zookeeper
   - https://zookeeper.apache.org/
-version: 6.5.4
+version: 6.6.0

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -147,6 +147,8 @@ The following tables lists the configurable parameters of the ZooKeeper chart an
 | `service.tls.quorum_enable`              | Enable tls for quorum protocol                                                                     | `false`                                              |
 | `service.tls.disable_base_client_port`   | Remove client port from service definitions.                                                       | `false`                                              |
 | `service.tls.client_port`                | Service port for tls client connections                                                            | `3181`                                               |
+| `service.tls.client_key_pem_path`        | Key pem file path. Refer to extraVolumes amd extraVolumeMounts for mounting files into the pods    | `/tls_key_store/key_store_file`                      |
+| `service.tls.client_cert_pem_path`       | Cert pem file path. Refer to extraVolumes amd extraVolumeMounts for mounting files into the pods   | `/tls_key_store/key_store_file`                      |
 | `service.tls.client_keystore_path`       | KeyStore file path. Refer to extraVolumes amd extraVolumeMounts for mounting files into the pods   | `/tls_key_store/key_store_file`                      |
 | `service.tls.client_keystore_password`   | KeyStore password. You can use environment variables.                                              | `nil`                                                |
 | `service.tls.client_truststore_path`     | TrustStore file path. Refer to extraVolumes amd extraVolumeMounts for mounting files into the pods | `/tls_trust_store/trust_store_file`                  |

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -253,7 +253,11 @@ spec:
               {{- if not .Values.service.tls.disable_base_client_port }}
               command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.livenessProbe.probeCommandTimeout }} nc -w {{ .Values.livenessProbe.probeCommandTimeout }} localhost {{ .Values.service.port }} | grep imok']
               {{- else }}
-              command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.livenessProbe.probeCommandTimeout }} openssl s_client -quiet -crlf -connect localhost:{{ .Values.service.tls.client_port }} | grep imok']
+                {{- if not .Values.service.tls.client_enable }}
+                command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.livenessProbe.probeCommandTimeout }} openssl s_client -quiet -crlf -connect localhost:{{ .Values.service.tls.client_port }} | grep imok']
+                {{- else }}
+                command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.livenessProbe.probeCommandTimeout }} openssl s_client -quiet -crlf -connect localhost:{{ .Values.service.tls.client_port }} -cert {{ .Values.service.tls.client_cert_pem_path }} -key {{ .Values.service.tls.client_key_pem_path }} | grep imok']
+                {{- end }}
               {{- end }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -267,7 +271,11 @@ spec:
               {{- if not .Values.service.tls.disable_base_client_port }}
               command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.readinessProbe.probeCommandTimeout }} nc -w {{ .Values.readinessProbe.probeCommandTimeout }} localhost {{ .Values.service.port }} | grep imok']
               {{- else }}
-              command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.readinessProbe.probeCommandTimeout }} openssl s_client -quiet -crlf -connect localhost:{{ .Values.service.tls.client_port }} | grep imok']
+                {{- if not .Values.service.tls.client_enable }}
+                command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.livenessProbe.probeCommandTimeout }} openssl s_client -quiet -crlf -connect localhost:{{ .Values.service.tls.client_port }} | grep imok']
+                {{- else }}
+                command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.livenessProbe.probeCommandTimeout }} openssl s_client -quiet -crlf -connect localhost:{{ .Values.service.tls.client_port }} -cert {{ .Values.service.tls.client_cert_pem_path }} -key {{ .Values.service.tls.client_key_pem_path }} | grep imok']
+                {{- end }}
               {{- end }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Modifies the liveness/readiness probes to include two new test in case that the tls client is enabled. This change includes also two new variables to set up the key and cert pem paths.

**Benefits**

Users can activate the liveness and readiness probes with the tls client enabled without any crashes. Moreover, this change allows them to set up the paths of the key and cert files needed to execute properly the probes.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes [#4811](https://github.com/bitnami/charts/issues/4811)

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
