### PR TITLE
[bitnami/mariadb] add revisionHistoryLimit support for secondary/primary

### DIFF
--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -26,4 +26,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-mariadb
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 9.3.13
+version: 9.3.14

--- a/bitnami/mariadb/README.md
+++ b/bitnami/mariadb/README.md
@@ -147,6 +147,7 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `primary.pdb.enabled`                        | Enable/disable a Pod Disruption Budget creation for MariaDB primary pods                                          | `false`                        |
 | `primary.pdb.minAvailable`                   | Minimum number/percentage of MariaDB primary pods that should remain scheduled                                    | `1`                            |
 | `primary.pdb.maxUnavailable`                 | Maximum number/percentage of MariaDB primary pods that may be made unavailable                                    | `nil`                          |
+| `primary.revisionHistoryLimit`               | Maximum number of revisions that will be maintained in the StatefulSet’s revision history for primary pods.       | `10`                           |
 
 ### MariaDB Secondary parameters
 
@@ -205,6 +206,7 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `secondary.pdb.enabled`                        | Enable/disable a Pod Disruption Budget creation for MariaDB secondary pods                                            | `false`                        |
 | `secondary.pdb.minAvailable`                   | Minimum number/percentage of MariaDB secondary pods that should remain scheduled                                      | `1`                            |
 | `secondary.pdb.maxUnavailable`                 | Maximum number/percentage of MariaDB secondary pods that may be made unavailable                                      | `nil`                          |
+| `secondary.revisionHistoryLimit`               | Maximum number of revisions that will be maintained in the StatefulSet’s revision history for secondary pods.         | `10`                           |
 
 ### RBAC parameters
 

--- a/bitnami/mariadb/templates/primary/statefulset.yaml
+++ b/bitnami/mariadb/templates/primary/statefulset.yaml
@@ -13,6 +13,7 @@ metadata:
   {{- end }}
 spec:
   replicas: 1
+  revisionHistoryLimit: {{ .Values.primary.revisionHistoryLimit }}
   selector:
     matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: primary

--- a/bitnami/mariadb/templates/secondary/statefulset.yaml
+++ b/bitnami/mariadb/templates/secondary/statefulset.yaml
@@ -14,6 +14,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.secondary.replicaCount }}
+  revisionHistoryLimit: {{ .Values.secondary.revisionHistoryLimit }}
   selector:
     matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: secondary

--- a/bitnami/mariadb/values.yaml
+++ b/bitnami/mariadb/values.yaml
@@ -407,6 +407,10 @@ primary:
     ##
     # maxUnavailable: 1
 
+  ## Revision history limit for Mariadb Primary
+  ##
+  revisionHistoryLimit: 10
+
 ## Mariadb Secondary parameters
 ##
 secondary:
@@ -698,6 +702,10 @@ secondary:
     ## Max number of pods that can be unavailable after the eviction
     ##
     # maxUnavailable: 1
+
+  ## Revision history limit for Mariadb Secondary
+  ##
+  revisionHistoryLimit: 10
 
 ## MariaDB pods ServiceAccount
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Add revisionHistoryLimit support for secondary/primary.

**Benefits**

Anyone using this chart can set their own revisionHistoryLimit.

**Possible drawbacks**

Nothing notable.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
