### PR TITLE
bitnami/dataplatform-bp2 metric prefixes were updated to keep in sync with TO platfrom

### DIFF
--- a/bitnami/dataplatform-bp2/Chart.yaml
+++ b/bitnami/dataplatform-bp2/Chart.yaml
@@ -58,4 +58,4 @@ sources:
   - https://www.elastic.co/products/logstash
   - https://zookeeper.apache.org/
   - https://github.com/bitnami/bitnami-docker-zookeeper
-version: 2.0.0
+version: 3.0.0

--- a/bitnami/dataplatform-bp2/README.md
+++ b/bitnami/dataplatform-bp2/README.md
@@ -276,6 +276,11 @@ Regular upgrade is compatible from previous versions.
 
 ## Upgrading
 
+### To 3.0.0
+
+This major version updates the prefixes of individual applications metrics in Wavefront Collectors which are fed to Tanzu observability in order to light up the individual dashboards of Kafka, Spark ElasticSearch and Logstash on Tanzu Observability platform.
+
+
 ### To 2.0.0
 
 This major updates the wavefront subchart to it newest major, 3.0.0, which contains a new major for kube-state-metrics. For more information on this subchart's major, please refer to [wavefront upgrade notes](https://github.com/bitnami/charts/tree/master/bitnami/wavefront#to-300).

--- a/bitnami/dataplatform-bp2/values.yaml
+++ b/bitnami/dataplatform-bp2/values.yaml
@@ -51,7 +51,7 @@ kafka:
               - key: app.kubernetes.io/instance
                 operator: In
                 values:
-                  - '{{ .Release.Name }}'    
+                  - '{{ .Release.Name }}'
           topologyKey: "kubernetes.io/hostname"
     podAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -66,7 +66,7 @@ kafka:
                 - key: app.kubernetes.io/instance
                   operator: In
                   values:
-                    - '{{ .Release.Name }}'    
+                    - '{{ .Release.Name }}'
             topologyKey: "kubernetes.io/hostname"
   ## Prometheus Exporters / Metrics
   ##
@@ -153,7 +153,7 @@ kafka:
                 - key: app.kubernetes.io/instance
                   operator: In
                   values:
-                    - '{{ .Release.Name }}'    
+                    - '{{ .Release.Name }}'
             topologyKey: "kubernetes.io/hostname"
   ## This value is only used when zookeeper.enabled is set to false.
   ##
@@ -200,7 +200,7 @@ spark:
                 - key: app.kubernetes.io/instance
                   operator: In
                   values:
-                    - '{{ .Release.Name }}'    
+                    - '{{ .Release.Name }}'
             topologyKey: "kubernetes.io/hostname"
   ## Spark worker specific configuration
   ##
@@ -241,7 +241,7 @@ spark:
                 - key: app.kubernetes.io/instance
                   operator: In
                   values:
-                    - '{{ .Release.Name }}'    
+                    - '{{ .Release.Name }}'
             topologyKey: "kubernetes.io/hostname"
   ## Metrics configuration
   ##
@@ -305,7 +305,7 @@ elasticsearch:
                 - key: app.kubernetes.io/instance
                   operator: In
                   values:
-                    - '{{ .Release.Name }}'    
+                    - '{{ .Release.Name }}'
             topologyKey: "kubernetes.io/hostname"
 
     ## Elasticsearch master-eligible container's resource requests and limits
@@ -356,7 +356,7 @@ elasticsearch:
                 - key: app.kubernetes.io/instance
                   operator: In
                   values:
-                    - '{{ .Release.Name }}'    
+                    - '{{ .Release.Name }}'
             topologyKey: "kubernetes.io/hostname"
 
     ## Elasticsearch data container's resource requests and limits
@@ -402,7 +402,7 @@ elasticsearch:
                 - key: app.kubernetes.io/instance
                   operator: In
                   values:
-                    - '{{ .Release.Name }}'    
+                    - '{{ .Release.Name }}'
             topologyKey: "kubernetes.io/hostname"
 
     ## Elasticsearch coordinating-only container's resource requests and limits
@@ -476,7 +476,7 @@ logstash:
               - key: app.kubernetes.io/instance
                 operator: In
                 values:
-                  - '{{ .Release.Name }}'    
+                  - '{{ .Release.Name }}'
           topologyKey: "kubernetes.io/hostname"
 
   ## Logstash containers' resource requests and limits
@@ -580,7 +580,7 @@ wavefront:
           port: 9308
           path: /metrics
           scheme: http
-          prefix: kube.kafka.
+          prefix: kafka.
 
         ## auto-discover jmx exporter
         ##
@@ -592,7 +592,7 @@ wavefront:
           port: 5556
           path: /metrics
           scheme: http
-          prefix: kube.kafkajmx.
+          prefix: kafkajmx.
 
         ## auto-discover elasticsearch
         ##
@@ -604,7 +604,6 @@ wavefront:
           port: 9114
           path: /metrics
           scheme: http
-          prefix: kube.elasticsearch.
 
         ## auto-discover logstash
         ##
@@ -616,7 +615,6 @@ wavefront:
           port: 9198
           path: /metrics
           scheme: http
-          prefix: kube.logstash.
 
         ## auto-discover spark
         ##
@@ -628,7 +626,7 @@ wavefront:
           port: 8081
           path: /metrics/
           scheme: http
-          prefix: kube.spark.
+          prefix: spark.
 
         ## auto-discover spark
         ##
@@ -640,7 +638,7 @@ wavefront:
           port: 8080
           path: /metrics/
           scheme: http
-          prefix: kube.spark.
+          prefix: spark.
   proxy:
     ## Wavefront Proxy resource requests and limits
     ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
The prefixes for the metrics emitted were changed to have them in sync with individual dashboards of Kafka Spark and Elastic Search on Tanzu Observability platform.


**Benefits**

<!-- What benefits will be realized by the code change? -->
Individual Dashboard on wavefront will be lit up and users can use those dashboards once TO platfroms have prometheus exporter dashboards for each tech stack.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
