### PR TITLE
[bitnami/external-dns] Include readinessProbe and livenessProbe just in case that there are defined

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -24,4 +24,4 @@ sources:
   - https://github.com/kubernetes-sigs/external-dns
   - https://github.com/bitnami/bitnami-docker-external-dns
   - https://github.com/kubernetes-sigs/external-dns
-version: 5.0.1
+version: 5.0.2

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -498,11 +498,11 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
-          {{- if .Values.readinessProbe }}
-          readinessProbe: {{ toYaml .Values.readinessProbe | nindent 12 }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe: {{- omit .Values.readinessProbe "enabled" | toYaml | nindent 12 }}
           {{- end }}
-          {{- if .Values.livenessProbe }}
-          livenessProbe: {{ toYaml .Values.livenessProbe | nindent 12 }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe: {{- omit .Values.livenessProbe "enabled" | toYaml | nindent 12 }}
           {{- end }}
           {{- if .Values.securityContext }}
           securityContext: {{ toYaml .Values.securityContext | nindent 12 }}

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -498,8 +498,12 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
+          {{- if .Values.readinessProbe }}
           readinessProbe: {{ toYaml .Values.readinessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.livenessProbe }}
           livenessProbe: {{ toYaml .Values.livenessProbe | nindent 12 }}
+          {{- end }}
           {{- if .Values.securityContext }}
           securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
           {{- end }}

--- a/bitnami/external-dns/values.yaml
+++ b/bitnami/external-dns/values.yaml
@@ -657,6 +657,7 @@ resources: {}
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
 ##
 livenessProbe:
+  enabled: true
   httpGet:
     path: /healthz
     port: http
@@ -669,6 +670,7 @@ livenessProbe:
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
 ##
 readinessProbe:
+  enabled: true
   httpGet:
     path: /healthz
     port: http


### PR DESCRIPTION
**Description of the change**

Include a support to remove the livenessProbes and readinessProbes in case that the user doesn't want to use them.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #6471

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
