### PR TITLE
[bitnami/metallb] Add priorityClassName to avoid eviction

### DIFF
--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/metallb/metallb
   - https://github.com/bitnami/bitnami-docker-metallb
   - https://metallb.universe.tf
-version: 2.3.5
+version: 2.4.0

--- a/bitnami/metallb/README.md
+++ b/bitnami/metallb/README.md
@@ -125,6 +125,7 @@ The following tables lists the configurable parameters of the metallb chart and 
 | `controller.prometheus.serviceMonitor.interval`          | Specify the scrape interval if not specified use defaul prometheus scrapeIntervall           | `""`                                                    |
 | `controller.prometheus.serviceMonitor.metricRelabelings` | Specify additional relabeling of metrics.                                                    | `[]`                                                    |
 | `controller.prometheus.serviceMonitor.relabelings`       | Specify general relabeling.                                                                  | `[]`                                                    |
+| `controller.priorityClassName`                           | Specify priorityClassName.                                                                   | `system-node-critical`                                  |
 
 ### Speaker parameters
 
@@ -177,6 +178,8 @@ The following tables lists the configurable parameters of the metallb chart and 
 | `speaker.prometheus.serviceMonitor.interval`          | Specify the scrape interval if not specified use defaul prometheus scrapeIntervall           | `""`                                                    |
 | `speaker.prometheus.serviceMonitor.metricRelabelings` | Specify additional relabeling of metrics.                                                    | `[]`                                                    |
 | `speaker.prometheus.serviceMonitor.relabelings`       | Specify general relabeling.                                                                  | `[]`                                                    |
+| `speaker.priorityClassName`                           | Specify priorityClassName.                                                                   | `system-node-critical`                                  |
+
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/metallb/templates/controller/deployment.yaml
+++ b/bitnami/metallb/templates/controller/deployment.yaml
@@ -26,6 +26,7 @@ spec:
       annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.controller.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
     spec:
+      priorityClassName: {{ .Values.priorityClassName }}
       {{- include "common.images.pullSecrets" (dict "images" (list .Values.speaker.image .Values.controller.image) "global" .Values.global) | nindent 6 }}
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}

--- a/bitnami/metallb/templates/speaker/daemonset.yaml
+++ b/bitnami/metallb/templates/speaker/daemonset.yaml
@@ -25,6 +25,7 @@ spec:
       annotations: {{- include "common.tplvalues.render" (dict "value" .Values.speaker.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
     spec:
+      priorityClassName: {{ .Values.priorityClassName }}
       {{- include "common.images.pullSecrets" (dict "images" (list .Values.speaker.image .Values.controller.image) "global" .Values.global) | nindent 6 }}
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}

--- a/bitnami/metallb/values.yaml
+++ b/bitnami/metallb/values.yaml
@@ -264,6 +264,8 @@ controller:
       metricRelabelings: []
       relabelings: []
 
+  priorityClassName: system-node-critical
+
 ## Metallb Speaker daemonset.
 ## ref: https://hub.docker.com/r/bitnami/metallb-speaker/tags
 ##
@@ -437,3 +439,5 @@ speaker:
       interval: ""
       metricRelabelings: []
       relabelings: []
+
+  priorityClassName: system-node-critical


### PR DESCRIPTION
This PR adds `priorityClassName: system-node-critical` to controller and speakers.
Makes MetaLb pods system-critical, so they will not get evicted. 

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
