### PR TITLE
[bitnami/ghost] Extracted mountPath for Ghost volume and corrected default value

### DIFF
--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -33,4 +33,4 @@ name: ghost
 sources:
   - https://github.com/bitnami/bitnami-docker-ghost
   - http://www.ghost.org/
-version: 13.0.7
+version: 13.0.8

--- a/bitnami/ghost/README.md
+++ b/bitnami/ghost/README.md
@@ -128,7 +128,7 @@ The following table lists the configurable parameters of the Ghost chart and the
 | `persistence.accessMode`                | PVC Access Mode for Ghost volume                                                                                      | `ReadWriteOnce`                             |
 | `persistence.enabled`                   | Enable persistence using PVC                                                                                          | `true`                                      |
 | `persistence.existingClaim`             | An Existing PVC name                                                                                                  | `nil`                                       |
-| `persistence.path`                      | Host mount path for Ghost volume                                                                                      | `nil` (will not mount to a host path)       |
+| `persistence.path`                      | Path to mount the Ghost volume at                                                                                     | `/bitnami/ghost`                            |
 | `persistence.size`                      | PVC Storage Request for Ghost volume                                                                                  | `8Gi`                                       |
 | `persistence.storageClass`              | PVC Storage Class for Ghost volume                                                                                    | `nil` (uses alpha storage class annotation) |
 | `podAnnotations`                        | Pod annotations                                                                                                       | `{}`                                        |

--- a/bitnami/ghost/templates/deployment.yaml
+++ b/bitnami/ghost/templates/deployment.yaml
@@ -207,7 +207,7 @@ spec:
           {{- end }}
           volumeMounts:
             - name: ghost-data
-              mountPath: /bitnami/ghost
+              mountPath: {{ .Values.persistence.path }}
           {{- if .Values.extraVolumeMounts }}
             {{- include "common.tplvalues.render" ( dict "value" .Values.extraVolumeMounts "context" $ ) | nindent 12 }}
           {{- end }}

--- a/bitnami/ghost/values.yaml
+++ b/bitnami/ghost/values.yaml
@@ -323,7 +323,7 @@ persistence:
   ## Requires persistence.existingClaim: nil|false
   ## Default: nil.
   ##
-  path: /bitnami
+  path: /bitnami/ghost
 
 ## Ghost containers' resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

The existing `persistence.path` variable is used when setting volume permissions but hardcoded for the Ghost container. This change allows chart consumers to optionally modify this value.

Further, the current value of `persistence.path`, `/bitnami`, has been corrected to `/bitnami/ghost` as used in the Ghost container.

**Benefits**

Additional flexibility for chart consumers.

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
