### PR TITLE
[bitnami/common] Node affinity values must be quoted.

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: Infrastructure
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 1.4.3
+appVersion: 1.5.1
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://github.com/bitnami/charts/tree/master/bitnami/common
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -20,4 +20,4 @@ sources:
   - https://github.com/bitnami/charts
   - http://www.bitnami.com/
 type: library
-version: 1.4.3
+version: 1.5.1

--- a/bitnami/common/templates/_affinities.tpl
+++ b/bitnami/common/templates/_affinities.tpl
@@ -12,7 +12,7 @@ preferredDuringSchedulingIgnoredDuringExecution:
           operator: In
           values:
             {{- range .values }}
-            - {{ . }}
+            - {{ . | quote }}
             {{- end }}
     weight: 1
 {{- end -}}
@@ -29,7 +29,7 @@ requiredDuringSchedulingIgnoredDuringExecution:
           operator: In
           values:
             {{- range .values }}
-            - {{ . }}
+            - {{ . | quote }}
             {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
Label values _must_ be strings, but if they are not quoted then
boolean/numerical/etc values can be misinterpreted by kubernetes.

eg:

```
values:
  - "true"
```
**Description of the change**

Ensure that values in `matchExpressions` for `nodeAffinity` rules are quoted as strings.

**Benefits**

Value strings that can be misinterpreted as non-string types, eg: `"true"`, will no longer be.

**Possible drawbacks**

None

**Applicable issues**

#6349 

**Additional information**

Nada

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
