### PR TITLE
[bitnami/zookeeper] add customLivenessProbe and customReadinessProbe

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -21,4 +21,4 @@ name: zookeeper
 sources:
   - https://github.com/bitnami/bitnami-docker-zookeeper
   - https://zookeeper.apache.org/
-version: 6.7.4
+version: 6.8.0

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -126,6 +126,8 @@ The following tables lists the configurable parameters of the ZooKeeper chart an
 | `resources`                          | CPU/Memory resource requests/limits                                                       | Memory: `256Mi`, CPU: `250m`   |
 | `livenessProbe`                      | Liveness probe configuration for ZooKeeper                                                | Check `values.yaml` file       |
 | `readinessProbe`                     | Readiness probe configuration for ZooKeeper                                               | Check `values.yaml` file       |
+| `customLivenessProbe`                | Override default liveness probe                                                           | `nil`                          |
+| `customReadinessProbe`               | Override default readiness probe                                                          | `nil`                          |
 | `extraVolumes`                       | Extra volumes                                                                             | `nil`                          |
 | `extraVolumeMounts`                  | Mount extra volume(s)                                                                     | `nil`                          |
 | `initContainers`                     | Extra init container to add to the statefulset                                            | `nil`                          |

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -264,6 +264,8 @@ spec:
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- else if .Values.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
@@ -282,6 +284,8 @@ spec:
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- else if .Values.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: data

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -408,6 +408,14 @@ readinessProbe:
   successThreshold: 1
   probeCommandTimeout: 2
 
+## Custom Liveness probes for ZooKeeper
+##
+customLivenessProbe: {}
+
+## Custom Readiness probes for ZooKeeper
+##
+customReadinessProbe: {}
+
 ## Network policies
 ## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 ##


### PR DESCRIPTION
**Description of the change**

Adds the ability to specify `customLivenessProbe` and `customReadinessProbe` to the ZooKeeper chart. This brings it in line with many other bitnami charts and the recommended default values.

**Benefits**

Beyond the benefit of bringing the ZooKeeper chart in line with the standard, users of ZooKeeper would benefit from setting the liveness and readiness probes to use the admin port instead of the client port as is recommended by Apache ZooKeeper.

**Possible drawbacks**

Nothing about ZooKeeper in particular makes this feature inappropriate or dangerous for use.

**Applicable issues**

None

**Additional information**

The “four letter word” feature that backs the current liveness and readiness probes has been deprecated by Apache ZooKeeper (https://zookeeper.apache.org/doc/current/zookeeperAdmin.html#sc_4lw).

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
