### PR TITLE
 [bitnami/kubeapps] Add missing $ to use the global scope

### DIFF
--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 7.0.3
+version: 7.0.4

--- a/bitnami/kubeapps/templates/apprepository/apprepositories-secret.yaml
+++ b/bitnami/kubeapps/templates/apprepository/apprepositories-secret.yaml
@@ -10,10 +10,10 @@ metadata:
   namespace: {{ $.Release.Namespace | quote }}
   {{- end }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
-    {{- if .Values.commonLabels }}
+    {{- if $.Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if .Values.commonAnnotations }}
+  {{- if $.Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
@@ -34,10 +34,10 @@ metadata:
   name: {{ printf "%s-apprepo-%s" .namespace .name }}
   namespace: {{ $.Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
-    {{- if .Values.commonLabels }}
+    {{- if $.Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if .Values.commonAnnotations }}
+  {{- if $.Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:

--- a/bitnami/kubeapps/templates/apprepository/apprepositories-secret.yaml
+++ b/bitnami/kubeapps/templates/apprepository/apprepositories-secret.yaml
@@ -11,10 +11,10 @@ metadata:
   {{- end }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     {{- if $.Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" $.Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if $.Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
   {{- if .caCert }}
@@ -35,10 +35,10 @@ metadata:
   namespace: {{ $.Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     {{- if $.Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" $.Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if $.Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
   {{- if .caCert }}


### PR DESCRIPTION
**Description of the change**

Currently, adding an `initialRepos` with `authorizationHeader` prevents the chart to be installed. It tries to retrieve `.Values.commonLabels` but, since it's under a `range` it's not in the scope.  

```console
Error: UPGRADE FAILED: template: kubeapps/templates/apprepository/apprepositories-secret.yaml:13:18: executing "kubeapps/templates/apprepository/apprepositories-secret.yaml" at <.Values.commonLabels>: nil pointer evaluating interface {}.commonLabels
```

This PR just adds `$` to use the global scope when necessary.

**Benefits**

Adding an `initialRepos` with `authorizationHeader` will work again:

```yaml
apprepository:
  initialRepos:
    - authorizationHeader: Basic <redacted>
      name: myrepo
      namespace: kubeapps
      ...
```

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A
**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
