### PR TITLE
[bitnami/influxdb] Fix Backup (influxdb-backup-dummy-container)

### DIFF
--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -24,4 +24,4 @@ name: influxdb
 sources:
   - https://github.com/bitnami/bitnami-docker-influxdb
   - https://www.influxdata.com/products/influxdb-overview/
-version: 2.2.2
+version: 2.2.3

--- a/bitnami/influxdb/templates/influxdb/cronjob-backup.yaml
+++ b/bitnami/influxdb/templates/influxdb/cronjob-backup.yaml
@@ -76,7 +76,7 @@ spec:
                   subPath: backup.sh
           containers:
             - name: influxdb-backup-dummy-container
-              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              image: {{ include "influxdb.image" . | quote }}
               command:
                 - "/bin/true"
             {{- if .Values.backup.uploadProviders.google.enabled }}


### PR DESCRIPTION

**Description of the change**

Fix wrong container image declaration for influxdb-backup-dummy-container

**Benefits**

Backup of InfluxDB will work fine even with private repositories

**Possible drawbacks**

-

**Applicable issues**

  - fixes #6401

**Additional information**
-