### PR TITLE
[bitnami/tomcat] deployment, statefulset choice

### DIFF
--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -26,4 +26,4 @@ name: tomcat
 sources:
   - https://github.com/bitnami/bitnami-docker-tomcat
   - http://tomcat.apache.org
-version: 9.1.0
+version: 9.2.0

--- a/bitnami/tomcat/README.md
+++ b/bitnami/tomcat/README.md
@@ -93,6 +93,7 @@ The following tables lists the configurable parameters of the Tomcat chart and t
 
 | Parameter                   | Description                                                                               | Default                                     |
 |-----------------------------|-------------------------------------------------------------------------------------------|---------------------------------------------|
+| `deployment.type`           | Use Deployment or StatefulSet                                                              | `pvc`                                      |
 | `replicaCount`              | Specify number of Tomcat replicas                                                         | `1`                                         |
 | `containerPort`             | HTTP port to expose at container level                                                    | `8080`                                      |
 | `containerExtraPorts`       | Extra ports to expose at container level                                               | `{}`                                      |
@@ -121,7 +122,6 @@ The following tables lists the configurable parameters of the Tomcat chart and t
 | `initContainers`            | Add additional init containers to the Tomcat pods                                         | `{}` (evaluated as a template)              |
 | `sidecars`                  | Add additional sidecar containers to the Tomcat pods                                      | `{}` (evaluated as a template)              |
 | `persistence.enabled`       | Enable persistence                                                              | `true`                                      |
-| `persistence.type`          | Use Deployment or StatefulSet                                                              | `pvc`                                      |
 | `persistence.storageClass`  | PVC Storage Class for Tomcat volume                                                       | `nil` (uses alpha storage class annotation) |
 | `persistence.existingClaim` | An Existing PVC name for Tomcat volume                                                    | `nil` (uses alpha storage class annotation) |
 | `persistence.accessMode`    | PVC Access Mode for Tomcat volume                                                         | `ReadWriteOnce`                             |

--- a/bitnami/tomcat/README.md
+++ b/bitnami/tomcat/README.md
@@ -93,7 +93,7 @@ The following tables lists the configurable parameters of the Tomcat chart and t
 
 | Parameter                   | Description                                                                               | Default                                     |
 |-----------------------------|-------------------------------------------------------------------------------------------|---------------------------------------------|
-| `deployment.type`           | Use Deployment or StatefulSet                                                              | `pvc`                                      |
+| `deployment.type`           | Use Deployment or StatefulSet                                                              | `deployment`                                      |
 | `replicaCount`              | Specify number of Tomcat replicas                                                         | `1`                                         |
 | `containerPort`             | HTTP port to expose at container level                                                    | `8080`                                      |
 | `containerExtraPorts`       | Extra ports to expose at container level                                               | `{}`                                      |

--- a/bitnami/tomcat/README.md
+++ b/bitnami/tomcat/README.md
@@ -116,10 +116,12 @@ The following tables lists the configurable parameters of the Tomcat chart and t
 | `podLabels`                 | Extra labels for Tomcat pods                                                              | `{}` (evaluated as a template)              |
 | `podAnnotations`            | Annotations for Tomcat pods                                                               | `{}` (evaluated as a template)              |
 | `extraVolumeMounts`         | Optionally specify extra list of additional volumeMounts for Tomcat container(s)          | `[]`                                        |
-| `extraVolumes`              | Optionally specify extra list of additional volumes for Tomcat pods                       | `[]`                                        |
+| `extraVolumes`              | Optionally specify extra list of additional volumes for Tomcat pods in Deployment                      | `[]`                                        |
+| `extraVolumeClaimTemplates` | Optionally specify extra list of additional volume claim templates for Tomcat pods in StatefulSet      | `[]`                                        |
 | `initContainers`            | Add additional init containers to the Tomcat pods                                         | `{}` (evaluated as a template)              |
 | `sidecars`                  | Add additional sidecar containers to the Tomcat pods                                      | `{}` (evaluated as a template)              |
-| `persistence.enabled`       | Enable persistence using PVC                                                              | `true`                                      |
+| `persistence.enabled`       | Enable persistence                                                              | `true`                                      |
+| `persistence.type`          | Use Deployment or StatefulSet                                                              | `pvc`                                      |
 | `persistence.storageClass`  | PVC Storage Class for Tomcat volume                                                       | `nil` (uses alpha storage class annotation) |
 | `persistence.existingClaim` | An Existing PVC name for Tomcat volume                                                    | `nil` (uses alpha storage class annotation) |
 | `persistence.accessMode`    | PVC Access Mode for Tomcat volume                                                         | `ReadWriteOnce`                             |

