### PR TITLE
[bitnami/thanos] Fix securityContext for Receive

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 3.17.5
+version: 3.17.6

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -2340,7 +2340,9 @@ receive:
   ## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
   securityContext:
-    enabled: false
+    enabled: true
+    fsGroup: 1001
+    runAsUser: 1001
 
   ## Thanos Receive GRPC TLS parameters
   ## ref: https://github.com/thanos-io/thanos/blob/master/docs/components/receive.md#flags


### PR DESCRIPTION
Signed-off-by: fktkrt <fktkrt@gmail.com>

**Description of the change**

The current defaults seems to be off for Receive, as myself and others can experience permission denied errors, for example here: https://github.com/bitnami/charts/pull/5069.

```console
level=error ts=2021-02-07T13:11:32.087598081Z caller=main.go:130 err="configuration file is not parsable\ngithub.com/thanos-io/thanos/pkg/receive.init\n\t/app/pkg/receive/config.go:26\nruntime.doInit\n\t/usr/local/go/src/runtime/proc.go:5652\nruntime.doInit\n\t/usr/local/go/src/runtime/proc.go:5647\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:191\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1374\nfailed to parse configuration file: json: cannot unmarshal string into Go value of type []receive.HashringConfig\ngithub.com/thanos-io/thanos/pkg/receive.loadConfig\n\t/app/pkg/receive/config.go:257\ngithub.com/thanos-io/thanos/pkg/receive.(*ConfigWatcher).ValidateConfig\n\t/app/pkg/receive/config.go:179\nmain.runReceive\n\t/app/cmd/thanos/receive.go:382\nmain.registerReceive.func1\n\t/app/cmd/thanos/receive.go:130\nmain.main\n\t/app/cmd/thanos/main.go:128\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:204\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1374\nfailed to validate hashring configuration file\nmain.runReceive\n\t/app/cmd/thanos/receive.go:385\nmain.registerReceive.func1\n\t/app/cmd/thanos/receive.go:130\nmain.main\n\t/app/cmd/thanos/main.go:128\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:204\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1374\npreparing receive command failed\nmain.main\n\t/app/cmd/thanos/main.go:130\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:204\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1374"
```
Additionally, the docs for the Receive parameters seems to be fine: https://github.com/bitnami/charts/tree/master/bitnami/thanos#thanos-receive-parameters 
As this mentions the exact parameters that are being used at other components, and I was also able to mitigate the problem by adding these.

**Benefits**

No permission denied messages for Receive by default.

**Possible drawbacks**
I am not aware of any. Although I am not sure why was the `securityContext` added as disabled originally.

**Additional information**

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
