### PR TITLE
[bitnami/haproxy] Add chart

### DIFF
--- a/bitnami/haproxy/Chart.lock
+++ b/bitnami/haproxy/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.5.2
+digest: sha256:7b5a8ece9b57d70ef47eb7ed27e6f66b059fb0fc1f2ca59a15bb495e32366690
+generated: "2021-05-27T18:15:54.751873+02:00"

--- a/bitnami/haproxy/Chart.yaml
+++ b/bitnami/haproxy/Chart.yaml
@@ -1,0 +1,26 @@
+annotations:
+  category: Infrastructure
+apiVersion: v2
+appVersion: 2.4.0
+dependencies:
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
+description: HAProxy is a TCP proxy and a HTTP reverse proxy. It supports SSL termination and offloading, TCP and HTTP normalization, traffic regulation, caching and protection against DDoS attacks.
+engine: gotpl
+home: http://www.haproxy.org/
+icon: https://bitnami.com/assets/stacks/haproxy/img/haproxy-stack-220x234.png
+keywords:
+  - haproxy
+  - proxy
+  - infrastructure
+maintainers:
+  - email: containers@bitnami.com
+    name: Bitnami
+name: haproxy
+sources:
+  - https://github.com/bitnami/bitnami-docker-haproxy
+  - https://github.com/haproxytech/haproxy
+version: 0.1.0

--- a/bitnami/haproxy/README.md
+++ b/bitnami/haproxy/README.md
@@ -29,7 +29,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 To install the chart with the release name `my-release`:
 
 ```console
-helm install my-release bitnami/haproxys
+helm install my-release bitnami/haproxy
 ```
 
 The command deploys haproxy on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
@@ -51,15 +51,16 @@ The command removes all the Kubernetes components associated with the chart and 
 ### Global parameters
 
 | Name                      | Description                                     | Value |
-|---------------------------|-------------------------------------------------|-------|
+| ------------------------- | ----------------------------------------------- | ----- |
 | `global.imageRegistry`    | Global Docker image registry                    | `nil` |
 | `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
 | `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `nil` |
 
+
 ### Common parameters
 
 | Name                | Description                                        | Value           |
-|---------------------|----------------------------------------------------|-----------------|
+| ------------------- | -------------------------------------------------- | --------------- |
 | `kubeVersion`       | Override Kubernetes version                        | `nil`           |
 | `nameOverride`      | String to partially override common.names.fullname | `nil`           |
 | `fullnameOverride`  | String to fully override common.names.fullname     | `nil`           |
@@ -68,10 +69,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | `clusterDomain`     | Kubernetes cluster domain name                     | `cluster.local` |
 | `extraDeploy`       | Array of extra objects to deploy with the release  | `[]`            |
 
+
 ### Traffic Exposure Parameters
 
 | Name                               | Description                                       | Value          |
-|------------------------------------|---------------------------------------------------|----------------|
+| ---------------------------------- | ------------------------------------------------- | -------------- |
 | `service.type`                     | haproxy service type                              | `LoadBalancer` |
 | `service.ports`                    | List of haproxy service ports                     | `[]`           |
 | `service.clusterIP`                | haproxy service Cluster IP                        | `nil`          |
@@ -80,153 +82,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | `service.externalTrafficPolicy`    | haproxy service external traffic policy           | `Cluster`      |
 | `service.annotations`              | Additional custom annotations for haproxy service | `{}`           |
 
