### PR TITLE
[bitnami/thanos] fixes thanos/receive HPA

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 3.15.0
+version: 3.15.1

--- a/bitnami/thanos/templates/receive/hpa.yaml
+++ b/bitnami/thanos/templates/receive/hpa.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/component: receive
 spec:
   scaleTargetRef:
-    apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
-    kind: Deployment
+    apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
+    kind: StatefulSet
     name: {{ include "common.names.fullname" . }}-receive
   minReplicas: {{ .Values.receive.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.receive.autoscaling.maxReplicas }}


### PR DESCRIPTION
**Description of the change**
Fixes the thanos/receive HPA which currently looks for a `Deployment` instead of a `StatefulSet` set resulting in only one pod when HPA is enabled.

**Benefits**
Thanos Recieve can now be scaled with an HPA properly

**Possible drawbacks**
more pods = more money 💵 

**Applicable issues**
No existing issue open, the component is fairly new so I may be the first to notice 🤓 

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
