### PR TITLE
[bitnami/minio] Make runAsNonRoot configurable

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -25,4 +25,4 @@ name: minio
 sources:
   - https://github.com/bitnami/bitnami-docker-minio
   - https://min.io
-version: 6.7.16
+version: 6.7.17

--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -25,4 +25,4 @@ name: minio
 sources:
   - https://github.com/bitnami/bitnami-docker-minio
   - https://min.io
-version: 6.7.17
+version: 6.8.0

--- a/bitnami/minio/README.md
+++ b/bitnami/minio/README.md
@@ -118,7 +118,7 @@ The following table lists the configurable parameters of the MinIO&reg; chart an
 | `securityContext.enabled`         | Enable security context                                                                   | `true`                         |
 | `securityContext.fsGroup`         | Group ID for the container                                                                | `1001`                         |
 | `securityContext.runAsUser`       | User ID for the container                                                                 | `1001`                         |
-| `securityContext.runAsNonRoot`    | Avoid running as root User                                                                | `false`                        |
+| `securityContext.runAsNonRoot`    | Avoid running as root User                                                                | `true`                         |
 | `containerPort`                   | MinIO(R) container port to open                                                           | `9000`                         |
 | `resources.limits`                | The resources limits for the MinIO&reg; container                                         | `{}`                           |
 | `resources.requests`              | The requested resources for the MinIO&reg; container                                      | `{}`                           |

--- a/bitnami/minio/README.md
+++ b/bitnami/minio/README.md
@@ -118,6 +118,7 @@ The following table lists the configurable parameters of the MinIO&reg; chart an
 | `securityContext.enabled`         | Enable security context                                                                   | `true`                         |
 | `securityContext.fsGroup`         | Group ID for the container                                                                | `1001`                         |
 | `securityContext.runAsUser`       | User ID for the container                                                                 | `1001`                         |
+| `securityContext.runAsNonRoot`    | Avoid running as root User                                                                | `false`                        |
 | `containerPort`                   | MinIO(R) container port to open                                                           | `9000`                         |
 | `resources.limits`                | The resources limits for the MinIO&reg; container                                         | `{}`                           |
 | `resources.requests`              | The requested resources for the MinIO&reg; container                                      | `{}`                           |

--- a/bitnami/minio/templates/distributed/statefulset.yaml
+++ b/bitnami/minio/templates/distributed/statefulset.yaml
@@ -114,6 +114,7 @@ spec:
           {{- if .Values.securityContext.enabled }}
           securityContext:
             runAsUser: {{ .Values.securityContext.runAsUser }}
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
           {{- end }}
           {{- if .Values.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.command "context" $) | nindent 12 }}

--- a/bitnami/minio/templates/gateway/deployment.yaml
+++ b/bitnami/minio/templates/gateway/deployment.yaml
@@ -70,6 +70,7 @@ spec:
           {{- if .Values.securityContext.enabled }}
           securityContext:
             runAsUser: {{ .Values.securityContext.runAsUser }}
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
           {{- end }}
           command:
             {{- if .Values.command }}

--- a/bitnami/minio/templates/standalone/deployment.yaml
+++ b/bitnami/minio/templates/standalone/deployment.yaml
@@ -90,6 +90,7 @@ spec:
           {{- if .Values.securityContext.enabled }}
           securityContext:
             runAsUser: {{ .Values.securityContext.runAsUser }}
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
           {{- end }}
           {{- if .Values.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.command "context" $) | nindent 12 }}

--- a/bitnami/minio/values.yaml
+++ b/bitnami/minio/values.yaml
@@ -26,7 +26,7 @@ global:
 image:
   registry: docker.io
   repository: bitnami/minio
-  tag: 2021.5.27-debian-10-r0
+  tag: 2021.5.27-debian-10-r6
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -50,7 +50,7 @@ image:
 clientImage:
   registry: docker.io
   repository: bitnami/minio-client
-  tag: 2021.5.26-debian-10-r0
+  tag: 2021.5.26-debian-10-r5
 
 ## String to partially override common.names.fullname template (will maintain the release name)
 ##
@@ -547,7 +547,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r92
+    tag: 10-debian-10-r98
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/minio/values.yaml
+++ b/bitnami/minio/values.yaml
@@ -224,7 +224,7 @@ securityContext:
   enabled: true
   fsGroup: 1001
   runAsUser: 1001
-  runAsNonRoot: false
+  runAsNonRoot: true
 
 ## Pod labels
 ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/

--- a/bitnami/minio/values.yaml
+++ b/bitnami/minio/values.yaml
@@ -224,6 +224,7 @@ securityContext:
   enabled: true
   fsGroup: 1001
   runAsUser: 1001
+  runAsNonRoot: false
 
 ## Pod labels
 ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/


### PR DESCRIPTION
Signed-off-by: Christian Kotzbauer christian.kotzbauer@gmail.com

**Description of the change**
Add "runAsNonRoot" config-option to the securityContext.

**Benefits**
It is possible to set "runAsNonRoot" to "true" now.

**Possible drawbacks**

**Applicable issues**

**Additional information**

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
