### PR TITLE
[bitnami/wordpress] Add support for custom httpd.conf file

### DIFF
--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -35,4 +35,4 @@ name: wordpress
 sources:
   - https://github.com/bitnami/bitnami-docker-wordpress
   - https://wordpress.org/
-version: 10.10.13
+version: 10.11.0

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -48,8 +48,6 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Parameters
 
-The following table lists the configurable parameters of the WordPress chart and their default values per section/component:
-
 ### Global parameters
 
 | Name                      | Description                                     | Value |
@@ -76,7 +74,7 @@ The following table lists the configurable parameters of the WordPress chart and
 | ------------------- | ---------------------------------------------------- | --------------------- |
 | `image.registry`    | WordPress image registry                             | `docker.io`           |
 | `image.repository`  | WordPress image repository                           | `bitnami/wordpress`   |
-| `image.tag`         | WordPress image tag (immutable tags are recommended) | `5.7.0-debian-10-r11` |
+| `image.tag`         | WordPress image tag (immutable tags are recommended) | `5.7.1-debian-10-r11` |
 | `image.pullPolicy`  | WordPress image pull policy                          | `IfNotPresent`        |
 | `image.pullSecrets` | WordPress image pull secrets                         | `[]`                  |
 | `image.debug`       | Enable image debug mode                              | `false`               |
@@ -99,6 +97,8 @@ The following table lists the configurable parameters of the WordPress chart and
 | `wordpressConfiguration`               | The content for your custom wp-config.php file (experimental feature)                     | `nil`              |
 | `existingWordPressConfigurationSecret` | The name of an existing secret with your custom wp-config.php file (experimental feature) | `nil`              |
 | `wordpressConfigureCache`              | Enable W3 Total Cache plugin and configure cache settings                                 | `false`            |
+| `apacheConfiguration`                  | The content for your custom httpd.conf file (experimental feature)                        | `nil`              |
+| `existingApacheConfigurationConfigMap` | The name of an existing secret with your custom wp-config.php file (experimental feature) | `nil`              |
 | `customPostInitScripts`                | Custom post-init.d user scripts                                                           | `{}`               |
 | `smtpHost`                             | SMTP server host                                                                          | `""`               |
 | `smtpPort`                             | SMTP server port                                                                          | `""`               |
@@ -234,7 +234,7 @@ The following table lists the configurable parameters of the WordPress chart and
 | `metrics.enabled`                         | Start a sidecar prometheus exporter to expose metrics                        | `false`                   |
 | `metrics.image.registry`                  | Apache Exporter image registry                                               | `docker.io`               |
 | `metrics.image.repository`                | Apache Exporter image repository                                             | `bitnami/apache-exporter` |
-| `metrics.image.tag`                       | Apache Exporter image tag (immutable tags are recommended)                   | `0.8.0-debian-10-r334`    |
+| `metrics.image.tag`                       | Apache Exporter image tag (immutable tags are recommended)                   | `0.8.0-debian-10-r364`    |
 | `metrics.image.pullPolicy`                | Apache Exporter image pull policy                                            | `IfNotPresent`            |
 | `metrics.image.pullSecrets`               | Apache Exporter image pull secrets                                           | `[]`                      |
 | `metrics.resources.limits`                | The resources limits for the Prometheus exporter container                   | `{}`                      |
@@ -251,28 +251,28 @@ The following table lists the configurable parameters of the WordPress chart and
 
 ### Database Parameters
 
