### PR TITLE
[bitnami/zookeeper] Add selector to pvc

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -21,4 +21,4 @@ name: zookeeper
 sources:
   - https://github.com/bitnami/bitnami-docker-zookeeper
   - https://zookeeper.apache.org/
-version: 6.8.0
+version: 6.9.0

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -176,8 +176,8 @@ The following tables lists the configurable parameters of the ZooKeeper chart an
 | `persistence.size`                     | PVC Storage Request for ZooKeeper data volume                                  | `8Gi`                           |
 | `persistence.annotations`              | Annotations for the PVC                                                        | `{}` (evaluated as a template)  |
 | `persistence.selector`                 | Selector to match an existing Persistent Volume for Zookeeper's data PVC. If set, the PVC can't have a PV dynamically provisioned for it                                                                        | `{}` (evaluated as a template)  |
-| `persistence.dataLogDir.existingClaim` | Provide an existing `PersistentVolumeClaim` for Zookeeper's Data log directory | `nil` (evaluated as a template) |
 | `persistence.dataLogDir.size`          | PVC Storage Request for ZooKeeper's Data log directory                         | `8Gi`                           |
+| `persistence.dataLogDir.existingClaim` | Provide an existing `PersistentVolumeClaim` for Zookeeper's Data log directory | `nil` (evaluated as a template) |
 | `persistence.dataLogDir.selector`      | Selector to match an existing Persistent Volume for Zookeeper's Data log PVC. If set, the PVC can't have a PV dynamically provisioned for it                                                                    | `{}` (evaluated as a template)  |
 
 ### Volume Permissions parameters

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -175,8 +175,10 @@ The following tables lists the configurable parameters of the ZooKeeper chart an
 | `persistence.accessMode`               | PVC Access Mode for ZooKeeper data volume                                      | `ReadWriteOnce`                 |
 | `persistence.size`                     | PVC Storage Request for ZooKeeper data volume                                  | `8Gi`                           |
 | `persistence.annotations`              | Annotations for the PVC                                                        | `{}` (evaluated as a template)  |
-| `persistence.dataLogDir.size`          | PVC Storage Request for ZooKeeper's Data log directory                         | `8Gi`                           |
+| `persistence.selector`                 | Selector to match an existing Persistent Volume for Zookeeper's data PVC. If set, the PVC can't have a PV dynamically provisioned for it                                                                        | `{}` (evaluated as a template)  |
 | `persistence.dataLogDir.existingClaim` | Provide an existing `PersistentVolumeClaim` for Zookeeper's Data log directory | `nil` (evaluated as a template) |
+| `persistence.dataLogDir.size`          | PVC Storage Request for ZooKeeper's Data log directory                         | `8Gi`                           |
+| `persistence.dataLogDir.selector`      | Selector to match an existing Persistent Volume for Zookeeper's Data log PVC. If set, the PVC can't have a PV dynamically provisioned for it                                                                    | `{}` (evaluated as a template)  |
 
 ### Volume Permissions parameters
 

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -345,6 +345,9 @@ spec:
           requests:
             storage: {{ .Values.persistence.size | quote }}
         {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 8 }}
+        {{- if .Values.persistence.selector }}
+        selector: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.selector "context" $) | nindent 10 }}
+        {{- end -}}
     {{- end }}
     {{- if and (not .Values.persistence.dataLogDir.existingClaim) .Values.dataLogDir }}
     - metadata:
@@ -362,5 +365,8 @@ spec:
           requests:
             storage: {{ .Values.persistence.dataLogDir.size | quote }}
         {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 8 }}
+        {{- if .Values.persistence.dataLogDir.selector }}
+        selector: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.dataLogDir.selector "context" $) | nindent 10 }}
+        {{- end -}}
     {{- end }}
   {{- end }}

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -347,7 +347,7 @@ spec:
         {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 8 }}
         {{- if .Values.persistence.selector }}
         selector: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.selector "context" $) | nindent 10 }}
-        {{- end -}}
+        {{- end }}
     {{- end }}
     {{- if and (not .Values.persistence.dataLogDir.existingClaim) .Values.dataLogDir }}
     - metadata:
@@ -367,6 +367,6 @@ spec:
         {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 8 }}
         {{- if .Values.persistence.dataLogDir.selector }}
         selector: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.dataLogDir.selector "context" $) | nindent 10 }}
-        {{- end -}}
+        {{- end }}
     {{- end }}
   {{- end }}

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -301,13 +301,25 @@ persistence:
     - ReadWriteOnce
   size: 8Gi
   annotations: {}
+  ## selector can be used to match an existing PersistentVolume
+  ## selector:
+  ##   matchLabels:
+  ##     app: my-app
+  selector: {}
+
   dataLogDir:
-    size: 8Gi
     ## A manually managed Persistent Volume and Claim
     ## If defined, PVC must be created manually before volume will be bound
     ## The value is evaluated as a template
     ##
     # existingClaim:
+
+    size: 8Gi
+    ## selector can be used to match an existing PersistentVolume
+    ## selector:
+    ##   matchLabels:
+    ##     app: my-app
+    selector: {}
 
 ## Pod affinity preset
 ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -301,10 +301,12 @@ persistence:
     - ReadWriteOnce
   size: 8Gi
   annotations: {}
-  ## selector can be used to match an existing PersistentVolume
+  ## Selector to match an existing PersistentVolume
+  ## E.g.
   ## selector:
   ##   matchLabels:
   ##     app: my-app
+  ##
   selector: {}
 
   dataLogDir:
@@ -315,10 +317,12 @@ persistence:
     # existingClaim:
 
     size: 8Gi
-    ## selector can be used to match an existing PersistentVolume
+    ## Selector to match an existing PersistentVolume
+    ## E.g.
     ## selector:
     ##   matchLabels:
     ##     app: my-app
+    ##
     selector: {}
 
 ## Pod affinity preset

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -310,13 +310,13 @@ persistence:
   selector: {}
 
   dataLogDir:
+    size: 8Gi
     ## A manually managed Persistent Volume and Claim
     ## If defined, PVC must be created manually before volume will be bound
     ## The value is evaluated as a template
     ##
     # existingClaim:
 
-    size: 8Gi
     ## Selector to match an existing PersistentVolume
     ## E.g.
     ## selector:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Add selector for Zookeeper data PVC and Zookeeper dataLogDir PVC, aiming to further filter the set of volumes. Only the volumes whose labels match the selector can be bound to the claim.
Inspired from this existing feature in [bitnami/postgres](https://github.com/bitnami/charts/blob/master/bitnami/postgresql) chart.

> <https://kubernetes.io/docs/concepts/storage/persistent-volumes/#selector>

**Benefits**

Ability to select an existing Persistent Volume using `matchLabels` or `matchExpressions`. 

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes https://github.com/bitnami/charts/issues/6506

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
