### PR TITLE
[bitnami/zookeeper] Allow to specify a nodePort in zookeeper service

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -21,4 +21,4 @@ name: zookeeper
 sources:
   - https://github.com/bitnami/bitnami-docker-zookeeper
   - https://zookeeper.apache.org/
-version: 6.9.0
+version: 6.10.0

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -142,6 +142,8 @@ The following tables lists the configurable parameters of the ZooKeeper chart an
 | `service.port`                           | ZooKeeper port                                                                                     | `2181`                                               |
 | `service.followerPort`                   | ZooKeeper follower port                                                                            | `2888`                                               |
 | `service.electionPort`                   | ZooKeeper election port                                                                            | `3888`                                               |
+| `service.nodePorts.client`               | Nodeport for client connections                                                                    | `""`                                                 |
+| `service.nodePorts.clientTls`            | Nodeport for tls client connections                                                                | `""`                                                 | 
 | `service.publishNotReadyAddresses`       | If the ZooKeeper headless service should publish DNS records for not ready pods                    | `true`                                               |
 | `serviceAccount.create`                  | Enable creation of ServiceAccount for zookeeper pod                                                | `false`                                              |
 | `serviceAccount.name`                    | The name of the service account to use. If not set and `create` is `true`, a name is generated     | Generated using the `common.names.fullname` template |

--- a/bitnami/zookeeper/templates/svc.yaml
+++ b/bitnami/zookeeper/templates/svc.yaml
@@ -27,11 +27,21 @@ spec:
     - name: tcp-client
       port: 2181
       targetPort: client
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.client)) }}
+      nodePort: {{ .Values.service.nodePorts.client }}
+      {{- else if eq .Values.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
     {{ end }}
     {{ if .Values.service.tls.client_enable }}
     - name: tcp-client-tls
       port: {{ .Values.service.tls.client_port }}
       targetPort: client-tls
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.clientTls)) }}
+      nodePort: {{ .Values.service.nodePorts.clientTls }}
+      {{- else if eq .Values.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
     {{ end }}
     - name: follower
       port: 2888

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -227,6 +227,12 @@ service:
   port: 2181
   followerPort: 2888
   electionPort: 3888
+  ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+  ##
+  nodePorts:
+    client: ""
+    clientTls: ""
   publishNotReadyAddresses: true
   tls:
     client_enable: false


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Allow to specify a nodePort in zookeeper service

**Benefits**

<!-- What benefits will be realized by the code change? -->
Allow the service to be of type NodePort with a chosen nodePort 

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
None

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
None

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
