### PR TITLE
[bitnami/kubeapps] Fix typo in kubeops deployment for namespace header values

### DIFF
--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 7.1.0
+version: 7.1.1

--- a/bitnami/kubeapps/templates/kubeops/deployment.yaml
+++ b/bitnami/kubeapps/templates/kubeops/deployment.yaml
@@ -83,10 +83,10 @@ spec:
             - --qps={{ .Values.kubeops.QPS }}
             {{- end }}
             {{- if .Values.kubeops.namespaceHeaderName }}
-            - --ns-header-name={{ .Values.kubeops.namespaceHeaderName }}
+            - --namespace-header-name={{ .Values.kubeops.namespaceHeaderName }}
             {{- end }}
             {{- if .Values.kubeops.namespaceHeaderPattern }}
-            - --ns-header-pattern={{ .Values.kubeops.namespaceHeaderPattern }}
+            - --namespace-header-pattern={{ .Values.kubeops.namespaceHeaderPattern }}
             {{- end }}
           env:
             - name: POD_NAMESPACE


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Values set at `kubeops.namespaceHeaderName` and `kubeops.namespaceHeaderPattern` cannot be passed to kubeops at initialization due to a typo.

**Benefits**

Ability to use the kubeops namespace whitelist feature implemented in https://github.com/kubeapps/kubeapps/pull/2671.

**Possible drawbacks**

N/A.

**Applicable issues**

N/A.

**Additional information**

Mirror of https://github.com/kubeapps/kubeapps/pull/2981/files.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
