### PR TITLE
NGINX Ingress Controller - Fix podAnnotations for default backend

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -26,4 +26,4 @@ name: nginx-ingress-controller
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx-ingress-controller
   - https://github.com/kubernetes/ingress-nginx
-version: 7.6.8
+version: 7.6.9

--- a/bitnami/nginx-ingress-controller/templates/default-backend-deployment.yaml
+++ b/bitnami/nginx-ingress-controller/templates/default-backend-deployment.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       {{- if .Values.defaultBackend.podAnnotations }}
-      annotations: {{- include "nginx-ingress-controller.annotations" (dict "annotations" .Values.defaultBackend.podAnnotations "context" $) | trim | nindent 8 }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.defaultBackend.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: default-backend


### PR DESCRIPTION
**Description of the change**

We're using a macro (`"nginx-ingress-controller.annotations"`) that doesn't exist. Therefore, we can't set custom annotations for default backend pods. This PR addresses this issue using the `"common.tplvalues.render"` macro.

**Benefits**

Custom annotations for Default Backend work

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/6439

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
