### PR TITLE
bitnami/rabbitmq Race fix

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -23,4 +23,4 @@ name: rabbitmq
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq
   - https://www.rabbitmq.com
-version: 8.14.1
+version: 8.14.2

--- a/bitnami/rabbitmq/templates/statefulset.yaml
+++ b/bitnami/rabbitmq/templates/statefulset.yaml
@@ -272,6 +272,7 @@ spec:
                         echo "Waiting for cluster readiness..."
                         sleep 5
                     done
+                    sleep 10s 
                     rabbitmq-queues rebalance "all"
           {{- end }}
             preStop:


### PR DESCRIPTION
**Description of the change**
Fixing race condition between plugins loading and cluster rebalance

**Benefits**
Obvious...

**Possible drawbacks**
No the best solution

**Additional information**
Faced with issue of postStart: the rabbitmq-queues rebalance "all" exited with code 69 "Discarding message in an old incarnation (2) of this node...".

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
