### PR TITLE
[bitnami/wordpress] Fix custom htaccess configmap mount path

### DIFF
--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -35,4 +35,4 @@ name: wordpress
 sources:
   - https://github.com/bitnami/bitnami-docker-wordpress
   - https://wordpress.org/
-version: 11.0.13
+version: 11.0.14

--- a/bitnami/wordpress/templates/deployment.yaml
+++ b/bitnami/wordpress/templates/deployment.yaml
@@ -243,7 +243,7 @@ spec:
               subPath: httpd.conf
             {{- end }}
             {{- if and (not .Values.allowOverrideNone) .Values.customHTAccessCM }}
-            - mountPath: /htaccess
+            - mountPath: /opt/bitnami/apache/conf/vhosts/htaccess
               name: custom-htaccess
             {{- end }}
             {{- if or .Values.customPostInitScripts .Values.wordpressConfigureCache }}


### PR DESCRIPTION
**Description of the change**
This change fixes the functionality to mount custom htaccess files into the wordpress application using the `customHTAccessCM` value.

It changes the mountpoint to /opt/bitnami/apache/conf/vhosts/htaccess, where it is expected by the docker wordpress image (see https://github.com/bitnami/bitnami-docker-wordpress/blob/aa3e7c32881842fbdd91bc0aeddb42e16e471dbb/5/debian-10/rootfs/opt/bitnami/scripts/libapache.sh#L400 )

**Benefits**

- Custom htaccess functionality works.

**Possible drawbacks**

- I did not test for incompatibilities with other htaccess related functionality, like the persistence feature `htaccessPersistenceEnabled`

**Applicable issues**

  - fixes #6553

**Additional information**

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
