### PR TITLE
[bitnami/kube-prometheus] Use new cmdline options for config-reloader resources

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-prometheus
   - https://github.com/bitnami/bitnami-docker-alertmanager
   - https://github.com/prometheus-operator/kube-prometheus
-version: 4.3.1
+version: 4.4.0

--- a/bitnami/kube-prometheus/README.md
+++ b/bitnami/kube-prometheus/README.md
@@ -517,10 +517,7 @@ $ helm upgrade my-release bitnami/kube-prometheus
 
 ### To 4.4.0
 
-This version replaced the old `configReloaderCpu` and `configReloaderMemory`
-variables in favor of the new `configReloaderResources` map to define the
-requests and limits for the config-reloader sidecards. Users who made use
-of the old variables will need to migrate to the new ones.
+This version replaced the old `configReloaderCpu` and `configReloaderMemory` variables in favor of the new `configReloaderResources` map to define the requests and limits for the config-reloader sidecards. Users who made use of the old variables will need to migrate to the new ones.
 
 ### To 4.0.0
 

--- a/bitnami/kube-prometheus/README.md
+++ b/bitnami/kube-prometheus/README.md
@@ -132,8 +132,7 @@ The following table lists the configurable parameters of the kube-prometheus cha
 | `operator.logLevel`                                   | Log Level                                                                                                     | `info`                                                           |
 | `operator.logFormat`                                  | Log Format                                                                                                    | `logfmt`                                                         |
 | `operator.kubeletService.enabled`                     | Whether to maintain a service for scraping kubelets                                                           | `true`                                                           |
-| `operator.configReloaderCpu`                          | Set the prometheus config reloader side-car CPU limit. If unset, uses the kube-prometheus project default     | `nil`                                                            |
-| `operator.configReloaderMemory`                       | Set the prometheus config reloader side-car memory limit. If unset, uses the kube-prometheus project default  | `nil`                                                            |
+| `operator.configReloaderResources                     | CPU/Memory resources requests/limits for config-reloader sidecars                                             | `{}`                                                             |
 | `operator.kubeletService.namespace`                   | Namespace to deploy the kubelet service                                                                       | `kube-system`                                                    |
 | `operator.prometheusConfigReloader.image.registry`    | Prometheus Config Reloader image registry                                                                     | same as `operator.image.registry`                                |
 | `operator.prometheusConfigReloader.image.repository`  | Prometheus Config Reloader Image name                                                                         | same as `operator.image.repository`                              |
@@ -515,6 +514,13 @@ Find more information about how to deal with common errors related to Bitnami’
 ```bash
 $ helm upgrade my-release bitnami/kube-prometheus
 ```
+
+### To 4.4.0
+
+This version replaced the old `configReloaderCpu` and `configReloaderMemory`
+variables in favor of the new `configReloaderResources` map to define the
+requests and limits for the config-reloader sidecards. Users who made use
+of the old variables will need to migrate to the new ones.
 
 ### To 4.0.0
 

--- a/bitnami/kube-prometheus/templates/prometheus-operator/deployment.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/deployment.yaml
@@ -68,12 +68,22 @@ spec:
             {{- end }}
             - --localhost=127.0.0.1
             - --prometheus-config-reloader=$(PROMETHEUS_CONFIG_RELOADER)
-          {{- if .Values.operator.configReloaderCpu }}
-            - --config-reloader-cpu={{ .Values.operator.configReloaderCpu }}
-          {{- end }}
-          {{- if .Values.operator.configReloaderMemory }}
-            - --config-reloader-memory={{ .Values.operator.configReloaderMemory }}
-          {{- end }}
+            {{- if .Values.operator.configReloaderResources.requests }}
+              {{- if .Values.operator.configReloaderResources.requests.cpu }}
+                - --config-reloader-cpu-request={{ .Values.operator.configReloaderResources.requests.cpu }}
+              {{- end }}
+              {{- if .Values.operator.configReloaderResources.requests.memory }}
+                - --config-reloader-memory-request={{ .Values.operator.configReloaderResources.requests.memory }}
+              {{- end }}
+            {{- end }}
+            {{- if .Values.operator.configReloaderResources.limits }}
+              {{- if .Values.operator.configReloaderResources.limits.cpu }}
+                - --config-reloader-cpu-limit={{ .Values.operator.configReloaderResources.limits.cpu }}
+              {{- end }}
+              {{- if .Values.operator.configReloaderResources.limits.memory }}
+                - --config-reloader-memory-limit={{ .Values.operator.configReloaderResources.limits.memory }}
+              {{- end }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/bitnami/kube-prometheus/values.yaml
+++ b/bitnami/kube-prometheus/values.yaml
@@ -230,13 +230,17 @@ operator:
   ##
   logFormat: logfmt
 
-  ## Set the prometheus config reloader side-car CPU limit. If unset, uses the prometheus-operator project default
-  ##
-  # configReloaderCpu: 100m
 
-  ## Set the prometheus config reloader side-car memory limit. If unset, uses the prometheus-operator project default
+  ## Set the prometheus config reloader side-car CPU and memory requests and limits.
   ##
-  # configReloaderMemory: 25Mi
+  configReloaderResources: {}
+  #  limits:
+  #    cpu: 200m
+  #    memory: 100Mi
+  #  requests:
+  #    cpu: 100m
+  #    memory: 50Mi
+
 
   ## If true, the operator will create and maintain a service for scraping kubelets
   ##


### PR DESCRIPTION
**Description of the change**

The old --config-reloader-{cpu,memory} cmdline options have been
deprecated in favour of --config-reloader-{cpu,memory}-{request,limit}[1]
which allows us to set diffrent values for requests and limits on the
config-reloader sidecar. This change first appeard in version v0.47.0

As such, lets migrate away from the previous variables and options and
define a new 'configReloaderResources' to define these values similar to
the well known 'resources: {}' one.

[1] https://github.com/prometheus-operator/prometheus-operator/commit/bcf61aacda782d6c8ffc79f55ea1def9cfd97933

**Benefits**

- Be able to set distinct values for config-reloader sidecar resources

**Possible drawbacks**

- Users need to migrate manually to new variables

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
