### PR TITLE
[bitnami/thanos] Put /api/v1/receive at the first of rules (thanos-receive ingress)

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 3.17.0
+version: 3.17.1

--- a/bitnami/thanos/templates/receive/ingress.yaml
+++ b/bitnami/thanos/templates/receive/ingress.yaml
@@ -17,19 +17,19 @@ spec:
     - host: {{ .Values.receive.ingress.hostname }}
       http:
         paths:
-          - path: {{ .Values.receive.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
-            pathType: {{ .Values.receive.ingress.pathType }}
-            {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" .) "receive") "servicePort" "http" "context" $)  | nindent 14 }}
-    - host: {{ .Values.receive.ingress.hostname }}
-      http:
-        paths:
           - path: /api/v1/receive
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.receive.ingress.pathType }}
             {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" .) "receive") "servicePort" "remote-write" "context" $)  | nindent 14 }}
+    - host: {{ .Values.receive.ingress.hostname }}
+      http:
+        paths:
+          - path: {{ .Values.receive.ingress.path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.receive.ingress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" .) "receive") "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.receive.ingress.extraHosts }}
     - host: {{ .name | quote }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Put /api/v1/receive at the first of rules.

**Benefits**

When using AWS ALB for ingress, if default rule "/*" has higher order, other rules will never be matched.

**Possible drawbacks**

N/A

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - N/A

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
