### PR TITLE
[bitnami/solr] allow specifying an existing secret for the ingress objects

### DIFF
--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -27,4 +27,4 @@ name: solr
 sources:
   - https://github.com/bitnami/bitnami-docker-solr
   - https://lucene.apache.org/solr/
-version: 0.3.1
+version: 0.3.2

--- a/bitnami/solr/README.md
+++ b/bitnami/solr/README.md
@@ -179,7 +179,7 @@ The following tables lists the configurable parameters of the solr chart and the
 | `ingress.pathType`               | Path type for the ingress resource                       | `ImplementationSpecific`       |
 | `ingress.path`                   | Default path for the ingress resource                    | `/`                            |
 | `ingress.tls`                    | Create TLS Secret                                        | `false`                        |
-| `ingress.existingSecretName`     | The name of an existing Secret to use for the ingress object | `nil`                          |
+| `ingress.existingSecret`         | The name of an existing Secret to use for the ingress object | `nil`                          |
 | `ingress.annotations`            | Ingress annotations                                      | `[]` (evaluated as a template) |
 | `ingress.extraHosts[0].name`     | Additional hostnames to be covered                       | `nil`                          |
 | `ingress.extraHosts[0].path`     | Additional hostnames to be covered                       | `nil`                          |

--- a/bitnami/solr/README.md
+++ b/bitnami/solr/README.md
@@ -179,6 +179,7 @@ The following tables lists the configurable parameters of the solr chart and the
 | `ingress.pathType`               | Path type for the ingress resource                       | `ImplementationSpecific`       |
 | `ingress.path`                   | Default path for the ingress resource                    | `/`                            |
 | `ingress.tls`                    | Create TLS Secret                                        | `false`                        |
+| `ingress.existingSecretName`     | The name of an existing Secret to use for the ingress object | `nil`                          |
 | `ingress.annotations`            | Ingress annotations                                      | `[]` (evaluated as a template) |
 | `ingress.extraHosts[0].name`     | Additional hostnames to be covered                       | `nil`                          |
 | `ingress.extraHosts[0].path`     | Additional hostnames to be covered                       | `nil`                          |

--- a/bitnami/solr/templates/ingress.yaml
+++ b/bitnami/solr/templates/ingress.yaml
@@ -9,9 +9,9 @@ metadata:
   {{- end }}
   annotations:
     {{- if .Values.ingress.certManager }}
-      {{- if not .Values.ingress.existingSecretName }}
+    {{- if not .Values.ingress.existingSecret }}
     kubernetes.io/tls-acme: "true"
-      {{- end }}
+    {{- end }}
     {{- end }}
     {{- if .Values.ingress.annotations }}
     {{- include "common.tplvalues.render" (dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
@@ -50,8 +50,8 @@ spec:
     {{- if .Values.ingress.tls }}
     - hosts:
         - {{ .Values.ingress.hostname }}
-      {{- if .Values.ingress.existingSecretName }}
-      secretName: {{ .Values.ingress.existingSecretName }}
+      {{- if .Values.ingress.existingSecret }}
+      secretName: {{ .Values.ingress.existingSecret }}
       {{- else }}
       secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
       {{- end }}

--- a/bitnami/solr/templates/ingress.yaml
+++ b/bitnami/solr/templates/ingress.yaml
@@ -9,7 +9,9 @@ metadata:
   {{- end }}
   annotations:
     {{- if .Values.ingress.certManager }}
+      {{- if not .Values.ingress.existingSecretName }}
     kubernetes.io/tls-acme: "true"
+      {{- end }}
     {{- end }}
     {{- if .Values.ingress.annotations }}
     {{- include "common.tplvalues.render" (dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
@@ -48,7 +50,11 @@ spec:
     {{- if .Values.ingress.tls }}
     - hosts:
         - {{ .Values.ingress.hostname }}
+      {{- if .Values.ingress.existingSecretName }}
+      secretName: {{ .Values.ingress.existingSecretName }}
+      {{- else }}
       secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
+      {{- end }}
     {{- end }}
     {{- if .Values.ingress.extraTls }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.extraTls "context" $ ) | nindent 4 }}

--- a/bitnami/solr/templates/tls-secrets.yaml
+++ b/bitnami/solr/templates/tls-secrets.yaml
@@ -19,7 +19,7 @@ data:
   tls.key: {{ .key | b64enc }}
 ---
 {{- end }}
-{{- else if and .Values.ingress.tls (not .Values.ingress.certManager) }}
+{{- else if and .Values.ingress.tls (not .Values.ingress.certManager) (not .Values.ingress.existingSecret) }}
 {{- $ca := genCA "solr-ca" 365 }}
 {{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
 apiVersion: v1

--- a/bitnami/solr/values.yaml
+++ b/bitnami/solr/values.yaml
@@ -710,6 +710,11 @@ ingress:
   ##
   tls: false
 
+
+  ## The name of an existing Secret in the same namespase to use on the generated Ingress resource
+  ## This option will override certManager: true
+  existingSecretName: ~
+
   ## The list of additional hostnames to be covered with this ingress record.
   ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
   ## extraHosts:

--- a/bitnami/solr/values.yaml
+++ b/bitnami/solr/values.yaml
@@ -710,10 +710,9 @@ ingress:
   ##
   tls: false
 
-
   ## The name of an existing Secret in the same namespase to use on the generated Ingress resource
   ## This option will override certManager: true
-  existingSecretName: ~
+  existingSecret:
 
   ## The list of additional hostnames to be covered with this ingress record.
   ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array


### PR DESCRIPTION
Signed-off-by: mamiller <mamiller@rosettastone.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
This allows you to specify the name of an existing TLS secret to use for the Ingress object instead of relying on cert generation to happen by cert-manager.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
