### PR TITLE
[bitnami/kong] Added service.clusterIP option

### DIFF
--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -34,4 +34,4 @@ name: kong
 sources:
   - https://github.com/bitnami/bitnami-docker-kong
   - https://konghq.com/
-version: 3.5.4
+version: 3.6.0

--- a/bitnami/kong/README.md
+++ b/bitnami/kong/README.md
@@ -135,6 +135,7 @@ The following tables list the configurable parameters of the kong chart and thei
 | `service.adminHttpNodePort`      | Port to bind to for NodePort service type (admin HTTP)           | `nil`                          |
 | `service.aminHttpsNodePort`      | Port to bind to for NodePort service type (proxy HTTP)           | `nil`                          |
 | `service.annotations`            | Annotations for kong service                                     | `{}`                           |
+| `service.clusterIP`              | Cluster internal IP of the service                               | `nil`                          |
 | `service.loadBalancerIP`         | loadBalancerIP if kong service type is `LoadBalancer`            | `nil`                          |
 | `ingress.enabled`                | Enable ingress controller resource                               | `false`                        |
 | `ingress.certManager`            | Add annotations for cert-manager                                 | `false`                        |

--- a/bitnami/kong/templates/service.yaml
+++ b/bitnami/kong/templates/service.yaml
@@ -22,6 +22,9 @@ spec:
   {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.externalTrafficPolicy)) }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }} 
   {{- end }}
+  {{- if not (empty .Values.service.clusterIP) }}
+  clusterIP: {{ .Values.service.clusterIP }} 
+  {{- end }}
   {{- if and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP)) }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}

--- a/bitnami/kong/values.yaml
+++ b/bitnami/kong/values.yaml
@@ -335,6 +335,12 @@ service:
   ##
   type: ClusterIP
 
+  ## clusterIP for the service (optional)
+  ## This is the internal IP address of the service and is usually assigned randomly.
+  ## ref: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceSpec
+  ##
+  clusterIP:
+
   ## externalTrafficPolicy for the service
   ## default to "Cluster"
   ## set to "Local" in order to preserve the client source IP (only on service of type LoadBalancer or NodePort)
@@ -367,7 +373,7 @@ service:
   # adminHttpNodePort:
   # adminHttpsNodePort:
 
-  ## loadBalancerIP for the PrestaShop Service (optional, cloud specific)
+  ## loadBalancerIP for the Kong Service (optional, cloud specific)
   ## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
   ##
   loadBalancerIP:


### PR DESCRIPTION
**Description of the change**

This PR adds support to setting clusterIP on the exposed service.

**Benefits**

You can specify your own cluster IP address as part of the Service creation.

**Possible drawbacks**

As per Kubernetes documentation: The IP address that you choose must be a valid IPv4 or IPv6 address from within the service-cluster-ip-range CIDR range that is configured for the API server. If you try to create a Service with an invalid clusterIP address value, the API server will return a 422 HTTP status code to indicate that there's a problem.

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
