### PR TITLE
[bitnami/owncloud] Fix issue with SecretName

### DIFF
--- a/bitnami/owncloud/Chart.yaml
+++ b/bitnami/owncloud/Chart.yaml
@@ -31,4 +31,4 @@ name: owncloud
 sources:
   - https://github.com/bitnami/bitnami-docker-owncloud
   - https://owncloud.org/
-version: 10.2.15
+version: 10.2.16

--- a/bitnami/owncloud/templates/deployment.yaml
+++ b/bitnami/owncloud/templates/deployment.yaml
@@ -127,7 +127,7 @@ spec:
             - name: OWNCLOUD_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "common.names.fullname" . }}
+                  name: {{ include "owncloud.secretName" . }}
                   key: owncloud-password
             - name: OWNCLOUD_EMAIL
               value: {{ .Values.owncloudEmail | quote }}
@@ -141,7 +141,7 @@ spec:
             - name: OWNCLOUD_SMTP_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "common.names.fullname" . }}
+                  name: {{ include "owncloud.secretName" . }}
                   key: smtp-password
             {{- end }}
             - name: OWNCLOUD_SMTP_PROTOCOL


### PR DESCRIPTION
**Description of the change**

Fixes issue with Owncloud always using the Release fullname, ignoring `existingSecret`

**Applicable issues**

  - fixes #6719

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
