### PR TITLE
Explicitly only bootstrap the node specified by `galera.bootstrap.bootstrapFromNode`

### DIFF
--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-mariadb-galera
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 6.0.4
+version: 6.0.5

--- a/bitnami/mariadb-galera/templates/statefulset.yaml
+++ b/bitnami/mariadb-galera/templates/statefulset.yaml
@@ -80,6 +80,8 @@ spec:
                 if [[ "$NODE_ID" -eq "{{ $bootstrapFromNode }}" ]]; then
                     export MARIADB_GALERA_CLUSTER_BOOTSTRAP=yes
                     export MARIADB_GALERA_FORCE_SAFETOBOOTSTRAP={{ ternary "yes" "no" .Values.galera.bootstrap.forceSafeToBootstrap }}
+                else
+                    export MARIADB_GALERA_CLUSTER_BOOTSTRAP=no
                 fi
                 {{- end }}
                 exec /opt/bitnami/scripts/mariadb-galera/entrypoint.sh /opt/bitnami/scripts/mariadb-galera/run.sh


### PR DESCRIPTION
**Description of the change**

This is a continuation of my other PR over at https://github.com/bitnami/bitnami-docker-mariadb-galera/pull/53. As such, this PR should only be merged after the other one got merged, because it will be useless (but in no way harmful!) on its own.

Please especially read my comment https://github.com/bitnami/bitnami-docker-mariadb-galera/pull/53#issuecomment-867910704. 

Many people may not know it, but when not using specifying a value for `galera.bootstrap.bootstrapFromNode`, the first node of the StatefulSet deployed by this chart bootstraps "implicitly". This happens because the container tries to... be smart. Let's leave it at that, because detailed explanations can be found at the linked PR. 

Unfortunately, sometimes the container is just not smart enough. In these circumstances, it may happen that another node than the node specified by `galera.bootstrap.bootstrapFromNode` my bootstrap itself. If this happens, you suddenly have more than one bootstrap node, which leads to a partitioned cluster. 

This PR makes it so that *if* `galera.bootstrap.bootstrapFromNode` is defined, then all nodes that are *not* targeted by this value will have their environment variable `MARIADB_GALERA_CLUSTER_BOOTSTRAP` set to `no`. A value of `no` was previously semantically equal to the absence of the whole environment variable, but this opened the possibility of "implicit bootstrapping" (which is still possible by not setting a value for `galera.bootstrap.bootstrapFromNode`). As such, this PR is completely backwards compatible to the current and previous docker images.

There is one change in behavior that can be observed after https://github.com/bitnami/bitnami-docker-mariadb-galera/pull/53 got merged, but I would argue that this is a change for the better:

When you do the **initial** installation of the helm chart (which means that the volumes are still empty) using this helm chart and you specify a value for `galera.bootstrap.bootstrapFromNode` that is any other value than `0`, than you will see a drastic difference:
* Previously, all three pods got deployed, but two of them were in bootstrap mode: The very first pod (ordinal 0) because of the mentioned "implicit bootstrapping" and the other node defined by `galera.bootstrap.bootstrapFromNode`. The cluster will then be partitioned into a sub-cluster of two nodes that has quorum, and another node stuck in bootstrap mode, waiting for others to join him. This situation could only be resolved by destroying the the StatefulSet and deleting all volumes.
* After both my PR get merged, you will see that the first pod (ordinal 0) won't come up at all, because "implicit bootstrapping" will be disabled and `galera.bootstrap.bootstrapFromNode` targets another node. As the first pod tries to join another bootstrap node that is not available yet, the first pod will crash-loop. This can easily be fixed by re-deploying that chart with a sane (or without any) value for `galera.bootstrap.bootstrapFromNode`.

**Benefits**

When explicitly specifying the value `galera.bootstrap.bootstrapFromNode`, the user can now be sure that bootstrapping won't happen from any other node than the node defined by this value. Before, "implicit bootstrapping" could happen.

**Applicable issues**

  - Helps to avoid issue tried to fix by https://github.com/bitnami/bitnami-docker-mariadb-galera/pull/43



**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