-| Name                                         | Description                                                               | Value               |
-| -------------------------------------------- | ------------------------------------------------------------------------- | ------------------- |
-| `mariadb.enabled`                            | Deploy a MariaDB server to satisfy the applications database requirements | `true`              |
-| `mariadb.architecture`                       | MariaDB architecture. Allowed values: `standalone` or `replication`       | `standalone`        |
-| `mariadb.auth.rootPassword`                  | MariaDB root password                                                     | `""`                |
-| `mariadb.auth.database`                      | MariaDB custom database                                                   | `bitnami_wordpress` |
-| `mariadb.auth.username`                      | MariaDB custom user name                                                  | `bn_wordpress`      |
-| `mariadb.auth.password`                      | MariaDB custom user password                                              | `""`                |
-| `mariadb.primary.persistence.enabled`        | Enable persistence on MariaDB using PVC(s)                                | `true`              |
-| `mariadb.primary.persistence.storageClass`   | Persistent Volume storage class                                           | `nil`               |
-| `mariadb.primary.accessModes`                | Persistent Volume access modes                                            | `[ReadWriteOnce]`   |
-| `mariadb.primary.persistence.size`           | Persistent Volume size                                                    | `8Gi`               |
-| `externalDatabase.host`                      | External Database server host                                             | `localhost`         |
-| `externalDatabase.port`                      | External Database server port                                             | `3306`              |
-| `externalDatabase.user`                      | External Database username                                                | `bn_wordpress`      |
-| `externalDatabase.password`                  | External Database user password                                           | `""`                |
-| `externalDatabase.database`                  | External Database database name                                           | `bitnami_wordpress` |
-| `externalDatabase.existingSecret`            | The name of an existing secret with database credentials                  | `nil`               |
-| `memcached.enabled`                          | Deploy a Memcached server for caching database queries                    | `false`             |
-| `memcached.service.port`                     | Memcached service port                                                    | `11211`             |
-| `externalCache.host`                         | External cache server host                                                | `localhost`         |
-| `externalCache.port`                         | External cache server port                                                | `11211`             |
+| Name                                       | Description                                                               | Value               |
+| ------------------------------------------ | ------------------------------------------------------------------------- | ------------------- |
+| `mariadb.enabled`                          | Deploy a MariaDB server to satisfy the applications database requirements | `true`              |
+| `mariadb.architecture`                     | MariaDB architecture. Allowed values: `standalone` or `replication`       | `standalone`        |
+| `mariadb.auth.rootPassword`                | MariaDB root password                                                     | `""`                |
+| `mariadb.auth.database`                    | MariaDB custom database                                                   | `bitnami_wordpress` |
+| `mariadb.auth.username`                    | MariaDB custom user name                                                  | `bn_wordpress`      |
+| `mariadb.auth.password`                    | MariaDB custom user password                                              | `""`                |
+| `mariadb.primary.persistence.enabled`      | Enable persistence on MariaDB using PVC(s)                                | `true`              |
+| `mariadb.primary.persistence.storageClass` | Persistent Volume storage class                                           | `nil`               |
+| `mariadb.primary.persistence.accessModes`  | Persistent Volume access modes                                            | `[ReadWriteOnce]`   |
+| `mariadb.primary.persistence.size`         | Persistent Volume size                                                    | `8Gi`               |
+| `externalDatabase.host`                    | External Database server host                                             | `localhost`         |
+| `externalDatabase.port`                    | External Database server port                                             | `3306`              |
+| `externalDatabase.user`                    | External Database username                                                | `bn_wordpress`      |
+| `externalDatabase.password`                | External Database user password                                           | `""`                |
+| `externalDatabase.database`                | External Database database name                                           | `bitnami_wordpress` |
+| `externalDatabase.existingSecret`          | The name of an existing secret with database credentials                  | `nil`               |
+| `memcached.enabled`                        | Deploy a Memcached server for caching database queries                    | `false`             |
+| `memcached.service.port`                   | Memcached service port                                                    | `11211`             |
+| `externalCache.host`                       | External cache server host                                                | `localhost`         |
+| `externalCache.port`                       | External cache server port                                                | `11211`             |
 
 The above parameters map to the env variables defined in [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress). For more information please refer to the [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress) image documentation.
 

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -81,40 +81,41 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### WordPress Configuration parameters
 
