### PR TITLE
[bitnami/kafka] Added params `relabelings` and `metricRelabelings` into ServiceMonitor resource

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 12.18.3
+version: 12.19.0

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -293,6 +293,8 @@ The following tables lists the configurable parameters of the Kafka chart and th
 | `metrics.serviceMonitor.interval`      | Interval at which metrics should be scraped                                                                                      | `nil`                                                   |
 | `metrics.serviceMonitor.scrapeTimeout` | Timeout after which the scrape is ended                                                                                          | `nil` (Prometheus Operator default value)               |
 | `metrics.serviceMonitor.selector`      | ServiceMonitor selector labels                                                                                                   | `nil` (Prometheus Operator default value)               |
+| `metrics.serviceMonitor.relabelings`   | Relabel configuration for the metrics | `[]` |
+| `metrics.serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion | `[]` |
 
 ### Kafka provisioning parameters
 

--- a/bitnami/kafka/templates/servicemonitor-jmx-metrics.yaml
+++ b/bitnami/kafka/templates/servicemonitor-jmx-metrics.yaml
@@ -30,6 +30,12 @@ spec:
       {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
       {{- end }}
+      {{- if .Values.metrics.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml .Values.metrics.serviceMonitor.relabelings | nindent 6 }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.relabelings }}
+      metricRelabelings: {{- toYaml .Values.metrics.serviceMonitor.metricRelabelings | nindent 6 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/bitnami/kafka/templates/servicemonitor-metrics.yaml
+++ b/bitnami/kafka/templates/servicemonitor-metrics.yaml
@@ -30,6 +30,12 @@ spec:
       {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
       {{- end }}
+      {{- if .Values.metrics.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml .Values.metrics.serviceMonitor.relabelings | nindent 6 }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.relabelings }}
+      metricRelabelings: {{- toYaml .Values.metrics.serviceMonitor.metricRelabelings | nindent 6 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -1181,6 +1181,14 @@ metrics:
     # selector:
     #   prometheus: my-prometheus
 
+    ## Relabel configuration for the metrics.
+    ##
+    # relabelings: []
+
+    # MetricRelabelConfigs to apply to samples before ingestion.
+    ##
+    # metricRelabelings: []
+
 ##
 ## Zookeeper chart configuration
 ##


### PR DESCRIPTION
**Which chart:**
`bitnami/kafka`

**Description of the change**
This change adds additional `relabelings` and` metricRelabelings` parameters to the `ServiceMonitor` resource for more flexible label customization.

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
