### PR TITLE
Etcd init from snapshot

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -25,4 +25,4 @@ name: etcd
 sources:
   - https://github.com/bitnami/bitnami-docker-etcd
   - https://coreos.com/etcd/
-version: 6.1.3
+version: 6.1.4

--- a/bitnami/etcd/templates/cronjob.yaml
+++ b/bitnami/etcd/templates/cronjob.yaml
@@ -39,42 +39,42 @@ spec:
               command:
                 - /opt/bitnami/scripts/etcd/snapshot.sh
               env:
-              - name: BITNAMI_DEBUG
-                value: {{ ternary "true" "false" .Values.image.debug | quote }}
-              - name: ETCDCTL_API
-                value: "3"
-              - name: ETCD_ON_K8S
-                value: "yes"
-              {{- $releaseNamespace := .Release.Namespace }}
-              {{- $etcdFullname := include "common.names.fullname" . }}
-              {{- $etcdHeadlessServiceName := printf "%s-%s" $etcdFullname "headless" }}
-              {{- $clusterDomain := .Values.clusterDomain }}
-              - name: ETCD_CLUSTER_DOMAIN
-                value: {{ printf "%s.%s.svc.%s" $etcdHeadlessServiceName $releaseNamespace $clusterDomain | quote }}
-              - name: ETCD_SNAPSHOT_HISTORY_LIMIT
-                value: {{ .Values.disasterRecovery.cronjob.snapshotHistoryLimit | quote }}
-              {{- if .Values.auth.client.secureTransport }}
-              - name: ETCD_CERT_FILE
-                value: "/opt/bitnami/etcd/certs/client/{{ .Values.auth.client.certFilename }}"
-              - name: ETCD_KEY_FILE
-                value: "/opt/bitnami/etcd/certs/client/{{ .Values.auth.client.certKeyFilename }}"
-              {{- if .Values.auth.client.enableAuthentication }}
-              - name: ETCD_CLIENT_CERT_AUTH
-                value: "true"
-              - name: ETCD_TRUSTED_CA_FILE
-                value: "/opt/bitnami/etcd/certs/client/{{ .Values.auth.client.caFilename | default "ca.crt"}}"
-              {{- else if .Values.auth.client.caFilename }}
-              - name: ETCD_TRUSTED_CA_FILE
-                value: "/opt/bitnami/etcd/certs/client/{{ .Values.auth.client.caFilename | default "ca.crt"}}"
-              {{- end }}
-              {{- end }}
-              {{- if .Values.auth.rbac.enabled }}
-              - name: ETCD_ROOT_PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    name: {{ include "etcd.secretName" . }}
-                    key: etcd-root-password
-              {{- end }}
+                - name: BITNAMI_DEBUG
+                  value: {{ ternary "true" "false" .Values.image.debug | quote }}
+                - name: ETCDCTL_API
+                  value: "3"
+                - name: ETCD_ON_K8S
+                  value: "yes"
+                {{- $releaseNamespace := .Release.Namespace }}
+                {{- $etcdFullname := include "common.names.fullname" . }}
+                {{- $etcdHeadlessServiceName := printf "%s-%s" $etcdFullname "headless" }}
+                {{- $clusterDomain := .Values.clusterDomain }}
+                - name: ETCD_CLUSTER_DOMAIN
+                  value: {{ printf "%s.%s.svc.%s" $etcdHeadlessServiceName $releaseNamespace $clusterDomain | quote }}
+                - name: ETCD_SNAPSHOT_HISTORY_LIMIT
+                  value: {{ .Values.disasterRecovery.cronjob.snapshotHistoryLimit | quote }}
+                {{- if .Values.auth.client.secureTransport }}
+                - name: ETCD_CERT_FILE
+                  value: "/opt/bitnami/etcd/certs/client/{{ .Values.auth.client.certFilename }}"
+                - name: ETCD_KEY_FILE
+                  value: "/opt/bitnami/etcd/certs/client/{{ .Values.auth.client.certKeyFilename }}"
+                {{- if .Values.auth.client.enableAuthentication }}
+                - name: ETCD_CLIENT_CERT_AUTH
+                  value: "true"
+                - name: ETCD_TRUSTED_CA_FILE
+                  value: "/opt/bitnami/etcd/certs/client/{{ .Values.auth.client.caFilename | default "ca.crt"}}"
+                {{- else if .Values.auth.client.caFilename }}
+                - name: ETCD_TRUSTED_CA_FILE
+                  value: "/opt/bitnami/etcd/certs/client/{{ .Values.auth.client.caFilename | default "ca.crt"}}"
+                {{- end }}
+                {{- end }}
+                {{- if .Values.auth.rbac.enabled }}
+                - name: ETCD_ROOT_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "etcd.secretName" . }}
+                      key: etcd-root-password
+                {{- end }}
               {{- if .Values.disasterRecovery.cronjob.resources }}
               resources: {{- toYaml .Values.disasterRecovery.cronjob.resources | nindent 16 }}
               {{- end }}

--- a/bitnami/etcd/templates/statefulset.yaml
+++ b/bitnami/etcd/templates/statefulset.yaml
@@ -215,7 +215,7 @@ spec:
             {{- end }}
             {{- end }}
             {{- if .Values.startFromSnapshot.enabled }}
-            - name: ETCD_INIT_SNAPSHOTS_FILENAME
+            - name: ETCD_INIT_SNAPSHOT_FILENAME
               value: {{ .Values.startFromSnapshot.snapshotFilename | quote }}
             {{- end }}
             {{- if .Values.extraEnvVars }}

--- a/bitnami/etcd/templates/statefulset.yaml
+++ b/bitnami/etcd/templates/statefulset.yaml
@@ -214,6 +214,10 @@ spec:
               value: "/opt/bitnami/etcd/certs/peer/{{ .Values.auth.peer.caFilename | default "ca.crt"}}"
             {{- end }}
             {{- end }}
+            {{- if .Values.startFromSnapshot.enabled }}
+            - name: ETCD_INIT_SNAPSHOTS_FILENAME
+              value: {{ .Values.startFromSnapshot.snapshotFilename | quote }}
+            {{- end }}
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/bitnami/etcd/values.yaml
+++ b/bitnami/etcd/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/etcd
-  tag: 3.4.15-debian-10-r14
+  tag: 3.4.15-debian-10-r33
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

We're not properly setting in the **etcd** container logic a way to detect where to find the snapshot file to start the etcd cluster from. This PR attempts to fix that.

**Benefits**

Users can start their etcd cluster from snapshots

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/5989

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)