### PR TITLE
[bitnami/nats] Add tcp- to the beginning of each services port name to make them compatible with Istio

### DIFF
--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -24,4 +24,4 @@ name: nats
 sources:
   - https://github.com/bitnami/bitnami-docker-nats
   - https://nats.io/
-version: 6.2.4
+version: 6.2.5

--- a/bitnami/nats/templates/client-svc.yaml
+++ b/bitnami/nats/templates/client-svc.yaml
@@ -24,7 +24,7 @@ spec:
   ports:
     - port: {{ .Values.client.service.port }}
       targetPort: client
-      name: client
+      name: tcp-client
       {{- if and (eq .Values.client.service.type "NodePort") (not (empty .Values.client.service.nodePort)) }}
       nodePort: {{ .Values.client.service.nodePort  }}
       {{- end }}

--- a/bitnami/nats/templates/cluster-svc.yaml
+++ b/bitnami/nats/templates/cluster-svc.yaml
@@ -24,7 +24,7 @@ spec:
   ports:
     - port: {{ .Values.cluster.service.port }}
       targetPort: cluster
-      name: cluster
+      name: tcp-cluster
       {{- if and (eq .Values.cluster.service.type "NodePort") (not (empty .Values.cluster.service.nodePort)) }}
       nodePort: {{ .Values.cluster.service.nodePort  }}
       {{- end }}

--- a/bitnami/nats/templates/headless-svc.yaml
+++ b/bitnami/nats/templates/headless-svc.yaml
@@ -14,10 +14,10 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: client
+    - name: tcp-client
       port: {{ .Values.client.service.port }}
       targetPort: client
-    - name: cluster
+    - name: tcp-cluster
       port: {{ .Values.cluster.service.port }}
       targetPort: cluster
   selector: {{ include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/nats/templates/ingress.yaml
+++ b/bitnami/nats/templates/ingress.yaml
@@ -32,7 +32,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "monitoring" "context" $)  | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "tcp-monitoring" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
     - host: {{ .name | quote }}
@@ -42,7 +42,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "monitoring" "context" $) | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "tcp-monitoring" "context" $) | nindent 14 }}
     {{- end }}
   {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
   tls:

--- a/bitnami/nats/templates/metrics-svc.yaml
+++ b/bitnami/nats/templates/metrics-svc.yaml
@@ -24,7 +24,7 @@ spec:
   loadBalancerIP: {{ .Values.metrics.service.loadBalancerIP }}
   {{- end }}
   ports:
-    - name: metrics
+    - name: tcp-metrics
       port: {{ .Values.metrics.service.port }}
       targetPort: metrics
   selector: {{ include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/nats/templates/monitoring-svc.yaml
+++ b/bitnami/nats/templates/monitoring-svc.yaml
@@ -23,8 +23,8 @@ spec:
   {{- end }}
   ports:
     - port: {{ .Values.monitoring.service.port }}
-      targetPort: tcp-monitoring
-      name: monitoring
+      targetPort: monitoring
+      name: tcp-monitoring
       {{- if and (eq .Values.monitoring.service.type "NodePort") (not (empty .Values.monitoring.service.nodePort)) }}
       nodePort: {{ .Values.monitoring.service.nodePort  }}
       {{- end }}

--- a/bitnami/nats/templates/monitoring-svc.yaml
+++ b/bitnami/nats/templates/monitoring-svc.yaml
@@ -23,7 +23,7 @@ spec:
   {{- end }}
   ports:
     - port: {{ .Values.monitoring.service.port }}
-      targetPort: monitoring
+      targetPort: tcp-monitoring
       name: monitoring
       {{- if and (eq .Values.monitoring.service.type "NodePort") (not (empty .Values.monitoring.service.nodePort)) }}
       nodePort: {{ .Values.monitoring.service.nodePort  }}

--- a/bitnami/nats/templates/servicemonitor.yaml
+++ b/bitnami/nats/templates/servicemonitor.yaml
@@ -20,7 +20,7 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-    - port: metrics
+    - port: tcp-metrics
       {{- if .Values.metrics.serviceMonitor.interval }}
       interval: {{ .Values.metrics.serviceMonitor.interval }}
       {{- end }}


### PR DESCRIPTION
**Description of the change**
Alter the port names of each service to make them work with Istio
Add tcp- in front of each port name

**Benefits**
Make automatic routing with Istio and its sidecar for mutual TLS work out of the box .

**Possible drawbacks**
None that I know of.

**Applicable issues**
  - fixes #5999 

**Checklist** 
- [X ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X ] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)