### PR TITLE
[bitnami/mongodb] Add support for 'extraDeploy'

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 10.16.4
+version: 10.17.0

--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -76,6 +76,7 @@ The following tables lists the configurable parameters of the MongoDB&reg; chart
 | `nameOverride`      | String to partially override mongodb.fullname                  | `nil`                                                   |
 | `fullnameOverride`  | String to fully override mongodb.fullname                      | `nil`                                                   |
 | `clusterDomain`     | Default Kubernetes cluster domain                              | `cluster.local`                                         |
+| `extraDeploy`       | Array of extra objects to deploy with the release              | `[]` (evaluated as a template)                          |
 | `schedulerName`     | Name of the scheduler (other than default) to dispatch pods    | `nil`                                                   |
 | `image.registry`    | MongoDB&reg; image registry                                    | `docker.io`                                             |
 | `image.repository`  | MongoDB&reg; image name                                        | `bitnami/mongodb`                                       |

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -48,10 +48,13 @@ image:
 ##
 clusterDomain: cluster.local
 
+## Extra objects to deploy (value evaluated as a template)
+##
+extraDeploy: []
+
 ## Common annotations to add to all Mongo resources (sub-charts are not considered). Evaluated as a template
 ##
 commonAnnotations: {}
-
 
 ## Use an alternate scheduler, e.g. "stork".
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR adds support for 'extraDeploy' parameter, a very common parameter in other Bitnami charts

**Benefits**

Chart supports deploying any custom manifest.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