-| Name                                   | Description                                                                               | Value              |
-| -------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------ |
-| `wordpressUsername`                    | WordPress username                                                                        | `user`             |
-| `wordpressPassword`                    | WordPress user password                                                                   | `""`               |
-| `existingSecret`                       | Name of existing secret containing WordPress credentials                                  | `nil`              |
-| `wordpressEmail`                       | WordPress user email                                                                      | `user@example.com` |
-| `wordpressFirstName`                   | WordPress user first name                                                                 | `FirstName`        |
-| `wordpressLastName`                    | WordPress user last name                                                                  | `LastName`         |
-| `wordpressBlogName`                    | Blog name                                                                                 | `User's Blog!`     |
-| `wordpressTablePrefix`                 | Prefix to use for WordPress database tables                                               | `wp_`              |
-| `wordpressScheme`                      | Scheme to use to generate WordPress URLs                                                  | `http`             |
-| `wordpressSkipInstall`                 | Skip wizard installation                                                                  | `false`            |
-| `wordpressExtraConfigContent`          | Add extra content to the default wp-config.php file                                       | `nil`              |
-| `wordpressConfiguration`               | The content for your custom wp-config.php file (experimental feature)                     | `nil`              |
-| `existingWordPressConfigurationSecret` | The name of an existing secret with your custom wp-config.php file (experimental feature) | `nil`              |
-| `wordpressConfigureCache`              | Enable W3 Total Cache plugin and configure cache settings                                 | `false`            |
-| `apacheConfiguration`                  | The content for your custom httpd.conf file (experimental feature)                        | `nil`              |
-| `existingApacheConfigurationConfigMap` | The name of an existing secret with your custom wp-config.php file (experimental feature) | `nil`              |
-| `customPostInitScripts`                | Custom post-init.d user scripts                                                           | `{}`               |
-| `smtpHost`                             | SMTP server host                                                                          | `""`               |
-| `smtpPort`                             | SMTP server port                                                                          | `""`               |
-| `smtpUser`                             | SMTP username                                                                             | `""`               |
-| `smtpPassword`                         | SMTP user password                                                                        | `""`               |
-| `smtpProtocol`                         | SMTP protocol                                                                             | `""`               |
-| `smtpExistingSecret`                   | The name of an existing secret with SMTP credentials                                      | `nil`              |
-| `allowEmptyPassword`                   | Allow the container to be started with blank passwords                                    | `true`             |
-| `allowOverrideNone`                    | Configure Apache to prohibit overriding directives with htaccess files                    | `false`            |
-| `htaccessPersistenceEnabled`           | Persist custom changes on htaccess files                                                  | `false`            |
-| `customHTAccessCM`                     | The name of an existing ConfigMap with custom htaccess rules                              | `nil`              |
-| `command`                              | Override default container command (useful when using custom images)                      | `[]`               |
-| `args`                                 | Override default container args (useful when using custom images)                         | `[]`               |
-| `extraEnvVars`                         | Array with extra environment variables to add to the WordPress container                  | `[]`               |
-| `extraEnvVarsCM`                       | Name of existing ConfigMap containing extra env vars                                      | `nil`              |
-| `extraEnvVarsSecret`                   | Name of existing Secret containing extra env vars                                         | `nil`              |
+| Name                                   | Description                                                                           | Value              |
+| -------------------------------------- | ------------------------------------------------------------------------------------- | ------------------ |
+| `wordpressUsername`                    | WordPress username                                                                    | `user`             |
+| `wordpressPassword`                    | WordPress user password                                                               | `""`               |
+| `existingSecret`                       | Name of existing secret containing WordPress credentials                              | `nil`              |
+| `wordpressEmail`                       | WordPress user email                                                                  | `user@example.com` |
+| `wordpressFirstName`                   | WordPress user first name                                                             | `FirstName`        |
+| `wordpressLastName`                    | WordPress user last name                                                              | `LastName`         |
+| `wordpressBlogName`                    | Blog name                                                                             | `User's Blog!`     |
+| `wordpressTablePrefix`                 | Prefix to use for WordPress database tables                                           | `wp_`              |
+| `wordpressScheme`                      | Scheme to use to generate WordPress URLs                                              | `http`             |
+| `wordpressSkipInstall`                 | Skip wizard installation                                                              | `false`            |
+| `wordpressExtraConfigContent`          | Add extra content to the default wp-config.php file                                   | `nil`              |
+| `wordpressConfiguration`               | The content for your custom wp-config.php file (advanced feature)                     | `nil`              |
+| `existingWordPressConfigurationSecret` | The name of an existing secret with your custom wp-config.php file (advanced feature) | `nil`              |
+| `wordpressConfigureCache`              | Enable W3 Total Cache plugin and configure cache settings                             | `false`            |
+| `apacheConfiguration`                  | The content for your custom httpd.conf file (advanced feature)                        | `nil`              |
+| `existingApacheConfigurationConfigMap` | The name of an existing secret with your custom wp-config.php file (advanced feature) | `nil`              |
+| `customPostInitScripts`                | Custom post-init.d user scripts                                                       | `{}`               |
+| `smtpHost`                             | SMTP server host                                                                      | `""`               |
+| `smtpPort`                             | SMTP server port                                                                      | `""`               |
+| `smtpUser`                             | SMTP username                                                                         | `""`               |
+| `smtpPassword`                         | SMTP user password                                                                    | `""`               |
+| `smtpProtocol`                         | SMTP protocol                                                                         | `""`               |
+| `smtpExistingSecret`                   | The name of an existing secret with SMTP credentials                                  | `nil`              |
+| `allowEmptyPassword`                   | Allow the container to be started with blank passwords                                | `true`             |
+| `allowOverrideNone`                    | Configure Apache to prohibit overriding directives with htaccess files                | `false`            |
+| `htaccessPersistenceEnabled`           | Persist custom changes on htaccess files                                              | `false`            |
+| `customHTAccessCM`                     | The name of an existing ConfigMap with custom htaccess rules                          | `nil`              |
+| `command`                              | Override default container command (useful when using custom images)                  | `[]`               |
+| `args`                                 | Override default container args (useful when using custom images)                     | `[]`               |
+| `extraEnvVars`                         | Array with extra environment variables to add to the WordPress container              | `[]`               |
+| `extraEnvVarsCM`                       | Name of existing ConfigMap containing extra env vars                                  | `nil`              |
+| `extraEnvVarsSecret`                   | Name of existing Secret containing extra env vars                                     | `nil`              |
+
 
 ### WordPress deployment parameters
 
