### PR TITLE
[bitnami/mongodb] remove nodePort: null

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 10.12.5
+version: 10.12.6

--- a/bitnami/mongodb/templates/replicaset/external-access-svc.yaml
+++ b/bitnami/mongodb/templates/replicaset/external-access-svc.yaml
@@ -34,8 +34,6 @@ spec:
       port: {{ $root.Values.externalAccess.service.port }}
       {{- if not (empty $root.Values.externalAccess.service.nodePorts) }}
       nodePort: {{ index $root.Values.externalAccess.service.nodePorts $i }}
-      {{- else }}
-      nodePort: null
       {{- end }}
       targetPort: mongodb
   selector: {{- include "common.labels.matchLabels" $ | nindent 4 }}


### PR DESCRIPTION
If no externalAccess.service.nodePorts is set remove the nodePort: null value;
nodePort: null is useless and prevent argocd to sync. This is arguably a bug/issue with argocd but it's easy to correct on the chart.

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
