### PR TITLE
[bitnami/memcached] Fix persistence + custom sidecars/init containers

### DIFF
--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -22,4 +22,4 @@ name: memcached
 sources:
   - https://github.com/bitnami/bitnami-docker-memcached
   - http://memcached.org/
-version: 5.12.2
+version: 5.13.0

--- a/bitnami/memcached/README.md
+++ b/bitnami/memcached/README.md
@@ -67,74 +67,83 @@ The following tables lists the configurable parameters of the Memcached chart an
 
 ### Memcached parameters
 
-| Parameter                                | Description                                                                               | Default                                                      |
-|------------------------------------------|-------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `image.registry`                         | Memcached image registry                                                                  | `docker.io`                                                  |
-| `image.repository`                       | Memcached Image name                                                                      | `bitnami/memcached`                                          |
-| `image.tag`                              | Memcached Image tag                                                                       | `{TAG_NAME}`                                                 |
-| `image.pullPolicy`                       | Memcached image pull policy                                                               | `IfNotPresent`                                               |
-| `image.pullSecrets`                      | Specify docker-registry secret names as an array                                          | `[]` (does not add image pull secrets to deployed pods)      |
-| `architecture`                           | Memcached architecture. Allowed values: standalone or high-availability                   | `standalone`                                                 |
-| `replicaCount`                           | Number of containers                                                                      | `1`                                                          |
-| `command`                                | Default container command (useful when using custom images)                               | `[]`                                                         |
-| `arguments`                              | Default container args (useful when using custom images)                                  | `["/run.sh"]`                                                |
-| `extraEnv`                               | Additional env vars to pass                                                               | `{}`                                                         |
-| `hostAliases`                            | Add deployment host aliases                                                               | `[]`                                                         |
-| `memcachedUsername`                      | Memcached admin user                                                                      | `nil`                                                        |
-| `memcachedPassword`                      | Memcached admin password                                                                  | `nil`                                                        |
-| `podDisruptionBudget.create`             | Whether to create a pod disruption budget                                                 | `false`                                                      |
-| `podDisruptionBudget.minAvailable`       | Minimum number of pods that need to be available                                          | `nil`                                                        |
-| `podDisruptionBudget.maxUnavailable`     | Maximum number of pods that can be unavailable                                            | `1`                                                          |
-| `service.type`                           | Kubernetes service type for Memcached                                                     | `ClusterIP`                                                  |
-| `service.port`                           | Memcached service port                                                                    | `11211`                                                      |
-| `service.nodePort`                       | Kubernetes Service nodePort                                                               | `nil`                                                        |
-| `service.loadBalancerIP`                 | `loadBalancerIP` if service type is `LoadBalancer`                                        | `nil`                                                        |
-| `service.annotations`                    | Additional annotations for Memcached service                                              | `{}`                                                         |
-| `resources.requests`                     | CPU/Memory resource requests                                                              | `{memory: "256Mi", cpu: "250m"}`                             |
-| `resources.limits`                       | CPU/Memory resource limits                                                                | `{}`                                                         |
-| `portName`                               | Name of the main port exposed by memcached                                                | `memcache`                                                   |
-| `persistence.enabled`                    | Enable persistence using PVC (Requires architecture: "high-availability")                 | `true`                                                       |
-| `persistence.storageClass`               | PVC Storage Class for Memcached volume                                                    | `nil` (uses alpha storage class annotation)                  |
-| `persistence.accessMode`                 | PVC Access Mode for Memcached volume                                                      | `ReadWriteOnce`                                              |
-| `persistence.size`                       | PVC Storage Request for Memcached volume                                                  | `8Gi`                                                        |
-| `securityContext.enabled`                | Enable security context                                                                   | `true`                                                       |
-| `securityContext.fsGroup`                | Group ID for the container                                                                | `1001`                                                       |
-| `securityContext.runAsUser`              | User ID for the container                                                                 | `1001`                                                       |
-| `securityContext.readOnlyRootFilesystem` | Enable read-only filesystem                                                               | `false`                                                      |
-| `podAnnotations`                         | Pod annotations                                                                           | `{}`                                                         |
-| `podAffinityPreset`                      | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                                                         |
-| `podAntiAffinityPreset`                  | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                                       |
-| `podLabels`                              | Add additional labels to the pod (evaluated as a template)                                | `nil`                                                        |
-| `nodeAffinityPreset.type`                | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                                                         |
-| `nodeAffinityPreset.key`                 | Node label key to match. Ignored if `affinity` is set.                                    | `""`                                                         |
-| `nodeAffinityPreset.values`              | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                                                         |
-| `affinity`                               | Affinity for pod assignment                                                               | `{}` (evaluated as a template)                               |
-| `nodeSelector`                           | Node labels for pod assignment                                                            | `{}` (evaluated as a template)                               |
-| `tolerations`                            | Tolerations for pod assignment                                                            | `[]` (evaluated as a template)                               |
-| `topologySpreadConstraints`              | Topology Spread Constraints for pod assignment                                            | `{}` (evaluated as a template)                               |
-| `priorityClassName`                      | Controller priorityClassName                                                              | `nil`                                                        |
-| `serviceAccount.create` | Enable creation of ServiceAccount for memcached pods                                               | `true`                                                  |
-| `serviceAccount.name`   | The name of the service account to use. If not set and `create` is `true`, a name is generated | Generated using the `memcached.serviceAccountName` template |
-| `serviceAccount.automountServiceAccountToken`   | Enable/disable auto mounting of the service account token | `true` |
-| `metrics.enabled`                        | Start a side-car prometheus exporter                                                      | `false`                                                      |
-| `metrics.image.registry`                 | Memcached exporter image registry                                                         | `docker.io`                                                  |
-| `metrics.image.repository`               | Memcached exporter image name                                                             | `bitnami/memcached-exporter`                                 |
-| `metrics.image.tag`                      | Memcached exporter image tag                                                              | `{TAG_NAME}`                                                 |
-| `metrics.image.pullPolicy`               | Image pull policy                                                                         | `IfNotPresent`                                               |
-| `metrics.image.pullSecrets`              | Specify docker-registry secret names as an array                                          | `[]` (does not add image pull secrets to deployed pods)      |
-| `metrics.podAnnotations`                 | Additional annotations for Metrics exporter                                               | `{prometheus.io/scrape: "true", prometheus.io/port: "9150"}` |
-| `metrics.resources`                      | Exporter resource requests/limit                                                          | `{}`                                                         |
-| `metrics.portName`                       | Memcached exporter port name                                                              | `metrics`                                                    |
-| `metrics.service.type`                   | Kubernetes service type for Prometheus metrics                                            | `ClusterIP`                                                  |
-| `metrics.service.port`                   | Prometheus metrics service port                                                           | `9150`                                                       |
-| `metrics.service.annotations`            | Prometheus exporter svc annotations                                                       | `{prometheus.io/scrape: "true", prometheus.io/port: "9150"}` |
-| `metrics.serviceMonitor.enabled`         | Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator           | `false`                                                      |
-| `metrics.serviceMonitor.namespace`       | The namespace in which the ServiceMonitor will be created                                 | `nil`                                                        |
-| `metrics.serviceMonitor.interval`        | The interval at which metrics should be scraped                                           | `nil`                                                        |
-| `metrics.serviceMonitor.scrapeTimeout`   | The timeout after which the scrape is ended                                               | `nil`                                                        |
-| `metrics.serviceMonitor.selector`        | Additional labels for ServiceMonitor resource                                             | `nil`                                                        |
-| `metrics.serviceMonitor.metricRelabelings` | Metrics relabelings to add to the scrape endpoint, applied before ingestion             | `nil`                                                        |
-| `metrics.serviceMonitor.relabelings`     | Metrics relabelings to add to the scrape endpoint, applied before scraping                | `nil`                                                        |
+| Parameter                                      | Description                                                                                    | Default                                                      |
+|------------------------------------------------|------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `image.registry`                               | Memcached image registry                                                                       | `docker.io`                                                  |
+| `image.repository`                             | Memcached Image name                                                                           | `bitnami/memcached`                                          |
+| `image.tag`                                    | Memcached Image tag                                                                            | `{TAG_NAME}`                                                 |
+| `image.pullPolicy`                             | Memcached image pull policy                                                                    | `IfNotPresent`                                               |
+| `image.pullSecrets`                            | Specify docker-registry secret names as an array                                               | `[]` (does not add image pull secrets to deployed pods)      |
+| `architecture`                                 | Memcached architecture. Allowed values: standalone or high-availability                        | `standalone`                                                 |
+| `replicaCount`                                 | Number of containers                                                                           | `1`                                                          |
+| `command`                                      | Default container command (useful when using custom images)                                    | `[]`                                                         |
+| `arguments`                                    | Default container args (useful when using custom images)                                       | `["/run.sh"]`                                                |
+| `extraEnv`                                     | Additional env vars to pass                                                                    | `{}`                                                         |
+| `hostAliases`                                  | Add deployment host aliases                                                                    | `[]`                                                         |
+| `memcachedUsername`                            | Memcached admin user                                                                           | `nil`                                                        |
+| `memcachedPassword`                            | Memcached admin password                                                                       | `nil`                                                        |
+| `podDisruptionBudget.create`                   | Whether to create a pod disruption budget                                                      | `false`                                                      |
+| `podDisruptionBudget.minAvailable`             | Minimum number of pods that need to be available                                               | `nil`                                                        |
+| `podDisruptionBudget.maxUnavailable`           | Maximum number of pods that can be unavailable                                                 | `1`                                                          |
+| `service.type`                                 | Kubernetes service type for Memcached                                                          | `ClusterIP`                                                  |
+| `service.port`                                 | Memcached service port                                                                         | `11211`                                                      |
+| `service.nodePort`                             | Kubernetes Service nodePort                                                                    | `nil`                                                        |
+| `service.loadBalancerIP`                       | `loadBalancerIP` if service type is `LoadBalancer`                                             | `nil`                                                        |
+| `service.annotations`                          | Additional annotations for Memcached service                                                   | `{}`                                                         |
+| `resources.requests`                           | CPU/Memory resource requests                                                                   | `{memory: "256Mi", cpu: "250m"}`                             |
+| `resources.limits`                             | CPU/Memory resource limits                                                                     | `{}`                                                         |
+| `portName`                                     | Name of the main port exposed by memcached                                                     | `memcache`                                                   |
+| `persistence.enabled`                          | Enable persistence using PVC (Requires architecture: "high-availability")                      | `true`                                                       |
+| `persistence.storageClass`                     | PVC Storage Class for Memcached volume                                                         | `nil` (uses alpha storage class annotation)                  |
+| `persistence.accessMode`                       | PVC Access Mode for Memcached volume                                                           | `ReadWriteOnce`                                              |
+| `persistence.size`                             | PVC Storage Request for Memcached volume                                                       | `8Gi`                                                        |
+| `securityContext.enabled`                      | Enable security context                                                                        | `true`                                                       |
+| `securityContext.fsGroup`                      | Group ID for the container                                                                     | `1001`                                                       |
+| `securityContext.runAsUser`                    | User ID for the container                                                                      | `1001`                                                       |
+| `securityContext.readOnlyRootFilesystem`       | Enable read-only filesystem                                                                    | `false`                                                      |
+| `podAnnotations`                               | Pod annotations                                                                                | `{}`                                                         |
+| `podAffinityPreset`                            | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`            | `""`                                                         |
+| `podAntiAffinityPreset`                        | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `soft`                                                       |
+| `podLabels`                                    | Add additional labels to the pod (evaluated as a template)                                     | `nil`                                                        |
+| `nodeAffinityPreset.type`                      | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`      | `""`                                                         |
+| `nodeAffinityPreset.key`                       | Node label key to match. Ignored if `affinity` is set.                                         | `""`                                                         |
+| `nodeAffinityPreset.values`                    | Node label values to match. Ignored if `affinity` is set.                                      | `[]`                                                         |
+| `affinity`                                     | Affinity for pod assignment                                                                    | `{}` (evaluated as a template)                               |
+| `nodeSelector`                                 | Node labels for pod assignment                                                                 | `{}` (evaluated as a template)                               |
+| `tolerations`                                  | Tolerations for pod assignment                                                                 | `[]` (evaluated as a template)                               |
+| `topologySpreadConstraints`                    | Topology Spread Constraints for pod assignment                                                 | `{}` (evaluated as a template)                               |
+| `priorityClassName`                            | Controller priorityClassName                                                                   | `nil`                                                        |
+| `initContainers`                               | Add additional init containers to the Memcached pod                                            | `{}` (evaluated as a template)                               |
+| `sidecars`                                     | Add additional sidecar containers to the Memcached pod                                         | `{}` (evaluated as a template)                               |
+| `serviceAccount.create`                        | Enable creation of ServiceAccount for memcached pods                                           | `true`                                                       |
+| `serviceAccount.name`                          | The name of the service account to use. If not set and `create` is `true`, a name is generated | Generated using the `memcached.serviceAccountName` template  |
+| `serviceAccount.automountServiceAccountToken`  | Enable/disable auto mounting of the service account token                                      | `true`                                                       |
+| `metrics.enabled`                              | Start a side-car prometheus exporter                                                           | `false`                                                      |
+| `metrics.image.registry`                       | Memcached exporter image registry                                                              | `docker.io`                                                  |
+| `metrics.image.repository`                     | Memcached exporter image name                                                                  | `bitnami/memcached-exporter`                                 |
+| `metrics.image.tag`                            | Memcached exporter image tag                                                                   | `{TAG_NAME}`                                                 |
+| `metrics.image.pullPolicy`                     | Image pull policy                                                                              | `IfNotPresent`                                               |
+| `metrics.image.pullSecrets`                    | Specify docker-registry secret names as an array                                               | `[]` (does not add image pull secrets to deployed pods)      |
+| `metrics.podAnnotations`                       | Additional annotations for Metrics exporter                                                    | `{prometheus.io/scrape: "true", prometheus.io/port: "9150"}` |
+| `metrics.resources`                            | Exporter resource requests/limit                                                               | `{}`                                                         |
+| `metrics.portName`                             | Memcached exporter port name                                                                   | `metrics`                                                    |
+| `metrics.service.type`                         | Kubernetes service type for Prometheus metrics                                                 | `ClusterIP`                                                  |
+| `metrics.service.port`                         | Prometheus metrics service port                                                                | `9150`                                                       |
+| `metrics.service.annotations`                  | Prometheus exporter svc annotations                                                            | `{prometheus.io/scrape: "true", prometheus.io/port: "9150"}` |
+| `metrics.serviceMonitor.enabled`               | Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator                | `false`                                                      |
+| `metrics.serviceMonitor.namespace`             | The namespace in which the ServiceMonitor will be created                                      | `nil`                                                        |
+| `metrics.serviceMonitor.interval`              | The interval at which metrics should be scraped                                                | `nil`                                                        |
+| `metrics.serviceMonitor.scrapeTimeout`         | The timeout after which the scrape is ended                                                    | `nil`                                                        |
+| `metrics.serviceMonitor.selector`              | Additional labels for ServiceMonitor resource                                                  | `nil`                                                        |
+| `metrics.serviceMonitor.metricRelabelings`     | Metrics relabelings to add to the scrape endpoint, applied before ingestion                    | `nil`                                                        |
+| `metrics.serviceMonitor.relabelings`           | Metrics relabelings to add to the scrape endpoint, applied before scraping                     | `nil`                                                        |
+| `volumePermissions.image.registry`             | Init container volume-permissions image registry                                               | `docker.io`                                                  |
+| `volumePermissions.image.repository`           | Init container volume-permissions image name                                                   | `bitnami/bitnami-shell`                                      |
+| `volumePermissions.image.tag`                  | Init container volume-permissions image tag                                                    | `"10"`                                                       |
+| `volumePermissions.image.pullPolicy`           | Init container volume-permissions image pull policy                                            | `Always`                                                     |
+| `volumePermissions.image.pullSecrets`          | Specify docker-registry secret names as an array                                               | `[]` (does not add image pull secrets to deployed pods)      |
+| `volumePermissions.resources.limits`           | Init container volume-permissions resource  limits                                             | `{}`                                                         |
+| `volumePermissions.resources.requests`         | Init container volume-permissions resource  requests                                           | `{}`                                                         |
 
 The above parameters map to the env variables defined in [bitnami/memcached](http://github.com/bitnami/bitnami-docker-memcached). For more information please refer to the [bitnami/memcached](http://github.com/bitnami/bitnami-docker-memcached) image documentation.
 
@@ -170,6 +179,32 @@ When using `architecture: "high-availability"` the [Bitnami Memcached](https://g
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
+
+### Sidecars and Init Containers
+
+If you have a need for additional containers to run within the same pod as the Memcached app (e.g. an additional metrics or logging exporter), you can do so via the `sidecars` config parameter. Simply define your container according to the Kubernetes container spec.
+
+```yaml
+sidecars:
+  - name: your-image-name
+    image: your-image
+    imagePullPolicy: Always
+    ports:
+      - name: portname
+       containerPort: 1234
+```
+
+Similarly, you can add extra init containers using the `initContainers` parameter.
+
+```yaml
+initContainers:
+  - name: your-image-name
+    image: your-image
+    imagePullPolicy: Always
+    ports:
+      - name: portname
+        containerPort: 1234
+```
 
 ### Setting Pod's affinity
 

--- a/bitnami/memcached/templates/_helpers.tpl
+++ b/bitnami/memcached/templates/_helpers.tpl
@@ -23,11 +23,19 @@ Return the proper image name (for the metrics image)
 {{ include "common.images.image" (dict "imageRoot" .Values.metrics.image "global" .Values.global) }}
 {{- end -}}
 
+
+{{/*
+Return the proper image name (for the init container volume-permissions image)
+*/}}
+{{- define "memcached.volumePermissions.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.volumePermissions.image "global" .Values.global) }}
+{{- end -}}
+
 {{/*
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "memcached.imagePullSecrets" -}}
-{{- include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.metrics.image) "global" .Values.global) -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.metrics.image .Values.volumePermissions.image) "global" .Values.global) -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/memcached/templates/deployment.yaml
+++ b/bitnami/memcached/templates/deployment.yaml
@@ -61,6 +61,9 @@ spec:
         runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- end }}
       serviceAccountName: {{ template "memcached.serviceAccountName" . }}
+      {{- if .Values.initContainers }}
+      initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+      {{- end }}
       containers:
         - name: memcached
           image: {{ template "memcached.image" . }}
@@ -135,6 +138,9 @@ spec:
           {{- if .Values.metrics.resources }}
           resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
           {{- end }}
+        {{- end }}
+        {{- if .Values.sidecars }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | nindent 8 }}
         {{- end }}
       volumes:
         - name: tmp

--- a/bitnami/memcached/templates/statefulset.yaml
+++ b/bitnami/memcached/templates/statefulset.yaml
@@ -62,13 +62,43 @@ spec:
         runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- end }}
       serviceAccountName: {{ template "memcached.serviceAccountName" . }}
+      {{- if or .Values.persistence.enabled .Values.initContainers }}
+      initContainers:
+        {{- if .Values.persistence.enabled }}
+        - name: volume-permissions
+          image: {{ include "memcached.volumePermissions.image" . }}
+          imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              touch /cache-state/memory_file
+              chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} /cache-state
+          securityContext:
+            runAsUser: 0
+          {{- if .Values.volumePermissions.resources }}
+          resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /cache-state
+        {{- end }}
+        {{- if .Values.initContainers }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: memcached
           {{- if .Values.persistence.enabled }}
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "/usr/bin/pkill -10 memcached ; sleep 60s"]
+                command:
+                  - /bin/bash
+                  - -ec
+                  - |
+                    /usr/bin/pkill -10 memcached
+                    sleep 60s
           {{- end }}
           image: {{ template "memcached.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
@@ -79,7 +109,7 @@ spec:
           args: {{- include "common.tplvalues.render" (dict "value" .Values.arguments "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.persistence.enabled }}
-            - -e/cache-state/memory_file
+            - --memory-file=/cache-state/memory_file
           {{- end }}
           {{- if or .Values.extraEnv .Values.memcachedUsername .Values.memcachedPassword }}
           env:
@@ -149,6 +179,9 @@ spec:
           {{- if .Values.metrics.resources }}
           resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
           {{- end }}
+        {{- end }}
+        {{- if .Values.sidecars }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | nindent 8 }}
         {{- end }}
       volumes:
         - name: tmp

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -227,6 +227,30 @@ topologySpreadConstraints: {}
 ##
 # priorityClassName: ""
 
+## Add init containers to the pod
+## Example:
+## initContainers:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+initContainers: {}
+
+## Add sidecars to the pod.
+## Example:
+## sidecars:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+sidecars: {}
+
 ## memcached pods ServiceAccount
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 ##
@@ -366,3 +390,39 @@ metrics:
     #   targetLabel: pod_name
     #   replacement: $1
     #   action: replace
+
+## Init Container parameters
+## Change the owner and group of the persistent volume(s) mountpoint(s) to 'runAsUser:fsGroup' on each component
+## values from the securityContext section of the component
+##
+volumePermissions:
+  image:
+    registry: docker.io
+    repository: bitnami/bitnami-shell
+    tag: 10-debian-10-r103
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: Always
+    ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+  ## Init Container resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits: {}
+    #   cpu: 100m
+    #   memory: 128Mi
+    requests: {}
+    #   cpu: 100m
+    #   memory: 128Mi


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR fixes the persistence setup since we were not passing the right flag to start Memcached, and when fixing it we found permissions issues:

```
failed to open file for mmap: No such file or directory
```

This PR also adds support to 2 common parameters: `initContainers` and `sidecars`

**Benefits**

The chart can be used with persistence.

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/6647

**Additional information**

N/A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
