### PR TITLE
[bitnami/redis] IPv4/IPv6 dualstack compatibility fixes

### DIFF
--- a/bitnami/redis/Chart.lock
+++ b/bitnami/redis/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.4.3
-digest: sha256:593addb8fcc250e4abee3a44aff3fbc1cf619d0c319e498c3c3342df71fd373e
-generated: "2021-05-04T06:18:47.33905768Z"
+  version: 1.5.1
+digest: sha256:d3e338772e7d4eca307e5eb080525d244a57e2eb26fd6787cb72b2bf5dbe848e
+generated: "2021-05-20T08:00:19.168796037Z"

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -25,4 +25,4 @@ name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 14.1.1
+version: 14.1.2

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -25,4 +25,4 @@ name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 14.1.2
+version: 14.2.0

--- a/bitnami/redis/templates/configmap.yaml
+++ b/bitnami/redis/templates/configmap.yaml
@@ -46,7 +46,6 @@ data:
   {{- if .Values.sentinel.enabled }}
   sentinel.conf: |-
     dir "/tmp"
-    bind 0.0.0.0
     port {{ .Values.sentinel.containerPort }}
     sentinel monitor {{ .Values.sentinel.masterSet }} {{ template "common.names.fullname" . }}-node-0.{{ template "common.names.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} {{ .Values.sentinel.service.port }} {{ .Values.sentinel.quorum }}
     sentinel down-after-milliseconds {{ .Values.sentinel.masterSet }} {{ .Values.sentinel.downAfterMilliseconds }}

--- a/bitnami/redis/templates/scripts-configmap.yaml
+++ b/bitnami/redis/templates/scripts-configmap.yaml
@@ -22,8 +22,7 @@ data:
     myip=$(hostname -i)
     
     #If >1 IP, use the first IPv4 address
-    if [[ "$myip" =~ ( ) ]]
-    then
+    if [[ "$myip" = *" "* ]]; then
         myip=$(echo $myip | awk '{if ( match($0,/([0-9]+\.){3}[0-9]+/) ) { print substr($0,RSTART,RLENGTH); } }')
     fi
 
@@ -149,8 +148,7 @@ data:
     myip=$(hostname -i)
     
     #If >1 IP, use the first IPv4 address
-    if [[ "$myip" =~ ( ) ]]
-    then
+    if [[ "$myip" = *" "* ]]; then
         myip=$(echo $myip | awk '{if ( match($0,/([0-9]+\.)([0-9]+\.)([0-9]+\.)[0-9]+/) ) { print substr($0,RSTART,RLENGTH); } }')
     fi
 

--- a/bitnami/redis/templates/scripts-configmap.yaml
+++ b/bitnami/redis/templates/scripts-configmap.yaml
@@ -18,10 +18,15 @@ data:
     . /opt/bitnami/scripts/libos.sh
     . /opt/bitnami/scripts/liblog.sh
     . /opt/bitnami/scripts/libvalidations.sh
+    myip=$(hostname -i)
+    
+    #If two IPs, use 2nd one (IPv4 in dualstack environment)
+    if [[ "$myip" =~ ( ) ]]
+    then
+        myip=$(echo $myip | cut -d ' ' -f 2)
+    fi
 
     not_exists_dns_entry() {
-        myip=$(hostname -i)
-
         if [[ -z "$(getent ahosts "$HEADLESS_SERVICE" | grep "^${myip}" )" ]]; then
             warn "$HEADLESS_SERVICE does not contain the IP of this pod: ${myip}"
             return 1
@@ -37,7 +42,7 @@ data:
     retry_while not_exists_dns_entry
 
     export REDIS_REPLICATION_MODE="slave"
-    [[ -z "$(getent ahosts "$HEADLESS_SERVICE" | grep -v "^$(hostname -i) ")" ]] && export REDIS_REPLICATION_MODE="master"
+    [[ -z "$(getent ahosts "$HEADLESS_SERVICE" | grep -v "^${myip}")" ]] && export REDIS_REPLICATION_MODE="master"
 
     {{- if and .Values.replica.containerSecurityContext.runAsUser (eq (.Values.replica.containerSecurityContext.runAsUser | int) 0) }}
     useradd redis
@@ -140,6 +145,14 @@ data:
     . /opt/bitnami/scripts/libvalidations.sh
     . /opt/bitnami/scripts/libfile.sh
 
+    myip=$(hostname -i)
+    
+    #If two IPs, use 2nd one (IPv4 in dualstack environment)
+    if [[ "$myip" =~ ( ) ]]
+    then
+        myip=$(echo $myip | cut -d ' ' -f 2)
+    fi
+
     sentinel_conf_set() {
         local -r key="${1:?missing key}"
         local value="${2:-}"
@@ -159,8 +172,6 @@ data:
         echo "$1" | openssl sha1 | awk '{print $2}'
     }
     not_exists_dns_entry() {
-        myip=$(hostname -i)
-
         if [[ -z "$(getent ahosts "$HEADLESS_SERVICE" | grep "^${myip}" )" ]]; then
             warn "$HEADLESS_SERVICE does not contain the IP of this pod: ${myip}"
             return 1
@@ -192,12 +203,12 @@ data:
     # Waits for DNS to add this ip to the service DNS entry
     retry_while not_exists_dns_entry
 
-    if [[ -z "$(getent ahosts "$HEADLESS_SERVICE" | grep -v "^$(hostname -i)")" ]]; then
+    if [[ -z "$(getent ahosts "$HEADLESS_SERVICE" | grep -v "^${myip}")" ]]; then
         export REDIS_REPLICATION_MODE="master"
     fi
 
     # Clean sentineles from the current sentinel nodes
-    for node in $( getent ahosts "$HEADLESS_SERVICE" | grep -v "^$(hostname -i)" | cut -f 1 -d ' ' | uniq ); do
+    for node in $( getent ahosts "$HEADLESS_SERVICE" | grep -v "^${myip}" | cut -f 1 -d ' ' | uniq ); do
         info "Cleaning sentinels in sentinel node: $node"
         if is_boolean_yes "$REDIS_SENTINEL_TLS_ENABLED"; then
             redis-cli {{- if .Values.auth.enabled }} -a $REDIS_PASSWORD {{- end }} -h $node -p {{ .Values.sentinel.service.sentinelPort }} --tls --cert ${REDIS_SENTINEL_TLS_CERT_FILE} --key ${REDIS_SENTINEL_TLS_KEY_FILE} --cacert ${REDIS_SENTINEL_TLS_CA_FILE} sentinel reset "*"
@@ -209,7 +220,7 @@ data:
     info "Sentinels clean up done"
 
     if [[ "$REDIS_REPLICATION_MODE" = "master" ]]; then
-        REDIS_MASTER_HOST="$(hostname -i)"
+        REDIS_MASTER_HOST=${myip}
         REDIS_MASTER_PORT_NUMBER="{{ .Values.master.service.port }}"
     else
         if is_boolean_yes "$REDIS_SENTINEL_TLS_ENABLED"; then
@@ -258,7 +269,7 @@ data:
             add_replica "$IP"
         fi
     done
-    add_replica "$(hostname -i)"
+    add_replica "${myip}"
     {{- end }}
 
     {{- if .Values.tls.enabled }}
@@ -293,7 +304,7 @@ data:
     failover_finished() {
       REDIS_SENTINEL_INFO=($(run_sentinel_command get-master-addr-by-name "{{ .Values.sentinel.masterSet }}"))
       REDIS_MASTER_HOST="${REDIS_SENTINEL_INFO[0]}"
-      [[ "$REDIS_MASTER_HOST" != "$(hostname -i)" ]]
+      [[ "$REDIS_MASTER_HOST" != "${myip}" ]]
     }
 
     REDIS_SERVICE="{{ include "common.names.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"

--- a/bitnami/redis/templates/scripts-configmap.yaml
+++ b/bitnami/redis/templates/scripts-configmap.yaml
@@ -151,7 +151,7 @@ data:
     #If >1 IP, use the first IPv4 address
     if [[ "$myip" =~ ( ) ]]
     then
-        myip=$(echo $myip | awk '{if ( match($0,/([0-9]+\.){3}[0-9]+/) ) { print substr($0,RSTART,RLENGTH); } }')
+        myip=$(echo $myip | awk '{if ( match($0,/([0-9]+\.)([0-9]+\.)([0-9]+\.)[0-9]+/) ) { print substr($0,RSTART,RLENGTH); } }')
     fi
 
     sentinel_conf_set() {

--- a/bitnami/redis/templates/scripts-configmap.yaml
+++ b/bitnami/redis/templates/scripts-configmap.yaml
@@ -21,7 +21,7 @@ data:
 
     myip=$(hostname -i)
     
-    #If >1 IP, use the first IPv4 address
+    # If there are more than one IP, use the first IPv4 address
     if [[ "$myip" = *" "* ]]; then
         myip=$(echo $myip | awk '{if ( match($0,/([0-9]+\.){3}[0-9]+/) ) { print substr($0,RSTART,RLENGTH); } }')
     fi
@@ -147,7 +147,7 @@ data:
 
     myip=$(hostname -i)
     
-    #If >1 IP, use the first IPv4 address
+    # If there are more than one IP, use the first IPv4 address
     if [[ "$myip" = *" "* ]]; then
         myip=$(echo $myip | awk '{if ( match($0,/([0-9]+\.)([0-9]+\.)([0-9]+\.)[0-9]+/) ) { print substr($0,RSTART,RLENGTH); } }')
     fi

--- a/bitnami/redis/templates/scripts-configmap.yaml
+++ b/bitnami/redis/templates/scripts-configmap.yaml
@@ -18,12 +18,13 @@ data:
     . /opt/bitnami/scripts/libos.sh
     . /opt/bitnami/scripts/liblog.sh
     . /opt/bitnami/scripts/libvalidations.sh
+
     myip=$(hostname -i)
     
-    #If two IPs, use 2nd one (IPv4 in dualstack environment)
+    #If >1 IP, use the first IPv4 address
     if [[ "$myip" =~ ( ) ]]
     then
-        myip=$(echo $myip | cut -d ' ' -f 2)
+        myip=$(echo $myip | awk '{if ( match($0,/([0-9]+\.){3}[0-9]+/) ) { print substr($0,RSTART,RLENGTH); } }')
     fi
 
     not_exists_dns_entry() {
@@ -147,10 +148,10 @@ data:
 
     myip=$(hostname -i)
     
-    #If two IPs, use 2nd one (IPv4 in dualstack environment)
+    #If >1 IP, use the first IPv4 address
     if [[ "$myip" =~ ( ) ]]
     then
-        myip=$(echo $myip | cut -d ' ' -f 2)
+        myip=$(echo $myip | awk '{if ( match($0,/([0-9]+\.){3}[0-9]+/) ) { print substr($0,RSTART,RLENGTH); } }')
     fi
 
     sentinel_conf_set() {

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -57,7 +57,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: bitnami/redis
-  tag: 6.2.3-debian-10-r0
+  tag: 6.2.3-debian-10-r15
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -731,7 +731,7 @@ sentinel:
   image:
     registry: docker.io
     repository: bitnami/redis-sentinel
-    tag: 6.2.2-debian-10-r12
+    tag: 6.2.3-debian-10-r14
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1039,7 +1039,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/redis-exporter
-    tag: 1.23.0-debian-10-r8
+    tag: 1.23.1-debian-10-r13
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -1129,7 +1129,7 @@ metrics:
     image:
       registry: docker.io
       repository: bitnami/redis-sentinel-exporter
-      tag: 1.7.1-debian-10-r131
+      tag: 1.7.1-debian-10-r143
       pullPolicy: IfNotPresent
       ## Optionally specify an array of imagePullSecrets.
       ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Fixed some issues within the bitnami/redis chart that were preventing it from working as-is on a dualstack (IPv4/IPv6) kubernetes installation.  Specifically, that nodes were failing to start due to improper ip detection.  After nodes properly started, sentinel was not communicating with other sentinel nodes until the bind directive was removed.

**Benefits**

bitnami/redis chart will work out of the box in a dualstack k8s installation

**Possible drawbacks**

I'm not aware of any drawbacks

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #6329 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
