### PR TITLE
[bitnami/redis] Fixing indentation on redis slave volume mount

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -25,4 +25,4 @@ name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 12.9.0
+version: 12.9.1

--- a/bitnami/redis/templates/redis-slave-statefulset.yaml
+++ b/bitnami/redis/templates/redis-slave-statefulset.yaml
@@ -210,7 +210,7 @@ spec:
               readOnly: true
             {{- end }}
             {{- if .Values.slave.extraVolumeMounts }}
-            {{- include "common.tplvalues.render" ( dict "value" .Values.slave.extraVolumeMounts "context" $ ) | nindent 8 }}
+            {{- include "common.tplvalues.render" ( dict "value" .Values.slave.extraVolumeMounts "context" $ ) | nindent 12 }}
             {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: metrics


### PR DESCRIPTION
**Description of the change**

Fixes the indentation on volume mount for the Redis slave volume mount as added in:
https://github.com/bitnami/charts/pull/5897

**Benefits**

Allows for the correct setting of extra volume mounts on the Redis slave Statefulset

**Possible drawbacks**

N/A

**Applicable issues**

  - fixes bug introduced by #5897

**Additional information**

N/A

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
