### PR TITLE
[bitnami/airflow] Avoid cloning dags/plugins repositories on container restarts

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -32,4 +32,4 @@ name: airflow
 sources:
   - https://github.com/bitnami/bitnami-docker-airflow
   - https://airflow.apache.org/
-version: 8.2.2
+version: 8.2.3

--- a/bitnami/airflow/templates/_git_helpers.tpl
+++ b/bitnami/airflow/templates/_git_helpers.tpl
@@ -87,22 +87,25 @@ Returns the init container that will clone repositories files from a given list 
 {{- else }}
   command:
     - /bin/bash
+{{- end }}
+{{- if .Values.git.clone.args }}
+  args: {{- include "common.tplvalues.render" (dict "value" .Values.git.clone.args "context" $) | nindent 4 }}
+{{- else }}
+  args:
     - -ec
     - |
-        [[ -f "/opt/bitnami/scripts/git/entrypoint.sh" ]] && source "/opt/bitnami/scripts/git/entrypoint.sh"
+      . /opt/bitnami/scripts/libfs.sh
+      [[ -f "/opt/bitnami/scripts/git/entrypoint.sh" ]] && . /opt/bitnami/scripts/git/entrypoint.sh
     {{- if .Values.git.dags.enabled }}
       {{- range .Values.git.dags.repositories }}
-        git clone {{ .repository }} --branch {{ .branch }} /dags_{{ include "airflow.git.repository.name" . }}
+      [[ is_mounted_dir_empty "/dags_{{ include "airflow.git.repository.name" . }}" ]] && git clone {{ .repository }} --branch {{ .branch }} /dags_{{ include "airflow.git.repository.name" . }}
       {{- end }}
     {{- end }}
     {{- if .Values.git.plugins.enabled }}
       {{- range .Values.git.plugins.repositories }}
-        git clone {{ .repository }} --branch {{ .branch }} /plugins_{{ include "airflow.git.repository.name" . }}
+      [[ is_mounted_dir_empty "/plugins_{{ include "airflow.git.repository.name" . }}" ]] && git clone {{ .repository }} --branch {{ .branch }} /plugins_{{ include "airflow.git.repository.name" . }}
       {{- end }}
     {{- end }}
-{{- end }}
-{{- if .Values.git.clone.args }}
-  args: {{- include "common.tplvalues.render" (dict "value" .Values.git.clone.args "context" $) | nindent 4 }}
 {{- end }}
   volumeMounts:
     {{- include "airflow.git.volumeMounts" . | trim | nindent 4 }}
@@ -145,9 +148,14 @@ Returns the a container that will pull and sync repositories files from a given 
 {{- else }}
   command:
     - /bin/bash
+{{- end }}
+{{- if .Values.git.sync.args }}
+  args: {{- include "common.tplvalues.render" (dict "value" .Values.git.sync.args "context" $) | nindent 4 }}
+{{- else }}
+  args:
     - -ec
     - |
-      [[ -f "/opt/bitnami/scripts/git/entrypoint.sh" ]] && source "/opt/bitnami/scripts/git/entrypoint.sh"
+      [[ -f "/opt/bitnami/scripts/git/entrypoint.sh" ]] && . /opt/bitnami/scripts/git/entrypoint.sh
       while true; do
       {{- if .Values.git.dags.enabled }}
         {{- range .Values.git.dags.repositories }}
@@ -161,9 +169,6 @@ Returns the a container that will pull and sync repositories files from a given 
       {{- end }}
           sleep {{ default "60" .Values.git.sync.interval }}
       done
-{{- end }}
-{{- if .Values.git.sync.args }}
-  args: {{- include "common.tplvalues.render" (dict "value" .Values.git.sync.args "context" $) | nindent 4 }}
 {{- end }}
   volumeMounts:
     {{- include "airflow.git.volumeMounts" . | trim | nindent 4 }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

An init container can be used to clone repositories with custom dags/plugins. This init container uses emptyDir volumes to clone the repositories and share them with the main container.

On container restarts, the init container attempts to clone again the repos, even if they're already cloned. This PR changes this to skip that once the repos are already cloned.

**Benefits**

Reliability

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/5995

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

