### PR TITLE
[bitnami/mysql] add parameter to set up my_custom.cnf

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -25,4 +25,4 @@ name: mysql
 sources:
   - https://github.com/bitnami/bitnami-docker-mysql
   - https://mysql.com
-version: 8.5.8
+version: 8.6.0

--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -99,6 +99,7 @@ The following table lists the configurable parameters of the MySQL chart and the
 | `primary.args`                               | Override default container args on MySQL Primary container(s) (useful when using custom images)                 | `nil`                          |
 | `primary.configuration`                      | MySQL Primary configuration to be injected as ConfigMap                                                         | Check `values.yaml` file       |
 | `primary.existingConfigmap`                  | Name of existing ConfigMap with MySQL Primary configuration                                                     | `nil`                          |
+| `primary.extendedConf`                       | MySQL Primary additional configuration to be injected as ConfigMap                                              | `nil`                          |
 | `primary.updateStrategy`                     | Update strategy type for the MySQL primary statefulset                                                          | `RollingUpdate`                |
 | `primary.podAnnotations`                     | Additional pod annotations for MySQL primary pods                                                               | `{}` (evaluated as a template) |
 | `primary.hostAliases`                        | Add deployment host aliases                                                                                     | `[]`                           |
@@ -155,6 +156,7 @@ The following table lists the configurable parameters of the MySQL chart and the
 | `secondary.args`                               | Override default container args on MySQL Secondary container(s) (useful when using custom images)                   | `nil`                          |
 | `secondary.configuration`                      | MySQL Secondary configuration to be injected as ConfigMap                                                           | Check `values.yaml` file       |
 | `secondary.existingConfigmap`                  | Name of existing ConfigMap with MySQL Secondary configuration                                                       | `nil`                          |
+| `secondary.extendedConf`                       | MySQL Secondary additional configuration to be injected as ConfigMap                                                | `nil`                          |
 | `secondary.replicaCount`                       | Number of MySQL secondary replicas                                                                                  | `1`                            |
 | `secondary.hostAliases`                        | Add deployment host aliases                                                                                         | `[]`                           |
 | `secondary.updateStrategy`                     | Update strategy type for the MySQL secondary statefulset                                                            | `RollingUpdate`                |

--- a/bitnami/mysql/templates/primary/configmap.yaml
+++ b/bitnami/mysql/templates/primary/configmap.yaml
@@ -13,6 +13,6 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
-  my.cnf: |-
+  my.cnf: |+
     {{ .Values.primary.configuration | nindent 4 }}
 {{- end -}}

