### PR TITLE
[bitnami/zookeeper] Allow the use of the admin server to provide live…

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -21,4 +21,4 @@ name: zookeeper
 sources:
   - https://github.com/bitnami/bitnami-docker-zookeeper
   - https://zookeeper.apache.org/
-version: 7.1.0
+version: 7.0.5

--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -21,4 +21,4 @@ name: zookeeper
 sources:
   - https://github.com/bitnami/bitnami-docker-zookeeper
   - https://zookeeper.apache.org/
-version: 7.0.4
+version: 7.1.0

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -251,7 +251,9 @@ Bitnami will release a new chart updating its containers if a new version of the
 
 ### Configure log level
 
-You can configure the ZooKeeper log level using the `ZOO_LOG_LEVEL` environment variable. By default, it is set to `ERROR` because of each readiness probe produce an `INFO` message on connection and a `WARN` message on disconnection.
+You can configure the ZooKeeper log level using the `ZOO_LOG_LEVEL` environment variable or the parameter `logLevel`. By default, it is set to `ERROR` because each instance of the liveness probe and the readiness probe produces an `INFO` message on connection and a `WARN` message on disconnection.
+
+To avoid the connection/disconnection messages from the probes, you can enable the use of the ZooKeeper Admin Server for these checks by setting both `livenessProbe.useAdmin` and `readinessProbe.useAdmin` to `true`. If you are polling for ZooKeeper metrics then you must also ensure that you are using the ZooKeeper metrics server (`metrics.enabled` set to `true`) and not the deprecated pattern of polling 'mntr' on the ZooKeeper client port. If these precautions are taken, it is recommended that you set log level to ‘INFO’.
 
 ## Persistence
 

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -251,9 +251,32 @@ Bitnami will release a new chart updating its containers if a new version of the
 
 ### Configure log level
 
-You can configure the ZooKeeper log level using the `ZOO_LOG_LEVEL` environment variable or the parameter `logLevel`. By default, it is set to `ERROR` because each instance of the liveness probe and the readiness probe produces an `INFO` message on connection and a `WARN` message on disconnection.
+You can configure the ZooKeeper log level using the `ZOO_LOG_LEVEL` environment variable or the parameter `logLevel`. By default, it is set to `ERROR` because each use of the liveness probe and the readiness probe produces an `INFO` message on connection and a `WARN` message on disconnection, generating a high volume of noise in your logs.
 
-To avoid the connection/disconnection messages from the probes, you can enable the use of the ZooKeeper Admin Server for these checks by setting both `livenessProbe.useAdmin` and `readinessProbe.useAdmin` to `true`. If you are polling for ZooKeeper metrics then you must also ensure that you are using the ZooKeeper metrics server (`metrics.enabled` set to `true`) and not the deprecated pattern of polling 'mntr' on the ZooKeeper client port. If these precautions are taken, it is recommended that you set log level to ‘INFO’.
+In order to remove that log noise so levels can be set to ‘INFO’, two changes must be made.
+
+First, ensure that you are not getting metrics via the deprecated pattern of polling 'mntr' on the ZooKeeper client port. The preferred method of polling for Apache ZooKeeper metrics is the ZooKeeper metrics server. This is supported in this chart when setting `metrics.enabled` to `true`.
+
+Second, to avoid the connection/disconnection messages from the probes, you can set custom values for these checks which directly them to the ZooKeeper Admin Server instead of the client port. An example is given below which preserves default probe behavior of this chart. By default, an Admin Server will be started that listens on localhost at 8080 and if you have specified either of `zookeeper.admin.serverAddress` or `zookeeper.admin.serverPort` then change the values of the probe to match. The Admin Server is on by default and you must not have disabled it (via `zookeeper.admin.enableServer`) if you wish to use it for the probes.
+
+```
+customLivenessProbe:
+  exec:
+    command: ['/bin/bash', '-c', 'curl -s -m 2 http://localhost:8080/commands/ruok | grep ruok']
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 6
+customReadinessProbe:
+  exec:
+    command: ['/bin/bash', '-c', 'curl -s -m 2 http://localhost:8080/commands/ruok | grep error | grep null']
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 6
+```
 
 ## Persistence
 

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -257,9 +257,13 @@ In order to remove that log noise so levels can be set to ‘INFO’, two change
 
 First, ensure that you are not getting metrics via the deprecated pattern of polling 'mntr' on the ZooKeeper client port. The preferred method of polling for Apache ZooKeeper metrics is the ZooKeeper metrics server. This is supported in this chart when setting `metrics.enabled` to `true`.
 
