### PR TITLE
[bitnami/postgresql-ha] remove ldap restriction on pgpool probes

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -27,4 +27,4 @@ name: postgresql-ha
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 6.9.1
+version: 7.0.0

--- a/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
@@ -272,7 +272,7 @@ spec:
             - name: postgresql
               containerPort: 5432
               protocol: TCP
-          {{- if and .Values.pgpool.livenessProbe.enabled (not .Values.ldap.enabled) }}
+          {{- if .Values.pgpool.livenessProbe.enabled }}
           livenessProbe:
             exec:
               command:
@@ -285,7 +285,7 @@ spec:
           {{- else if .Values.pgpool.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.pgpool.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if and .Values.pgpool.readinessProbe.enabled (not .Values.ldap.enabled) }}
+          {{- if .Values.pgpool.readinessProbe.enabled }}
           readinessProbe:
             exec:
               command:
@@ -300,7 +300,7 @@ spec:
           {{- else if .Values.pgpool.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.pgpool.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if and .Values.pgpool.startupProbe.enabled (not .Values.ldap.enabled) }}
+          {{- if .Values.pgpool.startupProbe.enabled }}
           startupProbe:
             exec:
               command:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Remove the requirement that LDAP be disabled to enable pgpool liveness/readiness/startup probes.

**Benefits**

<!-- What benefits will be realized by the code change? -->
Currently, to enable pgpool probes with LDAP also enabled, you have to dig into the deployment template and copy the probes to custom* versions in your values YAML. This requires reproducing the values from the deployment and hardcoding parts of it. This increases maintenance requirements for the user.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
I'm not sure why the probes were disabled with LDAP originally as I can't find any explanation in the history. I made this a major version change since it has at least the potential to be breaking. If the configured user and password could not authenticate, I believe other configurations in this chart would fail as well. However, the liveness and readiness probes are enabled by default and if the user was relying on the fact that enabling LDAP disabled the probes (without doing so explicitly), there might be a surprise if this change is not understood first.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
N/A

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
I tested this with custom probes performing the same action as the default probes on my own deployment of postgresql-ha with LDAP enabled for the past week and I have not seen a problem from enabling these probes. Furthermore, having the probes enabled would have helped me avoid an outage earlier this month when one of the pool members lost connectivity to the backend causing intermittent errors.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
