### PR TITLE
[bitnami/discourse] Fix health probes for Discourse container

### DIFF
--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-discourse
   - https://github.com/spinnaker
   - https://www.discourse.org/
-version: 4.1.2
+version: 4.1.3

--- a/bitnami/discourse/templates/deployment.yaml
+++ b/bitnami/discourse/templates/deployment.yaml
@@ -137,7 +137,7 @@ spec:
           {{- if .Values.discourse.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /
+              path: /srv/status
               port: http
             initialDelaySeconds: {{ .Values.discourse.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.discourse.livenessProbe.periodSeconds }}
@@ -150,7 +150,7 @@ spec:
           {{- if .Values.discourse.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /
+              path: /srv/status
               port: http
             initialDelaySeconds: {{ .Values.discourse.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.discourse.readinessProbe.periodSeconds }}


### PR DESCRIPTION
**Description of the change**

Changes the health probes on the Discourse container from `/` to `/srv/status`.

**Benefits**

`/srv/status` is the dedicated endpoint for health checks on Discourse so should respond with `200 OK` when the server is up and running.

When `login_required` is enabled in Discourse settings the health probes start returning 302 as `/` is now being redirected to the login page. This creates a warning about the health probe in Kubernetes. Changing the health probe to `/srv/status` resolves this issue as the `/srv/status` endpoint is excluded from the login requirement.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #4927 

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
