### PR TITLE
[bitnami/redis] Service account automountServiceAccountToken

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -25,4 +25,4 @@ name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 14.4.0
+version: 14.5.0

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -322,31 +322,32 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Other Parameters
 
-| Name                                    | Description                                                                                                         | Value   |
-| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------- |
-| `networkPolicy.enabled`                 | Enable creation of NetworkPolicy resources                                                                          | `false` |
-| `networkPolicy.allowExternal`           | Don't require client label for connections                                                                          | `true`  |
-| `networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                                                                        | `[]`    |
-| `networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                                                                        | `[]`    |
-| `networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces                                                              | `{}`    |
-| `networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces                                                          | `{}`    |
-| `podSecurityPolicy.enabled`             | Enable PodSecurityPolicy                                                                                            | `false` |
-| `podSecurityPolicy.create`              | Specifies whether a PodSecurityPolicy should be created. You also need to set `podSecurityPolicy.enabled` to `true` | `false` |
-| `rbac.create`                           | Specifies whether RBAC resources should be created                                                                  | `false` |
-| `rbac.rules`                            | Custom RBAC rules to set                                                                                            | `[]`    |
-| `serviceAccount.create`                 | Specifies whether a ServiceAccount should be created                                                                | `true`  |
-| `serviceAccount.name`                   | The name of the ServiceAccount to use.                                                                              | `""`    |
-| `serviceAccount.annotations`            | Additional custom annotations for the ServiceAccount                                                                | `{}`    |
-| `pdb.create`                            | Specifies whether a ServiceAccount should be created                                                                | `false` |
-| `pdb.minAvailable`                      | Min number of pods that must still be available after the eviction                                                  | `1`     |
-| `pdb.maxUnavailable`                    | Max number of pods that can be unavailable after the eviction                                                       | `nil`   |
-| `tls.enabled`                           | Enable TLS traffic                                                                                                  | `false` |
-| `tls.authClients`                       | Require clients to authenticate                                                                                     | `true`  |
-| `tls.certificatesSecret`                | Then name of the existing secret that contains the TLS certificates                                                 | `nil`   |
-| `tls.certFilename`                      | Certificate filename                                                                                                | `nil`   |
-| `tls.certKeyFilename`                   | Certificate Key filename                                                                                            | `nil`   |
-| `tls.certCAFilename`                    | CA Certificate filename                                                                                             | `nil`   |
-| `tls.dhParamsFilename`                  | File containing DH params (in order to support DH based ciphers)                                                    | `nil`   |
+| Name                                          | Description                                                                                                         | Value   |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------- |
+| `networkPolicy.enabled`                       | Enable creation of NetworkPolicy resources                                                                          | `false` |
+| `networkPolicy.allowExternal`                 | Don't require client label for connections                                                                          | `true`  |
+| `networkPolicy.extraIngress`                  | Add extra ingress rules to the NetworkPolicy                                                                        | `[]`    |
+| `networkPolicy.extraEgress`                   | Add extra ingress rules to the NetworkPolicy                                                                        | `[]`    |
+| `networkPolicy.ingressNSMatchLabels`          | Labels to match to allow traffic from other namespaces                                                              | `{}`    |
+| `networkPolicy.ingressNSPodMatchLabels`       | Pod labels to match to allow traffic from other namespaces                                                          | `{}`    |
+| `podSecurityPolicy.enabled`                   | Enable PodSecurityPolicy                                                                                            | `false` |
+| `podSecurityPolicy.create`                    | Specifies whether a PodSecurityPolicy should be created. You also need to set `podSecurityPolicy.enabled` to `true` | `false` |
+| `rbac.create`                                 | Specifies whether RBAC resources should be created                                                                  | `false` |
+| `rbac.rules`                                  | Custom RBAC rules to set                                                                                            | `[]`    |
+| `serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                                                                | `true`  |
+| `serviceAccount.automountServiceAccountToken` | Enable/disable auto mounting of service account token                                                               | `true`  |
+| `serviceAccount.name`                         | The name of the ServiceAccount to use.                                                                              | `""`    |
+| `serviceAccount.annotations`                  | Additional custom annotations for the ServiceAccount                                                                | `{}`    |
+| `pdb.create`                                  | Specifies whether a PodDisruptionBudget should be created                                                           | `false` |
+| `pdb.minAvailable`                            | Min number of pods that must still be available after the eviction                                                  | `1`     |
+| `pdb.maxUnavailable`                          | Max number of pods that can be unavailable after the eviction                                                       | `nil`   |
+| `tls.enabled`                                 | Enable TLS traffic                                                                                                  | `false` |
+| `tls.authClients`                             | Require clients to authenticate                                                                                     | `true`  |
+| `tls.certificatesSecret`                      | Then name of the existing secret that contains the TLS certificates                                                 | `nil`   |
+| `tls.certFilename`                            | Certificate filename                                                                                                | `nil`   |
+| `tls.certKeyFilename`                         | Certificate Key filename                                                                                            | `nil`   |
+| `tls.certCAFilename`                          | CA Certificate filename                                                                                             | `nil`   |
+| `tls.dhParamsFilename`                        | File containing DH params (in order to support DH based ciphers)                                                    | `nil`   |
 
 
 ### Metrics Parameters

--- a/bitnami/redis/templates/serviceaccount.yaml
+++ b/bitnami/redis/templates/serviceaccount.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ template "redis.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -1000,6 +1000,10 @@ serviceAccount:
   ## If not set and create is true, a name is generated using the common.names.fullname template
   ##
   name: ""
+  ## @param serviceAccount.automountServiceAccountToken Whether to auto mount the service account token
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server
+  ##
+  automountServiceAccountToken: true
   ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
   ##
   annotations: {}


### PR DESCRIPTION
* Add support for disabling automountServiceAccountToken
  * Defaults to true
* Increment chart version 14.3.3 -> 14.4.0

**Description of the change**

Add support for disabling automountServiceAccountToken for the Redis ServiceAccount.

Also updated `pdb.create` in the README.md to reflect that its for creating the Pod Disruption Budget, NOT the ServiceAccount.

**Benefits**

Allows users to opt into disabling automountServiceAccountToken to keep the Redis pods from communicating with the Kubernetes API.

**Possible drawbacks**

None, as automountServiceAccountToken will default to true, keeping the default behavior of giving pods access to the Kubernetes API.

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X ] Variables are documented in the README.md
- [ X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
