### PR TITLE
[bitnami/nats] Update NATS client instructions in NOTES.txt

### DIFF
--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -24,4 +24,4 @@ name: nats
 sources:
   - https://github.com/bitnami/bitnami-docker-nats
   - https://nats.io/
-version: 6.3.7
+version: 6.3.8

--- a/bitnami/nats/templates/NOTES.txt
+++ b/bitnami/nats/templates/NOTES.txt
@@ -42,11 +42,16 @@ You can create a Golang pod to be used as a NATS client:
 
       kubectl run {{ include "common.names.fullname" . }}-client --restart='Never' --image docker.io/bitnami/golang --namespace {{ .Release.Namespace }} --command -- sleep infinity
       kubectl exec --tty -i {{ include "common.names.fullname" . }}-client --namespace {{ .Release.Namespace }} -- bash
-      go get github.com/nats-io/nats.go
+      GO111MODULE=off go get github.com/nats-io/nats.go
       cd $GOPATH/src/github.com/nats-io/nats.go/examples/nats-pub && go install && cd
       cd $GOPATH/src/github.com/nats-io/nats.go/examples/nats-echo && go install && cd
+      {{- if .Values.auth.enabled }}
+      nats-echo -s nats://NATS_USER:NATS_PASS@{{ template "common.names.fullname" . }}-client.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.client.service.port }} SomeSubject
+      nats-pub -s nats://NATS_USER:NATS_PASS@{{ template "common.names.fullname" . }}-client.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.client.service.port }} -reply Hi SomeSubject "Hi everyone"
+      {{- else }}
       nats-echo -s nats://{{ template "common.names.fullname" . }}-client.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.client.service.port }} SomeSubject
       nats-pub -s nats://{{ template "common.names.fullname" . }}-client.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.client.service.port }} -reply Hi SomeSubject "Hi everyone"
+      {{- end }}
 
 To access the Monitoring svc from outside the cluster, follow the steps below:
 


### PR DESCRIPTION
**Description of the change**

Fixes issue with instructions for the NATS client pod.

**Possible drawbacks**

None known.

**Applicable issues**

  - fixes #6680

**Additional information**

Without `GO111MODULE=off`, the `go get` command would download the nats.go package to `$GOPATH/pkg/mod` instead of `$GOPATH/src`:
```console
# go get github.com/nats-io/nats.go
go: downloading github.com/nats-io/nats.go v1.11.0
# ls $GOPATH/pkg/mod/github.com/nats-io/nats.go\@v1.11.0/
CODE-OF-CONDUCT.md  context.go       go.mod       nats_test.go    timer_test.go
GOVERNANCE.md       dependencies.md  go.sum       netchan.go      util
LICENSE             enc.go           go_test.mod  norace_test.go  ws.go
MAINTAINERS.md      enc_test.go      go_test.sum  parser.go       ws_test.go
README.md           encoders         js.go        scripts
TODO.md             example_test.go  jsm.go       test
bench               examples         nats.go      timer.go
```
This causes the following commands to fail:
```console
# cd $GOPATH/src/github.com/nats-io/nats.go/examples/nats-pub && go install && cd
bash: cd: /go/src/github.com/nats-io/nats.go/examples/nats-pub: No such file or directory
```

Additionally, if `auth.enabed=true`, the nats examples will include the credentials placeholder `NATS_USER:NATS_PASS`.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
