### PR TITLE
[bitnami/airflow] Fixed Git Sync Plugin Path

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -32,4 +32,4 @@ name: airflow
 sources:
   - https://github.com/bitnami/bitnami-docker-airflow
   - https://airflow.apache.org/
-version: 10.0.1
+version: 10.0.2

--- a/bitnami/airflow/templates/_git_helpers.tpl
+++ b/bitnami/airflow/templates/_git_helpers.tpl
@@ -42,7 +42,7 @@ Returns the volume mounts that will be used by the main container
 {{- if .Values.git.plugins.enabled }}
   {{- range .Values.git.plugins.repositories }}
 - name: git-cloned-plugins-files-{{ include "airflow.git.repository.name" . }}
-  mountPath: /opt/bitnami/airflow/git_{{ include "airflow.git.repository.name" . }}
+  mountPath: /opt/bitnami/airflow/plugins/git_{{ include "airflow.git.repository.name" . }}
     {{- if .path }}
   subPath: {{ .path }}
     {{- end }}


### PR DESCRIPTION
**Description of the change**
This PR fixes a missing segment of the plugin path. Without the correct path, Airflow cannot find plugins at the default plugin location. 

**Benefits**

Correct plugin path location by git sync.

**Possible drawbacks**

Previous workarounds to this bug might fail to work.

**Applicable issues**

  - fixes #5647 

**Additional information**

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

