### PR TITLE
[bitnami/mariadb-galera] Change mountpath of custom config to /bitnami/mariadb/conf/my_custom.cnf

### DIFF
--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-mariadb-galera
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 5.10.0
+version: 5.10.1

--- a/bitnami/mariadb-galera/templates/configmap.yaml
+++ b/bitnami/mariadb-galera/templates/configmap.yaml
@@ -8,7 +8,7 @@ data:
 {{- if (.Files.Glob "files/my.cnf") }}
 {{ (.Files.Glob "files/my.cnf").AsConfig | indent 2 }}
 {{- else if .Values.mariadbConfiguration }}
-  my.cnf: |
+  my_custom.cnf: |
 {{ .Values.mariadbConfiguration | indent 4 }}
 {{- end }}
 {{ end }}

--- a/bitnami/mariadb-galera/templates/statefulset.yaml
+++ b/bitnami/mariadb-galera/templates/statefulset.yaml
@@ -277,8 +277,8 @@ spec:
             {{- end }}
             {{- if or (.Files.Glob "files/my.cnf") .Values.mariadbConfiguration .Values.configurationConfigMap }}
             - name: mariadb-galera-config
-              mountPath: /bitnami/conf/my.cnf
-              subPath: my.cnf
+              mountPath: /bitnami/mariadb/conf/my_custom.cnf
+              subPath: my_custom.cnf
             {{- end }}
             {{- if .Values.tls.enabled }}
             - name: mariadb-galera-certificates


### PR DESCRIPTION
**Description of the change**

Changes path to which custom config is mounted, in order for it to be picked up by the mariadb image's `mysql_initialize` function.

**Benefits**

Fixes broken custom config defined in values.yaml

**Possible drawbacks**

None, the new config mount would be following the standards defined in the [base image repo](https://github.com/bitnami/bitnami-docker-mariadb-galera)

**Applicable issues**

  - fixes #6651 

**Additional information**

From the bitnami/bitnami-docker-mariadb-galera repo, upon inspecting both `libmariadbgalera.sh` and `mariadb-env.sh` in all the versions, two things are evident -
  - All config files are in a directory of the format `${BASE_DIR}/mariadb/conf` as opposed to just `${BASE_DIR}/conf`, and hence moved the custom conf path in the statefulset to `/bitnami/mariadb/conf` as opposed to `/bitnami/conf`
  - All *custom* config files picked up by the `mysql_initialize` function are of the form `my_custom.cnf`, not `my.cnf`

The relevant script is available in - [libmariadbgalera.sh:1126](https://github.com/bitnami/bitnami-docker-mariadb-galera/blob/master/10.5/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh#L1541) and [libmariadbgalera.sh:1085](https://github.com/bitnami/bitnami-docker-mariadb-galera/blob/master/10.5/debian-10/rootfs/opt/bitnami/scripts/libmariadbgalera.sh#L1085)

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
