### PR TITLE
[bitnami/nats] Adds auth.timeout value to manage client authentication timeout

### DIFF
--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -24,4 +24,4 @@ name: nats
 sources:
   - https://github.com/bitnami/bitnami-docker-nats
   - https://nats.io/
-version: 6.2.6
+version: 6.3.0

--- a/bitnami/nats/README.md
+++ b/bitnami/nats/README.md
@@ -79,6 +79,7 @@ The following tables lists the configurable parameters of the NATS chart and the
 | `auth.user`                | Client authentication user                                                     | `nats_client`                                           |
 | `auth.password`            | Client authentication password                                                 | `random alhpanumeric string (10)`                       |
 | `auth.token`               | Client authentication token                                                    | `nil`                                                   |
+| `auth.timeout`             | Client authentication timeout (seconds)                                        | `1`                                                     |
 | `clusterAuth.enabled`      | Switch to enable/disable cluster authentication                                | `true`                                                  |
 | `clusterAuth.user`         | Cluster authentication user                                                    | `nats_cluster`                                          |
 | `clusterAuth.password`     | Cluster authentication password                                                | `random alhpanumeric string (10)`                       |

--- a/bitnami/nats/templates/configmap.yaml
+++ b/bitnami/nats/templates/configmap.yaml
@@ -26,7 +26,7 @@ data:
       {{- else if .Values.auth.token }}
       token: {{ .Values.auth.token | quote }}
       {{- end }}
-      timeout:  1
+      timeout:  {{ int .Values.auth.timeout }}
     }
     {{- end }}
 

--- a/bitnami/nats/values.yaml
+++ b/bitnami/nats/values.yaml
@@ -63,6 +63,7 @@ auth:
   user: nats_client
   # password:
   # token:
+  timeout: 1
 
 ## Cluster Authentication
 ## ref: https://github.com/nats-io/gnatsd#authentication


### PR DESCRIPTION
**Description of the change**

This change is a minor update of parameters for NATS chart. It is introducing a new parameter `auth.timeout`. This parameter is used in ConfigMap to control how long authentication of the nats client may hang before timeout. 

**Benefits**

Current ConfigMap contains the hardcoded value of 1 second.  With this PR I propose to make it a parameter but keep `1` second as a default value.

Hardcoded value in the current ConfigMap:
```yaml
    authorization {
      {{- if .Values.auth.user }}
      user: {{ .Values.auth.user | quote }}
      password: {{ $authPwd | quote }}
      {{- else if .Values.auth.token }}
      token: {{ .Values.auth.token | quote }}
      {{- end }}
      timeout:  1 
    }
```

After the change:
```yaml
timeout: {{ int .Values.auth.timeout }}
```

New parameter:
```yaml
## Client Authentication
## ref: https://github.com/nats-io/gnatsd#authentication
##
auth:
  enabled: true
  user: nats_client
  # password:
  # token:
  timeout: 1
```

**Possible drawbacks**

I see no downsides to this change.

**Applicable issues**

I haven't found any issues related to this change.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

