### PR TITLE
[bitnami/tomcat] Fix incorrect identation using imagePullSecrets

### DIFF
--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -26,4 +26,4 @@ name: tomcat
 sources:
   - https://github.com/bitnami/bitnami-docker-tomcat
   - http://tomcat.apache.org
-version: 9.2.1
+version: 9.2.2

--- a/bitnami/tomcat/templates/_pod.tpl
+++ b/bitnami/tomcat/templates/_pod.tpl
@@ -2,7 +2,7 @@
 Pod Spec
 */}}
 {{- define "tomcat.pod" -}}
-{{- include "tomcat.imagePullSecrets" . | nindent 6 }}
+{{- include "tomcat.imagePullSecrets" . }}
 {{- if .Values.hostAliases }}
 hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This change solves this problem:

Error: YAML parse error on tomcat/templates/deployment.yaml: error converting YAML to JSON: yaml: line 30: did not find expected key
helm.go:81: [debug] error converting YAML to JSON: yaml: line 30: did not find expected key

**Benefits**

Fix a crash

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #6134

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
