### PR TITLE
[bitnami/kube-prometheus] Fix indentation of command line arguments for config reloader

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-prometheus
   - https://github.com/bitnami/bitnami-docker-alertmanager
   - https://github.com/prometheus-operator/kube-prometheus
-version: 5.0.0
+version: 5.0.1

--- a/bitnami/kube-prometheus/templates/prometheus-operator/deployment.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/deployment.yaml
@@ -70,18 +70,18 @@ spec:
             - --prometheus-config-reloader=$(PROMETHEUS_CONFIG_RELOADER)
             {{- if .Values.operator.configReloaderResources.requests }}
               {{- if .Values.operator.configReloaderResources.requests.cpu }}
-                - --config-reloader-cpu-request={{ .Values.operator.configReloaderResources.requests.cpu }}
+            - --config-reloader-cpu-request={{ .Values.operator.configReloaderResources.requests.cpu }}
               {{- end }}
               {{- if .Values.operator.configReloaderResources.requests.memory }}
-                - --config-reloader-memory-request={{ .Values.operator.configReloaderResources.requests.memory }}
+            - --config-reloader-memory-request={{ .Values.operator.configReloaderResources.requests.memory }}
               {{- end }}
             {{- end }}
             {{- if .Values.operator.configReloaderResources.limits }}
               {{- if .Values.operator.configReloaderResources.limits.cpu }}
-                - --config-reloader-cpu-limit={{ .Values.operator.configReloaderResources.limits.cpu }}
+            - --config-reloader-cpu-limit={{ .Values.operator.configReloaderResources.limits.cpu }}
               {{- end }}
               {{- if .Values.operator.configReloaderResources.limits.memory }}
-                - --config-reloader-memory-limit={{ .Values.operator.configReloaderResources.limits.memory }}
+            - --config-reloader-memory-limit={{ .Values.operator.configReloaderResources.limits.memory }}
               {{- end }}
             {{- end }}
           ports:


### PR DESCRIPTION
Fix indentation of command line arguments for config reloader

**Description of the change**

Dedent arguments. Otherwise, if resources of config reloader are specified, the rendered manifest is:

```yaml
containers:
        - name: prometheus-operator
          image: 'docker.io/bitnami/prometheus-operator:0.47.1-debian-10-r0'
          args:
            - '--kubelet-service=kube-system/prometheus-kube-prometheus-kubelet'
            - '--log-format=logfmt'
            - '--log-level=info'
            - '--localhost=127.0.0.1'
            - >-
              --prometheus-config-reloader=$(PROMETHEUS_CONFIG_RELOADER) -
              --config-reloader-cpu-request=10m -
              --config-reloader-memory-request=25Mi -
              --config-reloader-cpu-limit=200m -
              --config-reloader-memory-limit=25Mi
          ports:
```

**Benefits**

It works!

**Possible drawbacks**

None.

**Applicable issues**

None.

**Additional information**

None.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
