### PR TITLE
[bitnami/kafka] Update lock file to get latest version of Zookeeper chart

### DIFF
--- a/bitnami/kafka/Chart.lock
+++ b/bitnami/kafka/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.4.2
 - name: zookeeper
   repository: https://charts.bitnami.com/bitnami
-  version: 6.5.4
-digest: sha256:a4554870cb574a210de06ce7bd23275b372041ce49dce1e34faabdee588bcf2d
-generated: "2021-03-29T07:17:47.707038297Z"
+  version: 6.7.0
+digest: sha256:0da52fe1d329f5c75ec82f1b1131b7dd0d72ab26fe7bc8798ef846d92d5b7155
+generated: "2021-04-06T15:56:00.853005-04:00"

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 12.16.0
+version: 12.16.1


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Updates the Chart.lock file to get latest version of Zookeeper chart.
From 6.5.4 to 6.7.0

**Benefits**

I believe without this change, if Chart A has kafka chart as dependency and uses latest version of kafka chart (12.16.0) and tries to use `helm dep update`, zookeeper chart version pulled is 6.5.4 instead of the latest (6.7.0). 

**Possible drawbacks**

Should be no side-effects.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

Related converstation: https://github.com/bitnami/charts/pull/5996#issuecomment-814332142

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
