### PR TITLE
[bitnami/nginx] Add git custom commands

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -25,4 +25,4 @@ name: nginx
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx
   - http://www.nginx.org
-version: 8.8.5
+version: 8.9.0

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -142,6 +142,10 @@ The following tables lists the configurable parameters of the NGINX chart and th
 | `cloneStaticSiteFromGit.interval`          | Interval for sidecar container pull from the GIT repository | `60`                                                    |
 | `cloneStaticSiteFromGit.extraEnvVars`      | Extra environment variables to be set on GIT containers     | `[]`                                                    |
 | `cloneStaticSiteFromGit.extraVolumeMounts` | Add extra volume mounts for the GIT containers              | `[]`                                                    |
+| `cloneStaticSiteFromGit.gitClone.command`  | Override default container command for git-clone-repository | `[]`                                                    |
+| `cloneStaticSiteFromGit.gitClone.args`     | Override default container args for git-clone-repository    | `[]`                                                    |
+| `cloneStaticSiteFromGit.gitSync.command`   | Override default container command for git-repo-syncer      | `[]`                                                    |
+| `cloneStaticSiteFromGit.gitSync.args`      | Override default container args for git-repo-syncer         | `[]`                                                    |
 | `serverBlock`                              | Custom NGINX server block                                   | `nil`                                                   |
 | `existingServerBlockConfigmap`             | Name of existing PVC with custom NGINX server block         | `nil`                                                   |
 | `staticSiteConfigmap`                      | Name of existing ConfigMap with the server static content   | `nil`                                                   |

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -59,12 +59,19 @@ spec:
         - name: git-clone-repository
           image: {{ include "nginx.cloneStaticSiteFromGit.image" . }}
           imagePullPolicy: {{ .Values.cloneStaticSiteFromGit.image.pullPolicy | quote }}
+          {{- if .Values.cloneStaticSiteFromGit.gitClone.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.cloneStaticSiteFromGit.gitClone.command "context" $) | nindent 12 }}
+          {{- else}}
           command:
             - /bin/bash
             - -ec
             - |
               [[ -f "/opt/bitnami/scripts/git/entrypoint.sh" ]] && source "/opt/bitnami/scripts/git/entrypoint.sh"
               git clone {{ .Values.cloneStaticSiteFromGit.repository }} --branch {{ .Values.cloneStaticSiteFromGit.branch }} /app
+          {{- end}}
+          {{- if .Values.cloneStaticSiteFromGit.gitClone.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.cloneStaticSiteFromGit.gitClone.args "context" $) | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: staticsite
               mountPath: /app
@@ -79,6 +86,9 @@ spec:
         - name: git-repo-syncer
           image: {{ include "nginx.cloneStaticSiteFromGit.image" . }}
           imagePullPolicy: {{ .Values.cloneStaticSiteFromGit.image.pullPolicy | quote }}
+          {{- if .Values.cloneStaticSiteFromGit.gitSync.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.cloneStaticSiteFromGit.gitSync.command "context" $) | nindent 12 }}
+          {{- else}}
           command:
             - /bin/bash
             - -ec
@@ -88,6 +98,10 @@ spec:
                   cd /app && git pull origin {{ .Values.cloneStaticSiteFromGit.branch }}
                   sleep {{ .Values.cloneStaticSiteFromGit.interval }}
               done
+          {{- end}}
+          {{- if .Values.cloneStaticSiteFromGit.gitSync.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.cloneStaticSiteFromGit.gitSync.args "context" $) | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: staticsite
               mountPath: /app

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -117,6 +117,24 @@ cloneStaticSiteFromGit:
   ## Interval for sidecar container pull from the repository
   ##
   interval: 60
+  ## Additional configuration for git-clone-repository initContainer
+  ##
+  gitClone:
+    ## Override container command
+    ##
+    command: []
+    ## Override container args
+    ##
+    args:
+  ## Additional configuration for the git-repo-syncer container
+  ##
+  gitSync:
+    ## Override container command
+    ##
+    command: []
+    ## Override container args
+    ##
+    args: []
 
   ## Additional environment variables to set for the in the containers that clone static site from git
   ## E.g:


### PR DESCRIPTION
**Description of the change**

This PR adds the settings `.Values.cloneStaticSiteFromGit.gitRepoSync.command` and `Values.cloneStaticSiteFromGit.gitClone.command`.

This is especially useful for users using a custom image who would like to run a custom command.

**Possible drawbacks**

None known.

**Applicable issues**

  - fixes #6066

**Additional information**

```yaml
> helm template bitnami/nginx --set cloneStaticSiteFromGit.enabled=true,cloneStaticSiteFromGit.repository=my_repo,cloneStaticSiteFromGit.branch=master
...
      initContainers:
        - name: git-clone-repository
          image: docker.io/bitnami/git:2.31.1-debian-10-r31
          imagePullPolicy: "IfNotPresent"
          command:
            - /bin/sh
          args:
            - -c
            - echo 'Hello World'
          volumeMounts:
            - name: staticsite
              mountPath: /app
      containers:
        - name: git-repo-syncer
          image: docker.io/bitnami/git:2.31.1-debian-10-r31
          imagePullPolicy: "IfNotPresent"
          command:
            - /bin/sh
          args:
            - -c
            - echo 'Hello World'
          volumeMounts:
            - name: staticsite
              mountPath: /app
...
```

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
