### PR TITLE
[bitnami/postgresql-ha] Fix pgpool service annotations

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -27,4 +27,4 @@ name: postgresql-ha
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 6.8.2
+version: 6.8.3

--- a/bitnami/postgresql-ha/templates/pgpool/service.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/service.yaml
@@ -15,7 +15,9 @@ metadata:
   {{- if .Values.service.annotations }}
   {{- include "common.tplvalues.render" (dict "value" .Values.service.annotations "context" $) | nindent 4 }}
   {{- end }}
+  {{- if .Values.commonAnnotations }}
   {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 
 spec:
   type: {{ .Values.service.type }}


### PR DESCRIPTION
**Description of the change**
Only render `commonAnnotations` if the key is set and not empty. This fixes an issue that would render an invalid manifest when only setting `service.annotations`.

**Applicable issues**
  - fixes #6064

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

