### PR TITLE
[bitnami/external-dns] Fix typo in service name template

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -24,4 +24,4 @@ sources:
   - https://github.com/kubernetes-sigs/external-dns
   - https://github.com/bitnami/bitnami-docker-external-dns
   - https://github.com/kubernetes-sigs/external-dns
-version: 4.11.1
+version: 4.11.2

--- a/bitnami/external-dns/templates/_helpers.tpl
+++ b/bitnami/external-dns/templates/_helpers.tpl
@@ -737,7 +737,7 @@ external-dns: scaleway.scwDefaultOrganizationId
 {{- end -}}
 {{- end -}}
 
-{/*
+{{/*
 Return the ExternalDNS service account name
 */}}
 {{- define "external-dns.serviceAccountName" -}}


### PR DESCRIPTION
**Description of the change**

ExternalDNS service account name had missing {

**Benefits**

Value set in serviceAccountName should be set correctly

**Possible drawbacks**


**Applicable issues**

**Additional information**


**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
