### PR TITLE
[bitnami/redis]: Fix hardcoded target port name in headless service

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -25,4 +25,4 @@ name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 14.3.0
+version: 14.3.1

--- a/bitnami/redis/templates/headless-svc.yaml
+++ b/bitnami/redis/templates/headless-svc.yaml
@@ -23,6 +23,6 @@ spec:
     {{- if .Values.sentinel.enabled }}
     - name: tcp-sentinel
       port: {{ .Values.sentinel.service.sentinelPort }}
-      targetPort: sentinel
+      targetPort: redis-sentinel
     {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This PR fixes a hardcoded naming mismatch

**Benefits**

A working deployment

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

I ran into this issue when I tried to deploy it alongside the envoy rate limiting service and a istio service mesh with mTLS enforced. In the old version the sentinel port name of the pod did not match the port name of the service.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
