### PR TITLE
[bitnami/kafka] Allow empty value for 'auth.tlsEndpointIdentificationAlgorithm'

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 12.17.4
+version: 12.17.5

--- a/bitnami/kafka/templates/NOTES.txt
+++ b/bitnami/kafka/templates/NOTES.txt
@@ -4,7 +4,7 @@
 {{- $fullname := include "kafka.fullname" . -}}
 {{- $clientProtocol := include "kafka.listenerType" (dict "protocol" .Values.auth.clientProtocol) -}}
 {{- $saslMechanisms := coalesce .Values.auth.sasl.mechanisms .Values.auth.saslMechanisms -}}
-{{- $tlsEndpointIdentificationAlgorithm := coalesce .Values.auth.tls.endpointIdentificationAlgorithm .Values.auth.tlsEndpointIdentificationAlgorithm -}}
+{{- $tlsEndpointIdentificationAlgorithm := default "" (coalesce .Values.auth.tls.endpointIdentificationAlgorithm .Values.auth.tlsEndpointIdentificationAlgorithm) -}}
 {{- $tlsPassword := coalesce .Values.auth.tls.password .Values.auth.jksPassword -}}
 {{- $servicePort := int .Values.service.port -}}
 {{- $loadBalancerIPListLength := len .Values.externalAccess.service.loadBalancerIPs -}}

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -254,7 +254,7 @@ spec:
             - name: KAFKA_CFG_TLS_TYPE
               value: {{ upper .Values.auth.tls.type | quote }}
             - name: KAFKA_CFG_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM
-              value: {{ coalesce .Values.auth.tls.endpointIdentificationAlgorithm .Values.auth.tlsEndpointIdentificationAlgorithm | quote }}
+              value: {{ default "" (coalesce .Values.auth.tls.endpointIdentificationAlgorithm .Values.auth.tlsEndpointIdentificationAlgorithm) | quote }}
             - name: KAFKA_CFG_TLS_CLIENT_AUTH
               value: {{ ternary "required" "none" (eq .Values.auth.clientProtocol "mtls") | quote }}
             {{- $tlsPassword := coalesce .Values.auth.tls.password .Values.auth.jksPassword }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

When you use TLS as authentication protocol and disable host name verification, the chart installation complains with the error below:

```
Error: template: kafka/templates/NOTES.txt:110:11: executing "kafka/templates/NOTES.txt" at <eq $tlsEndpointIdentificationAlgorithm "">: error calling eq: incompatible types for comparison
```

You can reproduce it using these values:

```
auth:
  clientProtocol: tls
  interBrokerProtocol: tls
  tls:
    type: jks
    existingSecret: kafka-certificates
    password: password
    endpointIdentificationAlgorithm: ""
  tlsEndpointIdentificationAlgorithm: ""
```

This PR fixes this bug.

**Benefits**

Fixes TLS  authentication protocol when disabling host name verification.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

