### PR TITLE
feat: add support for one service per mongos replica

### DIFF
--- a/bitnami/mongodb-sharded/templates/mongos/mongos-service-per-replica.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-service-per-replica.yaml
@@ -1,0 +1,48 @@
+{{- if and .Values.mongos.useStatefulSet .Values.mongos.servicePerReplica.enabled -}}
+{{- $count := .Values.mongos.replicas -}}
+{{- range $i, $e := until $count }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mongodb-sharded.serviceName" $ }}-{{ $i }}
+  labels: {{ include "common.labels.standard" $ | nindent 4 }}
+    app.kubernetes.io/component: mongos
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $ ) | nindent 4 }}  
+spec:
+  type: {{ .Values.service.type }}
+  {{- if and .Values.service.loadBalancerIP (eq .Values.service.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{ with .Values.service.loadBalancerSourceRanges }}
+{{ toYaml . | indent 4 }}
+  {{- end }}
+  {{- end }}
+  {{- if and (eq .Values.service.type "ClusterIP") .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
+  ports:
+    - name: mongodb
+      port: {{ .Values.service.port }}
+      targetPort: mongodb
+      {{- if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- else if eq .Values.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+    {{- if .Values.metrics.enabled }}
+    - name: metrics
+      port: 9216
+      targetPort: metrics
+    {{- end }}
+    {{- if .Values.service.extraPorts }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
+  selector: {{ include "common.labels.matchLabels" $ | nindent 4 }}
+    app.kubernetes.io/component: mongos
+    statefulset.kubernetes.io/pod-name: {{ include "common.names.fullname" $ }}-mongos-{{ $i }}
+  sessionAffinity: {{ default "None" .Values.service.sessionAffinity }}
+{{- end -}}
+{{- end -}}

--- a/bitnami/mongodb-sharded/values.yaml
+++ b/bitnami/mongodb-sharded/values.yaml
@@ -776,6 +776,11 @@ mongos:
   ## Use StatefulSet instead of Deployment
   ##
   useStatefulSet: false
+  ## When using a statefulset, you can enable one service per replica
+  ## This is useful when exposing the mongos through load balancers to make sure clients
+  ## connect to the same mongos and therefore can follow their cursors
+  ##
+  servicePerReplica: false
   ## Pod disruption budget
   ##
   pdb:


### PR DESCRIPTION
This PR adds support for one service per mongos replica.

When using a statefulset, you can enable one service per replica.

This is useful when exposing the mongos through load balancers to make sure clients connect to the same mongos and therefore can follow their cursors.
