### PR TITLE
[bitnami/kafka] Fixed duplicate for `reabelings` condition in service monitor templates

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 12.19.0
+version: 12.19.1

--- a/bitnami/kafka/templates/servicemonitor-jmx-metrics.yaml
+++ b/bitnami/kafka/templates/servicemonitor-jmx-metrics.yaml
@@ -33,7 +33,7 @@ spec:
       {{- if .Values.metrics.serviceMonitor.relabelings }}
       relabelings: {{- toYaml .Values.metrics.serviceMonitor.relabelings | nindent 6 }}
       {{- end }}
-      {{- if .Values.metrics.serviceMonitor.relabelings }}
+      {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
       metricRelabelings: {{- toYaml .Values.metrics.serviceMonitor.metricRelabelings | nindent 6 }}
       {{- end }}
   namespaceSelector:

--- a/bitnami/kafka/templates/servicemonitor-metrics.yaml
+++ b/bitnami/kafka/templates/servicemonitor-metrics.yaml
@@ -33,7 +33,7 @@ spec:
       {{- if .Values.metrics.serviceMonitor.relabelings }}
       relabelings: {{- toYaml .Values.metrics.serviceMonitor.relabelings | nindent 6 }}
       {{- end }}
-      {{- if .Values.metrics.serviceMonitor.relabelings }}
+      {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
       metricRelabelings: {{- toYaml .Values.metrics.serviceMonitor.metricRelabelings | nindent 6 }}
       {{- end }}
   namespaceSelector:


### PR DESCRIPTION
**Description of the change**

Hotfix for PR  #6511

Fixed duplicate  for `reabelings` condition in service monitor templates.




**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
