### PR TITLE
[bitnami/metrics-server] Modify metadata.name checking common.capabilities.kubeVersion

### DIFF
--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -23,4 +23,4 @@ name: metrics-server
 sources:
   - https://github.com/bitnami/bitnami-docker-metrics-server
   - https://github.com/kubernetes-incubator/metrics-server
-version: 5.8.1
+version: 5.8.2

--- a/bitnami/metrics-server/templates/metrics-api-service.yaml
+++ b/bitnami/metrics-server/templates/metrics-api-service.yaml
@@ -6,7 +6,11 @@ apiVersion: apiregistration.k8s.io/v1
 {{- end }}
 kind: APIService
 metadata:
+{{- if semverCompare "<1.19-0" (include "common.capabilities.kubeVersion" .) }}
   name: v1beta1.metrics.k8s.io
+{{- else }}
+  name: v1.metrics.k8s.io
+{{- end }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   service:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

A Chart user has reported cosmetic inconsistency setting up the metadata.name. Now, the Chart is checking the common.capabilities.kubeVersion to set up different apiVersions but with metatada.name not. Therefore, this patch includes the logic to set up the metadata.name looking the common.capabilities.kubeVersion to choose the best option.

**Benefits**

Fix a cosmetic inconsistency

**Possible drawbacks**

**Applicable issues**

* fixes #5906 

**Additional information**

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
