### PR TITLE
[bitnami/kubeapps] Add Cookie refresh for default authProxy

### DIFF
--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 7.0.4
+version: 7.0.5

--- a/bitnami/kubeapps/templates/frontend/deployment.yaml
+++ b/bitnami/kubeapps/templates/frontend/deployment.yaml
@@ -128,7 +128,7 @@ spec:
             - --skip-auth-regex=^\/static\/
             - --skip-auth-regex=^\/$
             - --scope=openid email groups
-            - --cookie-refresh=2mn
+            - --cookie-refresh=2m
             {{- range .Values.authProxy.additionalFlags }}
             - {{ . }}
             {{- end }}

--- a/bitnami/kubeapps/templates/frontend/deployment.yaml
+++ b/bitnami/kubeapps/templates/frontend/deployment.yaml
@@ -128,6 +128,7 @@ spec:
             - --skip-auth-regex=^\/static\/
             - --skip-auth-regex=^\/$
             - --scope=openid email groups
+            - --cookie-refresh=2mn
             {{- range .Values.authProxy.additionalFlags }}
             - {{ . }}
             {{- end }}


### PR DESCRIPTION
**Description of the change**

By default, the ootb authProxy does not refresh the access/id tokens, meaning that the user is being logged out once the token expires (and the expiration time can be very short, e.g. 5mn for Keycloak).
The default auth proxy supports automatic refresh of the token using the refresh token when the parameter --cookie-refresh is set.

The change is to add the --cookie-refresh parameters for a better UI experience, with a default value low enough that it should work for most or all providers ootb.

**Benefits**

Provide a better user experience with the UI console out of the box. 

**Possible drawbacks**

The default value is relatively short to accomodate the majority of OIDC providers. For providers with a default expiration that is relatively long (e.g. 1hr) this means the cookie will be refreshed at a higher rate than required.

**Applicable issues**

N/A

**Additional information**

According to the OAuth2 Proxy documentation, the --cookie-refresh parameter is not used by all providers (see https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview/#footnote1).

**Checklist** 
- [x ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [ x] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
