### PR TITLE
[bitnami/redis-cluster] Replace cluster creator job by cluster update job in pdb selector

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -23,4 +23,4 @@ name: redis-cluster
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 6.1.4
+version: 6.1.5

--- a/bitnami/redis-cluster/templates/poddisruptionbudget.yaml
+++ b/bitnami/redis-cluster/templates/poddisruptionbudget.yaml
@@ -13,5 +13,7 @@ metadata:
 spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+    matchExpressions:
+      - {key: job-name, operator: NotIn, values: [{{ template "common.names.fullname" . }}-cluster-update]}
   {{- toYaml .Values.podDisruptionBudget | nindent 2 }}
 {{- end }}

--- a/bitnami/redis-cluster/templates/poddisruptionbudget.yaml
+++ b/bitnami/redis-cluster/templates/poddisruptionbudget.yaml
@@ -13,7 +13,5 @@ metadata:
 spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-    matchExpressions:
-      - {key: job-name, operator: NotIn, values: [{{ template "common.names.fullname" . }}-cluster-create]}
   {{- toYaml .Values.podDisruptionBudget | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
**Description of the change**

Replace cluster creator job by cluster update job in pdb selector as the creator job was removed some versions ago. The initialization is now done directly inside the first pod of the statefulset.

**Benefits**

Less unused code is in the chart.

**Possible drawbacks**

None I can think of.

**Applicable issues**

None.

**Additional information**

None.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