-### HAProxy Parameters
-
-| Name                                 | Description                                                                               | Value                   |
-|--------------------------------------|-------------------------------------------------------------------------------------------|-------------------------|
-| `image.registry`                     | HAProxy image registry                                                                    | `docker.io`             |
-| `image.repository`                   | HAProxy image repository                                                                  | `bitnami/haproxy`       |
-| `image.tag`                          | HAProxy image tag (immutable tags are recommended)                                        | `2.4.0-debian-10-r0`    |
-| `image.pullPolicy`                   | HAProxy image pull policy                                                                 | `IfNotPresent`          |
-| `image.pullSecrets`                  | HAProxy image pull secrets                                                                | `[]`                    |
-| `replicaCount`                       | Number of haproxy replicas to deploy                                                      | `1`                     |
-| `livenessProbe.enabled`              | Enable livenessProbe on haproxy nodes                                                     | `true`                  |
-| `livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                   | `15`                    |
-| `livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                          | `10`                    |
-| `livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                         | `5`                     |
-| `livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                       | `5`                     |
-| `livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                       | `1`                     |
-| `readinessProbe.enabled`             | Enable readinessProbe on haproxy nodes                                                    | `true`                  |
-| `readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                  | `15`                    |
-| `readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                         | `10`                    |
-| `readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                        | `5`                     |
-| `readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                      | `5`                     |
-| `readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                      | `1`                     |
-| `customLivenessProbe`                | Custom livenessProbe that overrides the default one                                       | `{}`                    |
-| `customReadinessProbe`               | Custom readinessProbe that overrides the default one                                      | `{}`                    |
-| `resources.limits`                   | The resources limits for the haproxy containers                                           | `{}`                    |
-| `resources.requests`                 | The requested resources for the haproxy containers                                        | `{}`                    |
-| `podSecurityContext.enabled`         | Enabled haproxy pods' Security Context                                                    | `true`                  |
-| `podSecurityContext.fsGroup`         | Set haproxy pod's Security Context fsGroup                                                | `1001`                  |
-| `containerSecurityContext.enabled`   | Enabled haproxy containers' Security Context                                              | `true`                  |
-| `containerSecurityContext.runAsUser` | Set haproxy containers' Security Context runAsUser                                        | `1001`                  |
-| `pdb.create`                         | Enable a Pod Disruption Budget creation                                                   | `false`                 |
-| `pdb.minAvailable`                   | Minimum number/percentage of pods that should remain scheduled                            | `1`                     |
-| `pdb.maxUnavailable`                 | Maximum number/percentage of pods that may be made unavailable                            | `nil`                   |
-| `autoscaling.enabled`                | Enable Horizontal POD autoscaling for HAProxy                                             | `false`                 |
-| `autoscaling.minReplicas`            | Minimum number of HAProxy replicas                                                        | `1`                     |
-| `autoscaling.maxReplicas`            | Maximum number of HAProxy replicas                                                        | `11`                    |
-| `autoscaling.targetCPU`              | Target CPU utilization percentage                                                         | `50`                    |
-| `autoscaling.targetMemory`           | Target Memory utilization percentage                                                      | `50`                    |
-| `command`                            | Override default container command (useful when using custom images)                      | `[]`                    |
-| `args`                               | Override default container args (useful when using custom images)                         | `[]`                    |
-| `hostAliases`                        | haproxy pods host aliases                                                                 | `[]`                    |
-| `podLabels`                          | Extra labels for haproxy pods                                                             | `{}`                    |
-| `podAnnotations`                     | Annotations for haproxy pods                                                              | `{}`                    |
-| `podAffinityPreset`                  | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                    |
-| `podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                  |
-| `nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                    |
-| `nodeAffinityPreset.key`             | Node label key to match. Ignored if `affinity` is set                                     | `""`                    |
-| `nodeAffinityPreset.values`          | Node label values to match. Ignored if `affinity` is set                                  | `[]`                    |
-| `configuration`                      | haproxy configuration                                                                     | `<dummy configuration>` |
-| `containerPorts`                     | List of container ports to enable in the haproxy container                                | `[]`                    |
-| `existingConfigmap`                  | configmap with HAProxy configuration                                                      | `""`                    |
-| `affinity`                           | Affinity for haproxy pods assignment                                                      | `{}`                    |
-| `nodeSelector`                       | Node labels for haproxy pods assignment                                                   | `{}`                    |
-| `tolerations`                        | Tolerations for haproxy pods assignment                                                   | `[]`                    |
-| `updateStrategy.type`                | haproxy statefulset strategy type                                                         | `RollingUpdate`         |
-| `priorityClassName`                  | haproxy pods' priorityClassName                                                           | `""`                    |
-| `lifecycleHooks`                     | for the haproxy container(s) to automate configuration before or after startup            | `{}`                    |
-| `extraEnvVars`                       | Array with extra environment variables to add to haproxy nodes                            | `[]`                    |
-| `extraEnvVarsCM`                     | Name of existing ConfigMap containing extra env vars for haproxy nodes                    | `nil`                   |
-| `extraEnvVarsSecret`                 | Name of existing Secret containing extra env vars for haproxy nodes                       | `nil`                   |
-| `extraVolumes`                       | Optionally specify extra list of additional volumes for the haproxy pod(s)                | `[]`                    |
-| `extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the haproxy container(s)     | `[]`                    |
-| `sidecars`                           | Add additional sidecar containers to the haproxy pod(s)                                   | `[]`                    |
-| `initContainers`                     | Add additional init containers to the haproxy pod(s)                                      | `{}`                    |
-
-### Other Parameters
-
-| Name                    | Description                                          | Value  |
-|-------------------------|------------------------------------------------------|--------|
-| `serviceAccount.create` | Specifies whether a ServiceAccount should be created | `true` |
-| `serviceAccount.name`   | The name of the ServiceAccount to use.               | `""`   |
-
-  log stdout format raw local0
-  maxconn 1024
-defaults
-  log global
-  timeout client 60s
-  timeout connect 60s
-  timeout server 60s
-frontend fe_main
-  bind :8080
-  default_backend be_main
-backend be_main
-  server web1 10.0.0.1:8080 check
-` |
-| `containerPorts`                     | List of container ports to enable in the haproxy container                                | `[]`                                                                                                                                                                                                                                                    |
-| `existingConfigmap`                  | configmap with HAProxy configuration                                                      | `""`                                                                                                                                                                                                                                                    |
-| `affinity`                           | Affinity for haproxy pods assignment                                                      | `{}`                                                                                                                                                                                                                                                    |
-| `nodeSelector`                       | Node labels for haproxy pods assignment                                                   | `{}`                                                                                                                                                                                                                                                    |
-| `tolerations`                        | Tolerations for haproxy pods assignment                                                   | `[]`                                                                                                                                                                                                                                                    |
-| `updateStrategy.type`                | haproxy statefulset strategy type                                                         | `RollingUpdate`                                                                                                                                                                                                                                         |
-| `priorityClassName`                  | haproxy pods' priorityClassName                                                           | `""`                                                                                                                                                                                                                                                    |
-| `lifecycleHooks`                     | for the haproxy container(s) to automate configuration before or after startup            | `{}`                                                                                                                                                                                                                                                    |
-| `extraEnvVars`                       | Array with extra environment variables to add to haproxy nodes                            | `[]`                                                                                                                                                                                                                                                    |
-| `extraEnvVarsCM`                     | Name of existing ConfigMap containing extra env vars for haproxy nodes                    | `nil`                                                                                                                                                                                                                                                   |
-| `extraEnvVarsSecret`                 | Name of existing Secret containing extra env vars for haproxy nodes                       | `nil`                                                                                                                                                                                                                                                   |
-| `extraVolumes`                       | Optionally specify extra list of additional volumes for the haproxy pod(s)                | `[]`                                                                                                                                                                                                                                                    |
-| `extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the haproxy container(s)     | `[]`                                                                                                                                                                                                                                                    |
-| `sidecars`                           | Add additional sidecar containers to the haproxy pod(s)                                   | `[]`                                                                                                                                                                                                                                                    |
-| `initContainers`                     | Add additional init containers to the haproxy pod(s)                                      | `{}`                                                                                                                                                                                                                                                    |
-
-### Other Parameters
-
-| Name                    | Description                                          | Value   |
-|-------------------------|------------------------------------------------------|---------|
-| `rbac.create`           | Specifies whether RBAC resources should be created   | `false` |
-| `serviceAccount.create` | Specifies whether a ServiceAccount should be created | `true`  |
-| `serviceAccount.name`   | The name of the ServiceAccount to use.               | `""`    |
-
-The following table lists the configurable parameters of the JupyterHub chart and their default values per section/component:
-
-### Global parameters
-
-| Name                      | Description                                     | Value |
-|---------------------------|-------------------------------------------------|-------|
-| `global.imageRegistry`    | Global Docker image registry                    | `nil` |
-| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
-| `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `nil` |
-
-### Common parameters
-
-| Name                | Description                                        | Value           |
-|---------------------|----------------------------------------------------|-----------------|
-| `kubeVersion`       | Override Kubernetes version                        | `nil`           |
-| `nameOverride`      | String to partially override common.names.fullname | `nil`           |
-| `fullnameOverride`  | String to fully override common.names.fullname     | `nil`           |
-| `commonLabels`      | Labels to add to all deployed objects              | `{}`            |
-| `commonAnnotations` | Annotations to add to all deployed objects         | `{}`            |
-| `clusterDomain`     | Kubernetes cluster domain name                     | `cluster.local` |
-| `extraDeploy`       | Array of extra objects to deploy with the release  | `[]`            |
-
-### Traffic Exposure Parameters
-
-| Name                               | Description                                       | Value          |
-|------------------------------------|---------------------------------------------------|----------------|
-| `service.type`                     | haproxy service type                              | `LoadBalancer` |
-| `service.ports`                    | List of haproxy service ports                     | `[]`           |
-| `service.clusterIP`                | haproxy service Cluster IP                        | `nil`          |
-| `service.loadBalancerIP`           | haproxy service Load Balancer IP                  | `nil`          |
-| `service.loadBalancerSourceRanges` | haproxy service Load Balancer sources             | `[]`           |
-| `service.externalTrafficPolicy`    | haproxy service external traffic policy           | `Cluster`      |
-| `service.annotations`              | Additional custom annotations for haproxy service | `{}`           |
 
 ### HAProxy Parameters
 
 | Name                                 | Description                                                                               | Value                |
-|--------------------------------------|-------------------------------------------------------------------------------------------|----------------------|
+| ------------------------------------ | ----------------------------------------------------------------------------------------- | -------------------- |
 | `image.registry`                     | HAProxy image registry                                                                    | `docker.io`          |
 | `image.repository`                   | HAProxy image repository                                                                  | `bitnami/haproxy`    |
 | `image.tag`                          | HAProxy image tag (immutable tags are recommended)                                        | `2.4.0-debian-10-r0` |
@@ -261,7 +121,6 @@ The following table lists the configurable parameters of the JupyterHub chart an
 | `autoscaling.maxReplicas`            | Maximum number of HAProxy replicas                                                        | `11`                 |
 | `autoscaling.targetCPU`              | Target CPU utilization percentage                                                         | `50`                 |
 | `autoscaling.targetMemory`           | Target Memory utilization percentage                                                      | `50`                 |
-| `existingConfigmap`                  | The name of an existing ConfigMap with your custom configuration for haproxy              | `nil`                |
 | `command`                            | Override default container command (useful when using custom images)                      | `[]`                 |
 | `args`                               | Override default container args (useful when using custom images)                         | `[]`                 |
 | `hostAliases`                        | haproxy pods host aliases                                                                 | `[]`                 |
