### PR TITLE
[bitnami/kube-prometheus] Force new release

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-prometheus
   - https://github.com/bitnami/bitnami-docker-alertmanager
   - https://github.com/prometheus-operator/kube-prometheus
-version: 5.0.1
+version: 5.0.2

--- a/bitnami/kube-prometheus/values.yaml
+++ b/bitnami/kube-prometheus/values.yaml
@@ -42,7 +42,7 @@ operator:
   image:
     registry: docker.io
     repository: bitnami/prometheus-operator
-    tag: 0.47.1-debian-10-r15
+    tag: 0.47.1-debian-10-r16
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -274,7 +274,7 @@ prometheus:
   image:
     registry: docker.io
     repository: bitnami/prometheus
-    tag: 2.27.1-debian-10-r4
+    tag: 2.27.1-debian-10-r5
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION
**Description of the change**

No changes apart from the chart's version.

A fix was introduced in 50fa206e84e20b2e477c5ec1603efd5114bc2570, however the Bitnami bot released 7bdf67c3acbee13b9bb194687b7dc41479b4669b a few hours before and it seems that we'll have to wait for a new "update components versions" by the bot in order to get the fix from 50fa206e84e20b2e477c5ec1603efd5114bc2570 which is not the best because I would need the changes from 50fa206e84e20b2e477c5ec1603efd5114bc2570 ASAP.

**Benefits**

Release is done sooner.

**Possible drawbacks**

None.

**Applicable issues**

None.

**Additional information**

If this PR does not make sense or if there is another way of triggering the new release, then feel free to close this PR.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