--- a/bitnami/mysql/templates/primary/extended-configmap.yaml
+++ b/bitnami/mysql/templates/primary/extended-configmap.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.primary.extendedConf }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mysql.primary.configmapName" . }}-extended
+  labels:
+  {{- include "common.labels.standard" . | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+  namespace: {{ .Release.Namespace }}
+data:
+  my_custom.cnf: |-
+  {{ .Values.primary.extendedConf | nindent 4 }}
+{{- end }}

--- a/bitnami/mysql/templates/primary/statefulset.yaml
+++ b/bitnami/mysql/templates/primary/statefulset.yaml
@@ -222,6 +222,11 @@ spec:
               mountPath: /opt/bitnami/mysql/conf/my.cnf
               subPath: my.cnf
             {{- end }}
+            {{- if .Values.primary.extendedConf }}
+            - name: config-extended
+              mountPath: /opt/bitnami/mysql/conf/bitnami/my_custom.cnf
+              subPath: my_custom.cnf
+            {{- end }}
             {{- if and .Values.auth.usePasswordFiles (not .Values.auth.customPasswordFiles) }}
             - name: mysql-credentials
               mountPath: /opt/bitnami/mysql/secrets/
@@ -285,6 +290,11 @@ spec:
         - name: config
           configMap:
             name: {{ include "mysql.primary.configmapName" . }}
+        {{- end }}
+        {{- if .Values.primary.extendedConf }}
+        - name: config-extended
+          configMap:
+            name: {{ include "mysql.primary.configmapName" . }}-extended
         {{- end }}
         {{- if or .Values.initdbScriptsConfigMap .Values.initdbScripts }}
         - name: custom-init-scripts

--- a/bitnami/mysql/templates/primary/statefulset.yaml
+++ b/bitnami/mysql/templates/primary/statefulset.yaml
@@ -34,6 +34,9 @@ spec:
         {{- if (include "mysql.primary.createConfigmap" .) }}
         checksum/configuration: {{ include (print $.Template.BasePath "/primary/configmap.yaml") . | sha256sum }}
         {{- end }}
+        {{- if  .Values.primary.extendedConf }}
+        checksum/extendedConf: {{ .Values.primary.extendedConf | sha256sum }}
+        {{- end }}
         {{- if .Values.primary.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.primary.podAnnotations "context" $) | nindent 8 }}
         {{- end }}

--- a/bitnami/mysql/templates/secondary/configmap.yaml
+++ b/bitnami/mysql/templates/secondary/configmap.yaml
@@ -13,6 +13,6 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
-  my.cnf: |-
+  my.cnf: |+
     {{ .Values.secondary.configuration | nindent 4 }}
 {{- end -}}

--- a/bitnami/mysql/templates/secondary/extended-configmap.yaml
+++ b/bitnami/mysql/templates/secondary/extended-configmap.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.secondary.extendedConf }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mysql.secondary.configmapName" . }}-extended
+  labels:
+  {{- include "common.labels.standard" . | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+  namespace: {{ .Release.Namespace }}
+data:
+  my_custom.cnf: |-
+  {{ .Values.secondary.extendedConf | nindent 4 }}
+{{- end }}

--- a/bitnami/mysql/templates/secondary/statefulset.yaml
+++ b/bitnami/mysql/templates/secondary/statefulset.yaml
@@ -35,6 +35,9 @@ spec:
         {{- if (include "mysql.secondary.createConfigmap" .) }}
         checksum/configuration: {{ include (print $.Template.BasePath "/secondary/configmap.yaml") . | sha256sum }}
         {{- end }}
+        {{- if  .Values.primary.extendedConf }}
+        checksum/extendedConf: {{ .Values.primary.extendedConf | sha256sum }}
+        {{- end }}
         {{- if .Values.secondary.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.secondary.podAnnotations "context" $) | nindent 8 }}
         {{- end }}

--- a/bitnami/mysql/templates/secondary/statefulset.yaml
+++ b/bitnami/mysql/templates/secondary/statefulset.yaml
@@ -204,6 +204,11 @@ spec:
               mountPath: /opt/bitnami/mysql/conf/my.cnf
               subPath: my.cnf
             {{- end }}
+            {{- if .Values.secondary.extendedConf }}
+            - name: config-extended
+              mountPath: /opt/bitnami/mysql/conf/bitnami/my_custom.cnf
+              subPath: my_custom.cnf
+            {{- end }}
             {{- if and .Values.auth.usePasswordFiles (not .Values.auth.customPasswordFiles) }}
             - name: mysql-credentials
               mountPath: /opt/bitnami/mysql/secrets/
@@ -267,6 +272,11 @@ spec:
         - name: config
           configMap:
             name: {{ include "mysql.secondary.configmapName" . }}
+        {{- end }}
+        {{- if .Values.secondary.extendedConf }}
+        - name: config-extended
+          configMap:
+              name: {{ include "mysql.secondary.configmapName" . }}-extended
         {{- end }}
         {{- if and .Values.auth.usePasswordFiles (not .Values.auth.customPasswordFiles) }}
         - name: mysql-credentials

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -157,6 +157,7 @@ primary:
     port=3306
     socket=/opt/bitnami/mysql/tmp/mysql.sock
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
+    !include /opt/bitnami/mysql/conf/bitnami/my_custom.cnf
 
   ## Name of existing ConfigMap with MySQL Primary configuration.
   ## NOTE: When it's set the 'configuration' parameter is ignored
@@ -170,9 +171,9 @@ primary:
   ## Write your my_custom.cnf file with the following content.
   ## https://github.com/bitnami/bitnami-docker-mysql#step-1-write-your-my_customcnf-file-with-the-following-content
   ##
-  ##extendedConf: |-
-  ##  [mysqld]
-  ##  max_allowed_packet=32M
+  ## extendedConf: |-
+  ##   [mysqld]
+  ##   max_allowed_packet=32M
 
   updateStrategy: RollingUpdate
 
@@ -464,6 +465,7 @@ secondary:
     port=3306
     socket=/opt/bitnami/mysql/tmp/mysql.sock
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
+    !include /opt/bitnami/mysql/conf/bitnami/my_custom.cnf
 
   ## Name of existing ConfigMap with MySQL Secondary configuration.
   ## NOTE: When it's set the 'configuration' parameter is ignored
@@ -477,9 +479,9 @@ secondary:
   ## Write your my_custom.cnf file with the following content.
   ## https://github.com/bitnami/bitnami-docker-mysql#step-1-write-your-my_customcnf-file-with-the-following-content
   ##
-  ##extendedConf: |-
-  ##  [mysqld]
-  ##  max_allowed_packet=32M
+  ## extendedConf: |-
+  ##   [mysqld]
+  ##   max_allowed_packet=32M
 
   updateStrategy: RollingUpdate
 

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -166,6 +166,14 @@ primary:
   ## updateStrategy for MySQL Primary statefulset
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   ##
+
+  ## Write your my_custom.cnf file with the following content.
+  ## https://github.com/bitnami/bitnami-docker-mysql#step-1-write-your-my_customcnf-file-with-the-following-content
+  #
+  ##extendedConf: |-
+  ##  [mysqld]
+  ##  max_allowed_packet=32M
+
   updateStrategy: RollingUpdate
 
   ## Partition update strategy for MySQL Primary statefulset
@@ -465,6 +473,14 @@ secondary:
   ## updateStrategy for MySQL Secondary statefulset
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   ##
+
+  ## Write your my_custom.cnf file with the following content.
+  ## https://github.com/bitnami/bitnami-docker-mysql#step-1-write-your-my_customcnf-file-with-the-following-content
+  #
+  ##extendedConf: |-
+  ##  [mysqld]
+  ##  max_allowed_packet=32M
+
   updateStrategy: RollingUpdate
 
   ## Partition update strategy for MySQL Secondary statefulset

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -169,7 +169,7 @@ primary:
 
   ## Write your my_custom.cnf file with the following content.
   ## https://github.com/bitnami/bitnami-docker-mysql#step-1-write-your-my_customcnf-file-with-the-following-content
-  #
+  ##
   ##extendedConf: |-
   ##  [mysqld]
   ##  max_allowed_packet=32M
@@ -476,7 +476,7 @@ secondary:
 
   ## Write your my_custom.cnf file with the following content.
   ## https://github.com/bitnami/bitnami-docker-mysql#step-1-write-your-my_customcnf-file-with-the-following-content
-  #
+  ##
   ##extendedConf: |-
   ##  [mysqld]
   ##  max_allowed_packet=32M


### PR DESCRIPTION
**Description of the change**
I need add to replica some additional config 
```replicate-ignore-table=logtable```
or on master 
```
[mysqld]
max_allowed_packet=32M
```
like describe 
https://github.com/bitnami/bitnami-docker-mysql#step-1-write-your-my_customcnf-file-with-the-following-content

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #6423

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