@@ -248,6 +249,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.serviceMonitor.relabellings`     | Metrics relabellings to add to the scrape endpoint                           | `nil`                     |
 | `metrics.serviceMonitor.honorLabels`      | Labels to honor to add to the scrape endpoint                                | `false`                   |
 | `metrics.serviceMonitor.additionalLabels` | Additional custom labels for the ServiceMonitor                              | `{}`                      |
+
 
 ### Database Parameters
 

--- a/bitnami/wordpress/templates/_helpers.tpl
+++ b/bitnami/wordpress/templates/_helpers.tpl
@@ -58,7 +58,7 @@ Return the WordPress configuration secret
 {{- if .Values.existingWordPressConfigurationSecret -}}
     {{- printf "%s" (tpl .Values.existingWordPressConfigurationSecret $) -}}
 {{- else -}}
-    {{- printf "%s-configuration" (include "common.names.fullname" .) -}}
+    {{- printf "%s-configuration" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 
@@ -67,6 +67,26 @@ Return true if a secret object should be created for WordPress configuration
 */}}
 {{- define "wordpress.createConfigSecret" -}}
 {{- if and .Values.wordpressConfiguration (not .Values.existingWordPressConfigurationSecret) }}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the WordPress Apache configuration configmap
+*/}}
+{{- define "wordpress.apache.configmapName" -}}
+{{- if .Values.existingApacheConfigurationConfigMap -}}
+    {{- printf "%s" (tpl .Values.existingApacheConfigurationConfigMap $) -}}
+{{- else -}}
+    {{- printf "%s-apache-configuration" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if a secret object should be created for Apache configuration
+*/}}
+{{- define "wordpress.apache.createConfigmap" -}}
+{{- if and .Values.apacheConfiguration (not .Values.existingApacheConfigurationConfigMap) }}
     {{- true -}}
 {{- end -}}
 {{- end -}}

--- a/bitnami/wordpress/templates/deployment.yaml
+++ b/bitnami/wordpress/templates/deployment.yaml
@@ -221,6 +221,11 @@ spec:
               mountPath: /opt/bitnami/wordpress/wp-config.php
               subPath: wp-config.php
             {{- end }}
+            {{- if or .Values.apacheConfiguration .Values.existingApacheConfigurationConfigMap }}
+            - name: apache-config
+              mountPath: /opt/bitnami/apache/conf/httpd.conf
+              subPath: httpd.conf
+            {{- end }}
             {{- if and (not .Values.allowOverrideNone) .Values.customHTAccessCM }}
             - mountPath: /htaccess
               name: custom-htaccess
@@ -267,6 +272,12 @@ spec:
         - name: wordpress-config
           secret:
             secretName: {{ include "wordpress.configSecretName" . }}
+            defaultMode: 0644
+        {{- end }}
+        {{- if or .Values.apacheConfiguration .Values.existingApacheConfigurationConfigMap }}
+        - name: apache-config
+          configMap:
+            name: {{ include "wordpress.apache.configmapName" . }}
             defaultMode: 0644
         {{- end }}
         {{- if and (not .Values.allowOverrideNone) .Values.customHTAccessCM }}

--- a/bitnami/wordpress/templates/externaldb-secrets.yaml
+++ b/bitnami/wordpress/templates/externaldb-secrets.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-externaldb" (include "common.names.fullname" .) }}
+  name: {{ printf "%s-externaldb" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/bitnami/wordpress/templates/httpd-configmap.yaml
+++ b/bitnami/wordpress/templates/httpd-configmap.yaml
@@ -1,9 +1,9 @@
-{{- if (include "wordpress.createConfigSecret" .) }}
+{{- if (include "wordpress.apache.createConfigmap" .) }}
 apiVersion: v1
-kind: Secret
+kind: ConfigMap
 metadata:
-  name: {{ printf "%s-configuration" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ .Release.Namespace | quote }}
+  name: {{ printf "%s-apache-configuration" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
@@ -12,5 +12,6 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
-  wp-config.php: {{ .Values.wordpressConfiguration | b64enc }}
+  httpd.conf: |-
+    {{- .Values.apacheConfiguration | nindent 4 }}
 {{- end }}

--- a/bitnami/wordpress/templates/postinit-configmap.yaml
+++ b/bitnami/wordpress/templates/postinit-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ printf "%s-postinit" (include "common.names.fullname" .) }}
+  name: {{ printf "%s-postinit" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -118,12 +118,12 @@ wordpressSkipInstall: false
 ##   @ini_set( 'memory_limit', '256M' );
 ##
 wordpressExtraConfigContent:
-## @param wordpressConfiguration The content for your custom wp-config.php file (experimental feature)
+## @param wordpressConfiguration The content for your custom wp-config.php file (advanced feature)
 ## NOTE: This will override configuring WordPress based on environment variables (including those set by the chart)
 ## NOTE: Currently only supported when `wordpressSkipInstall=true`
 ##
 wordpressConfiguration:
-## @param existingWordPressConfigurationSecret The name of an existing secret with your custom wp-config.php file (experimental feature)
+## @param existingWordPressConfigurationSecret The name of an existing secret with your custom wp-config.php file (advanced feature)
 ## NOTE: When it's set the `wordpressConfiguration` parameter is ignored
 ##
 existingWordPressConfigurationSecret:
@@ -131,10 +131,10 @@ existingWordPressConfigurationSecret:
 ## NOTE: useful if you deploy Memcached for caching database queries or you use an external cache server
 ##
 wordpressConfigureCache: false
-## @param apacheConfiguration The content for your custom httpd.conf file (experimental feature)
+## @param apacheConfiguration The content for your custom httpd.conf file (advanced feature)
 ##
 apacheConfiguration:
-## @param existingApacheConfigurationConfigMap The name of an existing secret with your custom wp-config.php file (experimental feature)
+## @param existingApacheConfigurationConfigMap The name of an existing secret with your custom wp-config.php file (advanced feature)
 ## NOTE: When it's set the `apacheConfiguration` parameter is ignored
 ##
 existingApacheConfigurationConfigMap:

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -131,6 +131,13 @@ existingWordPressConfigurationSecret:
 ## NOTE: useful if you deploy Memcached for caching database queries or you use an external cache server
 ##
 wordpressConfigureCache: false
+## @param apacheConfiguration The content for your custom httpd.conf file (experimental feature)
+##
+apacheConfiguration:
+## @param existingApacheConfigurationConfigMap The name of an existing secret with your custom wp-config.php file (experimental feature)
+## NOTE: When it's set the `apacheConfiguration` parameter is ignored
+##
+existingApacheConfigurationConfigMap:
 ## @param customPostInitScripts Custom post-init.d user scripts
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress/tree/master/5/debian-10/rootfs/post-init.d
 ## NOTE: supported formats are `.sh`, `.sql` or `.php`


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR adds support for mounting a custom `httpd.conf` file to configure Apache using a ConfigMap (or directly passing it throw the **values.yaml**)

**Benefits**

Support for more customizations.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
