### PR TITLE
[bitnami/kubeapps] Switch pinnipedProxy refs to new containerPort.

### DIFF
--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 7.0.0
+version: 7.0.1

--- a/bitnami/kubeapps/templates/frontend/configmap.yaml
+++ b/bitnami/kubeapps/templates/frontend/configmap.yaml
@@ -89,7 +89,7 @@ data:
     {{- if .certificateAuthorityData }}
         proxy_set_header PINNIPED_PROXY_API_SERVER_CERT {{ .certificateAuthorityData }};
     {{- end }}
-        proxy_pass http://{{ template "kubeapps.pinniped-proxy.fullname" $ }}.{{ $.Release.Namespace }}:{{ $.Values.pinnipedProxy.service.port }};
+        proxy_pass http://{{ template "kubeapps.pinniped-proxy.fullname" $ }}.{{ $.Release.Namespace }}:{{ $.Values.pinnipedProxy.containerPort }};
     {{- else }}
         # Otherwise we route directly through to the clusters with existing credentials.
         proxy_pass {{ $apiServiceBaseURL }};

--- a/bitnami/kubeapps/templates/frontend/service.yaml
+++ b/bitnami/kubeapps/templates/frontend/service.yaml
@@ -67,7 +67,7 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: {{ .Values.pinnipedProxy.service.port }}
+    - port: {{ .Values.pinnipedProxy.containerPort }}
       targetPort: pinniped-proxy
       protocol: TCP
       name: pinniped-proxy

--- a/bitnami/kubeapps/templates/kubeops/deployment.yaml
+++ b/bitnami/kubeapps/templates/kubeops/deployment.yaml
@@ -74,7 +74,7 @@ spec:
             - --clusters-config-path=/config/clusters.conf
             {{- end }}
             {{- if .Values.pinnipedProxy.enabled }}
-            - --pinniped-proxy-url=http://{{ template "kubeapps.pinniped-proxy.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.pinnipedProxy.service.port }}
+            - --pinniped-proxy-url=http://{{ template "kubeapps.pinniped-proxy.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.pinnipedProxy.containerPort }}
             {{- end }}
             {{- if .Values.kubeops.burst }}
             - --burst={{ .Values.kubeops.burst }}


### PR DESCRIPTION
**Description of the change**

See #6398 . 

**Benefits**

Can deploy again with pinniped support :)

**Possible drawbacks**

None that I can see.

**Applicable issues**

  - fixes #6398 

**Additional information**

I've verified the same change in our local dev chart to deploy kubeapps with pinniped (while investigating https://github.com/kubeapps/kubeapps/issues/2827 )

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] (N/A) Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
