### PR TITLE
[bitnami/memcached] Add 'metricRelabelings' and 'relabelings' parameters

### DIFF
--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -22,4 +22,4 @@ name: memcached
 sources:
   - https://github.com/bitnami/bitnami-docker-memcached
   - http://memcached.org/
-version: 5.10.3
+version: 5.11.0

--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -22,4 +22,4 @@ name: memcached
 sources:
   - https://github.com/bitnami/bitnami-docker-memcached
   - http://memcached.org/
-version: 5.10.2
+version: 5.10.3

--- a/bitnami/memcached/README.md
+++ b/bitnami/memcached/README.md
@@ -126,6 +126,13 @@ The following tables lists the configurable parameters of the Memcached chart an
 | `metrics.service.type`                   | Kubernetes service type for Prometheus metrics                                            | `ClusterIP`                                                  |
 | `metrics.service.port`                   | Prometheus metrics service port                                                           | `9150`                                                       |
 | `metrics.service.annotations`            | Prometheus exporter svc annotations                                                       | `{prometheus.io/scrape: "true", prometheus.io/port: "9150"}` |
+| `metrics.serviceMonitor.enabled`         | Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator           | `false`                                                      |
+| `metrics.serviceMonitor.namespace`       | The namespace in which the ServiceMonitor will be created                                 | `nil`                                                        |
+| `metrics.serviceMonitor.interval`        | The interval at which metrics should be scraped                                           | `nil`                                                        |
+| `metrics.serviceMonitor.scrapeTimeout`   | The timeout after which the scrape is ended                                               | `nil`                                                        |
+| `metrics.serviceMonitor.selector`        | Additional labels for ServiceMonitor resource                                             | `nil`                                                        |
+| `metrics.serviceMonitor.metricRelabelings` | Metrics relabelings to add to the scrape endpoint, applied before ingestion             | `nil`                                                        |
+| `metrics.serviceMonitor.relabelings`     | Metrics relabelings to add to the scrape endpoint, applied before scraping                | `nil`                                                        |
 
 The above parameters map to the env variables defined in [bitnami/memcached](http://github.com/bitnami/bitnami-docker-memcached). For more information please refer to the [bitnami/memcached](http://github.com/bitnami/bitnami-docker-memcached) image documentation.
 

--- a/bitnami/memcached/templates/servicemonitor.yaml
+++ b/bitnami/memcached/templates/servicemonitor.yaml
@@ -31,6 +31,12 @@ spec:
       {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
       {{- end }}
+      {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- toYaml .Values.metrics.serviceMonitor.metricRelabelings | nindent 6 }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml .Values.metrics.serviceMonitor.relabelings | nindent 6 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -329,3 +329,26 @@ metrics:
     ##
     # selector:
     #   prometheus: my-prometheus
+
+    ## MetricRelabelConfigs to apply to samples before ingestion
+    ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+    ##
+    # metricRelabelings:
+    # - sourceLabels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
+    #   separator: ;
+    #   regex: ^(.*)$
+    #   targetLabel: pod_name
+    #   replacement: $1
+    #   action: replace
+
+
+    ## RelabelConfigs to apply to samples before scraping
+    ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
+    ##
+    # relabelings:
+    # - sourceLabels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
+    #   separator: ;
+    #   regex: ^(.*)$
+    #   targetLabel: pod_name
+    #   replacement: $1
+    #   action: replace


### PR DESCRIPTION
**Description of the change**

This PR adds the 'metricRelabelings' and 'relabelings' parameters to the ServiceMonitor resource

**Benefits**

Flexibility

**Possible drawbacks**

None

**Applicable issues**

N/A

**Checklist** 
- [x] Variables are documented in the README.md
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
