### PR TITLE
Fix race condition

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -23,4 +23,4 @@ name: rabbitmq
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq
   - https://www.rabbitmq.com
-version: 8.14.1
+version: 8.14.2

--- a/bitnami/rabbitmq/templates/statefulset.yaml
+++ b/bitnami/rabbitmq/templates/statefulset.yaml
@@ -272,6 +272,7 @@ spec:
                         echo "Waiting for cluster readiness..."
                         sleep 5
                     done
+                    sleep 10s 
                     rabbitmq-queues rebalance "all"
           {{- end }}
             preStop:


### PR DESCRIPTION
Faced with issue of race condition between loading plugins and cluster rebalance.
The solution is quite simple: wait a little after cluster becomes ready. Not the best way to fix it, but it works for me.
