### PR TITLE
[bitnami/metallb] Add priorityClassName support.

### DIFF
--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/metallb/metallb
   - https://github.com/bitnami/bitnami-docker-metallb
   - https://metallb.universe.tf
-version: 2.3.7
+version: 2.3.8

--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/metallb/metallb
   - https://github.com/bitnami/bitnami-docker-metallb
   - https://metallb.universe.tf
-version: 2.3.8
+version: 2.4.0

--- a/bitnami/metallb/README.md
+++ b/bitnami/metallb/README.md
@@ -84,6 +84,7 @@ The following tables lists the configurable parameters of the metallb chart and 
 | `controller.hostAliases`                                 | Add deployment host aliases                                                                  | `[]`                                                    |
 | `controller.rbac.create`                                 | create specifies whether to install and use RBAC rules.                                      | `true`                                                  |
 | `controller.psp.create`                                  | create specifies whether to install Pod Security Policies.                                   | `true`                                                  |
+| `controller.priorityClassName`                           | Set pod priorityClassName.                                                                   | `null`                                                  |
 | `controller.resources.limits`                            | Specify resource limits which the container is not allowed to succeed.                       | `{}` (does not add resource limits to deployed pods)    |
 | `controller.resources.requests`                          | Specify resource requests which the container needs to spawn.                                | `{}` (does not add resource limits to deployed pods)    |
 | `controller.nodeSelector`                                | Node labels for controller pod assignment                                                    | `{}`                                                    |
@@ -137,6 +138,7 @@ The following tables lists the configurable parameters of the metallb chart and 
 | `speaker.image.pullSecrets`                           | Specify docker-registry secret names as an array                                             | `[]` (does not add image pull secrets to deployed pods) |
 | `speaker.rbac.create`                                 | create specifies whether to install and use RBAC rules.                                      | `true`                                                  |
 | `speaker.psp.create`                                  | create specifies whether to install Pod Security Policies.                                   | `true`                                                  |
+| `speaker.priorityClassName`                           | Set pod priorityClassName.                                                                   | `null`                                                  |
 | `speaker.resources.limits`                            | Specify resource limits which the container is not allowed to succeed.                       | `{}` (does not add resource limits to deployed pods)    |
 | `speaker.resources.requests`                          | Specify resource requests which the container needs to spawn.                                | `{}` (does not add resource limits to deployed pods)    |
 | `speaker.nodeSelector`                                | Node labels for speaker pod assignment                                                       | `{}`                                                    |

--- a/bitnami/metallb/templates/controller/deployment.yaml
+++ b/bitnami/metallb/templates/controller/deployment.yaml
@@ -48,6 +48,9 @@ spec:
       {{- if .Values.controller.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.controller.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.controller.priorityClassName }}
+      priorityClassName: {{ .Values.controller.priorityClassName | quote }}
+      {{- end }}
       containers:
         - name: metallb-controller
           image: {{ include "common.images.image" (dict "imageRoot" .Values.controller.image "global" .Values.global) }}

--- a/bitnami/metallb/templates/speaker/daemonset.yaml
+++ b/bitnami/metallb/templates/speaker/daemonset.yaml
@@ -39,6 +39,9 @@ spec:
       initContainers:
       {{- include "common.tplvalues.render" (dict "value" .Values.speaker.initContainers "context" $) | nindent 8 }} 
       {{- end }}
+      {{- if .Values.speaker.priorityClassName }}
+      priorityClassName: {{ .Values.speaker.priorityClassName | quote }}
+      {{- end }}
       containers:
         - name: metallb-speaker
           image: {{ include "common.images.image" (dict "imageRoot" .Values.speaker.image "global" .Values.global) }}

--- a/bitnami/metallb/values.yaml
+++ b/bitnami/metallb/values.yaml
@@ -120,6 +120,9 @@ controller:
     ## create specifies whether to install Pod Security Policies.
     ##
     create: true
+  
+  ## Set pod priorityClassName
+  # priorityClassName: ""
 
   ## Controller container resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -307,6 +310,9 @@ speaker:
     ##
     create: true
 
+  ## Set pod priorityClassName
+  # priorityClassName: ""
+  
   ## Speaker container resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##

--- a/bitnami/metallb/values.yaml
+++ b/bitnami/metallb/values.yaml
@@ -120,7 +120,7 @@ controller:
     ## create specifies whether to install Pod Security Policies.
     ##
     create: true
-  
+
   ## Set pod priorityClassName
   # priorityClassName: ""
 
@@ -312,7 +312,7 @@ speaker:
 
   ## Set pod priorityClassName
   # priorityClassName: ""
-  
+
   ## Speaker container resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##


### PR DESCRIPTION
**Description of the change**

Adding priority class name attribute support for the MetalLB controller and speaker pods.

**Benefits**

Make the chart even more configurable. Allow user to specify custom priority class name for metallb pods.

**Possible drawbacks**

None.

**Applicable issues**

None.

**Additional information**

None.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
