### PR TITLE
[bitnami/common] Update Redis validation's helper

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: Infrastructure
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 1.4.2
+appVersion: 1.4.3
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://github.com/bitnami/charts/tree/master/bitnami/common
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -20,4 +20,4 @@ sources:
   - https://github.com/bitnami/charts
   - http://www.bitnami.com/
 type: library
-version: 1.4.2
+version: 1.4.3

--- a/bitnami/common/templates/validations/_redis.tpl
+++ b/bitnami/common/templates/validations/_redis.tpl
@@ -34,22 +34,6 @@ Params:
 {{- end -}}
 
 {{/*
-Redis Auxiliary function to get the right value for existingSecret.
-
-Usage:
-{{ include "common.redis.values.existingSecret" (dict "context" $) }}
-Params:
-  - subchart - Boolean - Optional. Whether Redis(TM) is used as subchart or not. Default: false
-*/}}
-{{- define "common.redis.values.existingSecret" -}}
-  {{- if .subchart -}}
-    {{- .context.Values.redis.existingSecret | quote -}}
-  {{- else -}}
-    {{- .context.Values.existingSecret | quote -}}
-  {{- end -}}
-{{- end -}}
-
-{{/*
 Auxiliary function to get the right value for enabled redis.
 
 Usage:

--- a/bitnami/common/templates/validations/_redis.tpl
+++ b/bitnami/common/templates/validations/_redis.tpl
@@ -14,11 +14,11 @@ Params:
   {{- $valueKeyPrefix := include "common.redis.values.keys.prefix" . -}}
   {{- $standarizedVersion := include "common.redis.values.standarized.version" . }}
 
-  {{- $existingSecret := (printf "%s%s" $valueKeyPrefix "auth.existingSecret") (printf "%s%s" $valueKeyPrefix "existingSecret") $standarizedVersion }}
+  {{- $existingSecret := ternary (printf "%s%s" $valueKeyPrefix "auth.existingSecret") (printf "%s%s" $valueKeyPrefix "existingSecret") (eq $standarizedVersion "true") }}
   {{- $existingSecretValue := include "common.utils.getValueFromKey" (dict "key" $existingSecret "context" .context) }}
 
-  {{- $valueKeyRedisPassword := (printf "%s%s" $valueKeyPrefix "auth.password") (printf "%s%s" $valueKeyPrefix "password") $standarizedVersion }}
-  {{- $valueKeyRedisUseAuth := (printf "%s%s" $valueKeyPrefix "auth.enabled") (printf "%s%s" $valueKeyPrefix "usePassword") $standarizedVersion }}
+  {{- $valueKeyRedisPassword := ternary (printf "%s%s" $valueKeyPrefix "auth.password") (printf "%s%s" $valueKeyPrefix "password") (eq $standarizedVersion "true") }}
+  {{- $valueKeyRedisUseAuth := ternary (printf "%s%s" $valueKeyPrefix "auth.enabled") (printf "%s%s" $valueKeyPrefix "usePassword") (eq $standarizedVersion "true") }}
 
   {{- if and (not $existingSecretValue) (eq $enabled "true") -}}
     {{- $requiredPasswords := list -}}
@@ -83,7 +83,7 @@ Usage:
 */}}
 {{- define "common.redis.values.standarized.version" -}}
 
-  {{- $standarizedAuth := printf "%s.%s" (include "common.redis.values.keys.prefix" .) "auth" -}}
+  {{- $standarizedAuth := printf "%s%s" (include "common.redis.values.keys.prefix" .) "auth" -}}
   {{- $standarizedAuthValues := include "common.utils.getValueFromKey" (dict "key" $standarizedAuth "context" .context) }}
 
   {{- if $standarizedAuthValues -}}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Following the latest major of the Redis chart introduced in #6102, we need to update the bitnami/common's validation's helper before updating the charts using Redis as a subchart.

**Benefits**

 - Updates common helper and implements backward compatibility to work with any Redis chart regardless of version.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
 - Unblocks #6079

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
