### PR TITLE
[bitnami/external-dns] Remove deprecated variables for Azure Private DNS

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -24,4 +24,4 @@ sources:
   - https://github.com/kubernetes-sigs/external-dns
   - https://github.com/bitnami/bitnami-docker-external-dns
   - https://github.com/kubernetes-sigs/external-dns
-version: 5.1.2
+version: 5.1.3

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -258,27 +258,6 @@ spec:
               value: {{ .Values.aws.credentials.mountPath }}/credentials
             {{- end }}
             {{- end }}
-            {{- if eq .Values.provider "azure-private-dns" }}
-            # Azure Private DNS variables
-            {{- if .Values.azure.tenantId }}
-            - name: AZURE_TENANT_ID
-              value: {{ .Values.azure.tenantId }}
-            {{- end }}
-            {{- if not .Values.azure.useManagedIdentityExtension }}
-            {{- if or .Values.azure.aadClientId .Values.azure.aadClientSecret .Values.azure.secretName }}
-            - name: AZURE_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "external-dns.secretName" . }}
-                  key: azure_aad_client_secret
-            - name: AZURE_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "external-dns.secretName" . }}
-                  key: azure_aad_client_id
-            {{- end }}
-            {{- end }}
-            {{- end }}
             {{- if eq .Values.provider "cloudflare" }}
             # Cloudflare environment variables
             - name: CF_API_TOKEN
@@ -589,7 +568,7 @@ spec:
             secretName: {{ template "external-dns.secretName" . }}
         {{- end }}
         {{- if or (eq .Values.provider "azure") (eq .Values.provider "azure-private-dns") }}
-        # Azure volume(s)
+        # Azure and Azure Private DNS volume(s)
         - name: azure-config-file
           {{- if or .Values.azure.secretName (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId) }}
           secret:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Remove deprecated variables for Azure Private DNS as it now uses the same exact config as the Azure provider.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #6738 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
Support for these variables was removed in #6657 

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
