### PR TITLE
[bitnami/mariadb-galera] Updating liveness probe to support vault secrets

### DIFF
--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-mariadb-galera
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 5.8.1
+version: 5.8.2

--- a/bitnami/mariadb-galera/templates/statefulset.yaml
+++ b/bitnami/mariadb-galera/templates/statefulset.yaml
@@ -213,6 +213,9 @@ spec:
                 - bash
                 - -ec
                 - |
+                  if [[ -f "${MARIADB_ROOT_PASSWORD_FILE:-}" ]]; then
+                      MARIADB_ROOT_PASSWORD=$(cat "$MARIADB_ROOT_PASSWORD_FILE")
+                  fi
                   exec mysqladmin status -u$MARIADB_ROOT_USER -p$MARIADB_ROOT_PASSWORD
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}

--- a/bitnami/mariadb-galera/templates/statefulset.yaml
+++ b/bitnami/mariadb-galera/templates/statefulset.yaml
@@ -213,10 +213,11 @@ spec:
                 - bash
                 - -ec
                 - |
+                  password_aux="${MARIADB_ROOT_PASSWORD:-}"
                   if [[ -f "${MARIADB_ROOT_PASSWORD_FILE:-}" ]]; then
-                      MARIADB_ROOT_PASSWORD=$(cat "$MARIADB_ROOT_PASSWORD_FILE")
+                      password_aux=$(cat "$MARIADB_ROOT_PASSWORD_FILE")
                   fi
-                  exec mysqladmin status -u$MARIADB_ROOT_USER -p$MARIADB_ROOT_PASSWORD
+                  exec mysqladmin status -u"${MARIADB_ROOT_USER}" -p"${password_aux}"
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}


### PR DESCRIPTION
liveness probe keeps failing if I use vault secrets. Needs to be updates in a similar fashion as readiness probe.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Updating liveness probe to support vault secrets

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Liveness probe won't fail anymore

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

No drawback.

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- ~Variables are documented in the README.md~
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
