### PR TITLE
[bitnami/wordpress] Respect deployment's strategy in case replicaCount is not defined

### DIFF
--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -35,4 +35,4 @@ name: wordpress
 sources:
   - https://github.com/bitnami/bitnami-docker-wordpress
   - http://www.wordpress.com/
-version: 10.7.3
+version: 10.8.0

--- a/bitnami/wordpress/templates/deployment.yaml
+++ b/bitnami/wordpress/templates/deployment.yaml
@@ -15,7 +15,9 @@ spec:
   {{- if .Values.updateStrategy }}
   strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This change gives us a support to set up the replicaCount in cases that deployment has a autoscaler enabled. This new implementation helps us to avoid problem during the upgrade.

During the upgrade, the wordpress Chart sets up always the replicaCount and if we do not specific the value by default will be 1. Setting up the value like this during the upgrade, if we have several pods running (because the autoscaler has ordered to create more than one pod), we are going to erase everything except one and then the autoscaler will order again the number of pods needed. 

**Benefits**

Solve unwanted behaviors during the upgrade. 

**Applicable issues**

  - fixes #5960

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
