### PR TITLE
[bitnami/wordpress] Values to follow 'readmenator' format

### DIFF
--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -35,4 +35,4 @@ name: wordpress
 sources:
   - https://github.com/bitnami/bitnami-docker-wordpress
   - http://www.wordpress.com/
-version: 10.8.0
+version: 10.9.0

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -15,7 +15,7 @@ This chart bootstraps a [WordPress](https://github.com/bitnami/bitnami-docker-wo
 
 It also packages the [Bitnami MariaDB chart](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) which is required for bootstrapping a MariaDB deployment for the database requirements of the WordPress application, and the [Bitnami Memcached chart](https://github.com/bitnami/charts/tree/master/bitnami/memcached) that can be used to cache database queries.
 
-Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters. This chart has been tested to work with NGINX Ingress, cert-manager, fluentd and Prometheus on top of the [BKPR](https://kubeprod.io/).
+Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters. This chart has been tested to work with NGINX Ingress, cert-manager, Fluentd and Prometheus on top of the [BKPR](https://kubeprod.io/).
 
 ## Prerequisites
 
@@ -52,208 +52,223 @@ The following table lists the configurable parameters of the WordPress chart and
 
 ### Global parameters
 
-| Parameter                 | Description                                     | Default                                                 |
-|---------------------------|-------------------------------------------------|---------------------------------------------------------|
-| `global.imageRegistry`    | Global Docker image registry                    | `nil`                                                   |
-| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
-| `global.storageClass`     | Global storage class for dynamic provisioning   | `nil`                                                   |
+| Name                      | Description                                     | Value |
+| ------------------------- | ----------------------------------------------- | ----- |
+| `global.imageRegistry`    | Global Docker image registry                    | `""`  |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
+| `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `""`  |
 
 ### Common parameters
 
-| Parameter           | Description                                                          | Default                        |
-|---------------------|----------------------------------------------------------------------|--------------------------------|
-| `nameOverride`      | String to partially override common.names.fullname                   | `nil`                          |
-| `fullnameOverride`  | String to fully override common.names.fullname                       | `nil`                          |
-| `clusterDomain`     | Default Kubernetes cluster domain                                    | `cluster.local`                |
-| `commonLabels`      | Labels to add to all deployed objects                                | `{}`                           |
-| `commonAnnotations` | Annotations to add to all deployed objects                           | `{}`                           |
-| `kubeVersion`       | Force target Kubernetes version (using Helm capabilities if not set) | `nil`                          |
-| `extraDeploy`       | Array of extra objects to deploy with the release                    | `[]` (evaluated as a template) |
+| Name                | Description                                        | Value           |
+| ------------------- | -------------------------------------------------- | --------------- |
+| `kubeVersion`       | Override Kubernetes version                        | `""`            |
+| `nameOverride`      | String to partially override common.names.fullname | `""`            |
+| `fullnameOverride`  | String to fully override common.names.fullname     | `""`            |
+| `commonLabels`      | Labels to add to all deployed objects              | `{}`            |
+| `commonAnnotations` | Annotations to add to all deployed objects         | `{}`            |
+| `clusterDomain`     | Kubernetes cluster domain name                     | `cluster.local` |
+| `extraDeploy`       | Array of extra objects to deploy with the release  | `[]`            |
 
-### WordPress parameters
+### WordPress Image parameters
 
-| Parameter                     | Description                                                                                                                                                                                                                      | Default                                                 |
-|-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `image.registry`              | WordPress image registry                                                                                                                                                                                                         | `docker.io`                                             |
-| `image.repository`            | WordPress image name                                                                                                                                                                                                             | `bitnami/wordpress`                                     |
-| `image.tag`                   | WordPress image tag                                                                                                                                                                                                              | `{TAG_NAME}`                                            |
-| `image.pullPolicy`            | WordPress image pull policy                                                                                                                                                                                                      | `IfNotPresent`                                          |
-| `image.pullSecrets`           | Specify docker-registry secret names as an array                                                                                                                                                                                 | `[]` (does not add image pull secrets to deployed pods) |
-| `image.debug`                 | Specify if debug logs should be enabled                                                                                                                                                                                          | `false`                                                 |
-| `hostAliases`                 | Add deployment host aliases                                                                                                                                                                                                      | `Check values.yaml`                                     |
-| `wordpressSkipInstall`        | Skip wizard installation when the external db already contains data from a previous WordPress installation [see](https://github.com/bitnami/bitnami-docker-wordpress#connect-wordpress-docker-container-to-an-existing-database) | `false`                                                 |
-| `wordpressUsername`           | User of the application                                                                                                                                                                                                          | `user`                                                  |
-| `existingSecret`              | Name of the existing Wordpress Secret (it must contain a key named `wordpress-password`). When it's set, `wordpressPassword` is ignored                                                                                          | `nil`                                                   |
-| `serviceAccountName`          | Name of a service account for the WordPress pods                                                                                                                                                                                 | `default`                                               |
-| `wordpressPassword`           | Application password                                                                                                                                                                                                             | _random 10 character long alphanumeric string_          |
-| `wordpressEmail`              | Admin email                                                                                                                                                                                                                      | `user@example.com`                                      |
-| `wordpressFirstName`          | First name                                                                                                                                                                                                                       | `FirstName`                                             |
-| `wordpressLastName`           | Last name                                                                                                                                                                                                                        | `LastName`                                              |
-| `wordpressBlogName`           | Blog name                                                                                                                                                                                                                        | `User's Blog!`                                          |
-| `wordpressTablePrefix`        | Table prefix                                                                                                                                                                                                                     | `wp_`                                                   |
-| `wordpressScheme`             | Scheme to generate application URLs [`http`, `https`]                                                                                                                                                                            | `http`                                                  |
-| `wordpressExtraConfigContent` | Add extra content to the configuration file                                                                                                                                                                                      | `""`                                                    |
-| `allowEmptyPassword`          | Allow DB blank passwords                                                                                                                                                                                                         | `true`                                                  |
-| `allowOverrideNone`           | Set Apache AllowOverride directive to None                                                                                                                                                                                       | `false`                                                 |
-| `htaccessPersistenceEnabled`  | Make `.htaccess` persistence so that it can be customized. [See](#disabling-htaccess)                                                                                                                                            | `false`                                                 |
-| `customHTAccessCM`            | Configmap with custom wordpress-htaccess.conf directives                                                                                                                                                                         | `nil`                                                   |
-| `customPostInitScripts`       | Custom post-init.d user scripts                                                                                                                                                                                                  | `nil`                                                   |
-| `smtpHost`                    | SMTP host                                                                                                                                                                                                                        | `nil`                                                   |
-| `smtpPort`                    | SMTP port                                                                                                                                                                                                                        | `nil`                                                   |
-| `smtpUser`                    | SMTP user                                                                                                                                                                                                                        | `nil`                                                   |
-| `smtpPassword`                | SMTP password                                                                                                                                                                                                                    | `nil`                                                   |
-| `smtpUsername`                | User name for SMTP emails                                                                                                                                                                                                        | `nil`                                                   |
-| `smtpProtocol`                | SMTP protocol [`tls`, `ssl`, `none`]                                                                                                                                                                                             | `nil`                                                   |
-| `smtpExistingPassword`        | Existing secret containing SMTP password in key `smtp-password`                                                                                                                                                                  | `nil`                                                   |
-| `command`                     | Override default container command (useful when using custom images)                                                                                                                                                             | `nil`                                                   |
-| `args`                        | Override default container args (useful when using custom images)                                                                                                                                                                | `nil`                                                   |
-| `extraEnvVars`                | Extra environment variables to be set on WordPress container                                                                                                                                                                     | `{}`                                                    |
-| `extraEnvVarsCM`              | Name of existing ConfigMap containing extra env vars                                                                                                                                                                             | `nil`                                                   |
-| `extraEnvVarsSecret`          | Name of existing Secret containing extra env vars                                                                                                                                                                                | `nil`                                                   |
+| Name                | Description                                          | Value                 |
+| ------------------- | ---------------------------------------------------- | --------------------- |
+| `image.registry`    | WordPress image registry                             | `docker.io`           |
+| `image.repository`  | WordPress image repository                           | `bitnami/wordpress`   |
+| `image.tag`         | WordPress image tag (immutable tags are recommended) | `5.7.0-debian-10-r11` |
+| `image.pullPolicy`  | WordPress image pull policy                          | `IfNotPresent`        |
+| `image.pullSecrets` | WordPress image pull secrets                         | `[]`                  |
+| `image.debug`       | Enable image debug mode                              | `false`               |
+
+### WordPress Configuration parameters
+
+| Name                                   | Description                                                              | Value              |
+| -------------------------------------- | ------------------------------------------------------------------------ | ------------------ |
+| `wordpressUsername`                    | WordPress username                                                       | `user`             |
+| `wordpressPassword`                    | WordPress user password                                                  | `""`               |
+| `existingSecret`                       | Name of existing secret containing WordPress credentials                 | `""`               |
+| `wordpressEmail`                       | WordPress user email                                                     | `user@example.com` |
+| `wordpressFirstName`                   | WordPress user first name                                                | `FirstName`        |
+| `wordpressLastName`                    | WordPress user last name                                                 | `LastName`         |
+| `wordpressBlogName`                    | Blog name                                                                | `User's Blog!`     |
+| `wordpressTablePrefix`                 | Prefix to use for WordPress database tables                              | `wp_`              |
+| `wordpressScheme`                      | Scheme to use to generate WordPress URLs                                 | `http`             |
+| `wordpressSkipInstall`                 | Skip wizard installation                                                 | `false`            |
+| `wordpressExtraConfigContent`          | Add extra content to the default wp-config.php file                      | `""`               |
+| `wordpressConfiguration`               | The content for your custom wp-config.php file                           | `""`               |
+| `existingWordPressConfigurationSecret` | The name of an existing secret with your custom wp-config.php file       | `""`               |
+| `customPostInitScripts`                | Custom post-init.d user scripts                                          | `{}`               |
+| `smtpHost`                             | SMTP server host                                                         | `""`               |
+| `smtpPort`                             | SMTP server port                                                         | `""`               |
+| `smtpUser`                             | SMTP username                                                            | `""`               |
+| `smtpPassword`                         | SMTP user password                                                       | `""`               |
+| `smtpProtocol`                         | SMTP protocol                                                            | `""`               |
+| `smtpExistingSecret`                   | The name of an existing secret with SMTP credentials                     | `""`               |
+| `allowEmptyPassword`                   | Allow the container to be started with blank passwords                   | `true`             |
+| `allowOverrideNone`                    | Configure Apache to prohibit overriding directives with htaccess files   | `false`            |
+| `htaccessPersistenceEnabled`           | Persist custom changes on htaccess files                                 | `false`            |
+| `customHTAccessCM`                     | The name of an existing ConfigMap with custom htaccess rules             | `""`               |
+| `command`                              | Override default container command (useful when using custom images)     | `[]`               |
+| `args`                                 | Override default container args (useful when using custom images)        | `[]`               |
+| `extraEnvVars`                         | Array with extra environment variables to add to the WordPress container | `[]`               |
+| `extraEnvVarsCM`                       | Name of existing ConfigMap containing extra env vars                     | `""`               |
+| `extraEnvVarsSecret`                   | Name of existing Secret containing extra env vars                        | `""`               |
 
 ### WordPress deployment parameters
 
-| Parameter                   | Description                                                                               | Default                              |
-|-----------------------------|-------------------------------------------------------------------------------------------|--------------------------------------|
-| `replicaCount`              | Number of WordPress Pods to run                                                           | `1`                                  |
-| `containerPorts.http`       | HTTP port to expose at container level                                                    | `8080`                               |
-| `containerPorts.https`      | HTTPS port to expose at container level                                                   | `8443`                               |
-| `podSecurityContext`        | WordPress pods' Security Context                                                          | Check `values.yaml` file             |
-| `containerSecurityContext`  | WordPress containers' Security Context                                                    | Check `values.yaml` file             |
-| `resources.limits`          | The resources limits for the WordPress container                                          | `{}`                                 |
-| `resources.requests`        | The requested resources for the WordPress container                                       | `{"memory": "512Mi", "cpu": "300m"}` |
-| `livenessProbe`             | Liveness probe configuration for WordPress                                                | Check `values.yaml` file             |
-| `readinessProbe`            | Readiness probe configuration for WordPress                                               | Check `values.yaml` file             |
-| `customLivenessProbe`       | Override default liveness probe                                                           | `nil`                                |
-| `customReadinessProbe`      | Override default readiness probe                                                          | `nil`                                |
-| `updateStrategy`            | Set up update strategy                                                                    | `RollingUpdate`                      |
-| `schedulerName`             | Name of the alternate scheduler                                                           | `nil`                                |
-| `podAntiAffinityPreset`     | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                               |
-| `nodeAffinityPreset.type`   | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                                 |
-| `nodeAffinityPreset.key`    | Node label key to match. Ignored if `affinity` is set.                                    | `""`                                 |
-| `nodeAffinityPreset.values` | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                                 |
-| `affinity`                  | Affinity for pod assignment                                                               | `{}` (evaluated as a template)       |
-| `nodeSelector`              | Node labels for pod assignment                                                            | `{}` (evaluated as a template)       |
-| `tolerations`               | Tolerations for pod assignment                                                            | `[]` (evaluated as a template)       |
-| `podLabels`                 | Extra labels for WordPress pods                                                           | `{}`                                 |
-| `podAnnotations`            | Annotations for WordPress pods                                                            | `{}`                                 |
-| `extraVolumeMounts`         | Additional volume mounts                                                                  | `[]`                                 |
-| `extraVolumes`              | Additional volumes                                                                        | `[]`                                 |
-| `initContainers`            | Add additional init containers to the WordPress pods                                      | `{}` (evaluated as a template)       |
-| `sidecars`                  | Attach additional sidecar containers to the pod                                           | `{}` (evaluated as a template)       |
+| Name                                    | Description                                                                               | Value           |
+| --------------------------------------- | ----------------------------------------------------------------------------------------- | --------------- |
+| `replicaCount`                          | Number of WordPress replicas to deploy                                                    | `1`             |
+| `updateStrategy.type`                   | WordPress deployment strategy type                                                        | `RollingUpdate` |
+| `updateStrategy.rollingUpdate`          | WordPress deployment rolling update configuration parameters                              | `{}`            |
+| `schedulerName`                         | Alternate scheduler                                                                       | `nil`           |
+| `serviceAccountName`                    | ServiceAccount name                                                                       | `default`       |
+| `hostAliases`                           | WordPress pod host aliases                                                                | `[]`            |
+| `extraVolumes`                          | Optionally specify extra list of additional volumes for WordPress pods                    | `[]`            |
+| `extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for WordPress container(s)       | `[]`            |
+| `sidecars`                              | Add additional sidecar containers to the WordPress pod                                    | `{}`            |
+| `initContainers`                        | Add additional init containers to the WordPress pods                                      | `{}`            |
+| `podLabels`                             | Extra labels for WordPress pods                                                           | `{}`            |
+| `podAnnotations`                        | Annotations for WordPress pods                                                            | `{}`            |
+| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `nil`           |
+| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`          |
+| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `nil`           |
+| `nodeAffinityPreset.key`                | Node label key to match. Ignored if `affinity` is set                                     | `nil`           |
+| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set                                  | `[]`            |
+| `affinity`                              | Affinity for pod assignment                                                               | `{}`            |
+| `nodeSelector`                          | Node labels for pod assignment                                                            | `{}`            |
+| `tolerations`                           | Tolerations for pod assignment                                                            | `{}`            |
+| `resources.limits`                      | The resources limits for the WordPress container                                          | `{}`            |
+| `resources.requests`                    | The requested resources for the WordPress container                                       | `{memory: 512Mi, cpu 300m}`            |
+| `containerPorts.http`                   | WordPress HTTP container port                                                             | `8080`          |
+| `containerPorts.https`                  | WordPress HTTPS container port                                                            | `8443`          |
+| `podSecurityContext.enabled`            | Enabled WordPress pods' Security Context                                                  | `true`          |
+| `podSecurityContext.fsGroup`            | Set WordPress pod's Security Context fsGroup                                              | `1001`          |
+| `containerSecurityContext.enabled`      | Enabled WordPress containers' Security Context                                            | `true`          |
+| `containerSecurityContext.runAsUser`    | Set WordPress container's Security Context runAsUser                                      | `1001`          |
+| `containerSecurityContext.runAsNonRoot` | Set WordPress container's Security Context runAsNonRoot                                   | `true`          |
+| `livenessProbe.enabled`                 | Enable livenessProbe                                                                      | `true`          |
+| `livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                   | `120`           |
+| `livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                          | `10`            |
+| `livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                         | `5`             |
+| `livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                       | `6`             |
+| `livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                       | `1`             |
+| `readinessProbe.enabled`                | Enable readinessProbe                                                                     | `true`          |
+| `readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                  | `30`            |
+| `readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                         | `10`            |
+| `readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                        | `5`             |
+| `readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                      | `6`             |
+| `readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                      | `1`             |
+| `customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                       | `{}`            |
+| `customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                      | `{}`            |
 
-### Exposure parameters
+### Traffic Exposure Parameters
 
-| Parameter                          | Description                                                                   | Default                        |
-|------------------------------------|-------------------------------------------------------------------------------|--------------------------------|
-| `service.type`                     | Kubernetes Service type                                                       | `LoadBalancer`                 |
-| `service.port`                     | Service HTTP port                                                             | `80`                           |
-| `service.httpsPort`                | Service HTTPS port                                                            | `443`                          |
-| `service.httpsTargetPort`          | Service Target HTTPS port                                                     | `https`                        |
-| `service.nodePorts.http`           | Kubernetes http node port                                                     | `""`                           |
-| `service.nodePorts.https`          | Kubernetes https node port                                                    | `""`                           |
-| `service.extraPorts`               | Extra ports to expose in the service (normally used with the `sidecar` value) | `nil`                          |
-| `service.clusterIP`                | WordPress service clusterIP IP                                                | `None`                         |
-| `service.loadBalancerSourceRanges` | Restricts access for LoadBalancer (only with `service.type: LoadBalancer`)    | `[]`                           |
-| `service.loadBalancerIP`           | loadBalancerIP if service type is `LoadBalancer`                              | `nil`                          |
-| `service.externalTrafficPolicy`    | Enable client source IP preservation                                          | `Cluster`                      |
-| `service.annotations`              | Service annotations                                                           | `{}` (evaluated as a template) |
-| `ingress.enabled`                  | Enable ingress controller resource                                            | `false`                        |
-| `ingress.certManager`              | Add annotations for cert-manager                                              | `false`                        |
-| `ingress.hostname`                 | Default host for the ingress resource                                         | `wordpress.local`              |
-| `ingress.path`                     | Default path for the ingress resource                                         | `/`                            |
-| `ingress.tls`                      | Create TLS Secret                                                             | `false`                        |
-| `ingress.annotations`              | Ingress annotations                                                           | `[]` (evaluated as a template) |
-| `ingress.extraHosts[0].name`       | Additional hostnames to be covered                                            | `nil`                          |
-| `ingress.extraHosts[0].path`       | Additional hostnames to be covered                                            | `nil`                          |
-| `ingress.extraPaths`               | Additional arbitrary path/backend objects                                     | `nil`                          |
-| `ingress.extraTls[0].hosts[0]`     | TLS configuration for additional hostnames to be covered                      | `nil`                          |
-| `ingress.extraTls[0].secretName`   | TLS configuration for additional hostnames to be covered                      | `nil`                          |
-| `ingress.secrets[0].name`          | TLS Secret Name                                                               | `nil`                          |
-| `ingress.secrets[0].certificate`   | TLS Secret Certificate                                                        | `nil`                          |
-| `ingress.secrets[0].key`           | TLS Secret Key                                                                | `nil`                          |
+| Name                               | Description                                                                                           | Value                    |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------ |
+| `service.type`                     | WordPress service type                                                                                | `LoadBalancer`           |
+| `service.port`                     | WordPress service HTTP port                                                                           | `80`                     |
+| `service.httpsPort`                | WordPress service HTTPS port                                                                          | `443`                    |
+| `service.httpsTargetPort`          | Target port for HTTPS                                                                                 | `https`                  |
+| `service.nodePorts.http`           | Node port for HTTP                                                                                    | `nil`                    |
+| `service.nodePorts.https`          | Node port for HTTPS                                                                                   | `nil`                    |
+| `service.clusterIP`                | WordPress service Cluster IP                                                                          | `nil`                    |
+| `service.loadBalancerIP`           | WordPress service Load Balancer IP                                                                    | `nil`                    |
+| `service.loadBalancerSourceRanges` | WordPress service Load Balancer sources                                                               | `[]`                     |
+| `service.externalTrafficPolicy`    | WordPress service external traffic policy                                                             | `Cluster`                |
+| `service.annotations`              | Additional custom annotations for WordPress service                                                   | `{}`                     |
+| `service.extraPorts`               | Extra port to expose on WordPress service                                                             | `[]`                     |
+| `ingress.enabled`                  | Enable ingress record generation for WordPress                                                        | `false`                  |
+| `ingress.certManager`              | Add the corresponding annotations for cert-manager integration                                        | `false`                  |
+| `ingress.pathType`                 | Ingress path type                                                                                     | `ImplementationSpecific` |
+| `ingress.apiVersion`               | Force Ingress API version (automatically detected if not set)                                         | `nil`                    |
+| `ingress.hostname`                 | Default host for the ingress record                                                                   | `wordpress.local`        |
+| `ingress.path`                     | Default path for the ingress record                                                                   | `/`                      |
+| `ingress.annotations`              | Additional custom annotations for the ingress record                                                  | `{}`                     |
+| `ingress.tls`                      | Enable TLS configuration for the host defined at `ingress.hostname` parameter                         | `false`                  |
+| `ingress.extraHosts`               | An array with additional hostname(s) to be covered with the ingress record                            | `[]`                     |
+| `ingress.extraPaths`               | An array with additional arbitrary paths that may need to be added to the ingress under the main host | `[]`                     |
+| `ingress.extraTls`                 | TLS configuration for additional hostname(s) to be covered with this ingress record                   | `[]`                     |
+| `ingress.secrets`                  | Custom TLS certificates as secrets                                                                    | `[]`                     |
 
-### Persistence parameters
+### Persistence Parameters
 
-| Parameter                   | Description                              | Default                                     |
-|-----------------------------|------------------------------------------|---------------------------------------------|
-| `persistence.enabled`       | Enable persistence using PVC             | `true`                                      |
-| `persistence.existingClaim` | Enable persistence using an existing PVC | `nil`                                       |
-| `persistence.storageClass`  | PVC Storage Class                        | `nil` (uses alpha storage class annotation) |
-| `persistence.accessModes`   | PVC Access Modes                        | `[ReadWriteOnce]`                            |
-| `persistence.size`          | PVC Storage Request                      | `10Gi`                                      |
-| `persistence.dataSource`    | PVC data source                          | `{}`                                        |
+| Name                                          | Description                                                                                     | Value                   |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------------- | ----------------------- |
+| `persistence.enabled`                         | Enable persistence using Persistent Volume Claims                                               | `true`                  |
+| `persistence.storageClass`                    | Persistent Volume storage class                                                                 | `nil`                   |
+| `persistence.accessModes`                     | Persistent Volume access modes                                                                  | `[ReadWriteOnce]`       |
+| `persistence.size`                            | Persistent Volume size                                                                          | `10Gi`                  |
+| `persistence.dataSource`                      | Custom PVC data source                                                                          | `{}`                    |
+| `persistence.existingClaim`                   | The name of an existing PVC to use for persistence                                              | `nil`                   |
+| `volumePermissions.enabled`                   | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup` | `false`                 |
+| `volumePermissions.image.registry`            | Bitnami Shell image registry                                                                    | `docker.io`             |
+| `volumePermissions.image.repository`          | Bitnami Shell image repository                                                                  | `bitnami/bitnami-shell` |
+| `volumePermissions.image.tag`                 | Bitnami Shell image tag (immutable tags are recommended)                                        | `10`                    |
+| `volumePermissions.image.pullPolicy`          | Bitnami Shell image pull policy                                                                 | `Always`                |
+| `volumePermissions.image.pullSecrets`         | Bitnami Shell image pull secrets                                                                | `[]`                    |
+| `volumePermissions.resources.limits`          | The resources limits for the init container                                                     | `{}`                    |
+| `volumePermissions.resources.requests`        | The requested resources for the init container                                                  | `{}`                    |
+| `volumePermissions.securityContext.runAsUser` | Set init container's Security Context runAsUser                                                 | `0`                     |
 
-### Database parameters
+### Other Parameters
 
-| Parameter                                 | Description                                          | Default                                        |
-|-------------------------------------------|------------------------------------------------------|------------------------------------------------|
-| `mariadb.enabled`                         | Deploy MariaDB container(s)                          | `true`                                         |
-| `mariadb.architecture`                    | MariaDB architecture (`standalone` or `replication`) | `standalone`                                   |
-| `mariadb.auth.rootPassword`               | Password for the MariaDB `root` user                 | _random 10 character alphanumeric string_      |
-| `mariadb.auth.database`                   | Database name to create                              | `bitnami_wordpress`                            |
-| `mariadb.auth.username`                   | Database user to create                              | `bn_wordpress`                                 |
-| `mariadb.auth.password`                   | Password for the database                            | _random 10 character long alphanumeric string_ |
-| `mariadb.primary.persistence.enabled`     | Enable database persistence using PVC                | `true`                                         |
-| `mariadb.primary.persistence.accessModes` | Database Persistent Volume Access Modes              | `[ReadWriteOnce]`                              |
-| `mariadb.primary.persistence.size`        | Database Persistent Volume Size                      | `8Gi`                                          |
-| `externalDatabase.host`                   | Host of the external database                        | `localhost`                                    |
-| `externalDatabase.user`                   | Existing username in the external db                 | `bn_wordpress`                                 |
-| `externalDatabase.password`               | Password for the above username                      | `nil`                                          |
-| `externalDatabase.database`               | Name of the existing database                        | `bitnami_wordpress`                            |
-| `externalDatabase.port`                   | Database port number                                 | `3306`                                         |
-| `externalDatabase.existingSecret`         | Name of the database existing Secret Object          | `nil`                                          |
-| `memcached.enabled`                       | Deploy Memcached for caching database queries        | `false`                                        |
-
-### Volume Permissions parameters
-
-| Parameter                                     | Description                                                                                                          | Default                                                 |
-|-----------------------------------------------|----------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `volumePermissions.enabled`                   | Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup` | `false`                                                 |
-| `volumePermissions.image.registry`            | Init container volume-permissions image registry                                                                     | `docker.io`                                             |
-| `volumePermissions.image.repository`          | Init container volume-permissions image name                                                                         | `bitnami/bitnami-shell`                                 |
-| `volumePermissions.image.tag`                 | Init container volume-permissions image tag                                                                          | `"10"`                                                  |
-| `volumePermissions.image.pullPolicy`          | Init container volume-permissions image pull policy                                                                  | `Always`                                                |
-| `volumePermissions.image.pullSecrets`         | Specify docker-registry secret names as an array                                                                     | `[]` (does not add image pull secrets to deployed pods) |
-| `volumePermissions.resources.limits`          | Init container volume-permissions resource  limits                                                                   | `{}`                                                    |
-| `volumePermissions.resources.requests`        | Init container volume-permissions resource  requests                                                                 | `{}`                                                    |
-| `volumePermissions.securityContext.*`         | Other container security context to be included as-is in the container spec                                          | `{}`                                                    |
-| `volumePermissions.securityContext.runAsUser` | User ID for the init container (when facing issues in OpenShift or uid unknown, try value "auto")                    | `0`                                                     |
-
-### Metrics parameters
-
-| Parameter                                 | Description                                                                  | Default                                                      |
-|-------------------------------------------|------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `metrics.enabled`                         | Start a side-car prometheus exporter                                         | `false`                                                      |
-| `metrics.image.registry`                  | Apache exporter image registry                                               | `docker.io`                                                  |
-| `metrics.image.repository`                | Apache exporter image name                                                   | `bitnami/apache-exporter`                                    |
-| `metrics.image.tag`                       | Apache exporter image tag                                                    | `{TAG_NAME}`                                                 |
-| `metrics.image.pullPolicy`                | Image pull policy                                                            | `IfNotPresent`                                               |
-| `metrics.image.pullSecrets`               | Specify docker-registry secret names as an array                             | `[]` (does not add image pull secrets to deployed pods)      |
-| `metrics.service.port`                    | Service Metrics port                                                         | `9117`                                                       |
-| `metrics.service.annotations`             | Annotations for enabling prometheus to access the metrics endpoints          | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
-| `metrics.resources.limits`                | The resources limits for the metrics exporter container                      | `{}`                                                         |
-| `metrics.resources.requests`              | The requested resources for the metrics exporter container                   | `{}`                                                         |
-| `metrics.serviceMonitor.enabled`          | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator | `false`                                                      |
-| `metrics.serviceMonitor.namespace`        | Namespace where servicemonitor resource should be created                    | `nil`                                                        |
-| `metrics.serviceMonitor.interval`         | Specify the interval at which metrics should be scraped                      | `30s`                                                        |
-| `metrics.serviceMonitor.scrapeTimeout`    | Specify the timeout after which the scrape is ended                          | `nil`                                                        |
-| `metrics.serviceMonitor.relabellings`     | Specify Metric Relabellings to add to the scrape endpoint                    | `nil`                                                        |
-| `metrics.serviceMonitor.honorLabels`      | honorLabels chooses the metric's labels on collisions with target labels.    | `false`                                                      |
-| `metrics.serviceMonitor.additionalLabels` | Used to pass Labels that are required by the Installed Prometheus Operator   | `{}`                                                         |
-
-### Other parameters
-
-| Parameter                  | Description                                                    | Default |
-|----------------------------|----------------------------------------------------------------|---------|
-| `pdb.create`               | Enable/disable a Pod Disruption Budget creation                | `false` |
+| Name                       | Description                                                    | Value   |
+| -------------------------- | -------------------------------------------------------------- | ------- |
+| `pdb.create`               | Enable a Pod Disruption Budget creation                        | `false` |
 | `pdb.minAvailable`         | Minimum number/percentage of pods that should remain scheduled | `1`     |
 | `pdb.maxUnavailable`       | Maximum number/percentage of pods that may be made unavailable | `nil`   |
-| `autoscaling.enabled`      | Enable autoscaling for WordPress                               | `false` |
+| `autoscaling.enabled`      | Enable Horizontal POD autoscaling for WordPress                | `false` |
 | `autoscaling.minReplicas`  | Minimum number of WordPress replicas                           | `1`     |
 | `autoscaling.maxReplicas`  | Maximum number of WordPress replicas                           | `11`    |
-| `autoscaling.targetCPU`    | Target CPU utilization percentage                              | `nil`   |
-| `autoscaling.targetMemory` | Target Memory utilization percentage                           | `nil`   |
+| `autoscaling.targetCPU`    | Target CPU utilization percentage                              | `50`    |
+| `autoscaling.targetMemory` | Target Memory utilization percentage                           | `50`    |
+
+### Metrics Parameters
+
+| Name                                      | Description                                                                  | Value                     |
+| ----------------------------------------- | ---------------------------------------------------------------------------- | ------------------------- |
+| `metrics.enabled`                         | Start a sidecar prometheus exporter to expose metrics                        | `false`                   |
+| `metrics.image.registry`                  | Apache Exporter image registry                                               | `docker.io`               |
+| `metrics.image.repository`                | Apache Exporter image repository                                             | `bitnami/apache-exporter` |
+| `metrics.image.tag`                       | Apache Exporter image tag (immutable tags are recommended)                   | `0.8.0-debian-10-r334`    |
+| `metrics.image.pullPolicy`                | Apache Exporter image pull policy                                            | `IfNotPresent`            |
+| `metrics.image.pullSecrets`               | Apache Exporter image pull secrets                                           | `[]`                      |
+| `metrics.resources.limits`                | The resources limits for the Prometheus exporter container                   | `{}`                      |
+| `metrics.resources.requests`              | The requested resources for the Prometheus exporter container                | `{}`                      |
+| `metrics.service.port`                    | Metrics service port                                                         | `9117`                    |
+| `metrics.service.annotations`             | Additional custom annotations for Metrics service                            | `{}`                      |
+| `metrics.serviceMonitor.enabled`          | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator | `false`                   |
+| `metrics.serviceMonitor.namespace`        | The namespace in which the ServiceMonitor will be created                    | `nil`                     |
+| `metrics.serviceMonitor.interval`         | The interval at which metrics should be scraped                              | `30s`                     |
+| `metrics.serviceMonitor.scrapeTimeout`    | The timeout after which the scrape is ended                                  | `nil`                     |
+| `metrics.serviceMonitor.relabellings`     | Metrics relabellings to add to the scrape endpoint                           | `nil`                     |
+| `metrics.serviceMonitor.honorLabels`      | Labels to honor to add to the scrape endpoint                                | `false`                   |
+| `metrics.serviceMonitor.additionalLabels` | Additional custom labels for the ServiceMonitor                              | `{}`                      |
+
+### Database Parameters
+
+| Name                                       | Description                                                               | Value               |
+| ------------------------------------------ | ------------------------------------------------------------------------- | ------------------- |
+| `mariadb.enabled`                          | Deploy a MariaDB server to satisfy the applications database requirements | `true`              |
+| `mariadb.architecture`                     | MariaDB architecture. Allowed values: `standalone` or `replication`       | `standalone`        |
+| `mariadb.auth.rootPassword`                | MariaDB root password                                                     | `""`                |
+| `mariadb.auth.database`                    | MariaDB custom database                                                   | `bitnami_wordpress` |
+| `mariadb.auth.username`                    | MariaDB custom user name                                                  | `bn_wordpress`      |
+| `mariadb.auth.password`                    | MariaDB custom user password                                              | `""`                |
+| `mariadb.primary.persistence.enabled`      | Enable persistence on MariaDB using PVC(s)                                | `true`              |
+| `mariadb.primary.persistence.storageClass` | Persistent Volume storage class                                           | `nil`               |
+| `mariadb.primary.persistence.accessModes`  | Persistent Volume access modes                                            | `[ReadWriteOnce]`   |
+| `mariadb.primary.persistence.size`         | Persistent Volume size                                                    | `8Gi`               |
+| `externalDatabase.host`                    | External Database server host                                             | `localhost`         |
+| `externalDatabase.port`                    | External Database server port                                             | `3306`              |
+| `externalDatabase.user`                    | External Database username                                                | `bn_wordpress`      |
+| `externalDatabase.password`                | External Database user password                                           | `""`                |
+| `externalDatabase.database`                | External Database database name                                           | `bitnami_wordpress` |
+| `externalDatabase.existingSecret`          | The name of an existing secret with database credentials                  | `nil`               |
+| `memcached.enabled`                        | Deploy a Memcached server for caching database queries                    | `false`             |
+| `memcached.service.port`                   | Memcached service port                                                    | `11211`             |
 
 The above parameters map to the env variables defined in [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress). For more information please refer to the [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress) image documentation.
 
@@ -367,7 +382,7 @@ As an alternative, use one of the preset configurations for pod affinity, pod an
 
 ## Troubleshooting
 
-Find more information about how to deal with common errors related to Bitnami’s Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
+Find more information about how to deal with common errors related to Bitnami's Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
 
 ## Upgrading
 
@@ -379,7 +394,7 @@ Find more information about how to deal with common errors related to Bitnami’
 
 #### Additional upgrade notes
 
-- MariaDB dependency version was bumped to a new major version that introduces several incompatabilitees. Therefore, backwards compatibility is not guaranteed unless an external database is used. Check [MariaDB Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/mariadb#to-800) for more information.
+- MariaDB dependency version was bumped to a new major version that introduces several incompatibilities. Therefore, backwards compatibility is not guaranteed unless an external database is used. Check [MariaDB Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/mariadb#to-800) for more information.
 - If you want to upgrade to this version from a previous one installed with Helm v3, there are two alternatives:
   - Install a new WordPress chart, and migrate your WordPress site using backup/restore tools such as [VaultPress](https://vaultpress.com/) or [All-in-One WP Migration](https://wordpress.org/plugins/all-in-one-wp-migration/).
   - Reuse the PVC used to hold the MariaDB data on your previous release. To do so, follow the instructions below (the following example assumes that the release name is `wordpress`).
@@ -434,7 +449,7 @@ To upgrade to `9.0.0`, it's recommended to install a new WordPress chart, and mi
 
 Helm performs a lookup for the object based on its group (apps), version (v1), and kind (Deployment). Also known as its GroupVersionKind, or GVK. Changing the GVK is considered a compatibility breaker from Kubernetes' point of view, so you cannot "upgrade" those objects to the new GVK in-place. Earlier versions of Helm 3 did not perform the lookup correctly which has since been fixed to match the spec.
 
-In https://github.com/helm/charts/pulls/12642 the `apiVersion` of the deployment resources was updated to `apps/v1` in tune with the api's deprecated, resulting in compatibility breakage.
+In https://github.com/helm/charts/pulls/12642 the `apiVersion` of the deployment resources was updated to `apps/v1` in tune with the API's deprecated, resulting in compatibility breakage.
 
 This major version signifies this change.
 

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -83,37 +83,37 @@ The following table lists the configurable parameters of the WordPress chart and
 
 ### WordPress Configuration parameters
 
-| Name                                   | Description                                                              | Value              |
-| -------------------------------------- | ------------------------------------------------------------------------ | ------------------ |
-| `wordpressUsername`                    | WordPress username                                                       | `user`             |
-| `wordpressPassword`                    | WordPress user password                                                  | `""`               |
-| `existingSecret`                       | Name of existing secret containing WordPress credentials                 | `""`               |
-| `wordpressEmail`                       | WordPress user email                                                     | `user@example.com` |
-| `wordpressFirstName`                   | WordPress user first name                                                | `FirstName`        |
-| `wordpressLastName`                    | WordPress user last name                                                 | `LastName`         |
-| `wordpressBlogName`                    | Blog name                                                                | `User's Blog!`     |
-| `wordpressTablePrefix`                 | Prefix to use for WordPress database tables                              | `wp_`              |
-| `wordpressScheme`                      | Scheme to use to generate WordPress URLs                                 | `http`             |
-| `wordpressSkipInstall`                 | Skip wizard installation                                                 | `false`            |
-| `wordpressExtraConfigContent`          | Add extra content to the default wp-config.php file                      | `""`               |
-| `wordpressConfiguration`               | The content for your custom wp-config.php file                           | `""`               |
-| `existingWordPressConfigurationSecret` | The name of an existing secret with your custom wp-config.php file       | `""`               |
-| `customPostInitScripts`                | Custom post-init.d user scripts                                          | `{}`               |
-| `smtpHost`                             | SMTP server host                                                         | `""`               |
-| `smtpPort`                             | SMTP server port                                                         | `""`               |
-| `smtpUser`                             | SMTP username                                                            | `""`               |
-| `smtpPassword`                         | SMTP user password                                                       | `""`               |
-| `smtpProtocol`                         | SMTP protocol                                                            | `""`               |
-| `smtpExistingSecret`                   | The name of an existing secret with SMTP credentials                     | `""`               |
-| `allowEmptyPassword`                   | Allow the container to be started with blank passwords                   | `true`             |
-| `allowOverrideNone`                    | Configure Apache to prohibit overriding directives with htaccess files   | `false`            |
-| `htaccessPersistenceEnabled`           | Persist custom changes on htaccess files                                 | `false`            |
-| `customHTAccessCM`                     | The name of an existing ConfigMap with custom htaccess rules             | `""`               |
-| `command`                              | Override default container command (useful when using custom images)     | `[]`               |
-| `args`                                 | Override default container args (useful when using custom images)        | `[]`               |
-| `extraEnvVars`                         | Array with extra environment variables to add to the WordPress container | `[]`               |
-| `extraEnvVarsCM`                       | Name of existing ConfigMap containing extra env vars                     | `""`               |
-| `extraEnvVarsSecret`                   | Name of existing Secret containing extra env vars                        | `""`               |
+| Name                                   | Description                                                                               | Value              |
+| -------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------ |
+| `wordpressUsername`                    | WordPress username                                                                        | `user`             |
+| `wordpressPassword`                    | WordPress user password                                                                   | `""`               |
+| `existingSecret`                       | Name of existing secret containing WordPress credentials                                  | `""`               |
+| `wordpressEmail`                       | WordPress user email                                                                      | `user@example.com` |
+| `wordpressFirstName`                   | WordPress user first name                                                                 | `FirstName`        |
+| `wordpressLastName`                    | WordPress user last name                                                                  | `LastName`         |
+| `wordpressBlogName`                    | Blog name                                                                                 | `User's Blog!`     |
+| `wordpressTablePrefix`                 | Prefix to use for WordPress database tables                                               | `wp_`              |
+| `wordpressScheme`                      | Scheme to use to generate WordPress URLs                                                  | `http`             |
+| `wordpressSkipInstall`                 | Skip wizard installation                                                                  | `false`            |
+| `wordpressExtraConfigContent`          | Add extra content to the default wp-config.php file                                       | `""`               |
+| `wordpressConfiguration`               | The content for your custom wp-config.php file (experimental feature)                     | `""`               |
+| `existingWordPressConfigurationSecret` | The name of an existing secret with your custom wp-config.php file (experimental feature) | `""`               |
+| `customPostInitScripts`                | Custom post-init.d user scripts                                                           | `{}`               |
+| `smtpHost`                             | SMTP server host                                                                          | `""`               |
+| `smtpPort`                             | SMTP server port                                                                          | `""`               |
+| `smtpUser`                             | SMTP username                                                                             | `""`               |
+| `smtpPassword`                         | SMTP user password                                                                        | `""`               |
+| `smtpProtocol`                         | SMTP protocol                                                                             | `""`               |
+| `smtpExistingSecret`                   | The name of an existing secret with SMTP credentials                                      | `""`               |
+| `allowEmptyPassword`                   | Allow the container to be started with blank passwords                                    | `true`             |
+| `allowOverrideNone`                    | Configure Apache to prohibit overriding directives with htaccess files                    | `false`            |
+| `htaccessPersistenceEnabled`           | Persist custom changes on htaccess files                                                  | `false`            |
+| `customHTAccessCM`                     | The name of an existing ConfigMap with custom htaccess rules                              | `""`               |
+| `command`                              | Override default container command (useful when using custom images)                      | `[]`               |
+| `args`                                 | Override default container args (useful when using custom images)                         | `[]`               |
+| `extraEnvVars`                         | Array with extra environment variables to add to the WordPress container                  | `[]`               |
+| `extraEnvVarsCM`                       | Name of existing ConfigMap containing extra env vars                                      | `""`               |
+| `extraEnvVarsSecret`                   | Name of existing Secret containing extra env vars                                         | `""`               |
 
 ### WordPress deployment parameters
 

--- a/bitnami/wordpress/templates/NOTES.txt
+++ b/bitnami/wordpress/templates/NOTES.txt
@@ -65,6 +65,7 @@ You can access Apache Prometheus metrics following the steps below:
 
 {{- end }}
 
+{{- include "wordpress.validateValues" . }}
 {{- include "common.warnings.rollingTag" .Values.image }}
 {{- include "common.warnings.rollingTag" .Values.metrics.image }}
 {{- $passwordValidationErrors := list -}}

--- a/bitnami/wordpress/templates/config-secret.yaml
+++ b/bitnami/wordpress/templates/config-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-configuration" (include "common.names.fullname" .) }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/wordpress/templates/config-secret.yaml
+++ b/bitnami/wordpress/templates/config-secret.yaml
@@ -1,8 +1,8 @@
-{{- if not (or .Values.mariadb.enabled .Values.externalDatabase.existingSecret) }}
+{{- if (include "wordpress.createConfigSecret" .) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-externaldb" (include "common.names.fullname" .) }}
+  name: {{ printf "%s-configuration" (include "common.names.fullname" .) }}
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -11,7 +11,6 @@ metadata:
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
-type: Opaque
 data:
-  mariadb-password: {{ .Values.externalDatabase.password | b64enc | quote }}
+  wp-config.php: {{ .Values.wordpressConfiguration | b64enc }}
 {{- end }}

--- a/bitnami/wordpress/templates/deployment.yaml
+++ b/bitnami/wordpress/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
@@ -24,13 +25,16 @@ spec:
         {{- if .Values.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
-      {{- if or .Values.podAnnotations .Values.metrics.enabled }}
+      {{- if or .Values.podAnnotations .Values.metrics.enabled (include "wordpress.createConfigSecret" .) }}
       annotations:
         {{- if .Values.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
         {{- if .Values.metrics.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.metrics.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
+        {{- if (include "wordpress.createConfigSecret" .) }}
+        checksum/config-secret: {{ include (print $.Template.BasePath "/config-secret.yaml") . | sha256sum }}
         {{- end }}
       {{- end }}
     spec:
@@ -147,6 +151,8 @@ spec:
               value: {{ .Values.wordpressBlogName | quote }}
             - name: WORDPRESS_SKIP_INSTALL
               value: {{ ternary "yes" "no" .Values.wordpressSkipInstall | quote }}
+            - name: WORDPRESS_READ_ONLY_CONFIG
+              value: {{ ternary "yes" "no" (or (not (empty .Values.wordpressConfiguration)) (not (empty .Values.existingWordPressConfigurationSecret))) | quote }}
             - name: WORDPRESS_TABLE_PREFIX
               value: {{ .Values.wordpressTablePrefix | quote }}
             - name: WORDPRESS_SCHEME
@@ -210,6 +216,11 @@ spec:
             - mountPath: /bitnami/wordpress
               name: wordpress-data
               subPath: wordpress
+            {{- if or .Values.wordpressConfiguration .Values.existingWordPressConfigurationSecret }}
+            - name: wordpress-config
+              mountPath: /opt/bitnami/wordpress/wp-config.php
+              subPath: wp-config.php
+            {{- end }}
             {{- if and .Values.allowOverrideNone .Values.customHTAccessCM }}
             - mountPath: /htaccess
               name: custom-htaccess
@@ -252,6 +263,12 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | nindent 8 }}
         {{- end }}
       volumes:
+        {{- if or .Values.wordpressConfiguration .Values.existingWordPressConfigurationSecret }}
+        - name: wordpress-config
+          secret:
+            secretName: {{ include "wordpress.configSecretName" . }}
+            defaultMode: 0644
+        {{- end }}
         {{- if and .Values.allowOverrideNone .Values.customHTAccessCM }}
         - name: custom-htaccess
           configMap:

--- a/bitnami/wordpress/templates/deployment.yaml
+++ b/bitnami/wordpress/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/wordpress/templates/externaldb-secrets.yaml
+++ b/bitnami/wordpress/templates/externaldb-secrets.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-externaldb" (include "common.names.fullname" .) }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/wordpress/templates/hpa.yaml
+++ b/bitnami/wordpress/templates/hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/wordpress/templates/ingress.yaml
+++ b/bitnami/wordpress/templates/ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/wordpress/templates/ingress.yaml
+++ b/bitnami/wordpress/templates/ingress.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/wordpress/templates/metrics-svc.yaml
+++ b/bitnami/wordpress/templates/metrics-svc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ printf "%s-metrics" (include "common.names.fullname" .) }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: metrics
     {{- if .Values.commonLabels }}

--- a/bitnami/wordpress/templates/pdb.yaml
+++ b/bitnami/wordpress/templates/pdb.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/wordpress/templates/postinit-configmap.yaml
+++ b/bitnami/wordpress/templates/postinit-configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ printf "%s-postinit" (include "common.names.fullname" .) }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/wordpress/templates/postinit-configmap.yaml
+++ b/bitnami/wordpress/templates/postinit-configmap.yaml
@@ -3,6 +3,14 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ printf "%s-postinit" (include "common.names.fullname" .) }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 data:
   {{- if .Values.memcached.enabled }}
   {{- $memcachedFullname := include "wordpress.memcached.fullname" . }}

--- a/bitnami/wordpress/templates/pvc.yaml
+++ b/bitnami/wordpress/templates/pvc.yaml
@@ -3,7 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/wordpress/templates/pvc.yaml
+++ b/bitnami/wordpress/templates/pvc.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
@@ -22,7 +23,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
-  {{- include "wordpress.storageClass" . | nindent 2 }}
+  {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 2 }}
   {{- if .Values.persistence.dataSource }}
   dataSource: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.dataSource "context" $) | nindent 4 }}
   {{- end }}

--- a/bitnami/wordpress/templates/secrets.yaml
+++ b/bitnami/wordpress/templates/secrets.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/wordpress/templates/secrets.yaml
+++ b/bitnami/wordpress/templates/secrets.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/wordpress/templates/servicemonitor.yaml
+++ b/bitnami/wordpress/templates/servicemonitor.yaml
@@ -4,7 +4,9 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "common.names.fullname" . }}
   {{- if .Values.metrics.serviceMonitor.namespace }}
-  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace | quote }}
+  {{- else }}
+  namespace: {{ .Release.Namespace | quote }}
   {{- end }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: metrics

--- a/bitnami/wordpress/templates/svc.yaml
+++ b/bitnami/wordpress/templates/svc.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/wordpress/templates/svc.yaml
+++ b/bitnami/wordpress/templates/svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/wordpress/templates/tls-secrets.yaml
+++ b/bitnami/wordpress/templates/tls-secrets.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .name }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ $.Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     {{- if $.Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
@@ -27,7 +27,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-tls" .Values.ingress.hostname }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -348,7 +348,7 @@ containerSecurityContext:
 ## Configure extra options for WordPress containers' liveness and readiness probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
 ## @param livenessProbe.enabled Enable livenessProbe
-## @skip livenessProbe.httpGet[object]
+## @skip livenessProbe.httpGet
 ## @param livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
 ## @param livenessProbe.periodSeconds Period seconds for livenessProbe
 ## @param livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
@@ -377,7 +377,7 @@ livenessProbe:
   failureThreshold: 6
   successThreshold: 1
 ## @param readinessProbe.enabled Enable readinessProbe
-## @skip readinessProbe.httpGet[object]
+## @skip readinessProbe.httpGet
 ## @param readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
 ## @param readinessProbe.periodSeconds Period seconds for readinessProbe
 ## @param readinessProbe.timeoutSeconds Timeout seconds for readinessProbe

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -121,12 +121,12 @@ wordpressSkipInstall: false
 ##   @ini_set( 'memory_limit', '256M' );
 ##
 wordpressExtraConfigContent:
-## @param wordpressConfiguration The content for your custom wp-config.php file
+## @param wordpressConfiguration The content for your custom wp-config.php file (experimental feature)
 ## NOTE: This will override configuring WordPress based on environment variables (including those set by the chart)
 ## NOTE: Currently only supported when `wordpressSkipInstall=true`
 ##
 wordpressConfiguration:
-## @param existingWordPressConfigurationSecret The name of an existing secret with your custom wp-config.php file
+## @param existingWordPressConfigurationSecret The name of an existing secret with your custom wp-config.php file (experimental feature)
 ## NOTE: When it's set the `wordpressConfiguration` parameter is ignored
 ##
 existingWordPressConfigurationSecret:

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -1,15 +1,58 @@
+## @section Global parameters
 ## Global Docker image parameters
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value
-## Current available global Docker image parameters: imageRegistry and imagePullSecrets
-##
-# global:
-#   imageRegistry: myRegistryName
-#   imagePullSecrets:
-#     - myRegistryKeySecretName
-#   storageClass: myStorageClass
+## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
 
-## Bitnami WordPress image version
+## @param global.imageRegistry Global Docker image registry
+## @param global.imagePullSecrets Global Docker registry secret names as an array
+## @param global.storageClass Global StorageClass for Persistent Volume(s)
+##
+global:
+  imageRegistry:
+  ## E.g.
+  ## imagePullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
+  ## E.g.
+  ## storageClass: myStorageClass
+  ##
+  storageClass:
+
+## @section Common parameters
+
+## @param kubeVersion Override Kubernetes version
+##
+kubeVersion:
+## @param nameOverride String to partially override common.names.fullname
+##
+nameOverride:
+## @param fullnameOverride String to fully override common.names.fullname
+##
+fullnameOverride:
+## @param commonLabels Labels to add to all deployed objects
+##
+commonLabels: {}
+## @param commonAnnotations Annotations to add to all deployed objects
+##
+commonAnnotations: {}
+## @param clusterDomain Kubernetes cluster domain name
+##
+clusterDomain: cluster.local
+## @param extraDeploy Array of extra objects to deploy with the release
+##
+extraDeploy: []
+
+## @section WordPress Image parameters
+
+## Bitnami WordPress image
 ## ref: https://hub.docker.com/r/bitnami/wordpress/tags/
+## @param image.registry WordPress image registry
+## @param image.repository WordPress image repository
+## @param image.tag WordPress image tag (immutable tags are recommended)
+## @param image.pullPolicy WordPress image pull policy
+## @param image.pullSecrets WordPress image pull secrets
+## @param image.debug Enable image debug mode
 ##
 image:
   registry: docker.io
@@ -28,106 +71,69 @@ image:
   ##   - myRegistryKeySecretName
   ##
   pullSecrets: []
-  ## Set to true if you would like to see extra information on logs
+  ## Enable debug mode
   ##
   debug: false
 
-## String to partially override common.names.fullname template (will maintain the release name)
-##
-# nameOverride:
-
-## String to fully override common.names.fullname template
-##
-# fullnameOverride:
-
-## Add labels to all the deployed resources
-##
-commonLabels: {}
-
-## Add annotations to all the deployed resources
-##
-commonAnnotations: {}
-
-## Force target Kubernetes version (using Helm capabilites if not set)
-##
-kubeVersion:
-
-## Kubernetes Cluster Domain
-##
-clusterDomain: cluster.local
-
-## Extra objects to deploy (value evaluated as a template)
-##
-extraDeploy: []
-
-## Use a service account for the WordPress pod
-##
-serviceAccountName: default
-
-## WordPress username
+## @section WordPress Configuration parameters
+## WordPress settings based on environment variables
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
+
+## @param wordpressUsername WordPress username
 ##
 wordpressUsername: user
-
-## WordPress user password
+## @param wordpressPassword WordPress user password
 ## Defaults to a random 10-character alphanumeric string if not set
-## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
 ##
 wordpressPassword: ""
-
-## Use existing secret (does not create the WordPress Secret object)
+## @param existingSecret Name of existing secret containing WordPress credentials
 ## NOTE: Must contain key `wordpress-password`
 ## NOTE: When it's set, the `wordpressPassword` parameter is ignored
 ##
-# existingSecret:
-
-## WordPress user email
-## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
+existingSecret:
+## @param wordpressEmail WordPress user email
 ##
 wordpressEmail: user@example.com
-
-## WordPress user first name
-## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
+## @param wordpressFirstName WordPress user first name
 ##
 wordpressFirstName: FirstName
-
-## WordPress user last name
-## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
+## @param wordpressLastName WordPress user last name
 ##
 wordpressLastName: LastName
-
-## Blog name
-## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
+## @param wordpressBlogName Blog name
 ##
 wordpressBlogName: User's Blog!
-
-## Table prefix
-## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
+## @param wordpressTablePrefix Prefix to use for WordPress database tables
 ##
 wordpressTablePrefix: wp_
-
-## Scheme to generate application URLs
-## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
+## @param wordpressScheme Scheme to use to generate WordPress URLs
 ##
 wordpressScheme: http
-
-## Skip wizard installation (recommended if you use an external database that already contains WordPress data)
+## @param wordpressSkipInstall Skip wizard installation
+## NOTE: useful if you use an external database that already contains WordPress data)
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#connect-wordpress-docker-container-to-an-existing-database
 ##
 wordpressSkipInstall: false
-
-## Add extra content to the default configuration file
+## @param wordpressExtraConfigContent Add extra content to the default wp-config.php file
 ## e.g:
 ## wordpressExtraConfigContent: |
 ##   @ini_set( 'post_max_size', '128M');
 ##   @ini_set( 'memory_limit', '256M' );
 ##
-wordpressExtraConfigContent: ""
-
-## Make use of custom post-init.d user scripts functionality inside the bitnami/wordpress image
-## ref: https://github.com/bitnami/bitnami-docker-wordpress/tree/master/5/debian-10/rootfs/post-init.d
+wordpressExtraConfigContent:
+## @param wordpressConfiguration The content for your custom wp-config.php file
+## NOTE: This will override configuring WordPress based on environment variables (including those set by the chart)
+## NOTE: Currently only supported when `wordpressSkipInstall=true`
 ##
-## The logic of the post-init.d user scripts is that all is all files with extensions .sh, .sql or .php are executed for one time only, at the very first initialization of the pod as the very last step of entrypoint.sh.
+wordpressConfiguration:
+## @param existingWordPressConfigurationSecret The name of an existing secret with your custom wp-config.php file
+## NOTE: When it's set the `wordpressConfiguration` parameter is ignored
+##
+existingWordPressConfigurationSecret:
+## @param customPostInitScripts Custom post-init.d user scripts
+## ref: https://github.com/bitnami/bitnami-docker-wordpress/tree/master/5/debian-10/rootfs/post-init.d
+## NOTE: supported formats are `.sh`, `.sql` or `.php`
+## NOTE: scripts are exclusively executed during the 1st boot of the container
 ## e.g:
 ## customPostInitScripts:
 ##   enable-multisite.sh: |
@@ -141,73 +147,71 @@ wordpressExtraConfigContent: ""
 ##     RewriteBase /
 ##     ...
 ##
-## NOTE: Combined with extraVolume and extraVolumeMounts to mount the configmap to /docker-entrypoint-init.d where custom user init scripts are looked for
-##
 customPostInitScripts: {}
-
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress/#smtp-configuration
+## @param smtpHost SMTP server host
+## @param smtpPort SMTP server port
+## @param smtpUser SMTP username
+## @param smtpPassword SMTP user password
+## @param smtpProtocol SMTP protocol
 ##
-# smtpHost:
-# smtpPort:
-# smtpUser:
-# smtpPassword:
-# smtpProtocol:
-
-## Use an existing secret for the SMTP Password
-## Can be the same secret as existingSecret
-## Must contain key `smtp-password`
+smtpHost: ""
+smtpPort: ""
+smtpUser: ""
+smtpPassword: ""
+smtpProtocol: ""
+## @param smtpExistingSecret The name of an existing secret with SMTP credentials
+## NOTE: Must contain key `smtp-password`
 ## NOTE: When it's set, the `smtpPassword` parameter is ignored
 ##
-# smtpExistingSecret:
-
-## Set to `false` to allow the container to be started with blank passwords
-## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
+smtpExistingSecret:
+## @param allowEmptyPassword Allow the container to be started with blank passwords
 ##
 allowEmptyPassword: true
-
-## Set Apache allowOverride to None
-## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
+## @param allowOverrideNone Configure Apache to prohibit overriding directives with htaccess files
 ##
 allowOverrideNone: false
-
-## Persist the custom changes of the htaccess.
+## @param htaccessPersistenceEnabled Persist custom changes on htaccess files
 ## If `allowOverrideNone` is `true`, it will persist `/opt/bitnami/wordpress/wordpress-htaccess.conf`
 ## If `allowOverrideNone` is `false`, it will persist `/opt/bitnami/wordpress/.htaccess`
 ##
 htaccessPersistenceEnabled: false
-
-## Existing ConfigMap with containing a custom wordpress-htaccess.conf file (requires `allowOverrideNone=true`)
+## @param customHTAccessCM The name of an existing ConfigMap with custom htaccess rules
+## NOTE: Must contain key `wordpress-htaccess.conf` with the file content
+## NOTE: Requires setting `allowOverrideNone=true`
 ##
-customHTAccessCM: ""
-
-## Command and args for running the container (set to default if not set). Use array form
+customHTAccessCM:
+## @param command Override default container command (useful when using custom images)
 ##
 command: []
+## @param args Override default container args (useful when using custom images)
+##
 args: []
-
-## An array to add extra env vars
+## @param extraEnvVars Array with extra environment variables to add to the WordPress container
 ## e.g:
 ## extraEnvVars:
 ##   - name: FOO
 ##     value: "bar"
 ##
 extraEnvVars: []
-
-## ConfigMap with extra environment variables
+## @param extraEnvVarsCM Name of existing ConfigMap containing extra env vars
 ##
 extraEnvVarsCM:
-
-## Secret with extra environment variables
+## @param extraEnvVarsSecret Name of existing Secret containing extra env vars
 ##
 extraEnvVarsSecret:
 
-## Number of replicas (requires ReadWriteMany PVC support)
+## @section WordPress deployment parameters
+
+## @param replicaCount Number of WordPress replicas to deploy
+## NOTE: ReadWriteMany PVC(s) are required if replicaCount > 1
 ##
 replicaCount: 1
-
-## Set up update strategy for wordpress installation. Set to Recreate if you use persistent volume that cannot be mounted by more than one pods to makesure the pods is destroyed first.
+## @param updateStrategy.type WordPress deployment strategy type
+## @param updateStrategy.rollingUpdate WordPress deployment rolling update configuration parameters
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+## NOTE: Set it to `Recreate` if you use a PV that cannot be mounted on multiple pods
 ## e.g:
 ## updateStrategy:
 ##  type: RollingUpdate
@@ -217,13 +221,15 @@ replicaCount: 1
 ##
 updateStrategy:
   type: RollingUpdate
-
-## Use an alternate scheduler, e.g. "stork".
+  rollingUpdate: {}
+## @param schedulerName Alternate scheduler
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
 ##
-# schedulerName:
-
-## WordPress pod host aliases
+schedulerName:
+## @param serviceAccountName ServiceAccount name
+##
+serviceAccountName: default
+## @param hostAliases[array] WordPress pod host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
 hostAliases:
@@ -231,16 +237,13 @@ hostAliases:
   - ip: "127.0.0.1"
     hostnames:
       - "status.localhost"
-
-## Extra volumes to add to the deployment
+## @param extraVolumes Optionally specify extra list of additional volumes for WordPress pods
 ##
 extraVolumes: []
-
-## Extra volume mounts to add to the container
+## @param extraVolumeMounts Optionally specify extra list of additional volumeMounts for WordPress container(s)
 ##
 extraVolumeMounts: []
-
-## Add sidecars to the pod.
+## @param sidecars Add additional sidecar containers to the WordPress pod
 ## e.g:
 ## sidecars:
 ##   - name: your-image-name
@@ -251,8 +254,7 @@ extraVolumeMounts: []
 ##         containerPort: 1234
 ##
 sidecars: {}
-
-## Add init containers to the pod.
+## @param initContainers Add additional init containers to the WordPress pods
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 ## e.g:
 ## initContainers:
@@ -262,92 +264,96 @@ sidecars: {}
 ##    command: ['sh', '-c', 'copy themes and plugins from git and push to /bitnami/wordpress/wp-content. Should work with extraVolumeMounts and extraVolumes']
 ##
 initContainers: {}
-
-## Pod Labels
+## @param podLabels Extra labels for WordPress pods
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ##
 podLabels: {}
-
-## Pod annotations
+## @param podAnnotations Annotations for WordPress pods
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 ##
 podAnnotations: {}
-
-## Pod affinity preset
+## @param podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
 ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
-## Allowed values: soft, hard
 ##
 podAffinityPreset: ""
-
-## Pod anti-affinity preset
+## @param podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
 ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
-## Allowed values: soft, hard
 ##
 podAntiAffinityPreset: soft
-
 ## Node affinity preset
 ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
-## Allowed values: soft, hard
 ##
 nodeAffinityPreset:
-  ## Node affinity type
-  ## Allowed values: soft, hard
+  ## @param nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
   ##
   type: ""
-  ## Node label key to match
-  ## E.g.
-  ## key: "kubernetes.io/e2e-az-name"
+  ## @param nodeAffinityPreset.key Node label key to match. Ignored if `affinity` is set
   ##
   key: ""
-  ## Node label values to match
+  ## @param nodeAffinityPreset.values Node label values to match. Ignored if `affinity` is set
   ## E.g.
   ## values:
   ##   - e2e-az1
   ##   - e2e-az2
   ##
   values: []
-
-## Affinity for pod assignment
+## @param affinity Affinity for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-## Note: podAffinityPreset, podAntiAffinityPreset, and  nodeAffinityPreset will be ignored when it's set
+## NOTE: podAffinityPreset, podAntiAffinityPreset, and  nodeAffinityPreset will be ignored when it's set
 ##
 affinity: {}
-
-## Node labels for pod assignment. Evaluated as a template.
+## @param nodeSelector Node labels for pod assignment
 ## ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##
 nodeSelector: {}
-
-## Tolerations for pod assignment. Evaluated as a template.
+## @param tolerations Tolerations for pod assignment
 ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
 tolerations: {}
-
 ## WordPress containers' resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+## @param resources.limits The resources limits for the WordPress container
+## @param resources.requests[object] The requested resources for the WordPress container
 ##
 resources:
   limits: {}
   requests:
     memory: 512Mi
     cpu: 300m
-
+## Container ports
+## @param containerPorts.http WordPress HTTP container port
+## @param containerPorts.https WordPress HTTPS container port
+##
+containerPorts:
+  http: 8080
+  https: 8443
 ## Configure Pods Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+## @param podSecurityContext.enabled Enabled WordPress pods' Security Context
+## @param podSecurityContext.fsGroup Set WordPress pod's Security Context fsGroup
 ##
 podSecurityContext:
   enabled: true
   fsGroup: 1001
-
 ## Configure Container Security Context (only main container)
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+## @param containerSecurityContext.enabled Enabled WordPress containers' Security Context
+## @param containerSecurityContext.runAsUser Set WordPress container's Security Context runAsUser
+## @param containerSecurityContext.runAsNonRoot Set WordPress container's Security Context runAsNonRoot
 ##
 containerSecurityContext:
   enabled: true
   runAsUser: 1001
-
-## WordPress containers' liveness and readiness probes.
+  runAsNonRoot: true
+## Configure extra options for WordPress containers' liveness and readiness probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+## @param livenessProbe.enabled Enable livenessProbe
+## @skip livenessProbe.httpGet[object]
+## @param livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+## @param livenessProbe.periodSeconds Period seconds for livenessProbe
+## @param livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+## @param livenessProbe.failureThreshold Failure threshold for livenessProbe
+## @param livenessProbe.successThreshold Success threshold for livenessProbe
 ##
 livenessProbe:
   enabled: true
@@ -359,7 +365,7 @@ livenessProbe:
     ## like the balancer to prevent HTTP 302 responses. According to the Kubernetes
     ## docs, 302 should be considered "successful", but this issue on GitHub
     ## (https://github.com/kubernetes/kubernetes/issues/47893) shows that it isn't.
-    ##
+    ## E.g.
     ## httpHeaders:
     ## - name: X-Forwarded-Proto
     ##   value: https
@@ -370,6 +376,14 @@ livenessProbe:
   timeoutSeconds: 5
   failureThreshold: 6
   successThreshold: 1
+## @param readinessProbe.enabled Enable readinessProbe
+## @skip readinessProbe.httpGet[object]
+## @param readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+## @param readinessProbe.periodSeconds Period seconds for readinessProbe
+## @param readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+## @param readinessProbe.failureThreshold Failure threshold for readinessProbe
+## @param readinessProbe.successThreshold Success threshold for readinessProbe
+##
 readinessProbe:
   enabled: true
   httpGet:
@@ -380,7 +394,7 @@ readinessProbe:
     ## like the balancer to prevent HTTP 302 responses. According to the Kubernetes
     ## docs, 302 should be considered "successful", but this issue on GitHub
     ## (https://github.com/kubernetes/kubernetes/issues/47893) shows that it isn't.
-    ##
+    ## E.g.
     ## httpHeaders:
     ## - name: X-Forwarded-Proto
     ##   value: https
@@ -391,124 +405,108 @@ readinessProbe:
   timeoutSeconds: 5
   failureThreshold: 6
   successThreshold: 1
-
-## Custom liveness and readiness probes, it overrides the default one (evaluated as a template)
+## @param customLivenessProbe Custom livenessProbe that overrides the default one
 ##
 customLivenessProbe: {}
+## @param customReadinessProbe Custom readinessProbe that overrides the default one
+#
 customReadinessProbe: {}
 
-## Container ports
-##
-containerPorts:
-  http: 8080
-  https: 8443
+## @section Traffic Exposure Parameters
 
-## WordPress Service properties
+## WordPress service parameters
 ##
 service:
-  ## WordPress Service type
-  ## For minikube, set this to NodePort, elsewhere use LoadBalancer or ClusterIP
+  ## @param service.type WordPress service type
   ##
   type: LoadBalancer
-  ## HTTP Port
+  ## @param service.port WordPress service HTTP port
   ##
   port: 80
-  ## HTTPS Port
+  ## @param service.httpsPort WordPress service HTTPS port
   ##
   httpsPort: 443
-  ## HTTPS Target Port
-  ## defaults to https unless overridden to the specified port.
-  ## if you want the target port to be "http" or "80" you can specify that here.
+  ## @param service.httpsTargetPort Target port for HTTPS
   ##
   httpsTargetPort: https
-  ## Node Ports to expose
-  ## nodePorts:
-  ##   http: <to set explicitly, choose port between 30000-32767>
-  ##   https: <to set explicitly, choose port between 30000-32767>
+  ## Node ports to expose
+  ## @param service.nodePorts.http Node port for HTTP
+  ## @param service.nodePorts.https Node port for HTTPS
+  ## NOTE: choose port between <30000-32767>
   ##
   nodePorts:
-    http: ""
-    https: ""
-  ## Service clusterIP
+    http:
+    https:
+  ## @param service.clusterIP WordPress service Cluster IP
+  ## e.g.:
+  ## clusterIP: None
   ##
-  # clusterIP: None
-  ## loadBalancerIP for the SuiteCRM Service (optional, cloud specific)
-  ## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
+  clusterIP:
+  ## @param service.loadBalancerIP WordPress service Load Balancer IP
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
   ##
-  # loadBalancerIP:
-  ## Load Balancer sources
-  ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  loadBalancerIP:
+  ## @param service.loadBalancerSourceRanges WordPress service Load Balancer sources
+  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
   ## e.g:
   ## loadBalancerSourceRanges:
   ##   - 10.10.10.0/24
   ##
   loadBalancerSourceRanges: []
-  ## Enable client source IP preservation
+  ## @param service.externalTrafficPolicy WordPress service external traffic policy
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   ##
   externalTrafficPolicy: Cluster
-  ## Provide any additional annotations which may be required (evaluated as a template).
+  ## @param service.annotations Additional custom annotations for WordPress service
   ##
   annotations: {}
-  ## Extra ports to expose (normally used with the `sidecar` value)
+  ## @param service.extraPorts Extra port to expose on WordPress service
   ##
-  # extraPorts:
-
-## Configure the ingress resource that allows you to access the
-## WordPress installation. Set up the URL
-## ref: http://kubernetes.io/docs/user-guide/ingress/
+  extraPorts: []
+## Configure the ingress resource that allows you to access the WordPress installation
+## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ##
 ingress:
-  ## Set to true to enable ingress record generation
+  ## @param ingress.enabled Enable ingress record generation for WordPress
   ##
   enabled: false
-
-  ## Set this to true in order to add the corresponding annotations for cert-manager
+  ## @param ingress.certManager Add the corresponding annotations for cert-manager integration
   ##
   certManager: false
-
-  ## Ingress Path type
+  ## @param ingress.pathType Ingress path type
   ##
   pathType: ImplementationSpecific
-
-  ## Override API Version (automatically detected if not set)
+  ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
   apiVersion:
-
-  ## When the ingress is enabled, a host pointing to this will be created
+  ## @param ingress.hostname Default host for the ingress record
   ##
   hostname: wordpress.local
-
-  ## The Path to WordPress. You may need to set this to '/*' in order to use this
-  ## with ALB ingress controllers.
+  ## @param ingress.path Default path for the ingress record
+  ## NOTE: You may need to set this to '/*' in order to use this with ALB ingress controllers
   ##
   path: /
-
-  ## Ingress annotations done as key:value pairs
-  ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
-  ##
-  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+  ## @param ingress.annotations Additional custom annotations for the ingress record
+  ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
   ##
   annotations: {}
-
-  ## Enable TLS configuration for the hostname defined at ingress.hostname parameter
-  ## TLS certificates will be retrieved from a TLS secret with name: {{- printf "%s-tls" .Values.ingress.hostname }}
-  ## You can use the ingress.secrets parameter to create this TLS secret or relay on cert-manager to create it
+  ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+  ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
+  ## You can:
+  ##   - Use the `ingress.secrets` parameter to create this TLS secret
+  ##   - Relay on cert-manager to create it by setting `ingress.certManager=true`
+  ##   - Relay on Helm to create self-signed certificates by setting `ingress.tls=true` and `ingress.certManager=false`
   ##
   tls: false
-
-  ## The list of additional hostnames to be covered with this ingress record.
-  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+  ## @param ingress.extraHosts An array with additional hostname(s) to be covered with the ingress record
   ## e.g:
   ## extraHosts:
   ##   - name: wordpress.local
   ##     path: /
   ##
   extraHosts: []
-
-  ## Any additional arbitrary paths that may need to be added to the ingress under the main host.
-  ## For example: The ALB ingress controller requires a special rule for handling SSL redirection.
+  ## @param ingress.extraPaths An array with additional arbitrary paths that may need to be added to the ingress under the main host
+  ## e.g:
   ## extraPaths:
   ## - path: /*
   ##   backend:
@@ -516,9 +514,8 @@ ingress:
   ##     servicePort: use-annotation
   ##
   extraPaths: []
-
-  ## The tls configuration for additional hostnames to be covered with this ingress record.
-  ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## @param ingress.extraTls TLS configuration for additional hostname(s) to be covered with this ingress record
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
   ## e.g:
   ## extraTls:
   ## - hosts:
@@ -526,61 +523,74 @@ ingress:
   ##   secretName: wordpress.local-tls
   ##
   extraTls: []
-
-  ## If you're providing your own certificates, please use this to add the certificates as secrets
-  ## key and certificate are expected in PEM format
-  ## name should line up with a secretName set further up
-  ##
+  ## @param ingress.secrets Custom TLS certificates as secrets
+  ## NOTE: 'key' and 'certificate' are expected in PEM format
+  ## NOTE: 'name' should line up with a 'secretName' set further up
   ## If it is not set and you're using cert-manager, this is unneeded, as it will create a secret for you with valid certificates
   ## If it is not set and you're NOT using cert-manager either, self-signed certificates will be created valid for 365 days
   ## It is also possible to create and manage the certificates outside of this helm chart
   ## Please see README.md for more information
-  ##
-  ## Example
+  ## e.g:
   ## secrets:
   ##   - name: wordpress.local-tls
-  ##     key: ""
-  ##     certificate: ""
+  ##     key: |-
+  ##       -----BEGIN RSA PRIVATE KEY-----
+  ##       ...
+  ##       -----END RSA PRIVATE KEY-----
+  ##     certificate: |-
+  ##       -----BEGIN CERTIFICATE-----
+  ##       ...
+  ##       -----END CERTIFICATE-----
   ##
   secrets: []
 
-## Enable persistence using Persistent Volume Claims
+## @section Persistence Parameters
+
+## Persistence Parameters
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##
 persistence:
-  ## If true, use a Persistent Volume Claim, If false, use emptyDir
+  ## @param persistence.enabled Enable persistence using Persistent Volume Claims
   ##
   enabled: true
-  ## wordpress data Persistent Volume Storage Class
+  ## @param persistence.storageClass Persistent Volume storage class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning
-  ## If undefined (the default) or set to null, no storageClassName spec is
-  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-  ##   GKE, AWS & OpenStack)
+  ## If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner
   ##
-  # storageClass: "-"
-  ## Persistent Volume Access Modes
+  storageClass:
+  ## @param persistence.accessModes[0] Persistent Volume access modes
   ##
   accessModes:
     - ReadWriteOnce
-  ## DEPRECATED: use `persistence.accessModes` instead
+  ## @param persistence.accessMode Persistent Volume access mode (DEPRECATED: use `persistence.accessModes` instead)
+  ##
   accessMode: ReadWriteOnce
-  ## Persistent Volume size
+  ## @param persistence.size Persistent Volume size
   ##
   size: 10Gi
-  ## Custom dataSource
+  ## @param persistence.dataSource Custom PVC data source
   ##
   dataSource: {}
-  ## Enable persistence using an existing PVC
+  ## @param persistence.existingClaim The name of an existing PVC to use for persistence
   ##
-  # existingClaim:
-
-## Init containers parameters:
-## volumePermissions: Change the owner and group of the persistent volume mount point to runAsUser:fsGroup values
-## based on the podSecurityContext/containerSecurityContext parameters
+  existingClaim:
+## 'volumePermissions' init container parameters
+## Changes the owner and group of the persistent volume mount point to runAsUser:fsGroup values
+##   based on the podSecurityContext/containerSecurityContext parameters
 ##
 volumePermissions:
+  ## @param volumePermissions.enabled Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`
+  ##
   enabled: false
+  ## Bitnami Shell image
+  ## ref: https://hub.docker.com/r/bitnami/bitnami-shell/tags/
+  ## @param volumePermissions.image.registry Bitnami Shell image registry
+  ## @param volumePermissions.image.repository Bitnami Shell image repository
+  ## @param volumePermissions.image.tag Bitnami Shell image tag (immutable tags are recommended)
+  ## @param volumePermissions.image.pullPolicy Bitnami Shell image pull policy
+  ## @param volumePermissions.image.pullSecrets Bitnami Shell image pull secrets
+  ##
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
@@ -594,58 +604,67 @@ volumePermissions:
     ##   - myRegistryKeySecretName
     ##
     pullSecrets: []
-  ## Init container' resource requests and limits
+  ## Init container's resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param volumePermissions.resources.limits The resources limits for the init container
+  ## @param volumePermissions.resources.requests The requested resources for the init container
   ##
   resources:
-    ## We usually recommend not to specify default resources and to leave this as a conscious
-    ## choice for the user. This also increases chances charts run on environments with little
-    ## resources, such as Minikube. If you do want to specify resources, uncomment the following
-    ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    ## e.g:
-    ## limits:
-    ##   cpu: 500m
-    ##   memory: 1Gi
-    ##
     limits: {}
     requests: {}
-  ## Init container Security Context
-  ## Note: the chown of the data folder is done to containerSecurityContext.runAsUser
-  ## and not the below volumePermissions.securityContext.runAsUser
-  ## When runAsUser is set to special value "auto", init container will try to chwon the
-  ## data folder to autodetermined user&group, using commands: `id -u`:`id -G | cut -d" " -f2`
-  ## "auto" is especially useful for OpenShift which has scc with dynamic userids (and 0 is not allowed).
-  ## You may want to use this volumePermissions.securityContext.runAsUser="auto" in combination with
-  ## podSecurityContext.enabled=false,containerSecurityContext.enabled=false
+  ## Init container Container Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  ## @param volumePermissions.securityContext.runAsUser Set init container's Security Context runAsUser
+  ## NOTE: when runAsUser is set to special value "auto", init container will try to chown the
+  ##   data folder to auto-determined user&group, using commands: `id -u`:`id -G | cut -d" " -f2`
+  ##   "auto" is especially useful for OpenShift which has scc with dynamic user ids (and 0 is not allowed)
   ##
   securityContext:
     runAsUser: 0
 
+## @section Other Parameters
+
 ## Wordpress Pod Disruption Budget configuration
 ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+## @param pdb.create Enable a Pod Disruption Budget creation
+## @param pdb.minAvailable Minimum number/percentage of pods that should remain scheduled
+## @param pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable
 ##
 pdb:
   create: false
-  ## Min number of pods that must still be available after the eviction
-  ##
   minAvailable: 1
-  ## Max number of pods that can be unavailable after the eviction
-  ##
-  # maxUnavailable: 1
-
+  maxUnavailable:
 ## Wordpress Autoscaling configuration
+## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+## @param autoscaling.enabled Enable Horizontal POD autoscaling for WordPress
+## @param autoscaling.minReplicas Minimum number of WordPress replicas
+## @param autoscaling.maxReplicas Maximum number of WordPress replicas
+## @param autoscaling.targetCPU Target CPU utilization percentage
+## @param autoscaling.targetMemory Target Memory utilization percentage
 ##
 autoscaling:
   enabled: false
   minReplicas: 1
   maxReplicas: 11
-  # targetCPU: 50
-  # targetMemory: 50
+  targetCPU: 50
+  targetMemory: 50
 
-## Prometheus Exporter / Metrics
+## @section Metrics Parameters
+
+## Prometheus Exporter / Metrics configuration
 ##
 metrics:
+  ## @param metrics.enabled Start a sidecar prometheus exporter to expose metrics
+  ##
   enabled: false
+  ## Bitnami Apache Exporter image
+  ## ref: https://hub.docker.com/r/bitnami/apache-exporter/tags/
+  ## @param metrics.image.registry Apache Exporter image registry
+  ## @param metrics.image.repository Apache Exporter image repository
+  ## @param metrics.image.tag Apache Exporter image tag (immutable tags are recommended)
+  ## @param metrics.image.pullPolicy Apache Exporter image pull policy
+  ## @param metrics.image.pullSecrets Apache Exporter image pull secrets
+  ##
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
@@ -659,135 +678,128 @@ metrics:
     ##   - myRegistryKeySecretName
     ##
     pullSecrets: []
-
-  ## Prometheus expoter service parameters
-  ##
-  service:
-    ## Metrics port
-    ##
-    port: 9117
-    ## Annotations for the Prometheus exporter service
-    ##
-    annotations:
-      prometheus.io/scrape: "true"
-      prometheus.io/port: "{{ .Values.metrics.service.port }}"
-
-  ## Metrics exporter containers' resource requests and limits
+  ## Prometheus exporter container's resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param metrics.resources.limits The resources limits for the Prometheus exporter container
+  ## @param metrics.resources.requests The requested resources for the Prometheus exporter container
   ##
   resources:
     limits: {}
     requests: {}
-
+  ## Prometheus exporter service parameters
+  ##
+  service:
+    ## @param metrics.service.port Metrics service port
+    ##
+    port: 9117
+    ## @param metrics.service.annotations[object] Additional custom annotations for Metrics service
+    ##
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "{{ .Values.metrics.service.port }}"
   ## Prometheus Service Monitor
   ## ref: https://github.com/coreos/prometheus-operator
   ##      https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
   ##
   serviceMonitor:
-    ## If the operator is installed in your cluster, set to true to create a Service Monitor Entry
+    ## @param metrics.serviceMonitor.enabled Create ServiceMonitor Resource for scraping metrics using PrometheusOperator
     ##
     enabled: false
-    ## Specify the namespace in which the serviceMonitor resource will be created
+    ## @param metrics.serviceMonitor.namespace The namespace in which the ServiceMonitor will be created
     ##
-    # namespace: ""
-    ## Specify the interval at which metrics should be scraped
+    namespace:
+    ## @param metrics.serviceMonitor.interval The interval at which metrics should be scraped
     ##
     interval: 30s
-    ## Specify the timeout after which the scrape is ended
+    ## @param metrics.serviceMonitor.scrapeTimeout The timeout after which the scrape is ended
     ##
-    # scrapeTimeout: 30s
-    ## Specify Metric Relabellings to add to the scrape endpoint
+    scrapeTimeout:
+    ## @param metrics.serviceMonitor.relabellings Metrics relabellings to add to the scrape endpoint
     ##
-    # relabellings:
-    ## Specify honorLabels parameter to add the scrape endpoint
+    relabellings:
+    ## @param metrics.serviceMonitor.honorLabels Labels to honor to add to the scrape endpoint
     ##
     honorLabels: false
-    ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with
-    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+    ## @param metrics.serviceMonitor.additionalLabels Additional custom labels for the ServiceMonitor
     ##
     additionalLabels: {}
 
-##
+## @section Database Parameters
+
 ## MariaDB chart configuration
 ## ref: https://github.com/bitnami/charts/blob/master/bitnami/mariadb/values.yaml
 ##
 mariadb:
-  ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+  ## @param mariadb.enabled Deploy a MariaDB server to satisfy the applications database requirements
+  ## To use an external database set this to false and configure the `externalDatabase.*` parameters
   ##
   enabled: true
-  ## MariaDB architecture. Allowed values: standalone or replication
+  ## @param mariadb.architecture MariaDB architecture. Allowed values: `standalone` or `replication`
   ##
   architecture: standalone
   ## MariaDB Authentication parameters
-  ##
+  ## @param mariadb.auth.rootPassword MariaDB root password
+  ## @param mariadb.auth.database MariaDB custom database
+  ## @param mariadb.auth.username MariaDB custom user name
+  ## @param mariadb.auth.password MariaDB custom user password
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
+  ##      https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+  ##      https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
   auth:
-    ## MariaDB root password
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
-    ##
     rootPassword: ""
-    ## MariaDB custom user and database
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
-    ##
     database: bitnami_wordpress
     username: bn_wordpress
     password: ""
+  ## MariaDB Primary configuration
+  ##
   primary:
-    ## Enable persistence using Persistent Volume Claims
+    ## MariaDB Primary Persistence parameters
     ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+    ## @param mariadb.primary.persistence.enabled Enable persistence on MariaDB using PVC(s)
+    ## @param mariadb.primary.persistence.storageClass Persistent Volume storage class
+    ## @param mariadb.primary.persistence.accessModes[0] Persistent Volume access modes
+    ## @param mariadb.primary.persistence.size Persistent Volume size
     ##
     persistence:
       enabled: true
-      ## mariadb data Persistent Volume Storage Class
-      ## If defined, storageClassName: <storageClass>
-      ## If set to "-", storageClassName: "", which disables dynamic provisioning
-      ## If undefined (the default) or set to null, no storageClassName spec is
-      ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-      ##   GKE, AWS & OpenStack)
-      ##
-      # storageClass: "-"
+      storageClass:
       accessModes:
         - ReadWriteOnce
       size: 8Gi
-
-##
 ## External Database Configuration
-##
-## All of these values are only used when mariadb.enabled is set to false
+## All of these values are only used if `mariadb.enabled=false`
 ##
 externalDatabase:
-  ## Database host
+  ## @param externalDatabase.host External Database server host
   ##
   host: localhost
-  ## non-root Username for Wordpress Database
-  ##
-  user: bn_wordpress
-  ## Database password
-  ##
-  password: ""
-  ## Database name
-  ##
-  database: bitnami_wordpress
-  ## Database port number
+  ## @param externalDatabase.port External Database server port
   ##
   port: 3306
-  ## Use existing secret (ignores previous password)
-  ## must contain key `mariadb-password`
+  ## @param externalDatabase.user External Database username
+  ##
+  user: bn_wordpress
+  ## @param externalDatabase.password External Database user password
+  ##
+  password: ""
+  ## @param externalDatabase.database External Database database name
+  ##
+  database: bitnami_wordpress
+  ## @param externalDatabase.existingSecret The name of an existing secret with database credentials
+  ## NOTE: Must contain key `mariadb-password`
   ## NOTE: When it's set, the `externalDatabase.password` parameter is ignored
   ##
-  # existingSecret:
-
-##
+  existingSecret:
 ## Memcached chart configuration
 ## ref: https://github.com/bitnami/charts/blob/master/bitnami/memcached/values.yaml
 ##
 memcached:
-  ## Whether to deploy a memcached server for caching database queries
+  ## @param memcached.enabled Deploy a Memcached server for caching database queries
   ##
   enabled: false
   ## Service parameters
   ##
   service:
-    ## Memcached port
+    ## @param memcached.service.port Memcached service port
     ##
     port: 11211


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR adapts WordPress **values.yaml** to follow the format supported by [readmenator](https://github.com/bitnami-labs/readmenator) to automatically generate the READMEs' tables based on the metadata.

It also adds a couple of new parameters:

| Name                                   | Description                                                              | Value              |
| -------------------------------------- | ------------------------------------------------------------------------ | ------------------ |
| `wordpressConfiguration`               | The content for your custom wp-config.php file                           | `""`               |
| `existingWordPressConfigurationSecret` | The name of an existing secret with your custom wp-config.php file       | `""`              

These parameters will allow overriding the **wp-config.php** with a custom one. It has some limitations since it's only supported currently when `wordpressSkipInstall=true` which implies that users must use an external database already populated with WordPress data.

> Note: this new feature should be considered **experimental**.

**Benefits**

Improve development process.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
