### PR TITLE
[bitnami/wavefront] Add nodes/proxy to role bindings

### DIFF
--- a/bitnami/wavefront/Chart.yaml
+++ b/bitnami/wavefront/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-wavefront-proxy
   - https://github.com/wavefrontHQ/wavefront-collector-for-kubernetes
   - https://github.com/wavefrontHQ/wavefront-proxy
-version: 3.1.2
+version: 3.1.3

--- a/bitnami/wavefront/templates/collector-cluster-role.yaml
+++ b/bitnami/wavefront/templates/collector-cluster-role.yaml
@@ -21,6 +21,7 @@ rules:
       - events
       - namespaces
       - nodes
+      - nodes/proxy
       - nodes/stats
       - pods
       - replicationcontrollers

--- a/bitnami/wavefront/values.yaml
+++ b/bitnami/wavefront/values.yaml
@@ -179,7 +179,9 @@ collector:
   discovery:
     enabled: true
 
-    annotationPrefix: "wavefront.com"
+    ## When specified, this replaces `prometheus.io` as the prefix for annotations used to
+    ## auto-discover Prometheus endpoints
+    #  annotationPrefix: "wavefront.com"
 
   ## Whether to enable runtime discovery configurations
   ## Ref: https://github.com/wavefrontHQ/wavefront-collector-for-kubernetes/blob/master/docs/discovery.md#runtime-configurations


### PR DESCRIPTION
**Description of the change**
Add `nodes/proxy` to role bindings. Upstream: 

https://github.com/wavefrontHQ/helm/commit/04da7cca365fa837635017c395a7a692a9420c51
https://github.com/wavefrontHQ/helm/commit/d6c5e8135aee025581d1625480dadad6b2e93212

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
