### PR TITLE
[bitnami/mongodb-sharded] Enabled support for priorityClassName

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb-sharded
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb-sharded
   - https://mongodb.org
-version: 3.6.1
+version: 3.7.0

--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb-sharded
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb-sharded
   - https://mongodb.org
-version: 3.6.0
+version: 3.6.1

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
@@ -54,8 +54,8 @@ spec:
       {{- if .Values.configsvr.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.configsvr.tolerations "context" $) | nindent 8 }}
       {{- end }}
-      {{- if .Values.configsvr.priorityClassName | quote }}
-      priorityClassName: {{ .Values.configsvr.priorityClassName }}
+      {{- if .Values.configsvr.priorityClassName }}
+      priorityClassName: {{ .Values.configsvr.priorityClassName | quote }}
       {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
@@ -54,7 +54,7 @@ spec:
       {{- if .Values.configsvr.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.configsvr.tolerations "context" $) | nindent 8 }}
       {{- end }}
-      {{- if .Values.configsvr.priorityClassName }}
+      {{- if .Values.configsvr.priorityClassName | quote }}
       priorityClassName: {{ .Values.configsvr.priorityClassName }}
       {{- end }}
       {{- if .Values.securityContext.enabled }}

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
@@ -54,6 +54,9 @@ spec:
       {{- if .Values.configsvr.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.configsvr.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.configsvr.priorityClassName }}
+      priorityClassName: {{ .Values.configsvr.priorityClassName }}
+      {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-dep-sts.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-dep-sts.yaml
@@ -58,6 +58,9 @@ spec:
       {{- if .Values.mongos.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.mongos.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.mongos.priorityClassName }}
+      priorityClassName: {{ .Values.mongos.priorityClassName }}
+      {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-dep-sts.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-dep-sts.yaml
@@ -59,7 +59,7 @@ spec:
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.mongos.tolerations "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.mongos.priorityClassName }}
-      priorityClassName: {{ .Values.mongos.priorityClassName }}
+      priorityClassName: {{ .Values.mongos.priorityClassName | quote }}
       {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
@@ -57,6 +57,9 @@ spec:
       {{- if $.Values.shardsvr.arbiter.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.arbiter.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.shardsvr.arbiter.priorityClassName }}
+      priorityClassName: {{ .Values.shardsvr.arbiter.priorityClassName }}
+      {{- end }}
       {{- if $.Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ $.Values.securityContext.fsGroup }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
@@ -57,7 +57,7 @@ spec:
       {{- if $.Values.shardsvr.arbiter.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.arbiter.tolerations "context" $) | nindent 8 }}
       {{- end }}
-      {{- if .Values.shardsvr.arbiter.priorityClassName }}
+      {{- if .Values.shardsvr.arbiter.priorityClassName | quote }}
       priorityClassName: {{ .Values.shardsvr.arbiter.priorityClassName }}
       {{- end }}
       {{- if $.Values.securityContext.enabled }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
@@ -57,8 +57,8 @@ spec:
       {{- if $.Values.shardsvr.arbiter.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.arbiter.tolerations "context" $) | nindent 8 }}
       {{- end }}
-      {{- if .Values.shardsvr.arbiter.priorityClassName | quote }}
-      priorityClassName: {{ .Values.shardsvr.arbiter.priorityClassName }}
+      {{- if .Values.shardsvr.arbiter.priorityClassName }}
+      priorityClassName: {{ .Values.shardsvr.arbiter.priorityClassName | quote }}
       {{- end }}
       {{- if $.Values.securityContext.enabled }}
       securityContext:

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
@@ -57,8 +57,8 @@ spec:
       {{- if $.Values.shardsvr.arbiter.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.arbiter.tolerations "context" $) | nindent 8 }}
       {{- end }}
-      {{- if .Values.shardsvr.arbiter.priorityClassName }}
-      priorityClassName: {{ .Values.shardsvr.arbiter.priorityClassName | quote }}
+      {{- if $.Values.shardsvr.arbiter.priorityClassName }}
+      priorityClassName: {{ $.Values.shardsvr.arbiter.priorityClassName | quote }}
       {{- end }}
       {{- if $.Values.securityContext.enabled }}
       securityContext:

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -57,6 +57,9 @@ spec:
       tolerations: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.dataNode.tolerations "context" (set $ "dataNodeLoopId" $i)) | nindent 8 }}      
       {{- end }}
       serviceAccountName: {{ include "mongodb-sharded.serviceAccountName" (dict "value" $.Values.shardsvr.dataNode.serviceAccount "context" $) }}
+      {{- if .Values.shardsvr.dataNode.priorityClassName }}
+      priorityClassName: {{ .Values.shardsvr.dataNode.priorityClassName }}
+      {{- end }}
       {{- if $.Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ $.Values.securityContext.fsGroup }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -57,8 +57,8 @@ spec:
       tolerations: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.dataNode.tolerations "context" (set $ "dataNodeLoopId" $i)) | nindent 8 }}      
       {{- end }}
       serviceAccountName: {{ include "mongodb-sharded.serviceAccountName" (dict "value" $.Values.shardsvr.dataNode.serviceAccount "context" $) }}
-      {{- if .Values.shardsvr.dataNode.priorityClassName }}
-      priorityClassName: {{ .Values.shardsvr.dataNode.priorityClassName | quote }}
+      {{- if $.Values.shardsvr.dataNode.priorityClassName }}
+      priorityClassName: {{ $.Values.shardsvr.dataNode.priorityClassName | quote }}
       {{- end }}
       {{- if $.Values.securityContext.enabled }}
       securityContext:

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -57,7 +57,7 @@ spec:
       tolerations: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.dataNode.tolerations "context" (set $ "dataNodeLoopId" $i)) | nindent 8 }}      
       {{- end }}
       serviceAccountName: {{ include "mongodb-sharded.serviceAccountName" (dict "value" $.Values.shardsvr.dataNode.serviceAccount "context" $) }}
-      {{- if .Values.shardsvr.dataNode.priorityClassName }}
+      {{- if .Values.shardsvr.dataNode.priorityClassName | quote }}
       priorityClassName: {{ .Values.shardsvr.dataNode.priorityClassName }}
       {{- end }}
       {{- if $.Values.securityContext.enabled }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -57,8 +57,8 @@ spec:
       tolerations: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.dataNode.tolerations "context" (set $ "dataNodeLoopId" $i)) | nindent 8 }}      
       {{- end }}
       serviceAccountName: {{ include "mongodb-sharded.serviceAccountName" (dict "value" $.Values.shardsvr.dataNode.serviceAccount "context" $) }}
-      {{- if .Values.shardsvr.dataNode.priorityClassName | quote }}
-      priorityClassName: {{ .Values.shardsvr.dataNode.priorityClassName }}
+      {{- if .Values.shardsvr.dataNode.priorityClassName }}
+      priorityClassName: {{ .Values.shardsvr.dataNode.priorityClassName | quote }}
       {{- end }}
       {{- if $.Values.securityContext.enabled }}
       securityContext:


### PR DESCRIPTION
**Description of the change**

Added support for the priorityClassName configuration that was already present in the value.yaml file, but not implemented in the templates.

**Benefits**

Deployed pods can be assigned a priority.  This is very important especially for database applications where eviction can cause major disruptions.

**Possible drawbacks**

None known.

**Applicable issues**

  - fixes #6699 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
