### PR TITLE
Upd kafka auto discovery for ext access

### DIFF
--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -452,6 +452,7 @@ Note: This option requires creating RBAC rules on clusters where RBAC policies a
 externalAccess.enabled=true
 externalAccess.service.type=LoadBalancer
 externalAccess.service.port=9094
+externalAccess.autoDiscovery.enabled=true
 externalAccess.service.loadBalancerIPs[0]='external-ip-1'
 externalAccess.service.loadBalancerIPs[1]='external-ip-2'}
 ```
@@ -479,6 +480,7 @@ Note: This option requires creating RBAC rules on clusters where RBAC policies a
 ```console
 externalAccess.enabled=true
 externalAccess.service.type=NodePort
+externalAccess.autoDiscovery.enabled=true
 externalAccess.service.nodePorts[0]='node-port-1'
 externalAccess.service.nodePorts[1]='node-port-2'
 ```


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Updated documentation related to Kafka Chart. External access fails currently, which was discussed in  #5975 and #4240

**Benefits**
Access Kafka broker from outside the Kubernetes cluster

**Possible drawbacks**

None

**Applicable issues**
#5975 #4240

**Additional information**
Validated in 

Kube version: 1.20.5
Helm version: 3.5.3