-Second, to avoid the connection/disconnection messages from the probes, you can set custom values for these checks which directly them to the ZooKeeper Admin Server instead of the client port. An example is given below which preserves default probe behavior of this chart. By default, an Admin Server will be started that listens on localhost at 8080 and if you have specified either of `zookeeper.admin.serverAddress` or `zookeeper.admin.serverPort` then change the values of the probe to match. The Admin Server is on by default and you must not have disabled it (via `zookeeper.admin.enableServer`) if you wish to use it for the probes.
+Second, to avoid the connection/disconnection messages from the probes, you can set custom values for these checks which direct them to the ZooKeeper Admin Server instead of the client port. By default, an Admin Server will be started that listens on `localhost` at port `8080`. The following is an example of this use of the Admin Server for probes:
 
 ```
+livenessProbe:
+  enabled: false
+readinessProbe:
+  enabled: false
 customLivenessProbe:
   exec:
     command: ['/bin/bash', '-c', 'curl -s -m 2 http://localhost:8080/commands/ruok | grep ruok']

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -404,6 +404,9 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             exec:
+              {{- if .Values.livenessProbe.useAdmin }}
+              command: ['/bin/bash', '-c', 'curl -s -m {{ .Values.livenessProbe.probeCommandTimeout }} http://localhost:8080/commands/ruok | grep ruok']
+              {{- else }}
               {{- if not .Values.service.disableBaseClientPort }}
               command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.livenessProbe.probeCommandTimeout }} nc -w {{ .Values.livenessProbe.probeCommandTimeout }} localhost {{ .Values.service.port }} | grep imok']
               {{- else }}
@@ -412,6 +415,7 @@ spec:
                 {{- else }}
                 command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.livenessProbe.probeCommandTimeout }} openssl s_client -quiet -crlf -connect localhost:{{ .Values.service.tlsClientPort }} -cert {{ .Values.service.tls.client_cert_pem_path }} -key {{ .Values.service.tls.client_key_pem_path }} | grep imok']
                 {{- end }}
+              {{- end }}
               {{- end }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -424,6 +428,9 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             exec:
+              {{- if .Values.readinessProbe.useAdmin }}
+              command: ['/bin/bash', '-c', 'curl -s -m {{ .Values.readinessProbe.probeCommandTimeout }} http://localhost:8080/commands/ruok | grep error | grep null']
+              {{- else }}
               {{- if not .Values.service.disableBaseClientPort }}
               command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.readinessProbe.probeCommandTimeout }} nc -w {{ .Values.readinessProbe.probeCommandTimeout }} localhost {{ .Values.service.port }} | grep imok']
               {{- else }}
@@ -432,6 +439,7 @@ spec:
                 {{- else }}
                 command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.livenessProbe.probeCommandTimeout }} openssl s_client -quiet -crlf -connect localhost:{{ .Values.service.tlsClientPort }} -cert {{ .Values.service.tls.client_cert_pem_path }} -key {{ .Values.service.tls.client_key_pem_path }} | grep imok']
                 {{- end }}
+              {{- end }}
               {{- end }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -410,11 +410,11 @@ spec:
               {{- if not .Values.service.disableBaseClientPort }}
               command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.livenessProbe.probeCommandTimeout }} nc -w {{ .Values.livenessProbe.probeCommandTimeout }} localhost {{ .Values.service.port }} | grep imok']
               {{- else }}
-                {{- if not .Values.tls.client.enabled }}
-                command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.livenessProbe.probeCommandTimeout }} openssl s_client -quiet -crlf -connect localhost:{{ .Values.service.tlsClientPort }} | grep imok']
-                {{- else }}
-                command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.livenessProbe.probeCommandTimeout }} openssl s_client -quiet -crlf -connect localhost:{{ .Values.service.tlsClientPort }} -cert {{ .Values.service.tls.client_cert_pem_path }} -key {{ .Values.service.tls.client_key_pem_path }} | grep imok']
-                {{- end }}
+              {{- if not .Values.tls.client.enabled }}
+              command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.livenessProbe.probeCommandTimeout }} openssl s_client -quiet -crlf -connect localhost:{{ .Values.service.tlsClientPort }} | grep imok']
+              {{- else }}
+              command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.livenessProbe.probeCommandTimeout }} openssl s_client -quiet -crlf -connect localhost:{{ .Values.service.tlsClientPort }} -cert {{ .Values.service.tls.client_cert_pem_path }} -key {{ .Values.service.tls.client_key_pem_path }} | grep imok']
+              {{- end }}
               {{- end }}
               {{- end }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
@@ -434,11 +434,11 @@ spec:
               {{- if not .Values.service.disableBaseClientPort }}
               command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.readinessProbe.probeCommandTimeout }} nc -w {{ .Values.readinessProbe.probeCommandTimeout }} localhost {{ .Values.service.port }} | grep imok']
               {{- else }}
-                {{- if not .Values.tls.client.enabled }}
-                command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.livenessProbe.probeCommandTimeout }} openssl s_client -quiet -crlf -connect localhost:{{ .Values.service.tlsClientPort }} | grep imok']
-                {{- else }}
-                command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.livenessProbe.probeCommandTimeout }} openssl s_client -quiet -crlf -connect localhost:{{ .Values.service.tlsClientPort }} -cert {{ .Values.service.tls.client_cert_pem_path }} -key {{ .Values.service.tls.client_key_pem_path }} | grep imok']
-                {{- end }}
+              {{- if not .Values.tls.client.enabled }}
+              command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.readinessProbe.probeCommandTimeout }} openssl s_client -quiet -crlf -connect localhost:{{ .Values.service.tlsClientPort }} | grep imok']
+              {{- else }}
+              command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.readinessProbe.probeCommandTimeout }} openssl s_client -quiet -crlf -connect localhost:{{ .Values.service.tlsClientPort }} -cert {{ .Values.service.tls.client_cert_pem_path }} -key {{ .Values.service.tls.client_key_pem_path }} | grep imok']
+              {{- end }}
               {{- end }}
               {{- end }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -404,9 +404,6 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             exec:
-              {{- if .Values.livenessProbe.useAdmin }}
-              command: ['/bin/bash', '-c', 'curl -s -m {{ .Values.livenessProbe.probeCommandTimeout }} http://localhost:8080/commands/ruok | grep ruok']
-              {{- else }}
               {{- if not .Values.service.disableBaseClientPort }}
               command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.livenessProbe.probeCommandTimeout }} nc -w {{ .Values.livenessProbe.probeCommandTimeout }} localhost {{ .Values.service.port }} | grep imok']
               {{- else }}
@@ -414,7 +411,6 @@ spec:
               command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.livenessProbe.probeCommandTimeout }} openssl s_client -quiet -crlf -connect localhost:{{ .Values.service.tlsClientPort }} | grep imok']
               {{- else }}
               command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.livenessProbe.probeCommandTimeout }} openssl s_client -quiet -crlf -connect localhost:{{ .Values.service.tlsClientPort }} -cert {{ .Values.service.tls.client_cert_pem_path }} -key {{ .Values.service.tls.client_key_pem_path }} | grep imok']
-              {{- end }}
               {{- end }}
               {{- end }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
@@ -428,9 +424,6 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             exec:
-              {{- if .Values.readinessProbe.useAdmin }}
-              command: ['/bin/bash', '-c', 'curl -s -m {{ .Values.readinessProbe.probeCommandTimeout }} http://localhost:8080/commands/ruok | grep error | grep null']
-              {{- else }}
               {{- if not .Values.service.disableBaseClientPort }}
               command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.readinessProbe.probeCommandTimeout }} nc -w {{ .Values.readinessProbe.probeCommandTimeout }} localhost {{ .Values.service.port }} | grep imok']
               {{- else }}
@@ -438,7 +431,6 @@ spec:
               command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.readinessProbe.probeCommandTimeout }} openssl s_client -quiet -crlf -connect localhost:{{ .Values.service.tlsClientPort }} | grep imok']
               {{- else }}
               command: ['/bin/bash', '-c', 'echo "ruok" | timeout {{ .Values.readinessProbe.probeCommandTimeout }} openssl s_client -quiet -crlf -connect localhost:{{ .Values.service.tlsClientPort }} -cert {{ .Values.service.tls.client_cert_pem_path }} -key {{ .Values.service.tls.client_key_pem_path }} | grep imok']
-              {{- end }}
               {{- end }}
               {{- end }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -478,6 +478,7 @@ livenessProbe:
   failureThreshold: 6
   successThreshold: 1
   probeCommandTimeout: 2
+  useAdmin: false
 
 readinessProbe:
   enabled: true
@@ -487,6 +488,7 @@ readinessProbe:
   failureThreshold: 6
   successThreshold: 1
   probeCommandTimeout: 2
+  useAdmin: false
 
 ## Custom Liveness probes for ZooKeeper
 ##

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -478,7 +478,6 @@ livenessProbe:
   failureThreshold: 6
   successThreshold: 1
   probeCommandTimeout: 2
-  useAdmin: false
 
 readinessProbe:
   enabled: true
@@ -488,7 +487,6 @@ readinessProbe:
   failureThreshold: 6
   successThreshold: 1
   probeCommandTimeout: 2
-  useAdmin: false
 
 ## Custom Liveness probes for ZooKeeper
 ##


### PR DESCRIPTION
…ness and readiness checks

**Description of the change**

Adds an option to the ZooKeeper chart that performs the kubernetes liveness and readiness probes using the ZooKeeper admin server (https://zookeeper.apache.org/doc/current/zookeeperAdmin.html#sc_adminserver). Previously the only options were to disable the probes or to direct them to the generic ZooKeeper client port.

**Benefits**

Unblocks responsible setting of INFO and WARN log levels (current default is ERROR).

Every iteration of the current liveness and readiness checks adds two log lines each (INFO level message on connect, WARN level message on disconnect) because they communicate with the ZooKeeper server on the port that all client traffic uses. The ZooKeeper admin server responds on a different port that avoids those log messages and provides the same guarantees about the state of the service with its response.

Log spam is also generated by the pattern of polling required for ZooKeeper 3.4 but with the addition of the admin server in 3.5 and metrics providers in 3.6 (https://zookeeper.apache.org/doc/current/zookeeperAdmin.html#sc_adminserver_config), this too can be avoided.

**Possible drawbacks**

This adds complication to the config by introducing a new port. The owner of the service can choose to turn off the admin server (jvm flag "zookeeper.admin.enableServer") or change the address that it uses (jvm flag "zookeeper.admin.serverAddress") or shift the port (jvm flag "zookeeper.admin.serverPort") and the chart would continue to try the contact that server on the default host:port. Making the chart responsive to these additional ZooKeeper settings requires a modification of the Docker image.

**Applicable issues**

None

**Additional information**

The “four letter word” feature that currently backs the liveness and readiness probes has been deprecated by Apache ZooKeeper and (https://zookeeper.apache.org/doc/current/zookeeperAdmin.html#sc_4lw).

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
