### PR TITLE
[bitnami/mysql] Remove references to deprecated approach to mount custom scripts

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -25,4 +25,4 @@ name: mysql
 sources:
   - https://github.com/bitnami/bitnami-docker-mysql
   - https://mysql.com
-version: 8.6.0
+version: 8.6.1

--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -292,7 +292,7 @@ To modify the MySQL version used in this chart you can specify a [valid image ta
 
 ### Customize a new MySQL instance
 
-The [Bitnami MySQL](https://github.com/bitnami/bitnami-docker-mysql) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, they must be located inside the chart folder `files/docker-entrypoint-initdb.d` so they can be consumed as a ConfigMap.
+The [Bitnami MySQL](https://github.com/bitnami/bitnami-docker-mysql) image allows you to use your custom scripts to initialize a fresh instance. Custom scripts may be specified using the `initdbScripts` parameter. Alternatively, an external ConfigMap may be created with all the initialization scripts and the ConfigMap passed to the chart via the `initdbScriptsConfigMap` parameter. Note that this will override the `initdbScripts` parameter.
 
 The allowed extensions are `.sh`, `.sql` and `.sql.gz`.
 

--- a/bitnami/mysql/files/docker-entrypoint-initdb.d/README.md
+++ b/bitnami/mysql/files/docker-entrypoint-initdb.d/README.md
@@ -1,3 +1,0 @@
-You can copy here your custom .sh, .sql or .sql.gz file so they are executed during the first boot of the image.
-
-More info in the [bitnami-docker-mysql](https://github.com/bitnami/bitnami-docker-mysql#initializing-a-new-instance) repository.


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

We deprecated the possibility of adding custom init scripts by placing them in the `files/docker-entrypoint-initdb.d` directory. This possibility was very error-prone since users didn't realize that they need to previously fetch the chart or clone the charts repository.

However, we didn't remove the instructions to use it from the **README.md**, this PR does so.

**Benefits**

Accurate docs

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/6485

**Additional information**

N/A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