@@ -272,7 +131,7 @@ The following table lists the configurable parameters of the JupyterHub chart an
 | `nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                 |
 | `nodeAffinityPreset.key`             | Node label key to match. Ignored if `affinity` is set                                     | `""`                 |
 | `nodeAffinityPreset.values`          | Node label values to match. Ignored if `affinity` is set                                  | `[]`                 |
-| `configuration`                      | haproxy configuration                                                                     | `{}`                 |
+| `configuration`                      | haproxy configuration                                                                     | `""`                 |
 | `containerPorts`                     | List of container ports to enable in the haproxy container                                | `[]`                 |
 | `existingConfigmap`                  | configmap with HAProxy configuration                                                      | `""`                 |
 | `affinity`                           | Affinity for haproxy pods assignment                                                      | `{}`                 |
@@ -289,13 +148,14 @@ The following table lists the configurable parameters of the JupyterHub chart an
 | `sidecars`                           | Add additional sidecar containers to the haproxy pod(s)                                   | `[]`                 |
 | `initContainers`                     | Add additional init containers to the haproxy pod(s)                                      | `{}`                 |
 
+
 ### Other Parameters
 
-| Name                    | Description                                          | Value   |
-|-------------------------|------------------------------------------------------|---------|
-| `rbac.create`           | Specifies whether RBAC resources should be created   | `false` |
-| `serviceAccount.create` | Specifies whether a ServiceAccount should be created | `true`  |
-| `serviceAccount.name`   | The name of the ServiceAccount to use.               | `""`    |
+| Name                    | Description                                          | Value  |
+| ----------------------- | ---------------------------------------------------- | ------ |
+| `serviceAccount.create` | Specifies whether a ServiceAccount should be created | `true` |
+| `serviceAccount.name`   | The name of the ServiceAccount to use.               | `""`   |
+
 
 The above parameters map to the env variables defined in [bitnami/haproxy](http://github.com/bitnami/bitnami-docker-haproxy). For more information please refer to the [bitnami/haproxy](http://github.com/bitnami/bitnami-docker-haproxy) image documentation.
 
@@ -329,9 +189,9 @@ Bitnami will release a new chart updating its containers if a new version of the
 
 ### Configuring HAProxy
 
-By default, HAProxy is deployed with a dummy configuration. You will need to edit the following several values to adapt it to your use case:
+By default, HAProxy is deployed with a sample, non-functional, configuration. You will need to edit the following several values to adapt it to your use case:
 
-First, set the set the configuration to be injected in the `haproxy.cfg` file. Alternatively, you can provide an existing ConfigMap with `haproxy.cfg` by using the `existingConfigmap` value. The example below configures HAProxy to forward all requests to port 8080 to a service called `service1:8080` (which we assume it is accessible from inside the cluster).
+First, set the set the configuration to be injected in the `haproxy.cfg` file by changing the `configuration` value. Alternatively, you can provide an existing ConfigMap with `haproxy.cfg` by using the `existingConfigmap` value. The example below configures HAProxy to forward all requests to port 8080 to a service called `service1:8080` (which we assume it is accessible from inside the cluster).
 
 ```yaml
 configuration: |

