### PR TITLE
[bitnami/redis-cluster] Fix installation notes when using custom secret with custom key

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -23,4 +23,4 @@ name: redis-cluster
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 6.0.5
+version: 6.0.6

--- a/bitnami/redis-cluster/templates/NOTES.txt
+++ b/bitnami/redis-cluster/templates/NOTES.txt
@@ -1,9 +1,10 @@
 {{- $secretName := include "redis-cluster.secretName" . -}}
+{{- $secretPasswordKey := include "redis-cluster.secretPasswordKey" . -}}
 ** Please be patient while the chart is being deployed **
 
 {{ if .Values.usePassword }}
 To get your password run:
-    {{ include "common.utils.secret.getvalue" (dict "secret" $secretName "field" "redis-password" "context" $) }}
+    {{ include "common.utils.secret.getvalue" (dict "secret" $secretName "field" $secretPasswordKey "context" $) }}
 {{- end }}
 
 {{- if .Values.cluster.externalAccess.enabled }}
@@ -80,7 +81,8 @@ will be able to connect to redis.
 {{- include "redis-cluster.checkRollingTags" . }}
 
 {{- if and .Values.usePassword (not .Values.existingSecret) -}}
-  {{- $requiredPassword := dict "valueKey" "password" "secret" $secretName "field" "redis-password" "context" $ -}}
+
+  {{- $requiredPassword := dict "valueKey" "password" "secret" $secretName "field" $secretPasswordKey "context" $ -}}
   {{- $requiredPasswordError := include "common.validations.values.single.empty" $requiredPassword -}}
 
   {{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" (list $requiredPasswordError) "context" $) -}}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

We're not considering in the NOTES.txt that users could be using custom secrets with custom secret keys to manage the Redis credentials. This PR addresses this bug.

**Benefits**

Accurate Installation Notes.

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/6408

**Additional information**

None

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
