### PR TITLE
[bitnami/wavefront] Update with upstream changes (1.5.2)

### DIFF
--- a/bitnami/wavefront/Chart.yaml
+++ b/bitnami/wavefront/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-wavefront-proxy
   - https://github.com/wavefrontHQ/wavefront-collector-for-kubernetes
   - https://github.com/wavefrontHQ/wavefront-proxy
-version: 3.1.2
+version: 3.1.3

--- a/bitnami/wavefront/templates/collector-cluster-role.yaml
+++ b/bitnami/wavefront/templates/collector-cluster-role.yaml
@@ -21,6 +21,7 @@ rules:
       - events
       - namespaces
       - nodes
+      - nodes/proxy
       - nodes/stats
       - pods
       - replicationcontrollers

--- a/bitnami/wavefront/values.yaml
+++ b/bitnami/wavefront/values.yaml
@@ -179,7 +179,9 @@ collector:
   discovery:
     enabled: true
 
-    annotationPrefix: "wavefront.com"
+    ## When specified, this replaces `prometheus.io` as the prefix for annotations used to
+    ## auto-discover Prometheus endpoints
+    #  annotationPrefix: "wavefront.com"
 
   ## Whether to enable runtime discovery configurations
   ## Ref: https://github.com/wavefrontHQ/wavefront-collector-for-kubernetes/blob/master/docs/discovery.md#runtime-configurations


### PR DESCRIPTION
**Description of the change**

Update Wavefront with upstream changes

**Commits**

https://github.com/wavefrontHQ/helm/commit/d6c5e8135aee025581d1625480dadad6b2e93212
https://github.com/wavefrontHQ/helm/commit/b3a356c2def6c471cf43a047949976d3ac796215
https://github.com/wavefrontHQ/helm/commit/04da7cca365fa837635017c395a7a692a9420c51

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] Variables are documented in the README.md.

Changes in README.md not necessary, as default value was `prometheus.io`:
https://github.com/bitnami/charts/blame/master/bitnami/wavefront/README.md#L114