### PR TITLE
[bitnami/redis-cluster] Fix readinessProbe when externalAccess.enabled=true

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -23,4 +23,4 @@ name: redis-cluster
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 6.1.1
+version: 6.1.2

--- a/bitnami/redis-cluster/templates/scripts-configmap.yaml
+++ b/bitnami/redis-cluster/templates/scripts-configmap.yaml
@@ -41,7 +41,7 @@ data:
       echo "$response"
       exit 1
     fi
-
+{{- if not .Values.cluster.externalAccess.enabled }}
     if [ ! -f "$REDIS_STATUS_FILE" ]; then
       response=$(
         timeout -s 3 $1 \
@@ -65,6 +65,7 @@ data:
         touch "$REDIS_STATUS_FILE"
       fi
     fi
+{{- end }}
   ping_liveness_local.sh: |-
     {{- if .Values.usePasswordFile }}
     password_aux=`cat ${REDIS_PASSWORD_FILE}`


### PR DESCRIPTION
**Description of the change**

ReadinessProbe won't check cluster status when `cluster.externalAccess.enabled=true`.

Using externalAccess caused the cluster to get stuck because of the following situation:
```
The pod is not Ready because cluster is not formed <--> Cluster can't be formed because pods are not ready
```
This does not happen when using `cluster.externalAccess.enabled=false` as the cluster is formed using the headless service.

**Possible drawbacks**

Redis nodes will receive traffic although the cluster might not be formed yet.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #6443

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
