### PR TITLE
[bitnami/kafka] Usage of Host IPs for external service without autodiscovery

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 12.14.1
+version: 12.15.0

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -198,6 +198,7 @@ The following tables lists the configurable parameters of the Kafka chart and th
 | `externalAccess.service.loadBalancerSourceRanges` | Address(es) that are allowed when service is LoadBalancer                                     | `[]`                          |
 | `externalAccess.service.domain`                   | Domain or external ip used to configure Kafka external listener when service type is NodePort | `nil`                         |
 | `externalAccess.service.nodePorts`                | Array of node ports used to configure Kafka external listener when service type is NodePort   | `[]`                          |
+| `externalAccess.service.useHostIPs`               | Use service host IPs to configure Kafka external listener when service type is NodePort       | `false`                       |
 | `externalAccess.service.annotations`              | Service annotations for external access                                                       | `{}`(evaluated as a template) |
 
 ### Persistence parameters
@@ -483,7 +484,7 @@ externalAccess.service.nodePorts[1]='node-port-2'
 
 Note: You need to know in advance the node ports that will be exposed so each Kafka broker advertised listener is configured with it.
 
-The pod will try to get the external ip of the node using `curl -s https://ipinfo.io/ip` unless `externalAccess.service.domain` is provided.
+The pod will try to get the external ip of the node using `curl -s https://ipinfo.io/ip` unless `externalAccess.service.domain` or `externalAccess.service.useHostIPs` is provided.
 
 Following the aforementioned steps will also allow to connect the brokers from the outside using the cluster's default service (when `service.type` is `LoadBalancer` or `NodePort`). Use the property `service.externalPort` to specify the port used for external connections.
 
@@ -570,7 +571,7 @@ extraDeploy:
       mongodb.properties: |-
         connection.uri=mongodb://root:password@mongodb-hostname:27017
         ...
-  - | 
+  - |
     apiVersion: v1
     kind: Service
     metadata:

--- a/bitnami/kafka/templates/scripts-configmap.yaml
+++ b/bitnami/kafka/templates/scripts-configmap.yaml
@@ -91,7 +91,7 @@ data:
     {{- end }}
     export EXTERNAL_ACCESS_PORT={{ .Values.externalAccess.service.port }}
     {{- else if eq .Values.externalAccess.service.type "NodePort" }}
-    {{- if .Values.externalAccess.autoDiscovery.enabled }}
+    {{- if or .Values.externalAccess.service.useHostIPs .Values.externalAccess.autoDiscovery.enabled }}
     export EXTERNAL_ACCESS_IP="${HOST_IP}"
     {{- else if .Values.externalAccess.service.domain }}
     export EXTERNAL_ACCESS_IP={{ .Values.externalAccess.service.domain }}

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -200,12 +200,12 @@ spec:
             {{- if .Values.externalAccess.autoDiscovery.enabled }}
             - name: SHARED_FILE
               value: "/shared/info.txt"
-            {{- if eq .Values.externalAccess.service.type "NodePort" }}
+            {{- end }}
+            {{- if eq .Values.externalAccess.service.useHostIPs "NodePort" }}
             - name: HOST_IP
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
-            {{- end }}
             {{- end }}
             {{- else }}
             - name: KAFKA_CFG_ADVERTISED_LISTENERS

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -201,7 +201,7 @@ spec:
             - name: SHARED_FILE
               value: "/shared/info.txt"
             {{- end }}
-            {{- if eq .Values.externalAccess.service.useHostIPs "NodePort" }}
+            {{- if eq .Values.externalAccess.service.type "NodePort" }}
             - name: HOST_IP
               valueFrom:
                 fieldRef:

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -708,6 +708,8 @@ externalAccess:
     ##   - 30002
     ##
     nodePorts: []
+    ## Use worker host ips
+    useHostIPs: false
     ## When service type is NodePort, you can specify the domain used for Kafka advertised listeners.
     ## If not specified, the container will try to get the kubernetes node external IP
     ##


### PR DESCRIPTION
Description of the change

HOST_IP environment variable is dependent from externalAccess.autoDiscovery.enabled This is not right. This is fix for that issue.

Benefits

Fix the issue

Possible drawbacks

Applicable issues

Additional information

Checklist

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
