### PR TITLE
bitnami/cert-manager fix: service account specific annotations not being used.

### DIFF
--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -26,4 +26,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-cert-manager-webhook
   - https://github.com/bitnami/bitnami-docker-cainjector
   - https://github.com/jetstack/cert-manager
-version: 0.1.2
+version: 0.1.3

--- a/bitnami/cert-manager/templates/cainjector/serviceaccount.yaml
+++ b/bitnami/cert-manager/templates/cainjector/serviceaccount.yaml
@@ -7,8 +7,9 @@ metadata:
     app.kubernetes.io/component: cainjector
   {{- include "common.labels.standard" . | nindent 4 }}
   name: {{ template "certmanager.cainjector.serviceAccountName" . }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- $mergedAnnotations := merge .Values.cainjector.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- if $mergedAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $mergedAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
   namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/bitnami/cert-manager/templates/controller/serviceaccount.yaml
+++ b/bitnami/cert-manager/templates/controller/serviceaccount.yaml
@@ -7,8 +7,9 @@ metadata:
     app.kubernetes.io/component: controller
   {{- include "common.labels.standard" . | nindent 4 }}
   name: {{ template "certmanager.controller.serviceAccountName" . }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- $mergedAnnotations := merge .Values.controller.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- if $mergedAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $mergedAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
   namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/bitnami/cert-manager/templates/webhook/serviceaccount.yaml
+++ b/bitnami/cert-manager/templates/webhook/serviceaccount.yaml
@@ -7,8 +7,9 @@ metadata:
     app.kubernetes.io/component: webhook
   {{- include "common.labels.standard" . | nindent 4 }}
   name: {{ template "certmanager.webhook.serviceAccountName" . }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- $mergedAnnotations := merge .Values.webhook.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- if $mergedAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $mergedAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
   namespace: {{ .Release.Namespace | quote }}
 {{- end }}


### PR DESCRIPTION
**Description of the change**

Fixes documented parameters were not used in the final rendering

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #6565 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
