### PR TITLE
[bitnami/nginx] Move sysctls to podSecurityContext

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -25,4 +25,4 @@ name: nginx
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx
   - http://www.nginx.org
-version: 8.8.2
+version: 8.8.3

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -236,6 +236,13 @@ tolerations: {}
 podSecurityContext:
   enabled: false
   fsGroup: 1001
+  ## sysctl settings
+  ## Example:
+  ## sysctls:
+  ## - name: net.core.somaxconn
+  ##   value: "10000"
+  ##
+  sysctls: {}
 
 ## NGINX Core containers' Security Context (only main container).
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
@@ -244,13 +251,6 @@ containerSecurityContext:
   enabled: false
   runAsUser: 1001
   runAsNonRoot: true
-  ## sysctl settings
-  ## Example:
-  ## sysctls:
-  ## - name: net.core.somaxconn
-  ##   value: "10000"
-  ##
-  sysctls: {}
 
 ## Configures the ports NGINX listens on
 ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

Moves the `sysctls` field from ``containerSecurityContext` to `podSecurityContext` where it belongs.

If you look at the docs the field `sysctls`does not exist in the container but does in the pod security context.
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#podsecuritycontext-v1-core
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#securitycontext-v1-core

**Benefits**

<!-- What benefits will be realized by the code change? -->

Fixes an incorrect helm chart.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

N/A

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
N/A

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

N/A

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
