### PR TITLE
[bitnami/tomcat] initContainers and sidecars indent fix

### DIFF
--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -26,4 +26,4 @@ name: tomcat
 sources:
   - https://github.com/bitnami/bitnami-docker-tomcat
   - http://tomcat.apache.org
-version: 9.2.8
+version: 9.2.9

--- a/bitnami/tomcat/templates/_pod.tpl
+++ b/bitnami/tomcat/templates/_pod.tpl
@@ -43,7 +43,7 @@ initContainers:
     mountPath: /bitnami/tomcat
 {{- end }}
 {{- if .Values.initContainers }}
-{{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 4 }}
+{{ include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) }}
 {{- end }}
 containers:
 - name: tomcat

--- a/bitnami/tomcat/templates/_pod.tpl
+++ b/bitnami/tomcat/templates/_pod.tpl
@@ -43,7 +43,7 @@ initContainers:
     mountPath: /bitnami/tomcat
 {{- end }}
 {{- if .Values.initContainers }}
-{{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) }}
+{{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 4 }}
 {{- end }}
 containers:
 - name: tomcat
@@ -110,7 +110,7 @@ containers:
   {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 2 }}
   {{- end }}
 {{- if .Values.sidecars }}
-{{- include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) }}
+{{ include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) }}
 {{- end }}
 volumes:
 {{- if and .Values.persistence.enabled (eq .Values.deployment.type "deployment") }}


### PR DESCRIPTION
**Description of the change**

Fix of indentations in tomcat chart

**Applicable issues**

  - fixes #6501

**Checklist** 
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])

NOTE: I did not know if i should bump version..