### PR TITLE
[bitnami/mongodb] Support for custom RBAC rules

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 10.17.0
+version: 10.18.0

--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -225,6 +225,7 @@ The following tables lists the configurable parameters of the MongoDB&reg; chart
 | `serviceAccount.name`                        | Name of the created serviceAccount                                                                   | Generated using the `mongodb.fullname` template |
 | `serviceAccount.annotations`                 | Additional Service Account annotations                                                               | `{}`                                            |
 | `rbac.create`                                | Whether to create & use RBAC resources or not                                                        | `false`                                         |
+| `rbac.role.rules`                            | Custom rules to create following the role specification                                              | `[]`                                            |
 | `podSecurityPolicy.create`                   | Whether to create & use PSP resource or not (Note: `rbac.create` needs to be `true`)                 | `false`                                         |
 | `podSecurityPolicy.allowPrivilegeEscalation` | Enable privilege escalation                                                                          | `false`                                         |
 | `podSecurityPolicy.privileged`               | Allow privileged                                                                                     | `false`                                         |

--- a/bitnami/mongodb/templates/role.yaml
+++ b/bitnami/mongodb/templates/role.yaml
@@ -14,6 +14,9 @@ rules:
       - get
       - list
       - watch
+{{- if .Values.rbac.role.rules }}
+{{- toYaml .Values.rbac.role.rules | nindent 2 }}
+{{- end -}}
 {{- if .Values.podSecurityPolicy.create }}
   - apiGroups: ['{{ template "podSecurityPolicy.apiGroup" . }}']
     resources: ['podsecuritypolicies']

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -957,6 +957,18 @@ rbac:
   ## that allows MongoDB(R) pods querying the K8s API
   ##
   create: false
+  role:
+    ## Custom rules to create following the role specification
+    ## e.g.
+    ## rules:
+    ##   - apiGroups:
+    ##       - ""
+    ##     resources:
+    ##       - pods
+    ##     verbs:
+    ##       - update
+    ##
+    rules: []
 
 ## PodSecurityPolicy configuration
 ## Be sure to also set rbac.create to true, otherwise Role and RoleBinding


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR adds support for custom RBAC rules in a similar way we already do the same in the Redis Cluster chart.

**Benefits**

User can choose their custom RBAC rules

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 


- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
