### PR TITLE
[bitnami/cert-manager] Set up static names for the webhook, cainjector containers

### DIFF
--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -26,4 +26,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-cert-manager-webhook
   - https://github.com/bitnami/bitnami-docker-cainjector
   - https://github.com/jetstack/cert-manager
-version: 0.1.0
+version: 0.1.1

--- a/bitnami/cert-manager/templates/cainjector/deployment.yaml
+++ b/bitnami/cert-manager/templates/cainjector/deployment.yaml
@@ -64,7 +64,7 @@ spec:
         {{- end }}
       serviceAccountName: {{ template "certmanager.cainjector.serviceAccountName" . }}
       containers:
-        - name: {{ include "certmanager.cainjector.fullname" . }}
+        - name: cainjector
           image: {{ template "certmanager.cainjector.image" . }}
           imagePullPolicy: {{ .Values.cainjector.image.pullPolicy | quote }}
           {{- if .Values.cainjector.command }}

--- a/bitnami/cert-manager/templates/controller/deployment.yaml
+++ b/bitnami/cert-manager/templates/controller/deployment.yaml
@@ -67,7 +67,7 @@ spec:
         {{- end }}
       serviceAccountName: {{ template "certmanager.controller.serviceAccountName" . }}
       containers:
-        - name: {{ include "certmanager.controller.fullname" . }}
+        - name: cert-manager
           image: {{ template "certmanager.image" . }}
           imagePullPolicy: {{ .Values.controller.image.pullPolicy | quote }}
           {{- if .Values.controller.command }}

--- a/bitnami/cert-manager/templates/webhook/deployment.yaml
+++ b/bitnami/cert-manager/templates/webhook/deployment.yaml
@@ -64,7 +64,7 @@ spec:
         {{- end }}
       serviceAccountName: {{ template "certmanager.webhook.serviceAccountName" . }}
       containers:
-        - name: {{ include "certmanager.webhook.fullname" . }}
+        - name: cert-manager-webhook
           image: {{ template "certmanager.webhook.image" . }}
           imagePullPolicy: {{ .Values.webhook.image.pullPolicy | quote }}
           {{- if .Values.webhook.command }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This commit fixes testing crash in some scenarios.

**Benefits**

Allow us to test the charts properly.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