--- a/bitnami/tomcat/templates/_pod.tpl
+++ b/bitnami/tomcat/templates/_pod.tpl
@@ -113,11 +113,11 @@ containers:
 {{- include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) | nindent 2 }}
 {{- end }}
 volumes:
-{{- if and .Values.persistence.enabled (eq .Values.persistence.type "pvc") }}
+{{- if and .Values.persistence.enabled (eq .Values.deployment.type "deployment") }}
   - name: data
     persistentVolumeClaim:
       claimName: {{ template "tomcat.pvc" . }}
-{{- else if and .Values.persistence.enabled (eq .Values.persistence.type "statefulset") }}
+{{- else if and .Values.persistence.enabled (eq .Values.deployment.type "statefulset") }}
 # nothing
 {{- else }}
   - name: data

--- a/bitnami/tomcat/templates/_pod.tpl
+++ b/bitnami/tomcat/templates/_pod.tpl
@@ -1,0 +1,129 @@
+{{/*
+Pod Spec
+*/}}
+{{- define "tomcat.pod" -}}
+{{- include "tomcat.imagePullSecrets" . | nindent 6 }}
+{{- if .Values.hostAliases }}
+hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 2 }}
+{{- end }}
+{{- if .Values.affinity }}
+affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 2 }}
+{{- else }}
+affinity:
+  podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAffinityPreset "context" $) | nindent 4 }}
+  podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAntiAffinityPreset "context" $) | nindent 4 }}
+  nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 4 }}
+{{- end }}
+{{- if .Values.nodeSelector }}
+nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.nodeSelector "context" $) | nindent 2 }}
+{{- end }}
+{{- if .Values.tolerations }}
+tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" .) | nindent 2 }}
+{{- end }}
+{{- if .Values.podSecurityContext.enabled }}
+securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 2 }}
+{{- end }}
+initContainers:
+{{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
+- name: volume-permissions
+  image: {{ template "tomcat.volumePermissions.image" . }}
+  imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
+  command:
+  - /bin/bash
+  - -ec
+  - |
+      chown -R {{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }} /bitnami/tomcat
+  securityContext:
+  runAsUser: 0
+  {{- if .Values.volumePermissions.resources }}
+  resources: {{- toYaml .Values.volumePermissions.resources | nindent 4 }}
+  {{- end }}
+  volumeMounts:
+  - name: data
+    mountPath: /bitnami/tomcat
+{{- end }}
+{{- if .Values.initContainers }}
+{{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 2 }}
+{{- end }}
+containers:
+- name: tomcat
+  image: {{ template "tomcat.image" . }}
+  imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+  {{- if .Values.containerSecurityContext.enabled }}
+  securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 4 }}
+  {{- end }}
+  {{- if .Values.command }}
+  command: {{- include "common.tplvalues.render" (dict "value" .Values.command "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.args }}
+  args: {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 4 }}
+  {{- end }}
+  env:
+  - name: BITNAMI_DEBUG
+    value: {{ ternary "true" "false" .Values.image.debug | quote }}
+  - name: TOMCAT_USERNAME
+    value: {{ .Values.tomcatUsername | quote }}
+  - name: TOMCAT_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: {{ template "common.names.fullname" . }}
+        key: tomcat-password
+  - name: TOMCAT_ALLOW_REMOTE_MANAGEMENT
+    value: {{ .Values.tomcatAllowRemoteManagement | quote }}
+    {{- if .Values.extraEnvVars }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.extraEnvVarsCM .Values.extraEnvVarsSecret }}
+  envFrom:
+  {{- if .Values.extraEnvVarsCM }}
+  - configMapRef:
+      name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsCM "context" $) }}
+  {{- end }}
+  {{- if .Values.extraEnvVarsSecret }}
+  - secretRef:
+      name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
+  {{- end }}
+  {{- end }}
+  ports:
+  - name: http
+    containerPort: {{ .Values.containerPort }}
+  {{- if .Values.containerExtraPorts }}
+  {{- include "common.tplvalues.render" (dict "value" .Values.containerExtraPorts "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.livenessProbe.enabled }}
+  livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 4 }}
+  {{- else if .Values.customLivenessProbe }}
+  livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.readinessProbe.enabled }}
+  readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 4 }}
+  {{- else if .Values.customReadinessProbe }}
+  readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.resources }}
+  resources: {{- toYaml .Values.resources | nindent 4 }}
+  {{- end }}
+  volumeMounts:
+  - name: data
+    mountPath: /bitnami/tomcat
+  {{- if .Values.extraVolumeMounts }}
+  {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 4 }}
+  {{- end }}
+{{- if .Values.sidecars }}
+{{- include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) | nindent 2 }}
+{{- end }}
+volumes:
+{{- if and .Values.persistence.enabled (eq .Values.persistence.type "pvc") }}
+  - name: data
+    persistentVolumeClaim:
+      claimName: {{ template "tomcat.pvc" . }}
+{{- else if and .Values.persistence.enabled (eq .Values.persistence.type "statefulset") }}
+# nothing
+{{- else }}
+  - name: data
+    emptyDir: {}
+{{- end -}}
+{{- if .Values.extraVolumes }}
+{{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 2 }}
+{{- end }}
+{{- end -}}

