### PR TITLE
Fix debug value to true instead of 1

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -32,4 +32,4 @@ name: airflow
 sources:
   - https://github.com/bitnami/bitnami-docker-airflow
   - https://airflow.apache.org/
-version: 10.1.0
+version: 10.1.1

--- a/bitnami/airflow/templates/_helpers.tpl
+++ b/bitnami/airflow/templates/_helpers.tpl
@@ -301,7 +301,7 @@ Add environment variables to configure airflow common values
 - name: BASH_DEBUG
   value: "1"
 - name: BITNAMI_DEBUG
-  value: "1"
+  value: "true"
 {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
**Description of the change**
Changed the `BITNAMI_DEBUG` variable to true value from 1.

**Benefits**
DEBUG messages start appearing one this is fixed


**Applicable issues**
With 1 the container did not enter the debug mode and had the error 
```
airflow 09:12:03.10 INFO  ==> Waiting for PostgreSQL to be available at ctlfwmaster.ccdwyedutqre.ap-southeast-2.rds.amazonaws.com:5432...
airflow 09:12:03.13 DEBUG ==> Executing /opt/bitnami/airflow/venv/bin/airflow db init
/opt/bitnami/scripts/libos.sh: line 253: 1: command not found
```
