### PR TITLE
[bitnami/etcd] Service account specification

### DIFF
--- a/bitnami/etcd/Chart.lock
+++ b/bitnami/etcd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.4.1
-digest: sha256:81be4c0ebd0a81952423b24268e82697231b8c07991ee60b23b950ff1db003a2
-generated: "2021-03-03T12:54:24.246921+01:00"
+  version: 1.4.2
+digest: sha256:4e3ec38e0e27e9fc1defb2a13f67a0aa12374bf0b15f06a6c13b1b46df6bffeb
+generated: "2021-04-08T09:54:13.075277-07:00"

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -25,4 +25,4 @@ name: etcd
 sources:
   - https://github.com/bitnami/bitnami-docker-etcd
   - https://coreos.com/etcd/
-version: 6.1.5
+version: 6.2.0

--- a/bitnami/etcd/README.md
+++ b/bitnami/etcd/README.md
@@ -218,6 +218,16 @@ The following tables lists the configurable parameters of the etcd chart and the
 | `disasterRecovery.pvc.size`                     | PVC Storage Request                                                                   | `2Gi`                                                       |
 | `disasterRecovery.pvc.storageClassName`         | Storage Class for snapshots volume                                                    | `nfs`                                                       |
 
+### Service account parameters
+
+| Parameter                                     | Description                                           | Default   |
+|-----------------------------------------------|-------------------------------------------------------|-----------|
+| `serviceAccount.create`                       | Enable/disable service account creation               | `false`   |
+| `serviceAccount.name`                         | Name of the service account to create or use          | `default` |
+| `serviceAccount.automountServiceAccountToken` | Enable/disable auto mounting of service account token | `true`    |
+| `serviceAccount.labels`                       | Additional labels to include on service account       | `{}`      |
+| `serviceAccount.annotations`                  | Additional annotations to include on service account  | `{}`      |
+
 ### Other parameters
 
 | Parameter                  | Description                                                    | Default |

--- a/bitnami/etcd/templates/_helpers.tpl
+++ b/bitnami/etcd/templates/_helpers.tpl
@@ -150,3 +150,14 @@ etcd: disasterRecovery
     Please enable persistence (--set persistence.enabled=true)
 {{- end -}}
 {{- end -}}
+
+{{/*
+ Create the name of the service account to use
+ */}}
+{{- define "etcd.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{ default (include "common.names.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+{{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/bitnami/etcd/templates/serviceaccount.yaml
+++ b/bitnami/etcd/templates/serviceaccount.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+metadata:
+  name: {{ include "etcd.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.serviceAccount.labels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.serviceAccount.labels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.commonAnnotations .Values.serviceAccount.annotations }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.serviceAccount.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.serviceAccount.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/bitnami/etcd/templates/statefulset.yaml
+++ b/bitnami/etcd/templates/statefulset.yaml
@@ -55,6 +55,7 @@ spec:
       {{- if .Values.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "etcd.serviceAccountName" $ | quote }}
       {{- if or .Values.initContainers (and .Values.volumePermissions.enabled .Values.persistence.enabled) }}
       initContainers:
         {{- if .Values.initContainers }}

--- a/bitnami/etcd/values.yaml
+++ b/bitnami/etcd/values.yaml
@@ -448,6 +448,26 @@ service:
   ##
   annotations: {}
 
+## Service account configuration
+##
+serviceAccount:
+  ## If true, create service account. If false, use service account defined by name.
+  ##
+  create: false
+  ## Name of service account to use or create.
+  ##
+  name: ""
+  ## Whether to auto mount the service account token
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server
+  ##
+  automountServiceAccountToken: true
+  ## Additional annotations to be included on the service account
+  ##
+  annotations: {}
+  ## Additional labels to be included on the service account
+  ##
+  labels: {}
+
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
* Add support for service account specification
  * Supports creation or using existing service account
  * Default to the 'default' service account
* Update common dependency for new patch release 1.4.1 -> 1.4.2
* Increment chart version 6.1.5 -> 6.2.0

**Benefits**

<!-- What benefits will be realized by the code change? -->
* Improves security posture by allowing the association of etcd with a specific service account instead of the default which may have certain permissions associated with it by default that etcd doesn't need

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
N/A

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
N/A

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
N/A

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
