### PR TITLE
[bitnami/mariadb] Add options for image's builtin startup check

### DIFF
--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -26,4 +26,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-mariadb
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 9.3.14
+version: 9.3.15

--- a/bitnami/mariadb/README.md
+++ b/bitnami/mariadb/README.md
@@ -120,6 +120,7 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `primary.readinessProbe`                     | Readiness probe configuration for MariaDB primary containers                                                      | Check `values.yaml` file       |
 | `primary.customLivenessProbe`                | Override default liveness probe for MariaDB primary containers                                                    | `nil`                          |
 | `primary.customReadinessProbe`               | Override default readiness probe for MariaDB primary containers                                                   | `nil`                          |
+| `primary.startupWaitOptions`                 | Override default builtin startup wait check options for MariaDB primary containers                                | `{}`                           |
 | `primary.resources.limits`                   | The resources limits for MariaDB primary containers                                                               | `{}`                           |
 | `primary.resources.requests`                 | The requested resources for MariaDB primary containers                                                            | `{}`                           |
 | `primary.extraEnvVars`                       | Extra environment variables to be set on MariaDB primary containers                                               | `{}`                           |
@@ -179,6 +180,7 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `secondary.readinessProbe`                     | Readiness probe configuration for MariaDB secondary containers                                                        | Check `values.yaml` file       |
 | `secondary.customLivenessProbe`                | Override default liveness probe for MariaDB secondary containers                                                      | `nil`                          |
 | `secondary.customReadinessProbe`               | Override default readiness probe for MariaDB secondary containers                                                     | `nil`                          |
+| `secondary.startupWaitOptions`                 | Override default builtin startup wait check options for MariaDB secondary containers                                  | `{}`                           |
 | `secondary.resources.limits`                   | The resources limits for MariaDB secondary containers                                                                 | `{}`                           |
 | `secondary.resources.requests`                 | The requested resources for MariaDB secondary containers                                                              | `{}`                           |
 | `secondary.extraEnvVars`                       | Extra environment variables to be set on MariaDB secondary containers                                                 | `{}`                           |

--- a/bitnami/mariadb/templates/primary/statefulset.yaml
+++ b/bitnami/mariadb/templates/primary/statefulset.yaml
@@ -160,6 +160,12 @@ spec:
             - name: MARIADB_EXTRA_FLAGS
               value: "{{ .Values.primary.extraFlags }}"
             {{- end }}
+            {{- if .Values.primary.startupWaitOptions }}
+            - name: MARIADB_STARTUP_WAIT_RETRIES
+              value: "{{ .Values.primary.startupWaitOptions.retries | default 300 }}"
+            - name: MARIADB_STARTUP_WAIT_SLEEP_TIME
+              value: "{{ .Values.primary.startupWaitOptions.sleepTime | default 2 }}"
+            {{- end }}
             {{- if .Values.primary.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.primary.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/bitnami/mariadb/templates/secondary/statefulset.yaml
+++ b/bitnami/mariadb/templates/secondary/statefulset.yaml
@@ -149,6 +149,12 @@ spec:
             - name: MARIADB_EXTRA_FLAGS
               value: "{{ .Values.secondary.extraFlags }}"
             {{- end }}
+            {{- if .Values.secondary.startupWaitOptions }}
+            - name: MARIADB_STARTUP_WAIT_RETRIES
+              value: "{{ .Values.secondary.startupWaitOptions.retries | default 300 }}"
+            - name: MARIADB_STARTUP_WAIT_SLEEP_TIME
+              value: "{{ .Values.secondary.startupWaitOptions.sleepTime | default 2 }}"
+            {{- end }}
             {{- if .Values.secondary.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.secondary.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/bitnami/mariadb/values.yaml
+++ b/bitnami/mariadb/values.yaml
@@ -286,6 +286,18 @@ primary:
   ##
   customReadinessProbe: {}
 
+  ## MariaDB startup wait options
+  ## `bitnami/mariadb` Docker image has built-in startup check mechanism,
+  ## which periodically checks if MariaDB service has started up and stops it
+  ## if all checks have failed after X tries. Use these to control these checks.
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/pull/240
+  ## Example (with default options):
+  ## startupWaitOptions:
+  ##   retries: 300
+  ##   waitTime: 2
+  ##
+  startupWaitOptions: {}
+
   ## MariaDB primary additional command line flags
   ## Can be used to specify command line flags, for example:
   ## E.g.
@@ -585,6 +597,18 @@ secondary:
   ## MariaDB secondary custom rediness probe
   ##
   customReadinessProbe: {}
+
+  ## MariaDB startup wait options
+  ## `bitnami/mariadb` Docker image has built-in startup check mechanism,
+  ## which periodically checks if MariaDB service has started up and stops it
+  ## if all checks have failed after X tries. Use these to control these checks.
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/pull/240
+  ## Example (with default options):
+  ## startupWaitOptions:
+  ##   retries: 300
+  ##   waitTime: 2
+  ##
+  startupWaitOptions: {}
 
   ## MariaDB secondary additional command line flags
   ## Can be used to specify command line flags, for example:


### PR DESCRIPTION
**Description of the change**

There is a builtin startup check in Bitnami's MariaDB Docker image. This PR adds a way to control this check's options via MariaDB's chart values.

**Benefits**

This addition will allow the users to control startup wait time if they need to, in case their MariaDB installation takes too much time to start (e.g. it hosts a big database and/or installed on a slow storage).

**Possible drawbacks**

These options could be accidentally set to incorrect values (say, 2 tries with 1 second wait time) and break startup on many installations.

**Applicable issues**

  - Fixes bitnami/bitnami-docker-mariadb#239
  - Implements bitnami/bitnami-docker-mariadb#240

**Additional information**

N/A

**Checklist** 

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name ([bitnami/mariadb])
