### PR TITLE
[bitnami/etcd] Add image pull secrets to cronjob

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -25,4 +25,4 @@ name: etcd
 sources:
   - https://github.com/bitnami/bitnami-docker-etcd
   - https://coreos.com/etcd/
-version: 6.2.0
+version: 6.2.1

--- a/bitnami/etcd/templates/cronjob.yaml
+++ b/bitnami/etcd/templates/cronjob.yaml
@@ -25,6 +25,7 @@ spec:
           annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.disasterRecovery.cronjob.podAnnotations "context" $) | nindent 12 }}
           {{- end }}
         spec:
+          {{- include "etcd.imagePullSecrets" . | nindent 10 }}
           restartPolicy: OnFailure
           {{- if .Values.podSecurityContext.enabled }}
           securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 12 }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

The "imagePullSecrets" are missing for the **etcd** cronjob used to snapshot the keyspace.

**Benefits**

Users can use the **etcd** chart with images pulled from private repos.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)