### PR TITLE
[bitnami/harbor] Remove deprecated notifications config from registry

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-harbor-registry
   - https://github.com/bitnami/bitnami-docker-harbor-registryctl
   - https://goharbor.io/
-version: 10.0.1
+version: 10.0.2

--- a/bitnami/harbor/templates/registry/registry-cm.yaml
+++ b/bitnami/harbor/templates/registry/registry-cm.yaml
@@ -185,14 +185,6 @@ data:
             ipfilteredby: {{ .Values.registry.middleware.cloudFront.ipfilteredby }}
     {{- end }}
     {{- end }}
-    notifications:
-      endpoints:
-        - name: harbor
-          disabled: false
-          url: http://{{ template "harbor.core" . }}/service/notifications
-          timeout: 3000ms
-          threshold: 5
-          backoff: 1s
   ctl-config.yml: |+
     ---
     {{- if .Values.internalTLS.enabled }}


### PR DESCRIPTION
Signed-off-by: David Young <davidy@funkypenguin.co.nz>

**Description of the change**

1. The official helm chart deprecated the registry config's notification section [during the update to v2.0](https://github.com/goharbor/harbor-helm/commit/4d5f65b8be7aec9e5170542f86779aa0df4172b0#diff-e480417def682cdbdf80291f789c5a323119804d9d47460f256088c989500357)
2. This was an intentional change, since the [notification handler was moved to the API](https://github.com/goharbor/harbor/pull/11085), and is now managed by middleware
3. Since this configuration has not yet been removed from our (Bitnami) charts, error messages like this are being outputted by the registry pod:
```
time="2021-05-11T22:31:28.597548803Z" level=error msg="retryingsink: error writing events: httpSink{http://harbor-core/service/notifications}: response status 404 Not Found unaccepted, retrying"
time="2021-05-11T22:31:29.604326823Z" level=error msg="retryingsink: error writing events: httpSink{http://harbor-core/service/notifications}: response status 404 Not Found unaccepted, retrying"
```
4. This PR deprecates the notification section and removes these unnecessary error messages

**Benefits**

Remove unnecessary and confusing error messages

**Possible drawbacks**

If the chart is being used in a 1.x deployment, notifications will break. However, given the scope of changes from 1.x to 2.x, lots of other things would break as well, so this is not a supported configuration anyway.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
