### PR TITLE
[bitnami/elasticsearch] Fixed c&p errors in templates

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/bitnami-docker-elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 15.6.0
+version: 15.6.1

--- a/bitnami/elasticsearch/templates/coordinating-deploy.yaml
+++ b/bitnami/elasticsearch/templates/coordinating-deploy.yaml
@@ -129,7 +129,7 @@ spec:
               path: /_cluster/health?local=true
               port: 9200
           {{- else if .Values.coordinating.customStartupProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.coordinating.customStartupProbe "context" $) | nindent 12 }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.coordinating.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.coordinating.livenessProbe.enabled }}
           livenessProbe:

--- a/bitnami/elasticsearch/templates/data-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/data-statefulset.yaml
@@ -158,7 +158,7 @@ spec:
               path: /_cluster/health?local=true
               port: 9200
           {{- else if .Values.data.customStartupProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.data.customStartupProbe "context" $) | nindent 12 }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.data.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.data.livenessProbe.enabled }}
           livenessProbe:

--- a/bitnami/elasticsearch/templates/ingest-deploy.yaml
+++ b/bitnami/elasticsearch/templates/ingest-deploy.yaml
@@ -124,7 +124,7 @@ spec:
               path: /_cluster/health?local=true
               port: 9200
           {{- else if .Values.ingest.customStartupProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ingest.customStartupProbe "context" $) | nindent 12 }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ingest.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.ingest.livenessProbe.enabled }}
           livenessProbe:

--- a/bitnami/elasticsearch/templates/master-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/master-statefulset.yaml
@@ -161,7 +161,7 @@ spec:
               path: /_cluster/health?local=true
               port: 9200
           {{- else if .Values.master.customStartupProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.master.customStartupProbe "context" $) | nindent 12 }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.master.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.master.livenessProbe.enabled }}
           livenessProbe:


### PR DESCRIPTION
**Description of the change**

I stumpled over this while settings up security and therefore need to define a *customStartupProbe*

Changed all incorrect referneces where *livenessProbe* was mapped to  *customStartupProbe*

**Benefits**

Should work now as aspected

**Possible drawbacks**

**Applicable issues**

**Additional information**

**Checklist** 
- [ X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [X ] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
