### PR TITLE
[bitnami/redis] format examples as yaml

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -25,4 +25,4 @@ name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 14.1.0
+version: 14.1.1

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -496,11 +496,11 @@ To use a password file for Redis<sup>TM</sup> you need to create a secret contai
 And then deploy the Helm Chart using the secret name as parameter:
 
 ```console
-auth.enabled=true
-auth.usePasswordFiles=true
-auth.existingSecret=redis-password-file
-sentinels.enabled=true
-metrics.enabled=true
+auth.enabled: true
+auth.usePasswordFiles: true
+auth.existingSecret: "redis-password-file"
+sentinels.enabled: true
+metrics.enabled: true
 ```
 
 ### Securing traffic using TLS
@@ -524,11 +524,11 @@ kubectl create secret generic certificates-tls-secret --from-file=./cert.pem --f
 Then, use the following parameters:
 
 ```console
-tls.enabled="true"
-tls.certificatesSecret="certificates-tls-secret"
-tls.certFilename="cert.pem"
-tls.certKeyFilename="cert.key"
-tls.certCAFilename="ca.pem"
+tls.enabled: true
+tls.certificatesSecret: "certificates-tls-secret"
+tls.certFilename: "cert.pem"
+tls.certKeyFilename: "cert.key"
+tls.certCAFilename: "ca.pem"
 ```
 
 ### Metrics


### PR DESCRIPTION
**Description of the change**
I like if you can copy&paste the examples.
Currently two of the examples in the README are not yaml compliant.
This fix that.

Additionally I removed the quotes from the bool field `tls.enabled` and added quotes for the string field `auth.existingSecret` according to helm best practices.

**Benefits**
Working examples on how to configure TLS.

**Possible drawbacks**
. / .

**Applicable issues**
. / .

**Additional information**
. / .

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name