### PR TITLE
[bitnami/jupyterhub] Fix issue with NOTES.txt when using proxy.ingress.enabled

### DIFF
--- a/bitnami/jupyterhub/templates/NOTES.txt
+++ b/bitnami/jupyterhub/templates/NOTES.txt
@@ -8,7 +8,7 @@
 
    export CLUSTER_IP=$(minikube ip) # On Minikube. Use: `kubectl cluster-info` on others K8s clusters
    export HOSTNAME=$(kubectl get ingress --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} -o jsonpath='{.spec.rules[0].host}')
-   echo "JupyterHub URL: http{{ if .Values.ingress.tls }}s{{ end }}://$HOSTNAME/"
+   echo "JupyterHub URL: http{{ if .Values.proxy.ingress.tls }}s{{ end }}://$HOSTNAME/"
    echo "$CLUSTER_IP  $HOSTNAME" | sudo tee -a /etc/hosts
 
 {{- else }}


### PR DESCRIPTION
**Description of the change**

This is a fix for templates/NOTES.txt incorrect reference in line 11.



**Benefits**

This change makes it possible to deploy the chart when proxy.ingress.enabled is set to true.

**Possible drawbacks**

Not aware of any.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #6339 

**Checklist** 
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
