### PR TITLE
[bitnami/kafka] adding a way to pass annotations to provisioning Pods

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 12.19.2
+version: 12.20.0

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -306,6 +306,7 @@ The following tables lists the configurable parameters of the Kafka chart and th
 | `provisioning.image`             | Kafka provisioning Job image                                          | `Check values.yaml file`       |
 | `provisioning.numPartitions`     | Default number of partitions for topics when unspecified.             | 1                              |
 | `provisioning.replicationFactor` | Default replication factor for topics when unspecified.               | 1                              |
+| `provisioning.podAnnotations`    | Provisioning Pod annotations.                                         | `{}` (evaluated as a template) |
 | `provisioning.resources`         | Kafka provisioning Job resources                                      | `Check values.yaml file`       |
 | `provisioning.topics`            | Kafka provisioning topics                                             | `[]`                           |
 | `provisioning.schedulerName`     | Name of the k8s scheduler (other than default) for kafka provisioning | `nil`                          |

--- a/bitnami/kafka/templates/kafka-provisioning.yaml
+++ b/bitnami/kafka/templates/kafka-provisioning.yaml
@@ -23,6 +23,9 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
+        {{- if .Values.provisioning.podAnnotations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.provisioning.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "kafka.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.provisioning.schedulerName }}

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -893,6 +893,8 @@ provisioning:
   ##
   # schedulerName:
 
+  podAnnotations: {}
+
   resources:
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
**Description of the change**

Hi,

First of all, thank you for sharing and maintaining these charts !  
I propose this humble contribution to address a minor issue i ran into.  

If you have Istio in your cluster, the provisionning Job never ends due to the istio sidecar running forever.  
https://github.com/bitnami/charts/issues/5835#issuecomment-805704862 propose a way to keep the Pod in the Mesh but kill the proxy at the end of the Job.  
This PR adds optional Pod annotations to the provisioning Pods.  
It allows, for example, to completely disable Istio for the provisioning Job by passing the `sidecar.istio.io/inject: "false"` annotation.

**Benefits**

- Provides more control over the Kubernetes resources created by this chart.
- Allow a wider variety of use cases for Istio Mesh users.

**Possible drawbacks**

None that i can think of.

**Applicable issues**

Related to #5835 

**Additional information**

N/A

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
