### PR TITLE
[bitnami/keycloak] Keycloak updated notes.txt

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 3.0.1
+version: 3.0.2

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 3.0.0
+version: 3.0.1

--- a/bitnami/keycloak/templates/NOTES.txt
+++ b/bitnami/keycloak/templates/NOTES.txt
@@ -49,7 +49,7 @@ To access Keycloak from outside the cluster execute the following commands:
 
   echo Username: {{ .Values.auth.adminUser }}
 {{- if not .Values.auth.existingSecretPerPassword }}  
-  echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ printf "%s" (include "common.names.fullname" .) }} -o jsonpath="{.data.admin-password}" | base64 --decode)
+  echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "common.secrets.name" (dict "existingSecret" .Values.auth.existingSecret "context" $) }} -o jsonpath="{.data.admin-password}" | base64 --decode)
 {{- else }}  
   echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "common.secrets.name" (dict "existingSecret" .Values.auth.existingSecretPerPassword.adminPassword "context" $) }} -o jsonpath="\{ {{ include "common.secrets.key" (dict "existingSecret" .Values.auth.existingSecretPerPassword "key" "adminPassword") }} \}" | base64 --decode)
 {{- end }}

--- a/bitnami/keycloak/templates/NOTES.txt
+++ b/bitnami/keycloak/templates/NOTES.txt
@@ -49,7 +49,7 @@ To access Keycloak from outside the cluster execute the following commands:
 
   echo Username: {{ .Values.auth.adminUser }}
 {{- if not .Values.auth.existingSecretPerPassword }}  
-  echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ printf "%s-env-vars" (include "common.names.fullname" .) }} -o jsonpath="{.data.admin-password}" | base64 --decode)
+  echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ printf "%s" (include "common.names.fullname" .) }} -o jsonpath="{.data.admin-password}" | base64 --decode)
 {{- else }}  
   echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "common.secrets.name" (dict "existingSecret" .Values.auth.existingSecretPerPassword.adminPassword "context" $) }} -o jsonpath="\{ {{ include "common.secrets.key" (dict "existingSecret" .Values.auth.existingSecretPerPassword "key" "adminPassword") }} \}" | base64 --decode)
 {{- end }}


### PR DESCRIPTION
Updated kubectl command to obtain admin password. The name of the secrets are common.names.fullname and env-vars need not be appended.

**Description of the change**

Updated the command in notes.txt to fetch admin password from secrets. The name of the secret is appended with env-vars which is not being created and the name of the secret is as same as the release name.

**Benefits**

Better readability and ease of use


**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
