### PR TITLE
[bitnami/zookeeper] Rework security context

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -21,4 +21,4 @@ name: zookeeper
 sources:
   - https://github.com/bitnami/bitnami-docker-zookeeper
   - https://zookeeper.apache.org/
-version: 7.0.4
+version: 7.0.5

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -120,9 +120,8 @@ The following tables lists the configurable parameters of the ZooKeeper chart an
 | `nodeSelector`                       | Node labels for pod assignment                                                            | `{}` (evaluated as a template) |
 | `tolerations`                        | Tolerations for pod assignment                                                            | `[]` (evaluated as a template) |
 | `priorityClassName`                  | Name of the existing priority class to be used by ZooKeeper pods                          | `""`                           |
-| `securityContext.enabled`            | Enable security context (ZooKeeper master pod)                                            | `true`                         |
-| `securityContext.fsGroup`            | Group ID for the container (ZooKeeper master pod)                                         | `1001`                         |
-| `securityContext.runAsUser`          | User ID for the container (ZooKeeper master pod)                                          | `1001`                         |
+| `podSecurityContext`                 | Pod Security Context                                                                      | Check `values.yaml` file       |
+| `containerSecurityContext`           | Containers Security Context                                                               | Check `values.yaml` file       |
 | `resources`                          | CPU/Memory resource requests/limits                                                       | Memory: `256Mi`, CPU: `250m`   |
 | `livenessProbe`                      | Liveness probe configuration for ZooKeeper                                                | Check `values.yaml` file       |
 | `readinessProbe`                     | Readiness probe configuration for ZooKeeper                                               | Check `values.yaml` file       |

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -53,9 +53,8 @@ spec:
       {{- end }}
       {{- include "zookeeper.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ template "zookeeper.serviceAccountName" . }}
-      {{- if .Values.securityContext.enabled }}
-      securityContext:
-        fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
@@ -95,8 +94,9 @@ spec:
             {{- if .Values.dataLogDir }}
             - {{ .Values.dataLogDir }}
             {{- end }}
-          securityContext:
-            runAsUser: 0
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           {{- if .Values.volumePermissions.resources }}
           resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
           {{- end }}
@@ -112,9 +112,8 @@ spec:
         - name: init-certs
           image: {{ include "zookeeper.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-          {{- if .Values.securityContext.enabled }}
-          securityContext:
-            runAsUser: {{ .Values.securityContext.runAsUser }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           command:
           - /bin/bash

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -328,9 +328,15 @@ serviceAccount:
 
 ## Zookeeper Pod Security Context
 ##
-securityContext:
+podSecurityContext:
   enabled: true
   fsGroup: 1001
+  runAsUser: 1001
+
+## Configure Container Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+containerSecurityContext:
+  enabled: true
   runAsUser: 1001
 
 ## Add initContainers to the web pods.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
In the zookeeper charts, thhe security context was shared between pod and container, and not all options could be overridden:
- only the `fsGroup` was used in the pod securityContext
- `runAsUser` was forced to `0` in the initContainer securityContext
- only the `runAsUser` was used in the container securityContext

**Benefits**

<!-- What benefits will be realized by the code change? -->
It is now possible to fully override the securityContext of both the pod and containers.
This is also more in line with the charts template provided in the repository.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
I am not sure why the `runAsUser` was force to `0` in the initContainer... there may be a regression there since the user is now `1001` by default.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
 None that I know of.

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
/

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
