### PR TITLE
[bitnami/elasticsearch] Bump major version

### DIFF
--- a/bitnami/elasticsearch/Chart.lock
+++ b/bitnami/elasticsearch/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.4.1
+  version: 1.4.2
 - name: kibana
   repository: https://charts.bitnami.com/bitnami
-  version: 7.2.4
-digest: sha256:f517a3c7a26bde235283c84fcd5471d975efd0b99d3726eb770efb803c46fe5d
-generated: "2021-03-18T10:14:50.80464015+01:00"
+  version: 8.0.0
+digest: sha256:dde5c1a73e02bd3f03d933c2d6a34703affc15caac0ec97c41f3165037fcbb09
+generated: "2021-04-07T07:51:00.80975257Z"

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Analytics
 apiVersion: v2
-appVersion: 7.10.2
+appVersion: 7.12.0
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -11,7 +11,7 @@ dependencies:
   - condition: global.kibanaEnabled
     name: kibana
     repository: https://charts.bitnami.com/bitnami
-    version: 7.x.x
+    version: 8.x.x
 description: A highly scalable open-source full-text search and analytics engine
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/elasticsearch
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/bitnami-docker-elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 14.5.3
+version: 15.0.0

--- a/bitnami/elasticsearch/README.md
+++ b/bitnami/elasticsearch/README.md
@@ -438,9 +438,11 @@ Find more information about how to deal with common errors related to Bitnami’
 
 ### To 15.0.0
 
-From this version onwards, Elasticsearch container components are now licensed under the Elastic License that is not currently accepted as an Open Source license by the Open Source Initiative (OSI).
+From this version onwards, Elasticsearch container components are now licensed under the [Elastic License](https://www.elastic.co/licensing/elastic-license) that is not currently accepted as an Open Source license by the Open Source Initiative (OSI).
 
 Also, from now on, the Helm Chart will include the X-Pack plugin installed by default.
+
+Regular upgrade is compatible from previous versions.
 
 ### To 14.0.0
 

--- a/bitnami/elasticsearch/README.md
+++ b/bitnami/elasticsearch/README.md
@@ -436,6 +436,12 @@ Find more information about how to deal with common errors related to Bitnami’
 
 ## Upgrading
 
+### To 15.0.0
+
+From this version onwards, Elasticsearch container components are now licensed under the Elastic License that is not currently accepted as an Open Source license by the Open Source Initiative (OSI).
+
+Also, from now on, the Helm Chart will include the X-Pack plugin installed by default.
+
 ### To 14.0.0
 
 This version standardizes the way of defining Ingress rules in the Kibana subchart. When configuring a single hostname for the Ingress rule, set the `kibana.ingress.hostname` value. When defining more than one, set the `kibana.ingress.extraHosts` array. Apart from this case, no issues are expected to appear when upgrading.

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -19,7 +19,7 @@ global:
 image:
   registry: docker.io
   repository: bitnami/elasticsearch
-  tag: 7.10.2-debian-10-r59
+  tag: 7.12.0-debian-10-r1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -847,7 +847,7 @@ curator:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch-curator
-    tag: 5.8.3-debian-10-r91
+    tag: 5.8.3-debian-10-r110
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -1073,7 +1073,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch-exporter
-    tag: 1.1.0-debian-10-r387
+    tag: 1.1.0-debian-10-r405
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**

Bumps major version of the chart due to major changes in the sub-charts and its components.

- Kibana container configuration logic was migrated to bash.
- Elasticsearch and Kibana container include X-Pack.
- Elasticsearch and Kibana components are now licensed under the Elastic License that is not currently accepted as an Open Source license by the Open Source Initiative (OSI).

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)