### PR TITLE
[bitnami/mediawiki] Don't create a PVC when using existing claim

### DIFF
--- a/bitnami/mediawiki/Chart.yaml
+++ b/bitnami/mediawiki/Chart.yaml
@@ -32,4 +32,4 @@ name: mediawiki
 sources:
   - https://github.com/bitnami/bitnami-docker-mediawiki
   - http://www.mediawiki.org/
-version: 12.2.7
+version: 12.2.8

--- a/bitnami/mediawiki/templates/mediawiki-pvc.yaml
+++ b/bitnami/mediawiki/templates/mediawiki-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.enabled -}}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:


### PR DESCRIPTION
This prevents a new PVC from being created when the `persistence.existingClaim` is used.

If an existing claim is used, another PVC will be created. This PVC will either remain unused or be provisioned if a default provisioner acts on it. In either case it will not be used by this chart [due to the custom claim being set](https://github.com/bitnami/charts/blob/master/bitnami/mediawiki/templates/deployment.yaml#L197).

**Description of the change**

Remove excess PVC object. This was causing my provisioner to act on the PVC and provision storage that would never be used.

**Benefits**

Reduce cost/clutter of unused PVC object.

**Possible drawbacks**

None that I can think of.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