--- a/bitnami/tomcat/templates/deployment.yaml
+++ b/bitnami/tomcat/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{ if (or (not .Values.persistence.enabled) (eq .Values.persistence.type "pvc")) }}
+{{ if (or (not .Values.persistence.enabled) (eq .Values.deployment.type "deployment")) }}
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:

--- a/bitnami/tomcat/templates/pvc.yaml
+++ b/bitnami/tomcat/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.persistence.type "pvc") -}}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.deployment.type "deployment") -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/bitnami/tomcat/templates/pvc.yaml
+++ b/bitnami/tomcat/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.persistence.type "pvc") -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/bitnami/tomcat/templates/statefulset.yaml
+++ b/bitnami/tomcat/templates/statefulset.yaml
@@ -1,6 +1,6 @@
-{{ if (or (not .Values.persistence.enabled) (eq .Values.persistence.type "pvc")) }}
-apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
-kind: Deployment
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.persistence.type "statefulset")}}
+apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
+kind: StatefulSet
 metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace }}
@@ -15,7 +15,8 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-  strategy: {{- include "common.tplvalues.render" (dict "value" .Values.updateStrategy "context" $ ) | nindent 4 }}
+  updateStrategy: {{- include "common.tplvalues.render" (dict "value" .Values.updateStrategy "context" $ ) | nindent 4 }}
+  serviceName: {{ template "common.names.fullname" . }}-headless
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
@@ -26,4 +27,20 @@ spec:
       annotations: {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
     spec: {{- include "tomcat.pod" . | nindent 6 }}
+  {{- if and .Values.persistence.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: {{ .Values.persistence.accessModes }}
+      storageClassName: {{ .Values.persistence.storageClassName }}
+      resources:
+        requests:
+          storage: {{ .Values.persistence.size }}
+      selector:
+        matchLabels: {{- include "common.labels.matchLabels" . | nindent 10 }}
+  {{- if .Values.extraVolumeClaimTemplates }}
+  {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeClaimTemplates "context" $) | nindent 2 }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/bitnami/tomcat/templates/statefulset.yaml
+++ b/bitnami/tomcat/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.persistence.type "statefulset")}}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.deployment.type "statefulset")}}
 apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
 kind: StatefulSet
 metadata:

--- a/bitnami/tomcat/templates/svc-headless.yaml
+++ b/bitnami/tomcat/templates/svc-headless.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.persistence.type "statefulset") }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "common.names.fullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.service.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.service.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  clusterIP: None
+  type: ClusterIP
+  selector: {{ include "common.labels.matchLabels" . | nindent 4 }}
+{{- end }}

--- a/bitnami/tomcat/templates/svc-headless.yaml
+++ b/bitnami/tomcat/templates/svc-headless.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.persistence.type "statefulset") }}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.deployment.type "statefulset") }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/bitnami/tomcat/values.yaml
+++ b/bitnami/tomcat/values.yaml
@@ -251,6 +251,10 @@ tolerations: []
 ##
 extraVolumes: []
 
+## Extra volume claim templates to add to the statefulset
+##
+extraVolumeClaimTemplates: []
+
 ## Extra volume mounts to add to the container
 ##
 extraVolumeMounts: []
@@ -286,6 +290,8 @@ persistence:
   ## If true, use a Persistent Volume Claim, If false, use emptyDir
   ##
   enabled: true
+  ## Type pvc or statefulset
+  type: pvc
   ## Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning

--- a/bitnami/tomcat/values.yaml
+++ b/bitnami/tomcat/values.yaml
@@ -105,6 +105,13 @@ extraEnvVarsSecret:
 ##
 replicaCount: 1
 
+## Deployment
+##
+deployment:
+  ## Deployment type: deployment or statefulset
+  ##
+  type: deployment
+
 ## Strategy to use to update Pods
 ##
 updateStrategy:
@@ -290,8 +297,6 @@ persistence:
   ## If true, use a Persistent Volume Claim, If false, use emptyDir
   ##
   enabled: true
-  ## Type pvc or statefulset
-  type: pvc
   ## Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Add the possibility to choose statefulset instead of deployment.

```
persistence.enabled == true || persistence.type == "pvc" => deployment + pvc
persistence.enabled == true && persistence.type == "statefulset" && len(existingClaim) == 0 => statefulset + svc-headless
```

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
