### PR TITLE
[bitnami/thanos] Added tls flag for thanos queryFrontend

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 3.14.1
+version: 3.14.2

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -261,6 +261,7 @@ The following tables lists the configurable parameters of the Thanos chart and t
 | `queryFrontend.ingress.certManager`              | Add annotations for cert-manager                                                                                              | `false`                        |
 | `queryFrontend.ingress.hostname`                 | Default host for the ingress resource                                                                                         | `thanos.local`                 |
 | `queryFrontend.ingress.annotations`              | Ingress annotations                                                                                                           | `[]`                           |
+| `queryFrontend.ingress.tls`                      | Create ingress TLS section                                                                                                    | `false`
 | `queryFrontend.ingress.extraHosts[0].name`       | Additional hostnames to be covered                                                                                            | `nil`                          |
 | `queryFrontend.ingress.extraHosts[0].path`       | Additional hostnames to be covered                                                                                            | `nil`                          |
 | `queryFrontend.ingress.extraTls[0].hosts[0]`     | TLS configuration for additional hostnames to be covered                                                                      | `nil`                          |

--- a/bitnami/thanos/templates/query-frontend/ingress.yaml
+++ b/bitnami/thanos/templates/query-frontend/ingress.yaml
@@ -35,7 +35,7 @@ spec:
     {{- end }}
   {{- if or .Values.queryFrontend.ingress.tls .Values.queryFrontend.ingress.extraTls .Values.queryFrontend.ingress.hosts }}
   tls:
-    {{- if .Values.queryFrontend.ingress.secrets }}
+    {{- if or .Values.queryFrontend.ingress.secrets .Values.queryFrontend.ingress.tls }}
     - hosts:
         - {{ .Values.queryFrontend.ingress.hostname }}
       secretName: {{ printf "%s-tls" .Values.queryFrontend.ingress.hostname }}

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -759,6 +759,11 @@ queryFrontend:
     ## It is also possible to create and manage the certificates outside of this helm chart
     ## Please see README.md for more information
     ##
+
+    ## When specifying cert-manager.io/cluster-issuer: nameOfClusterIssuer annotation, enable tls for ingress
+    ##
+    tls: false
+
     secrets: []
     # - name: thanos.local-tls
     #   key:


### PR DESCRIPTION
**Description of the change**

This PR adds a `tls` flag (default value: `false`) to the Thanos queryFrontend Ingress config section in order to be able to configure Cert-Manager issued certificates. Cert-Manager needs a TLS section inside the Ingress object but this was not possible until now since only the `.Values.queryFrontend.ingress.secrets` flag caused this section to be created.

The same kind of `tls` flag was already present in the Thanos bucketweb Ingress configuration which has the `.Values.bucketweb.ingress.tls` flag available (compare https://github.com/bitnami/charts/blob/master/bitnami/thanos/templates/bucketweb/ingress.yaml#L38 to https://github.com/bitnami/charts/blob/master/bitnami/thanos/templates/query-frontend/ingress.yaml#L38). So this PR also unifies the Thanos ingresses overall.

**Benefits**

Thanos queryFrontend now allows the usage of Cert-Manager issued certificates.

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
