### PR TITLE
[bitnami/logstash] Added support for kubernetes secrets in environment

### DIFF
--- a/bitnami/logstash/Chart.lock
+++ b/bitnami/logstash/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.4.1
-digest: sha256:81be4c0ebd0a81952423b24268e82697231b8c07991ee60b23b950ff1db003a2
-generated: "2021-03-11T00:23:11.75361253Z"
+  version: 1.4.2
+digest: sha256:4e3ec38e0e27e9fc1defb2a13f67a0aa12374bf0b15f06a6c13b1b46df6bffeb
+generated: "2021-04-15T19:08:19.593621+05:30"

--- a/bitnami/logstash/Chart.yaml
+++ b/bitnami/logstash/Chart.yaml
@@ -23,4 +23,4 @@ name: logstash
 sources:
   - https://github.com/bitnami/bitnami-docker-logstash
   - https://www.elastic.co/products/logstash
-version: 3.2.3
+version: 3.3.0

--- a/bitnami/logstash/README.md
+++ b/bitnami/logstash/README.md
@@ -67,6 +67,8 @@ The following tables lists the configurable parameters of the Logstash chart and
 | `enableMonitoringAPI`                      | Whether to enable the Logstash Monitoring API or not  Kubernetes cluster domain                                      | `true`                                                  |
 | `monitoringAPIPort`                        | Logstash Monitoring API Port                                                                                         | `9600`                                                  |
 | `extraEnvVars`                             | Array containing extra env vars to configure Logstash                                                                | `nil`                                                   |
+| `envFrom.secretRef.name`                   | Kubernetes Secrets name                                                                                             | `nil`                                                   |
+| `envFrom.configMapRef.name`                | Kubernetes Configmap name                                                                                           | `nil`                                                   |
 | `input`                                    | Input Plugins configuration                                                                                          | `Check values.yaml file`                                |
 | `filter`                                   | Filter Plugins configuration                                                                                         | `nil`                                                   |
 | `output`                                   | Output Plugins configuration                                                                                         | `Check values.yaml file`                                |
@@ -268,6 +270,17 @@ $ kubectl logs -f logstash-0
           "host" => "logstash-0",
        "message" => "bye"
 }
+```
+### Adding extra environment variables
+
+In case you want to add extra environment variables from an external configmap or secrets, you can use the `envFrom` property.
+
+```yaml
+envFrom:
+- secretRef:
+    name: logstash-secrets
+- configMapRef:
+    name: logstash-configmap
 ```
 
 ### Adding extra environment variables

--- a/bitnami/logstash/README.md
+++ b/bitnami/logstash/README.md
@@ -67,8 +67,8 @@ The following tables lists the configurable parameters of the Logstash chart and
 | `enableMonitoringAPI`                      | Whether to enable the Logstash Monitoring API or not  Kubernetes cluster domain                                      | `true`                                                  |
 | `monitoringAPIPort`                        | Logstash Monitoring API Port                                                                                         | `9600`                                                  |
 | `extraEnvVars`                             | Array containing extra env vars to configure Logstash                                                                | `nil`                                                   |
-| `envFrom.secretRef.name`                   | Kubernetes Secrets name                                                                                             | `nil`                                                   |
-| `envFrom.configMapRef.name`                | Kubernetes Configmap name                                                                                           | `nil`                                                   |
+| `extraEnvVarsSecret`                       | Kubernetes Secrets name                                                                                             | `nil`                                                   |
+| `extraEnvVarsCM`                           | Kubernetes Configmap name                                                                                           | `nil`                                                   |
 | `input`                                    | Input Plugins configuration                                                                                          | `Check values.yaml file`                                |
 | `filter`                                   | Filter Plugins configuration                                                                                         | `nil`                                                   |
 | `output`                                   | Output Plugins configuration                                                                                         | `Check values.yaml file`                                |
@@ -273,14 +273,11 @@ $ kubectl logs -f logstash-0
 ```
 ### Adding extra environment variables
 
-In case you want to add extra environment variables from an external configmap or secrets, you can use the `envFrom` property.
+In case you want to add extra environment variables from an external configmap or secrets, you can use the `extraEnvVarsCM` and `extraEnvVarsSecret` properties. Be aware that the secret and configmap should be already available in the namespace.
 
 ```yaml
-envFrom:
-- secretRef:
-    name: logstash-secrets
-- configMapRef:
-    name: logstash-configmap
+extraEnvVarsSecret: logstash-secrets
+extraEnvVarsCM: logstash-configmap
 ```
 
 ### Adding extra environment variables

--- a/bitnami/logstash/templates/sts.yaml
+++ b/bitnami/logstash/templates/sts.yaml
@@ -69,6 +69,10 @@ spec:
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
+          {{- if .Values.envFrom }}
+          envFrom:
+          {{ toYaml .Values.envFrom | nindent 12 }}
+          {{- end }}
           {{- if .Values.containerPorts }}
           ports: {{ toYaml .Values.containerPorts | nindent 12 }}
           {{- end }}

--- a/bitnami/logstash/templates/sts.yaml
+++ b/bitnami/logstash/templates/sts.yaml
@@ -69,10 +69,15 @@ spec:
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
-          {{- if .Values.envFrom }}
           envFrom:
-          {{ toYaml .Values.envFrom | nindent 12 }}
-          {{- end }}
+            {{- if .Values.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ .Values.extraEnvVarsCM }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ .Values.extraEnvVarsSecret }}
+            {{- end }}
           {{- if .Values.containerPorts }}
           ports: {{ toYaml .Values.containerPorts | nindent 12 }}
           {{- end }}

--- a/bitnami/logstash/values.yaml
+++ b/bitnami/logstash/values.yaml
@@ -67,6 +67,15 @@ monitoringAPIPort: 9600
 ##
 # extraEnvVars:
 
+## An array to add secrets or configmaps to environment if any
+## For example:
+## envFrom:
+## - secretRef:
+##     name: x.y.z
+## - configMapRef:
+##     name: x.y.z
+## envFrom:
+
 ## Input Plugins configuration
 ## ref: https://www.elastic.co/guide/en/logstash/current/input-plugins.html
 ##

--- a/bitnami/logstash/values.yaml
+++ b/bitnami/logstash/values.yaml
@@ -67,14 +67,10 @@ monitoringAPIPort: 9600
 ##
 # extraEnvVars:
 
-## An array to add secrets or configmaps to environment if any
-## For example:
-## envFrom:
-## - secretRef:
-##     name: x.y.z
-## - configMapRef:
-##     name: x.y.z
-## envFrom:
+## To add secrets or configmaps to environment
+## extraEnvVarsSecret: "x"
+## extraEnvVarsCM: "y"
+
 
 ## Input Plugins configuration
 ## ref: https://www.elastic.co/guide/en/logstash/current/input-plugins.html


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
     - None
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Added support to include `configmap / secrets` into environment for use as variables in the pipelines config.
Example: Ref #6111 for an example case.

**Benefits**
One can use Kubernetes secrets and substitute variables in the pipeline configs. 

Example: I may use username and password to authenticate with Elasticsearch within the VPC and provide the same as kubernetes secrets.

**Possible drawbacks**
I don't think there are any known drawbacks. Do let me know if there's something.

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #6111 

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
