### PR TITLE
[charts/mariadb] Right release label in NOTES.

### DIFF
--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -26,4 +26,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-mariadb
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 9.3.8
+version: 9.3.9

--- a/bitnami/mariadb/templates/NOTES.txt
+++ b/bitnami/mariadb/templates/NOTES.txt
@@ -3,7 +3,7 @@ Please be patient while the chart is being deployed
 
 Tip:
 
-  Watch the deployment status using the command: kubectl get pods -w --namespace {{ .Release.Namespace }} -l release={{ .Release.Name }}
+  Watch the deployment status using the command: kubectl get pods -w --namespace {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
 
 Services:
 


### PR DESCRIPTION

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

NOTES.txt post install command used old `release` label whereas templates use `app.kubernetes.io/instance`, as referred by current Helm best practices.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Command indicated to the chart user after installation will show expected result, not a blank screen without indications for as long as the user is able to wait.

**Possible drawbacks**

None came to mind.

**Applicable issues**

Didn't think about looking at issues before, my bad :) Will do next time I promise.

**Additional information**

**Checklist** 
- [ X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ X] Variables are documented in the README.md
- [ X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