--- a/bitnami/haproxy/README.md
+++ b/bitnami/haproxy/README.md
@@ -1,0 +1,408 @@
+# HAProxy
+
+[HAProxy](http://www.haproxy.org/) is a TCP proxy and a HTTP reverse proxy. It supports SSL termination and offloading, TCP and HTTP normalization, traffic regulation, caching and protection against DDoS attacks.
+
+## TL;DR
+
+```console
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm install my-release bitnami/haproxy
+```
+
+## Introduction
+
+Bitnami charts for Helm are carefully engineered, actively maintained and are the quickest and easiest way to deploy containers on a Kubernetes cluster that are ready to handle production workloads.
+
+This chart bootstraps a [HAProxy](https://github.com/haproxytech/haproxy) Deployment in a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters. This Helm chart has been tested on top of [Bitnami Kubernetes Production Runtime](https://kubeprod.io/) (BKPR). Deploy BKPR to get automated TLS certificates, logging and monitoring for your applications.
+
+[Learn more about the default configuration of the chart](https://docs.bitnami.com/kubernetes/infrastructure/haproxy/get-started/understand-default-configuration/).
+
+## Prerequisites
+
+- Kubernetes 1.12+
+- Helm 3.1.0
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+helm install my-release bitnami/haproxys
+```
+
+The command deploys haproxy on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Parameters
+
+### Global parameters
+
+| Name                      | Description                                     | Value |
+|---------------------------|-------------------------------------------------|-------|
+| `global.imageRegistry`    | Global Docker image registry                    | `nil` |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
+| `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `nil` |
+
+### Common parameters
+
+| Name                | Description                                        | Value           |
+|---------------------|----------------------------------------------------|-----------------|
+| `kubeVersion`       | Override Kubernetes version                        | `nil`           |
+| `nameOverride`      | String to partially override common.names.fullname | `nil`           |
+| `fullnameOverride`  | String to fully override common.names.fullname     | `nil`           |
+| `commonLabels`      | Labels to add to all deployed objects              | `{}`            |
+| `commonAnnotations` | Annotations to add to all deployed objects         | `{}`            |
+| `clusterDomain`     | Kubernetes cluster domain name                     | `cluster.local` |
+| `extraDeploy`       | Array of extra objects to deploy with the release  | `[]`            |
+
+### Traffic Exposure Parameters
+
+| Name                               | Description                                       | Value          |
+|------------------------------------|---------------------------------------------------|----------------|
+| `service.type`                     | haproxy service type                              | `LoadBalancer` |
+| `service.ports`                    | List of haproxy service ports                     | `[]`           |
+| `service.clusterIP`                | haproxy service Cluster IP                        | `nil`          |
+| `service.loadBalancerIP`           | haproxy service Load Balancer IP                  | `nil`          |
+| `service.loadBalancerSourceRanges` | haproxy service Load Balancer sources             | `[]`           |
+| `service.externalTrafficPolicy`    | haproxy service external traffic policy           | `Cluster`      |
+| `service.annotations`              | Additional custom annotations for haproxy service | `{}`           |
+
+### HAProxy Parameters
+
+| Name                                 | Description                                                                               | Value                   |
+|--------------------------------------|-------------------------------------------------------------------------------------------|-------------------------|
+| `image.registry`                     | HAProxy image registry                                                                    | `docker.io`             |
+| `image.repository`                   | HAProxy image repository                                                                  | `bitnami/haproxy`       |
+| `image.tag`                          | HAProxy image tag (immutable tags are recommended)                                        | `2.4.0-debian-10-r0`    |
+| `image.pullPolicy`                   | HAProxy image pull policy                                                                 | `IfNotPresent`          |
+| `image.pullSecrets`                  | HAProxy image pull secrets                                                                | `[]`                    |
+| `replicaCount`                       | Number of haproxy replicas to deploy                                                      | `1`                     |
+| `livenessProbe.enabled`              | Enable livenessProbe on haproxy nodes                                                     | `true`                  |
+| `livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                   | `15`                    |
+| `livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                          | `10`                    |
+| `livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                         | `5`                     |
+| `livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                       | `5`                     |
+| `livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                       | `1`                     |
+| `readinessProbe.enabled`             | Enable readinessProbe on haproxy nodes                                                    | `true`                  |
+| `readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                  | `15`                    |
+| `readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                         | `10`                    |
+| `readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                        | `5`                     |
+| `readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                      | `5`                     |
+| `readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                      | `1`                     |
+| `customLivenessProbe`                | Custom livenessProbe that overrides the default one                                       | `{}`                    |
+| `customReadinessProbe`               | Custom readinessProbe that overrides the default one                                      | `{}`                    |
+| `resources.limits`                   | The resources limits for the haproxy containers                                           | `{}`                    |
+| `resources.requests`                 | The requested resources for the haproxy containers                                        | `{}`                    |
+| `podSecurityContext.enabled`         | Enabled haproxy pods' Security Context                                                    | `true`                  |
+| `podSecurityContext.fsGroup`         | Set haproxy pod's Security Context fsGroup                                                | `1001`                  |
+| `containerSecurityContext.enabled`   | Enabled haproxy containers' Security Context                                              | `true`                  |
+| `containerSecurityContext.runAsUser` | Set haproxy containers' Security Context runAsUser                                        | `1001`                  |
+| `pdb.create`                         | Enable a Pod Disruption Budget creation                                                   | `false`                 |
+| `pdb.minAvailable`                   | Minimum number/percentage of pods that should remain scheduled                            | `1`                     |
+| `pdb.maxUnavailable`                 | Maximum number/percentage of pods that may be made unavailable                            | `nil`                   |
+| `autoscaling.enabled`                | Enable Horizontal POD autoscaling for HAProxy                                             | `false`                 |
+| `autoscaling.minReplicas`            | Minimum number of HAProxy replicas                                                        | `1`                     |
+| `autoscaling.maxReplicas`            | Maximum number of HAProxy replicas                                                        | `11`                    |
+| `autoscaling.targetCPU`              | Target CPU utilization percentage                                                         | `50`                    |
+| `autoscaling.targetMemory`           | Target Memory utilization percentage                                                      | `50`                    |
+| `command`                            | Override default container command (useful when using custom images)                      | `[]`                    |
+| `args`                               | Override default container args (useful when using custom images)                         | `[]`                    |
+| `hostAliases`                        | haproxy pods host aliases                                                                 | `[]`                    |
+| `podLabels`                          | Extra labels for haproxy pods                                                             | `{}`                    |
+| `podAnnotations`                     | Annotations for haproxy pods                                                              | `{}`                    |
+| `podAffinityPreset`                  | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                    |
+| `podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                  |
+| `nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                    |
+| `nodeAffinityPreset.key`             | Node label key to match. Ignored if `affinity` is set                                     | `""`                    |
+| `nodeAffinityPreset.values`          | Node label values to match. Ignored if `affinity` is set                                  | `[]`                    |
+| `configuration`                      | haproxy configuration                                                                     | `<dummy configuration>` |
+| `containerPorts`                     | List of container ports to enable in the haproxy container                                | `[]`                    |
+| `existingConfigmap`                  | configmap with HAProxy configuration                                                      | `""`                    |
+| `affinity`                           | Affinity for haproxy pods assignment                                                      | `{}`                    |
+| `nodeSelector`                       | Node labels for haproxy pods assignment                                                   | `{}`                    |
+| `tolerations`                        | Tolerations for haproxy pods assignment                                                   | `[]`                    |
+| `updateStrategy.type`                | haproxy statefulset strategy type                                                         | `RollingUpdate`         |
+| `priorityClassName`                  | haproxy pods' priorityClassName                                                           | `""`                    |
+| `lifecycleHooks`                     | for the haproxy container(s) to automate configuration before or after startup            | `{}`                    |
+| `extraEnvVars`                       | Array with extra environment variables to add to haproxy nodes                            | `[]`                    |
+| `extraEnvVarsCM`                     | Name of existing ConfigMap containing extra env vars for haproxy nodes                    | `nil`                   |
+| `extraEnvVarsSecret`                 | Name of existing Secret containing extra env vars for haproxy nodes                       | `nil`                   |
+| `extraVolumes`                       | Optionally specify extra list of additional volumes for the haproxy pod(s)                | `[]`                    |
+| `extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the haproxy container(s)     | `[]`                    |
+| `sidecars`                           | Add additional sidecar containers to the haproxy pod(s)                                   | `[]`                    |
+| `initContainers`                     | Add additional init containers to the haproxy pod(s)                                      | `{}`                    |
+
+### Other Parameters
+
+| Name                    | Description                                          | Value  |
+|-------------------------|------------------------------------------------------|--------|
+| `serviceAccount.create` | Specifies whether a ServiceAccount should be created | `true` |
+| `serviceAccount.name`   | The name of the ServiceAccount to use.               | `""`   |
+
+  log stdout format raw local0
+  maxconn 1024
+defaults
+  log global
+  timeout client 60s
+  timeout connect 60s
+  timeout server 60s
+frontend fe_main
+  bind :8080
+  default_backend be_main
+backend be_main
+  server web1 10.0.0.1:8080 check
+` |
+| `containerPorts`                     | List of container ports to enable in the haproxy container                                | `[]`                                                                                                                                                                                                                                                    |
+| `existingConfigmap`                  | configmap with HAProxy configuration                                                      | `""`                                                                                                                                                                                                                                                    |
+| `affinity`                           | Affinity for haproxy pods assignment                                                      | `{}`                                                                                                                                                                                                                                                    |
+| `nodeSelector`                       | Node labels for haproxy pods assignment                                                   | `{}`                                                                                                                                                                                                                                                    |
+| `tolerations`                        | Tolerations for haproxy pods assignment                                                   | `[]`                                                                                                                                                                                                                                                    |
+| `updateStrategy.type`                | haproxy statefulset strategy type                                                         | `RollingUpdate`                                                                                                                                                                                                                                         |
+| `priorityClassName`                  | haproxy pods' priorityClassName                                                           | `""`                                                                                                                                                                                                                                                    |
+| `lifecycleHooks`                     | for the haproxy container(s) to automate configuration before or after startup            | `{}`                                                                                                                                                                                                                                                    |
+| `extraEnvVars`                       | Array with extra environment variables to add to haproxy nodes                            | `[]`                                                                                                                                                                                                                                                    |
+| `extraEnvVarsCM`                     | Name of existing ConfigMap containing extra env vars for haproxy nodes                    | `nil`                                                                                                                                                                                                                                                   |
+| `extraEnvVarsSecret`                 | Name of existing Secret containing extra env vars for haproxy nodes                       | `nil`                                                                                                                                                                                                                                                   |
+| `extraVolumes`                       | Optionally specify extra list of additional volumes for the haproxy pod(s)                | `[]`                                                                                                                                                                                                                                                    |
+| `extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the haproxy container(s)     | `[]`                                                                                                                                                                                                                                                    |
+| `sidecars`                           | Add additional sidecar containers to the haproxy pod(s)                                   | `[]`                                                                                                                                                                                                                                                    |
+| `initContainers`                     | Add additional init containers to the haproxy pod(s)                                      | `{}`                                                                                                                                                                                                                                                    |
+
+### Other Parameters
+
+| Name                    | Description                                          | Value   |
+|-------------------------|------------------------------------------------------|---------|
+| `rbac.create`           | Specifies whether RBAC resources should be created   | `false` |
+| `serviceAccount.create` | Specifies whether a ServiceAccount should be created | `true`  |
+| `serviceAccount.name`   | The name of the ServiceAccount to use.               | `""`    |
+
+The following table lists the configurable parameters of the JupyterHub chart and their default values per section/component:
+
+### Global parameters
+
+| Name                      | Description                                     | Value |
+|---------------------------|-------------------------------------------------|-------|
+| `global.imageRegistry`    | Global Docker image registry                    | `nil` |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
+| `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `nil` |
+
+### Common parameters
+
+| Name                | Description                                        | Value           |
+|---------------------|----------------------------------------------------|-----------------|
+| `kubeVersion`       | Override Kubernetes version                        | `nil`           |
+| `nameOverride`      | String to partially override common.names.fullname | `nil`           |
+| `fullnameOverride`  | String to fully override common.names.fullname     | `nil`           |
+| `commonLabels`      | Labels to add to all deployed objects              | `{}`            |
+| `commonAnnotations` | Annotations to add to all deployed objects         | `{}`            |
+| `clusterDomain`     | Kubernetes cluster domain name                     | `cluster.local` |
+| `extraDeploy`       | Array of extra objects to deploy with the release  | `[]`            |
+
+### Traffic Exposure Parameters
+
+| Name                               | Description                                       | Value          |
+|------------------------------------|---------------------------------------------------|----------------|
+| `service.type`                     | haproxy service type                              | `LoadBalancer` |
+| `service.ports`                    | List of haproxy service ports                     | `[]`           |
+| `service.clusterIP`                | haproxy service Cluster IP                        | `nil`          |
+| `service.loadBalancerIP`           | haproxy service Load Balancer IP                  | `nil`          |
+| `service.loadBalancerSourceRanges` | haproxy service Load Balancer sources             | `[]`           |
+| `service.externalTrafficPolicy`    | haproxy service external traffic policy           | `Cluster`      |
+| `service.annotations`              | Additional custom annotations for haproxy service | `{}`           |
+
+### HAProxy Parameters
+
+| Name                                 | Description                                                                               | Value                |
+|--------------------------------------|-------------------------------------------------------------------------------------------|----------------------|
+| `image.registry`                     | HAProxy image registry                                                                    | `docker.io`          |
+| `image.repository`                   | HAProxy image repository                                                                  | `bitnami/haproxy`    |
+| `image.tag`                          | HAProxy image tag (immutable tags are recommended)                                        | `2.4.0-debian-10-r0` |
+| `image.pullPolicy`                   | HAProxy image pull policy                                                                 | `IfNotPresent`       |
+| `image.pullSecrets`                  | HAProxy image pull secrets                                                                | `[]`                 |
+| `replicaCount`                       | Number of haproxy replicas to deploy                                                      | `1`                  |
+| `livenessProbe.enabled`              | Enable livenessProbe on haproxy nodes                                                     | `true`               |
+| `livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                   | `15`                 |
+| `livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                          | `10`                 |
+| `livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                         | `5`                  |
+| `livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                       | `5`                  |
+| `livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                       | `1`                  |
+| `readinessProbe.enabled`             | Enable readinessProbe on haproxy nodes                                                    | `true`               |
+| `readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                  | `15`                 |
+| `readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                         | `10`                 |
+| `readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                        | `5`                  |
+| `readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                      | `5`                  |
+| `readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                      | `1`                  |
+| `customLivenessProbe`                | Custom livenessProbe that overrides the default one                                       | `{}`                 |
+| `customReadinessProbe`               | Custom readinessProbe that overrides the default one                                      | `{}`                 |
+| `resources.limits`                   | The resources limits for the haproxy containers                                           | `{}`                 |
+| `resources.requests`                 | The requested resources for the haproxy containers                                        | `{}`                 |
+| `podSecurityContext.enabled`         | Enabled haproxy pods' Security Context                                                    | `true`               |
+| `podSecurityContext.fsGroup`         | Set haproxy pod's Security Context fsGroup                                                | `1001`               |
+| `containerSecurityContext.enabled`   | Enabled haproxy containers' Security Context                                              | `true`               |
+| `containerSecurityContext.runAsUser` | Set haproxy containers' Security Context runAsUser                                        | `1001`               |
+| `pdb.create`                         | Enable a Pod Disruption Budget creation                                                   | `false`              |
+| `pdb.minAvailable`                   | Minimum number/percentage of pods that should remain scheduled                            | `1`                  |
+| `pdb.maxUnavailable`                 | Maximum number/percentage of pods that may be made unavailable                            | `nil`                |
+| `autoscaling.enabled`                | Enable Horizontal POD autoscaling for HAProxy                                             | `false`              |
+| `autoscaling.minReplicas`            | Minimum number of HAProxy replicas                                                        | `1`                  |
+| `autoscaling.maxReplicas`            | Maximum number of HAProxy replicas                                                        | `11`                 |
+| `autoscaling.targetCPU`              | Target CPU utilization percentage                                                         | `50`                 |
+| `autoscaling.targetMemory`           | Target Memory utilization percentage                                                      | `50`                 |
+| `existingConfigmap`                  | The name of an existing ConfigMap with your custom configuration for haproxy              | `nil`                |
+| `command`                            | Override default container command (useful when using custom images)                      | `[]`                 |
+| `args`                               | Override default container args (useful when using custom images)                         | `[]`                 |
+| `hostAliases`                        | haproxy pods host aliases                                                                 | `[]`                 |
+| `podLabels`                          | Extra labels for haproxy pods                                                             | `{}`                 |
+| `podAnnotations`                     | Annotations for haproxy pods                                                              | `{}`                 |
+| `podAffinityPreset`                  | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                 |
+| `podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`               |
+| `nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                 |
+| `nodeAffinityPreset.key`             | Node label key to match. Ignored if `affinity` is set                                     | `""`                 |
+| `nodeAffinityPreset.values`          | Node label values to match. Ignored if `affinity` is set                                  | `[]`                 |
+| `configuration`                      | haproxy configuration                                                                     | `{}`                 |
+| `containerPorts`                     | List of container ports to enable in the haproxy container                                | `[]`                 |
+| `existingConfigmap`                  | configmap with HAProxy configuration                                                      | `""`                 |
+| `affinity`                           | Affinity for haproxy pods assignment                                                      | `{}`                 |
+| `nodeSelector`                       | Node labels for haproxy pods assignment                                                   | `{}`                 |
+| `tolerations`                        | Tolerations for haproxy pods assignment                                                   | `[]`                 |
+| `updateStrategy.type`                | haproxy statefulset strategy type                                                         | `RollingUpdate`      |
+| `priorityClassName`                  | haproxy pods' priorityClassName                                                           | `""`                 |
+| `lifecycleHooks`                     | for the haproxy container(s) to automate configuration before or after startup            | `{}`                 |
+| `extraEnvVars`                       | Array with extra environment variables to add to haproxy nodes                            | `[]`                 |
+| `extraEnvVarsCM`                     | Name of existing ConfigMap containing extra env vars for haproxy nodes                    | `nil`                |
+| `extraEnvVarsSecret`                 | Name of existing Secret containing extra env vars for haproxy nodes                       | `nil`                |
+| `extraVolumes`                       | Optionally specify extra list of additional volumes for the haproxy pod(s)                | `[]`                 |
+| `extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the haproxy container(s)     | `[]`                 |
+| `sidecars`                           | Add additional sidecar containers to the haproxy pod(s)                                   | `[]`                 |
+| `initContainers`                     | Add additional init containers to the haproxy pod(s)                                      | `{}`                 |
+
+### Other Parameters
+
+| Name                    | Description                                          | Value   |
+|-------------------------|------------------------------------------------------|---------|
+| `rbac.create`           | Specifies whether RBAC resources should be created   | `false` |
+| `serviceAccount.create` | Specifies whether a ServiceAccount should be created | `true`  |
+| `serviceAccount.name`   | The name of the ServiceAccount to use.               | `""`    |
+
+The above parameters map to the env variables defined in [bitnami/haproxy](http://github.com/bitnami/bitnami-docker-haproxy). For more information please refer to the [bitnami/haproxy](http://github.com/bitnami/bitnami-docker-haproxy) image documentation.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+helm install my-release \
+  --set service.type=LoadBalancer \
+    bitnami/haproxy
+```
+
+The above command sets the HAProxy service type as LoadBalancer.
+
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+helm install my-release -f values.yaml bitnami/haproxy
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Configuration and installation details
+
+### [Rolling VS Immutable tags](https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/)
+
+It is strongly recommended to use immutable tags in a production environment. This ensures your deployment does not change automatically if the same tag is updated with a different image.
+
+Bitnami will release a new chart updating its containers if a new version of the main container, significant changes, or critical vulnerabilities exist.
+
+### Configuring HAProxy
+
+By default, HAProxy is deployed with a dummy configuration. You will need to edit the following several values to adapt it to your use case:
+
+First, set the set the configuration to be injected in the `haproxy.cfg` file. Alternatively, you can provide an existing ConfigMap with `haproxy.cfg` by using the `existingConfigmap` value. The example below configures HAProxy to forward all requests to port 8080 to a service called `service1:8080` (which we assume it is accessible from inside the cluster).
+
+```yaml
+configuration: |
+  global
+    log 127.0.0.1 local2
+    maxconn 4096
+
+  defaults
+    mode http
+    log global
+    option httplog
+    option dontlognull
+    option http-server-close
+    option forwardfor except 127.0.0.0/8
+    option redispatch
+    retries 3
+    timeout http-request 20s
+    timeout queue 1m
+    timeout connect 10s
+    timeout client 1m
+    timeout server 1m
+    timeout http-keep-alive 30s
+    timeout check 10s
+    maxconn 3000
+
+  frontend fe_http
+    option forwardfor except 127.0.0.1
+    option httpclose
+    bind *:8080
+    default_backend be_http
+
+  backend be_http
+    balance roundrobin
+    server nginx service:8080 check port 8080
+```
+
+After that, and based on your HAProxy configuration, edit the `containerPorts` and `service.ports` values. In `containerPorts` set all the ports that the HAProxy configuration uses, and set the ports you want to externally expose in the `service.ports` value. For the example above, it would look like this:
+
+```yaml
+service:
+  - name: http
+    port: 80 # We use port 80 in the service
+    targetPort: http
+
+containerPorts:
+  - name: http
+    containerPort: 8080
+```
+
+### Additional environment variables
+
+In case you want to add extra environment variables (useful for advanced operations like custom init scripts), you can use the `extraEnvVars` property.
+
+```yaml
+extraEnvVars:
+  - name: LOG_LEVEL
+    value: error
+```
+
+Alternatively, you can use a ConfigMap or a Secret with the environment variables. To do so, use the `extraEnvVarsCM` or the `extraEnvVarsSecret` values.
+
+### Sidecars
+
+If additional containers are needed in the same pod as haproxy (such as additional metrics or logging exporters), they can be defined using the `sidecars` parameter. If these sidecars export extra ports, extra port definitions can be added using the `service.extraPorts` parameter. [Learn more about configuring and using sidecar containers](https://docs.bitnami.com/kubernetes/apps/haproxy/administration/configure-use-sidecars/).
+
+### Pod affinity
+
+This chart allows you to set your custom affinity using the `affinity` parameter. Find more information about Pod affinity in the [kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity).
+
+As an alternative, use one of the preset configurations for pod affinity, pod anti-affinity, and node affinity available at the [bitnami/common](https://github.com/bitnami/charts/tree/master/bitnami/common#affinities) chart. To do so, set the `podAffinityPreset`, `podAntiAffinityPreset`, or `nodeAffinityPreset` parameters.
+
+## Troubleshooting
+
+Find more information about how to deal with common errors related to Bitnami's Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).

--- a/bitnami/haproxy/templates/NOTES.txt
+++ b/bitnami/haproxy/templates/NOTES.txt
@@ -1,0 +1,29 @@
+** Please be patient while the chart is being deployed **
+
+{{- if .Values.service.ports }}
+1. HAproxy has been started. You can find out the port numbers being used by HAProxy by running:
+
+          $ kubectl describe svc {{ include "common.names.fullname" . }} --namespace {{ .Release.Namespace }}
+
+{{- if eq .Values.service.type "LoadBalancer" }}
+2. Get HAProxy's load balancer IP/hostname:
+
+     NOTE: It may take a few minutes for this to become available.
+
+     You can watch the status by running:
+
+         $ kubectl get svc {{ include "common.names.fullname" . }} --namespace {{ .Release.Namespace }} -w
+
+     Once 'EXTERNAL-IP' is no longer '<pending>':
+
+         $ kubectl describe svc {{ include "common.names.fullname" . }} --namespace {{ .Release.Namespace }} | grep Ingress | awk '{print $3}'
+
+3. Configure DNS records corresponding to Kubernetes ingress resources to point to the load balancer IP/hostname found in step 3
+{{- end }}
+{{- else }}
+1. HAProxy has been started. As no ports in service.ports were specified, no service object was created. You can find out the ports used by the container by running
+          $ kubectl describe deploy {{ include "common.names.fullname" . }} --namespace {{ .Release.Namespace }}
+{{- end }}
+
+{{- include "common.warnings.rollingTag" .Values.image }}
+{{- include "haproxy.validateValues" . }}

--- a/bitnami/haproxy/templates/NOTES.txt
+++ b/bitnami/haproxy/templates/NOTES.txt
@@ -3,26 +3,26 @@
 {{- if .Values.service.ports }}
 1. HAproxy has been started. You can find out the port numbers being used by HAProxy by running:
 
-          $ kubectl describe svc {{ include "common.names.fullname" . }} --namespace {{ .Release.Namespace }}
+    $ kubectl describe svc {{ include "common.names.fullname" . }} --namespace {{ .Release.Namespace }}
 
 {{- if eq .Values.service.type "LoadBalancer" }}
 2. Get HAProxy's load balancer IP/hostname:
 
-     NOTE: It may take a few minutes for this to become available.
+    NOTE: It may take a few minutes for this to become available.
 
-     You can watch the status by running:
+    You can watch the status by running:
 
-         $ kubectl get svc {{ include "common.names.fullname" . }} --namespace {{ .Release.Namespace }} -w
+        $ kubectl get svc {{ include "common.names.fullname" . }} --namespace {{ .Release.Namespace }} -w
 
-     Once 'EXTERNAL-IP' is no longer '<pending>':
+    Once 'EXTERNAL-IP' is no longer '<pending>':
 
-         $ kubectl describe svc {{ include "common.names.fullname" . }} --namespace {{ .Release.Namespace }} | grep Ingress | awk '{print $3}'
+        $ kubectl describe svc {{ include "common.names.fullname" . }} --namespace {{ .Release.Namespace }} | grep Ingress | awk '{print $3}'
 
 3. Configure DNS records corresponding to Kubernetes ingress resources to point to the load balancer IP/hostname found in step 3
 {{- end }}
 {{- else }}
 1. HAProxy has been started. As no ports in service.ports were specified, no service object was created. You can find out the ports used by the container by running
-          $ kubectl describe deploy {{ include "common.names.fullname" . }} --namespace {{ .Release.Namespace }}
+    $ kubectl describe deploy {{ include "common.names.fullname" . }} --namespace {{ .Release.Namespace }}
 {{- end }}
 
 {{- include "common.warnings.rollingTag" .Values.image }}

--- a/bitnami/haproxy/templates/_helpers.tpl
+++ b/bitnami/haproxy/templates/_helpers.tpl
@@ -44,7 +44,7 @@ Compile all warnings into a single message.
 {{- $message := join "\n" $messages -}}
 
 {{- if $message -}}
-{{-   printf "\nVALUES VALIDATION:\n%s" $message -}}
+{{- printf "\nVALUES VALIDATION:\n%s" $message -}}
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/haproxy/templates/_helpers.tpl
+++ b/bitnami/haproxy/templates/_helpers.tpl
@@ -1,0 +1,59 @@
+{{/*
+Return the proper haproxy image name
+*/}}
+{{- define "haproxy.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Get the configmap name
+*/}}
+{{- define "haproxy.configMapName" -}}
+{{- if .Values.existingConfigmap -}}
+  {{- printf "%s" .Values.existingConfigmap -}}
+{{- else -}}
+  {{- include "common.names.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "haproxy.imagePullSecrets" -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.image) "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "haproxy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (printf "%s-foo" (include "common.names.fullname" .)) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Compile all warnings into a single message.
+*/}}
+{{- define "haproxy.validateValues" -}}
+{{- $messages := list -}}
+{{- $messages := append $messages (include "haproxy.validateValues.ports" .) -}}
+{{- $messages := without $messages "" -}}
+{{- $message := join "\n" $messages -}}
+
+{{- if $message -}}
+{{-   printf "\nVALUES VALIDATION:\n%s" $message -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "haproxy.validateValues.ports" -}}
+{{- if not .Values.containerPorts }}
+haproxy: No container ports
+    HAProxy should at least expose container ports. Please configure the containerPorts values using the following structure.
+    containerPorts:
+       - name: <NAME OF THE PORT>
+         containerPort: <PORT NUMBER>
+{{- end }}
+{{- end }}

--- a/bitnami/haproxy/templates/configmap.yaml
+++ b/bitnami/haproxy/templates/configmap.yaml
@@ -1,0 +1,18 @@
+{{- if not .Values.existingConfigmap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: haproxy
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+data:
+  haproxy.cfg: |
+    {{- include "common.tplvalues.render" ( dict "value" .Values.configuration "context" $ ) | nindent 4 }}
+{{- end }}

--- a/bitnami/haproxy/templates/deployment.yaml
+++ b/bitnami/haproxy/templates/deployment.yaml
@@ -1,0 +1,141 @@
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: haproxy
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  {{- if .Values.updateStrategy }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: haproxy
+  template:
+    metadata:
+      {{- if .Values.podAnnotations }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+      {{- end }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        app.kubernetes.io/component: haproxy
+        {{- if .Values.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ template "haproxy.serviceAccountName" . }}
+      {{- include "haproxy.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAffinityPreset "component" "haproxy" "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAntiAffinityPreset "component" "haproxy" "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" .) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.initContainers }}
+      initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: haproxy
+          image: {{ template "haproxy.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.containerPorts }}
+          ports: {{- include "common.tplvalues.render" (dict "value" .Values.containerPorts "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.command "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 12 }}
+          {{- end }}
+          env:
+            {{- if .Values.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- if .Values.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
+            {{- end }}
+          {{- if .Values.resources }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            # Using exec instead of tcpSocket to avoid noise in te logs
+            exec:
+              command:
+                - pgrep
+                - haproxy
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- else if .Values.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            # Using exec instead of tcpSocket to avoid noise in te logs
+            exec:
+              command:
+                - pgrep
+                - haproxy
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- else if .Values.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: haproxy-conf
+              mountPath: /bitnami/haproxy/conf
+          {{- if .Values.extraVolumeMounts }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
+        {{- if .Values.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: haproxy-conf
+          configMap:
+            name: {{ include "haproxy.configMapName"  . }}
+        {{- if .Values.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}

--- a/bitnami/haproxy/templates/extra-list.yaml
+++ b/bitnami/haproxy/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/bitnami/haproxy/templates/hpa.yaml
+++ b/bitnami/haproxy/templates/hpa.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+    kind: Deployment
+    name: {{ template "common.names.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPU }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPU }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemory }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemory  }}
+    {{- end }}
+{{- end }}

--- a/bitnami/haproxy/templates/pdb.yaml
+++ b/bitnami/haproxy/templates/pdb.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.pdb.create }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
+{{- end }}

--- a/bitnami/haproxy/templates/service-account.yaml
+++ b/bitnami/haproxy/templates/service-account.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "haproxy.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: haproxy
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}

--- a/bitnami/haproxy/templates/service.yaml
+++ b/bitnami/haproxy/templates/service.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.service.ports }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: haproxy
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.service.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if .Values.clusterIP }}
+  clusterIP: {{ .Values.clusterIP }}
+  {{- end }}
+  {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
+  {{- end }}
+  {{ if eq .Values.service.type "LoadBalancer" }}
+  loadBalancerSourceRanges: {{ .Values.service.loadBalancerSourceRanges }}
+  {{ end }}
+  {{- if (and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP))) }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  ports: {{- include "common.tplvalues.render" ( dict "value" .Values.service.ports "context" $ ) | nindent 4 }}
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: haproxy
+{{- end }}

--- a/bitnami/haproxy/values.yaml
+++ b/bitnami/haproxy/values.yaml
@@ -241,7 +241,8 @@ nodeAffinityPreset:
   ##
   values: []
 
-## @param configuration haproxy configuration
+## @param configuration [string] haproxy configuration
+## Taken from haproxytech/haproxy chart: https://github.com/haproxytech/helm-charts/tree/main/haproxy
 ##
 configuration: |
   global

--- a/bitnami/haproxy/values.yaml
+++ b/bitnami/haproxy/values.yaml
@@ -1,0 +1,351 @@
+## @section Global parameters
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
+##
+
+## @param global.imageRegistry Global Docker image registry
+## @param global.imagePullSecrets Global Docker registry secret names as an array
+## @param global.storageClass Global StorageClass for Persistent Volume(s)
+##
+global:
+  imageRegistry:
+  ## E.g.
+  ## imagePullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
+  storageClass:
+
+## @section Common parameters
+##
+
+## @param kubeVersion Override Kubernetes version
+##
+kubeVersion:
+## @param nameOverride String to partially override common.names.fullname
+##
+nameOverride:
+## @param fullnameOverride String to fully override common.names.fullname
+##
+fullnameOverride:
+## @param commonLabels Labels to add to all deployed objects
+##
+commonLabels: {}
+## @param commonAnnotations Annotations to add to all deployed objects
+##
+commonAnnotations: {}
+## @param clusterDomain Kubernetes cluster domain name
+##
+clusterDomain: cluster.local
+## @param extraDeploy Array of extra objects to deploy with the release
+##
+extraDeploy: []
+
+## @section Traffic Exposure Parameters
+##
+
+## haproxy service parameters
+##
+service:
+  ## @param service.type haproxy service type
+  ##
+  type: LoadBalancer
+  ## @param service.ports [array] List of haproxy service ports
+  ##
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+  ## @param service.clusterIP haproxy service Cluster IP
+  ## e.g.:
+  ## clusterIP: None
+  ##
+  clusterIP:
+  ## @param service.loadBalancerIP haproxy service Load Balancer IP
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+  ##
+  loadBalancerIP:
+  ## @param service.loadBalancerSourceRanges haproxy service Load Balancer sources
+  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  ## e.g:
+  ## loadBalancerSourceRanges:
+  ##   - 10.10.10.0/24
+  ##
+  loadBalancerSourceRanges: []
+  ## @param service.externalTrafficPolicy haproxy service external traffic policy
+  ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+  ##
+  externalTrafficPolicy: Cluster
+  ## @param service.annotations Additional custom annotations for haproxy service
+  ##
+  annotations: {}
+
+## @section HAProxy Parameters
+##
+## @param image.registry HAProxy image registry
+## @param image.repository HAProxy image repository
+## @param image.tag HAProxy image tag (immutable tags are recommended)
+## @param image.pullPolicy HAProxy image pull policy
+## @param image.pullSecrets HAProxy image pull secrets
+##
+image:
+  registry: docker.io
+  repository: bitnami/haproxy
+  tag: 2.4.0-debian-10-r0
+  ## Specify a imagePullPolicy
+  ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## e.g:
+  ## pullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  pullSecrets: []
+## @param replicaCount Number of haproxy replicas to deploy
+##
+replicaCount: 1
+## Configure extra options for haproxy containers' liveness and readiness probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+## @param livenessProbe.enabled Enable livenessProbe on haproxy nodes
+## @param livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+## @param livenessProbe.periodSeconds Period seconds for livenessProbe
+## @param livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+## @param livenessProbe.failureThreshold Failure threshold for livenessProbe
+## @param livenessProbe.successThreshold Success threshold for livenessProbe
+##
+livenessProbe:
+  enabled: true
+  failureThreshold: 5
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 5
+## @param readinessProbe.enabled Enable readinessProbe on haproxy nodes
+## @param readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+## @param readinessProbe.periodSeconds Period seconds for readinessProbe
+## @param readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+## @param readinessProbe.failureThreshold Failure threshold for readinessProbe
+## @param readinessProbe.successThreshold Success threshold for readinessProbe
+##
+readinessProbe:
+  enabled: true
+  failureThreshold: 5
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 5
+## @param customLivenessProbe Custom livenessProbe that overrides the default one
+##
+customLivenessProbe: {}
+## @param customReadinessProbe Custom readinessProbe that overrides the default one
+##
+customReadinessProbe: {}
+## haproxy resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+## @param resources.limits The resources limits for the haproxy containers
+## @param resources.requests The requested resources for the haproxy containers
+##
+resources:
+  limits: {}
+  requests: {}
+## Configure Pods Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+## @param podSecurityContext.enabled Enabled haproxy pods' Security Context
+## @param podSecurityContext.fsGroup Set haproxy pod's Security Context fsGroup
+##
+podSecurityContext:
+  enabled: true
+  fsGroup: 1001
+## Configure Container Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+## @param containerSecurityContext.enabled Enabled haproxy containers' Security Context
+## @param containerSecurityContext.runAsUser Set haproxy containers' Security Context runAsUser
+##
+containerSecurityContext:
+  enabled: true
+  runAsUser: 1001
+
+## HAProxy Pod Disruption Budget configuration
+## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+## @param pdb.create Enable a Pod Disruption Budget creation
+## @param pdb.minAvailable Minimum number/percentage of pods that should remain scheduled
+## @param pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable
+##
+pdb:
+  create: false
+  minAvailable: 1
+  maxUnavailable:
+
+## HAProxy Autoscaling configuration
+## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+## @param autoscaling.enabled Enable Horizontal POD autoscaling for HAProxy
+## @param autoscaling.minReplicas Minimum number of HAProxy replicas
+## @param autoscaling.maxReplicas Maximum number of HAProxy replicas
+## @param autoscaling.targetCPU Target CPU utilization percentage
+## @param autoscaling.targetMemory Target Memory utilization percentage
+##
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 11
+  targetCPU: 50
+  targetMemory: 50
+
+## @param command Override default container command (useful when using custom images)
+##
+command: []
+## @param args Override default container args (useful when using custom images)
+##
+args: []
+## @param hostAliases haproxy pods host aliases
+## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+##
+hostAliases: []
+## @param podLabels Extra labels for haproxy pods
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+##
+podLabels: {}
+## @param podAnnotations Annotations for haproxy pods
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+## @param podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+##
+podAffinityPreset: ""
+## @param podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+##
+podAntiAffinityPreset: soft
+## Node affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+##
+nodeAffinityPreset:
+  ## @param nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  ##
+  type: ""
+  ## @param nodeAffinityPreset.key Node label key to match. Ignored if `affinity` is set
+  ##
+  key: ""
+  ## @param nodeAffinityPreset.values Node label values to match. Ignored if `affinity` is set
+  ## E.g.
+  ## values:
+  ##   - e2e-az1
+  ##   - e2e-az2
+  ##
+  values: []
+
+## @param configuration haproxy configuration
+##
+configuration: |
+  global
+    log stdout format raw local0
+    maxconn 1024
+  defaults
+    log global
+    timeout client 60s
+    timeout connect 60s
+    timeout server 60s
+  frontend fe_main
+    bind :8080
+    default_backend be_main
+  backend be_main
+    server web1 10.0.0.1:8080 check
+
+## @param containerPorts [array] List of container ports to enable in the haproxy container
+##
+containerPorts:
+  - name: http
+    containerPort: 8080
+
+## @param existingConfigmap configmap with HAProxy configuration
+##
+existingConfigmap: ""
+
+## @param affinity Affinity for haproxy pods assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## NOTE: `podAffinityPreset`, `podAntiAffinityPreset`, and `nodeAffinityPreset` will be ignored when it's set
+##
+affinity: {}
+## @param nodeSelector Node labels for haproxy pods assignment
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+## @param tolerations Tolerations for haproxy pods assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+## @param updateStrategy.type haproxy statefulset strategy type
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+##
+updateStrategy:
+  ## StrategyType
+  ## Can be set to RollingUpdate or OnDelete
+  ##
+  type: RollingUpdate
+## @param priorityClassName haproxy pods' priorityClassName
+##
+priorityClassName: ""
+## @param lifecycleHooks for the haproxy container(s) to automate configuration before or after startup
+##
+lifecycleHooks: {}
+## @param extraEnvVars Array with extra environment variables to add to haproxy nodes
+## e.g:
+## extraEnvVars:
+##   - name: FOO
+##     value: "bar"
+##
+extraEnvVars: []
+## @param extraEnvVarsCM Name of existing ConfigMap containing extra env vars for haproxy nodes
+##
+extraEnvVarsCM:
+## @param extraEnvVarsSecret Name of existing Secret containing extra env vars for haproxy nodes
+##
+extraEnvVarsSecret:
+## @param extraVolumes Optionally specify extra list of additional volumes for the haproxy pod(s)
+##
+extraVolumes: []
+## @param extraVolumeMounts Optionally specify extra list of additional volumeMounts for the haproxy container(s)
+##
+extraVolumeMounts: []
+## @param sidecars Add additional sidecar containers to the haproxy pod(s)
+## e.g:
+## sidecars:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+sidecars: []
+## @param initContainers Add additional init containers to the haproxy pod(s)
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+## e.g:
+## initContainers:
+##  - name: your-image-name
+##    image: your-image
+##    imagePullPolicy: Always
+##    command: ['sh', '-c', 'echo "hello world"']
+##
+initContainers: {}
+
+## @section Other Parameters
+##
+
+## ServiceAccount configuration
+##
+serviceAccount:
+  ## @param serviceAccount.create Specifies whether a ServiceAccount should be created
+  ##
+  create: true
+  ## @param serviceAccount.name The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the common.names.fullname template
+  ##
+  name: ""

--- a/bitnami/haproxy/values.yaml
+++ b/bitnami/haproxy/values.yaml
@@ -93,7 +93,7 @@ service:
 image:
   registry: docker.io
   repository: bitnami/haproxy
-  tag: 2.4.0-debian-10-r0
+  tag: 2.4.0-debian-10-r6
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This PR adds a HAProxy helm chart based on https://github.com/haproxytech/helm-charts/tree/main/haproxy. It features the following:

  - Multiple replica support
  - HPA
  - PDBs
  - Custom configuration
  - Bitnami standards

In a future iteration, we should consider adding DaemonSet support. But for a first iteration, we will stick with a first version that is usable for several use cases that we had in support tickets.

*IMPORTANT TO NOTE*: The default configuration of this chart is just dummy, the user should specify its own configuration and define which ports wants to expose. This is similar to the bitnami/logstash chart.

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**


**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
