### PR TITLE
Add Update Chart README Github Actions workflow

### DIFF
--- a/.github/workflows/update-chart-readme.yml
+++ b/.github/workflows/update-chart-readme.yml
@@ -1,0 +1,77 @@
+name: Update Chart Readme
+
+on:
+  workflow_dispatch:
+    inputs:
+      chart-name:
+        description: 'Chart name (e.g. redis)'
+        required: true
+      branch:
+        description: 'Branch to commit'
+        required: false
+        default: master
+
+jobs:
+  update-chart-readme:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout bitnami-labs/readme-generator-for-helm
+        uses: actions/checkout@v2
+        with:
+          repository: 'bitnami-labs/readme-generator-for-helm'
+          path: readme-generator-for-helm
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('readme-generator-for-helm/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Install readme-generator-for-helm dependencies
+        run: cd readme-generator-for-helm && npm install
+
+      - name: Checkout bitnami/charts
+        uses: actions/checkout@v2
+        with:
+          path: charts
+
+      - name: Execute readme-generator-for-helm for ${{ github.event.inputs.chart-name }}
+        run: readme-generator-for-helm/bin/index.js -r charts/bitnami/${{ github.event.inputs.chart-name }}/README.md -v charts/bitnami/${{ github.event.inputs.chart-name }}/values.yaml
+
+      - name: Publish README for ${{ github.event.inputs.chart-name }}
+        if: ${{ github.event.inputs.branch == 'master' || github.event.inputs.branch == '' }}
+        id: publish-readme
+        uses: peter-evans/create-pull-request@v3
+        with:
+          path: charts
+          base: master
+          branch: ${{ github.event.inputs.chart-name }}/update-readme
+          delete-branch: true
+          author: github-actions <41898282+github-actions[bot]@users.noreply.github.com>
+          commit-message: Update ${{ github.event.inputs.chart-name }} chart README.md
+          title: '[bitnami/${{ github.event.inputs.chart-name }}] Update ${{ github.event.inputs.chart-name }} chart README.md'
+          body: |
+            Update `README.md` based on the `values.yaml` file using bitnami-labs/readme-generator-for-helm.
+          reviewers: ${{ github.actor }}
+
+      - name: Output publish information
+        if: ${{ github.event.inputs.branch == 'master' || github.event.inputs.branch == '' }}
+        run: |
+          echo "Pull Request URL - ${{ steps.publish-readme.outputs.pull-request-url }}"
+
+      - name: Update README for ${{ github.event.inputs.chart-name }} on ${{ github.event.inputs.branch }}
+        if: ${{ github.event.inputs.branch != 'master' && github.event.inputs.branch != '' }}
+        working-directory: charts
+        run: |
+          git config user.name 'github-actions'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git fetch
+          git checkout ${{ github.event.inputs.branch }}
+          git commit -am "Update ${{ github.event.inputs.chart-name }} chart README.md"
+          git push


### PR DESCRIPTION
**Description of the change**

POC for a Github Actions workflow that updates a `README.md` with `readme-generator`

**Benefits**

Less manual work and consistency between `values.yaml` and `README.md`.

**Possible drawbacks**

N/A

**Applicable issues**

- Relates to #6636 

**Additional information**

N/A

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
