### PR TITLE
[bitnami/charts] add periodic volumesnapshots for CSI drivers

### DIFF
--- a/bitnami/mongodb/templates/cron_volumesnapshot.yaml
+++ b/bitnami/mongodb/templates/cron_volumesnapshot.yaml
@@ -1,0 +1,63 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ include "mongodb.fullname" . }}-volume-snapshot
+spec:
+  schedule: "{{ .Values.volumeSnapshot.cron }}"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: {{ template "mongodb.serviceAccountName" . }}
+          containers:
+            - name: backup-cron
+              env:
+                - name: M_RELEASE_NAME
+                  value: {{ include "mongodb.fullname" . }}
+                - name: M_PORT
+                  value: {{ .Values.service.port | toString | quote }}
+                - name: M_ROOT_PASSWORD
+                  value: {{ .Values.auth.rootPassword | toString | quote }}
+                - name: VSC_NAME
+                  value: {{ .Values.volumeSnapshot.volumeSnapshotClass }}
+              image: {{ .Values.volumeSnapshot.image }}
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/bash
+                - -i
+                - -c
+                - |
+                    set -e
+                    echo alias M_CMD=\'mongo admin --host ${M_RELEASE_NAME}-1.{{ include "mongodb.service.nameOverride" . }}:${M_PORT} {{- if .Values.auth.enabled }} --authenticationDatabase admin -u root -p ${M_ROOT_PASSWORD} {{- end }} --quiet --eval\' >> ~/.bashrc
+                    source ~/.bashrc
+                    echo -e "[+] Check if it is a Primary node to make it stepDown\n"
+                    if [[ `M_CMD " db.runCommand( { isMaster: 1 } )['ismaster']"` != "false" ]]
+                    then
+                      echo -e "[+] Stepping Down\n"
+                      M_CMD "rs.stepDown()"
+                    fi
+                    echo -e "[+] Send Slave to Freeze\n"
+                    M_CMD "rs.freeze(99999999999)"
+                    export E_TIME=$(date +%s)
+                    echo -e "[+] Creating snapshot object\n"
+                    cat <<EOF | kubectl apply -f -
+                    apiVersion: snapshot.storage.k8s.io/v1beta1
+                    kind: VolumeSnapshot
+                    metadata:
+                      name: snapshot-${M_RELEASE_NAME}-${E_TIME}
+                    spec:
+                      volumeSnapshotClassName: ${VSC_NAME}
+                      source:
+                        persistentVolumeClaimName: datadir-${M_RELEASE_NAME}-1
+                    EOF
+                    echo -e "[+] Waiting for snapshot to finish\n"
+                    while : ; do
+                      result=$(kubectl get volumesnapshot   -o custom-columns='READY:.status.readyToUse' --field-selector metadata.name=snapshot-${M_RELEASE_NAME}-${E_TIME} | grep -v READY)
+                      [[ "${result}" == "true" ]] && break
+                      echo "[-] still waiting for snapshot to be ready .. "
+                      sleep 1
+                    done
+                    echo -e "[+] Snapshot finished, unfreeze Slave\n"
+                    M_CMD "rs.freeze(0)"
+                    echo -e "[+] Snapshotting finished successfully\n"
+          restartPolicy: OnFailure

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -500,6 +500,10 @@ spec:
         {{- if .Values.persistence.volumeClaimTemplates.selector }}
         selector: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.volumeClaimTemplates.selector "context" $) | nindent 10 }}
         {{- end }}
+        {{- if .Values.persistence.dataSource }}
+        dataSource:
+          {{ .Values.persistence.dataSource | toYaml | nindent 10 }}
+        {{- end }}
         {{ include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) }}
   {{- end }}
 {{- end }}

--- a/bitnami/mongodb/templates/role.yaml
+++ b/bitnami/mongodb/templates/role.yaml
@@ -20,4 +20,13 @@ rules:
     verbs: ['use']
     resourceNames: [{{ include "mongodb.fullname" . }}]
 {{- end -}}
+{{- if .Values.volumeSnapshot.enabled }}
+  - apiGroups:
+      - "snapshot.storage.k8s.io/v1beta1"
+      - "snapshot.storage.k8s.io"
+    resources:
+      - "volumesnapshots"
+    verbs:
+      - "*"
+  {{- end -}}
 {{- end }}

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -441,6 +441,9 @@ sidecars: {}
 ##
 extraVolumeMounts: []
 extraVolumes: []
+#  - name: master-old-db
+#    gcePersistentDisk:
+#      pdName: master-old-db
 
 ## MongoDB(R) Pod Disruption Budget configuration
 ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
@@ -474,6 +477,10 @@ persistence:
   # storageClass: "-"
   ## PV Access Mode
   ##
+  dataSource: {}
+#    name: datadir-test-mongodb-1
+#    kind: VolumeSnapshot
+#    apiGroup: snapshot.storage.k8s.io
   accessModes:
     - ReadWriteOnce
   ## PVC size
@@ -938,7 +945,14 @@ rbac:
   ## binding MongoDB(R) ServiceAccount to a role
   ## that allows MongoDB(R) pods querying the K8s API
   ##
-  create: false
+  create: true
+
+volumeSnapshot:
+  # note : if you are using replicaSet, you should at least have two nodes
+  enabled: true
+  cron: "0 0 1 1 1"
+  image: mrelite/kubectlmongoshell:v1.0
+  volumeSnapshotClass: snapshot-class
 
 ## PodSecurityPolicy configuration
 ## Be sure to also set rbac.create to true, otherwise Role and RoleBinding


### PR DESCRIPTION
**Description of the change**

This PR is a template for #6092 
**Benefits**

* periodic snapshots one of the slaves for DR
* ability to start mongo STS from a volumesnapshot/volumesnapshotcontent ( for other environments like staging for example )


**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

Dockerfile for the cron container
```
FROM ubuntu

ENV PATH /google-cloud-sdk/bin:$PATH

RUN apt update && apt install -y \
        wget \
        python \
        bash \
        curl \
        make \
        ca-certificates
RUN apt install -y mongodb-clients \
    && wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz && \
    tar xzf google-cloud-sdk.tar.gz && \
    rm google-cloud-sdk.tar.gz && \
    ln -s /lib /lib64 && \
    gcloud config set core/disable_usage_reporting true && \
    gcloud --quiet components install kubectl
```
