### PR TITLE
[bitnami/keycloak] bump chart version

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 2.4.3
+version: 2.4.4


### PR DESCRIPTION
**Description of the change**

No code changes.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - related to #6043 

**Additional information**

It seems in my last PR I didn't pull again and the version was bumped between committing my code changes and the PR being merged. This should just bump the version to release a new chart containing #6043.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
