### PR TITLE
[bitnami/airflow] Fix typo in web deployment when enabling LDAP

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -32,4 +32,4 @@ name: airflow
 sources:
   - https://github.com/bitnami/bitnami-docker-airflow
   - https://airflow.apache.org/
-version: 10.0.5
+version: 10.0.6

--- a/bitnami/airflow/templates/web/deployment.yaml
+++ b/bitnami/airflow/templates/web/deployment.yaml
@@ -106,7 +106,6 @@ spec:
             - name: AIRFLOW_LDAP_BIND_USER
               value: {{ .Values.ldap.binddn }}
             - name: AIRFLOW_LDAP_BIND_PASSWORD
-              value: {{ .Values.ldap.bindpw }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "airflow.ldapSecretName" . }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

There's a typo in the web's **deployment.yaml** when you enable LDAP.

**Benefits**

LDAP can be configured

**Possible drawbacks**

None

**Applicable issues**

  - fixes #6416

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
