### PR TITLE
[bitnami/prestashop] Change probe path to comply to deployments in other languages

### DIFF
--- a/bitnami/prestashop/Chart.lock
+++ b/bitnami/prestashop/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 9.3.9
+  version: 9.3.11
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.4.3
-digest: sha256:5e4eb3f06476e97370be0fdfd3fba2308e082008e2c45c52058a60d6877ff024
-generated: "2021-05-04T06:39:19.007548377Z"
+digest: sha256:97024cb0035702357f3c786d488567778d2256831b1593032302e4eaf6e65a42
+generated: "2021-05-13T08:31:18.788305517Z"

--- a/bitnami/prestashop/Chart.yaml
+++ b/bitnami/prestashop/Chart.yaml
@@ -29,4 +29,4 @@ name: prestashop
 sources:
   - https://github.com/bitnami/bitnami-docker-prestashop
   - https://prestashop.com/
-version: 13.1.9
+version: 13.1.10

--- a/bitnami/prestashop/values.yaml
+++ b/bitnami/prestashop/values.yaml
@@ -525,7 +525,7 @@ containerSecurityContext:
 ##
 livenessProbe:
   enabled: true
-  path: /login
+  path: /
   initialDelaySeconds: 600
   periodSeconds: 10
   timeoutSeconds: 5
@@ -533,7 +533,7 @@ livenessProbe:
   successThreshold: 1
 readinessProbe:
   enabled: true
-  path: /login
+  path: /
   initialDelaySeconds: 30
   periodSeconds: 5
   timeoutSeconds: 3
@@ -541,7 +541,7 @@ readinessProbe:
   successThreshold: 1
 startupProbe:
   enabled: false
-  path: /login
+  path: /
   initialDelaySeconds: 0
   periodSeconds: 10
   timeoutSeconds: 3

--- a/bitnami/prestashop/values.yaml
+++ b/bitnami/prestashop/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/prestashop
-  tag: 1.7.7-4-debian-10-r0
+  tag: 1.7.7-4-debian-10-r8
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -581,7 +581,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.8.0-debian-10-r370
+    tag: 0.8.0-debian-10-r378
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**

This merge request changes the `livenessProbe`, `readinessProbe` and `startupProbe` paths from `/login` to `/`

**Benefits**

On installations in other languages, the login path changes to the translation of "login" (such as "connexion" in french). Therefor `/login` becomes a 404 pages and the probes can't validate a ready state. Changing the probe path to `/` ensure the chart supports the most languages

**Possible drawbacks**

**Applicable issues**
  - fixes #6337

**Additional information**

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

