### PR TITLE
[bitnami/kafka] Add selector to pvc

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 12.19.3
+version: 12.19.0

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 12.18.3
+version: 12.19.3

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -211,12 +211,14 @@ The following tables lists the configurable parameters of the Kafka chart and th
 | `persistence.accessMode`       | PVC Access Mode for Kafka data volume                                                  | `ReadWriteOnce`               |
 | `persistence.size`             | PVC Storage Request for Kafka data volume                                              | `8Gi`                         |
 | `persistence.annotations`      | Annotations for the PVC                                                                | `{}`(evaluated as a template) |
+| `persistence.selector`         | Selector to match an existing Persistent Volume. Currently, a PVC with a non-empty selector can't have a PV dynamically provisioned for it                                                                            | `{}`(evaluated as a template) |
 | `persistence.mountPath`        | Mount path of the Kafka data volume                                                    | `/bitnami/kafka`              |
 | `logPersistence.enabled`       | Enable Kafka logs persistence using PVC, note that Zookeeper persistence is unaffected | `false`                       |
 | `logPersistence.existingClaim` | Provide an existing `PersistentVolumeClaim`, the value is evaluated as a template      | `nil`                         |
 | `logPersistence.accessMode`    | PVC Access Mode for Kafka logs volume                                                  | `ReadWriteOnce`               |
 | `logPersistence.size`          | PVC Storage Request for Kafka logs volume                                              | `8Gi`                         |
 | `logPersistence.annotations`   | Annotations for the PVC                                                                | `{}`(evaluated as a template) |
+| `logPersistence.selector`      | Selector to match an existing Persistent Volume. Currently, a PVC with a non-empty selector can't have a PV dynamically provisioned for it                                                                            | `{}`(evaluated as a template) |
 | `logPersistence.mountPath`     | Mount path of the Kafka logs volume                                                    | `/opt/bitnami/kafka/logs`     |
 
 ### RBAC parameters

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -211,14 +211,14 @@ The following tables lists the configurable parameters of the Kafka chart and th
 | `persistence.accessMode`       | PVC Access Mode for Kafka data volume                                                  | `ReadWriteOnce`               |
 | `persistence.size`             | PVC Storage Request for Kafka data volume                                              | `8Gi`                         |
 | `persistence.annotations`      | Annotations for the PVC                                                                | `{}`(evaluated as a template) |
-| `persistence.selector`         | Selector to match an existing Persistent Volume. Currently, a PVC with a non-empty selector can't have a PV dynamically provisioned for it                                                                            | `{}`(evaluated as a template) |
+| `persistence.selector`         | Selector to match an existing Persistent Volume for Kafka's data PVC. If set, the PVC can't have a PV dynamically provisioned for it                                                                                  | `{}`(evaluated as a template) |
 | `persistence.mountPath`        | Mount path of the Kafka data volume                                                    | `/bitnami/kafka`              |
 | `logPersistence.enabled`       | Enable Kafka logs persistence using PVC, note that Zookeeper persistence is unaffected | `false`                       |
 | `logPersistence.existingClaim` | Provide an existing `PersistentVolumeClaim`, the value is evaluated as a template      | `nil`                         |
 | `logPersistence.accessMode`    | PVC Access Mode for Kafka logs volume                                                  | `ReadWriteOnce`               |
 | `logPersistence.size`          | PVC Storage Request for Kafka logs volume                                              | `8Gi`                         |
 | `logPersistence.annotations`   | Annotations for the PVC                                                                | `{}`(evaluated as a template) |
-| `logPersistence.selector`      | Selector to match an existing Persistent Volume. Currently, a PVC with a non-empty selector can't have a PV dynamically provisioned for it                                                                            | `{}`(evaluated as a template) |
+| `logPersistence.selector`      | Selector to match an existing Persistent Volume for Kafka's log data PVC. If set, the PVC can't have a PV dynamically provisioned for it                                                                                  | `{}`(evaluated as a template) |
 | `logPersistence.mountPath`     | Mount path of the Kafka logs volume                                                    | `/opt/bitnami/kafka/logs`     |
 
 ### RBAC parameters

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -489,6 +489,9 @@ spec:
           requests:
             storage: {{ .Values.persistence.size | quote }}
         {{ include "kafka.storageClass" . | nindent 8 }}
+        {{- if .Values.persistence.selector }}
+        selector: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.selector "context" $) | nindent 10 }}
+        {{- end -}}
 {{- end }}
 {{- if and .Values.logPersistence.enabled (not .Values.logPersistence.existingClaim) }}
     - metadata:
@@ -505,5 +508,8 @@ spec:
           requests:
             storage: {{ .Values.logPersistence.size | quote }}
         {{ include "kafka.storageClass" . | nindent 8 }}
+        {{- if .Values.logPersistence.selector }}
+        selector: {{- include "common.tplvalues.render" (dict "value" .Values.logPersistence.selector "context" $) | nindent 10 }}
+        {{- end -}}
 {{- end }}
 {{- end }}

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -744,6 +744,11 @@ persistence:
   ## PVC annotations
   ##
   annotations: {}
+  ## selector can be used to match an existing PersistentVolume
+  ## selector:
+  ##   matchLabels:
+  ##     app: my-app
+  selector: {}
   ## Mount point for persistence
   ##
   mountPath: /bitnami/kafka
@@ -776,6 +781,11 @@ logPersistence:
   ## PVC annotations
   ##
   annotations: {}
+  ## selector can be used to match an existing PersistentVolume
+  ## selector:
+  ##   matchLabels:
+  ##     app: my-app
+  selector: {}
   ## Mount path for persistent logs
   ##
   mountPath: /opt/bitnami/kafka/logs


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Add selector for Kafka data PVC and Kafka logs PVC, aiming to further filter the set of volumes. Only the volumes whose labels match the selector can be bound to the claim.
Inspired from this existing feature in [bitnami/postgres](https://github.com/bitnami/charts/blob/master/bitnami/postgresql) chart.

> <https://kubernetes.io/docs/concepts/storage/persistent-volumes/#selector>

**Benefits**

Ability to select an existing Persistent Volume using `matchLabels` or `matchExpressions`. 

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes https://github.com/bitnami/charts/issues/6506

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
