### PR TITLE
[bitnami/metric-server] Fix issue with automountServiceAccountToken

### DIFF
--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -23,4 +23,4 @@ name: metrics-server
 sources:
   - https://github.com/bitnami/bitnami-docker-metrics-server
   - https://github.com/kubernetes-incubator/metrics-server
-version: 5.8.2
+version: 5.8.3

--- a/bitnami/metrics-server/templates/serviceaccount.yaml
+++ b/bitnami/metrics-server/templates/serviceaccount.yaml
@@ -4,7 +4,5 @@ kind: ServiceAccount
 metadata:
   name: {{ template "common.names.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-{{- if .Values.serviceAccount.automountServiceAccountToken }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
-{{- end }}
 {{- end -}}

--- a/bitnami/metrics-server/values.yaml
+++ b/bitnami/metrics-server/values.yaml
@@ -62,8 +62,9 @@ serviceAccount:
   ## If not set and create is true, a name is generated using the common.names.fullname template
   # name:
   ## Automount API credentials for a service account.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server
   ##
-  # automountServiceAccountToken: true
+  automountServiceAccountToken: true
 
 
 ## API service parameters


### PR DESCRIPTION
**Description of the change**

As mentioned by @mkilchhofer in https://github.com/bitnami/charts/pull/5673#discussion_r604695303.

The conditional would not allow setting `automountServiceAccountToken: false`

**Benefits**

Fixes isssue.

**Possible drawbacks**

None known.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

