### PR TITLE
[bitnami/kibana] Bump major version

### DIFF
--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Analytics
 apiVersion: v2
-appVersion: 7.10.2
+appVersion: 7.12.0
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -25,4 +25,4 @@ name: kibana
 sources:
   - https://github.com/bitnami/bitnami-docker-kibana
   - https://www.elastic.co/products/kibana
-version: 7.2.5
+version: 8.0.0

--- a/bitnami/kibana/README.md
+++ b/bitnami/kibana/README.md
@@ -328,9 +328,11 @@ Find more information about how to deal with common errors related to Bitnami’
 
 The Kibana container configuration logic was migrated to bash.
 
-From this version onwards, Kibana container components are now licensed under the Elastic License that is not currently accepted as an Open Source license by the Open Source Initiative (OSI).
+From this version onwards, Kibana container components are now licensed under the [Elastic License](https://www.elastic.co/licensing/elastic-license) that is not currently accepted as an Open Source license by the Open Source Initiative (OSI).
 
 Also, from now on, the Helm Chart will include the X-Pack plugin installed by default.
+
+Regular upgrade is compatible from previous versions.
 
 ### To 6.2.0
 

--- a/bitnami/kibana/README.md
+++ b/bitnami/kibana/README.md
@@ -324,6 +324,14 @@ Find more information about how to deal with common errors related to Bitnami’
 
 ## Upgrading
 
+### To 8.0.0
+
+The Kibana container configuration logic was migrated to bash.
+
+From this version onwards, Kibana container components are now licensed under the Elastic License that is not currently accepted as an Open Source license by the Open Source Initiative (OSI).
+
+Also, from now on, the Helm Chart will include the X-Pack plugin installed by default.
+
 ### To 6.2.0
 
 This version introduces `bitnami/common`, a [library chart](https://helm.sh/docs/topics/library_charts/#helm) as a dependency. More documentation about this new utility could be found [here](https://github.com/bitnami/charts/tree/master/bitnami/common#bitnami-common-library-chart). Please, make sure that you have updated the chart dependencies before executing any upgrade.

--- a/bitnami/kibana/values.yaml
+++ b/bitnami/kibana/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/kibana
-  tag: 7.10.2-debian-10-r58
+  tag: 7.12.0-debian-10-r0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
**Description of the change**

Bumps major version of the chart due to major changes in the container logic and its components.

- Kibana container configuration logic was migrated to bash.
- Kibana container includes X-Pack.
- Kibana component is now licensed under the Elastic License that is not currently accepted as an Open Source license by the Open Source Initiative (OSI).

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)