### PR TITLE
[bitnami/mongodb] fixed advertised hostname for hidden nodes

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 10.12.4
+version: 10.12.5

--- a/bitnami/mongodb/templates/hidden/statefulset.yaml
+++ b/bitnami/mongodb/templates/hidden/statefulset.yaml
@@ -119,7 +119,7 @@ spec:
             - |
               /bin/bash <<'EOF'
               my_hostname=$(hostname)
-              svc=$(echo -n "$my_hostname" | sed s/-[0-9]*$//)-headless
+              svc=$(echo -n "$my_hostname" | sed s/-[0-9]*$//)-hidden-headless
               cp /certs/CAs/* /certs/
               cat >/certs/openssl.cnf <<EOL
               [req]
@@ -214,6 +214,8 @@ spec:
                   fieldPath: metadata.namespace
             - name: K8S_SERVICE_NAME
               value: "{{ include "mongodb.fullname" . }}-headless"
+            - name: K8S_HIDDEN_NODE_SERVICE_NAME
+              value: "{{ include "mongodb.fullname" . }}-hidden-headless"
             - name: MONGODB_REPLICA_SET_MODE
               value: "hidden"
             - name: MONGODB_INITIAL_PRIMARY_HOST
@@ -222,7 +224,7 @@ spec:
               value: {{ .Values.replicaSetName | quote }}
             {{- if and .Values.replicaSetHostnames (not .Values.externalAccess.hidden.enabled) }}
             - name: MONGODB_ADVERTISED_HOSTNAME
-              value: "$(MY_POD_NAME).$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.{{ .Values.clusterDomain }}"
+              value: "$(MY_POD_NAME).$(K8S_HIDDEN_NODE_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.{{ .Values.clusterDomain }}"
             {{- end }}
             {{- if .Values.auth.username }}
             - name: MONGODB_USERNAME


### PR DESCRIPTION
**Description of the change**

Hidden nodes in bitnami/mongodb chart uses its own headless services e.g- **cluster-name-hidden-headless**. Currently it is configured wrong in `MONGODB_ADVERTISED_HOSTNAME`, It is using `"$(MY_POD_NAME).$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.{{ .Values.clusterDomain }}"` which is pointing to the headless service for replicaset.
- Added a new env var `K8S_HIDDEN_NODE_SERVICE_NAME`
- Fixed `MONGODB_ADVERTISED_HOSTNAME` for hidden nodes

**Benefits**

Fixes the hidden deployment

**Possible drawbacks**

N/A

**Applicable issues**



**Additional information**

NA

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
