### PR TITLE
[bitnami/postgresql-ha] Add Password validation on upgrade

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -27,4 +27,4 @@ name: postgresql-ha
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 7.3.0
+version: 7.3.1

--- a/bitnami/postgresql-ha/templates/NOTES.txt
+++ b/bitnami/postgresql-ha/templates/NOTES.txt
@@ -51,3 +51,18 @@ To connect to your database from outside the cluster execute the following comma
 
 {{- include "postgresql-ha.validateValues" . }}
 {{- include "postgresql-ha.checkRollingTags" . }}
+
+{{- $passwordValidationErrors := list -}}
+{{- $requiredPasswords := list -}}
+{{- $secretName := include "postgresql-ha.postgresqlSecretName" . -}}
+{{- $requiredPostgresqlPassword := dict "valueKey" "postgresql.password" "secret" $secretName "field" "postgresql-password" "context" $ -}}
+{{- $requiredPasswords = append $requiredPasswords $requiredPostgresqlPassword -}}
+{{- $requiredRepmgrPassword := dict "valueKey" "postgresql.repmgrPassword" "secret" $secretName "field" "repmgr-password" "context" $ -}}
+{{- $requiredPasswords = append $requiredPasswords $requiredRepmgrPassword -}}
+{{- $secretName := include "postgresql-ha.pgpoolSecretName" . -}}
+{{- $requiredPgpoolPassword := dict "valueKey" "pgpool.adminPassword" "secret" $secretName "field" "admin-password" "context" $ -}}
+{{- $requiredPasswords = append $requiredPasswords $requiredPgpoolPassword -}}
+
+{{- $passwordValidationErrors = include "common.validations.values.multiple.empty" (dict "required" $requiredPasswords "context" .) -}}
+
+{{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordValidationErrors "context" $) -}}


### PR DESCRIPTION
**Description of the change**

Adds password validation when upgrading for the Postgresql HA chart.

**Benefits**

Prevent users from accidentally upgrading without providing Postgresql, Repmgr and Pgpool passwords.

**Possible drawbacks**

None known.

**Applicable issues**

  - fixes #6133

**Additional information**

Testing output:
```
> helm install psql-test bitnami/postgresql-ha
...
> helm upgrade psql-test bitnami/postgresql-ha
Error: UPGRADE FAILED: template: postgresql-ha/templates/NOTES.txt:68:4: executing "postgresql-ha/templates/NOTES.txt" at <include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordValidationErrors "context" $)>: error calling include: template: postgresql-ha/charts/common/templates/_errors.tpl:21:48: executing "common.errors.upgrade.passwords.empty" at <fail>: error calling fail: 
PASSWORDS ERROR: You must provide your current passwords when upgrading the release.
                 Note that even after reinstallation, old credentials may be needed as they may be kept in persistent volume claims.
                 Further information can be obtained at https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues/#credential-errors-while-upgrading-chart-releases

    'postgresql.password' must not be empty, please add '--set postgresql.password=$POSTGRESQL_PASSWORD' to the command. To get the current value:

        export POSTGRESQL_PASSWORD=$(kubectl get secret --namespace "default" psql-test-postgresql-ha-postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode)

    'postgresql.repmgrPassword' must not be empty, please add '--set postgresql.repmgrPassword=$REPMGR_PASSWORD' to the command. To get the current value:

        export REPMGR_PASSWORD=$(kubectl get secret --namespace "default" psql-test-postgresql-ha-postgresql -o jsonpath="{.data.repmgr-password}" | base64 --decode)

    'pgpool.adminPassword' must not be empty, please add '--set pgpool.adminPassword=$ADMIN_PASSWORD' to the command. To get the current value:

        export ADMIN_PASSWORD=$(kubectl get secret --namespace "default" psql-test-postgresql-ha-pgpool -o jsonpath="{.data.admin-password}" | base64 --decode)

> helm upgrade psql-test bitnami/postgresql-ha --set postgresql.password=$POSTGRESQL_PASSWORD --set postgresql.repmgrPassword=$REPMGR_PASSWORD --set pgpool.adminPassword=$ADMIN_PASSWORD
Release "psql-test" has been upgraded. Happy Helming!
NAME: psql-test
LAST DEPLOYED: Tue May  4 09:32:16 2021
NAMESPACE: default
STATUS: deployed
REVISION: 2
TEST SUITE: None
NOTES:
** Please be patient while the chart is being deployed **

PostgreSQL can be accessed through Pgpool via port 5432 on the following DNS name from within your cluster:

    psql-test-postgresql-ha-pgpool.default.svc.cluster.local

Pgpool acts as a load balancer for PostgreSQL and forward read/write connections to the primary node while read-only connections are forwarded to standby nodes.

To get the password for "postgres" run:

    export POSTGRES_PASSWORD=$(kubectl get secret --namespace default psql-test-postgresql-ha-postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode)

To get the password for "repmgr" run:

    export REPMGR_PASSWORD=$(kubectl get secret --namespace default psql-test-postgresql-ha-postgresql -o jsonpath="{.data.repmgr-password}" | base64 --decode)

To connect to your database run the following command:

    kubectl run psql-test-postgresql-ha-client --rm --tty -i --restart='Never' --namespace default --image docker.io/bitnami/postgresql-repmgr:11.11.0-debian-10-r70 --env="PGPASSWORD=$POSTGRES_PASSWORD"  \
        --command -- psql -h psql-test-postgresql-ha-pgpool -p 5432 -U postgres -d postgres

To connect to your database from outside the cluster execute the following commands:

    kubectl port-forward --namespace default svc/psql-test-postgresql-ha-pgpool 5432:5432 &
    psql -h 127.0.0.1 -p 5432 -U postgres -d postgres

```
**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)