### PR TITLE
bitnami/solr: Fix duplicate solr exporter probe props

### DIFF
--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -27,4 +27,4 @@ name: solr
 sources:
   - https://github.com/bitnami/bitnami-docker-solr
   - https://lucene.apache.org/solr/
-version: 1.0.0
+version: 1.0.1

--- a/bitnami/solr/templates/exporter-deployment.yaml
+++ b/bitnami/solr/templates/exporter-deployment.yaml
@@ -112,11 +112,6 @@ spec:
             httpGet:
               path: "/metrics"
               port: {{ .Values.exporter.port }}
-            initialDelaySeconds: {{ .Values.exporter.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.exporter.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.exporter.livenessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.exporter.livenessProbe.failureThreshold }}
-            successThreshold: {{ .Values.exporter.livenessProbe.successThreshold }}
           {{- else if .Values.exporter.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.exporter.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
@@ -125,11 +120,6 @@ spec:
             httpGet:
               path: "/metrics"
               port: {{ .Values.exporter.port }}
-            initialDelaySeconds: {{ .Values.exporter.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.exporter.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.exporter.readinessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.exporter.readinessProbe.failureThreshold }}
-            successThreshold: {{ .Values.exporter.readinessProbe.successThreshold }}
           {{- else if .Values.exporter.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.exporter.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Fixes duplicate exporter probe properties

Demo of Issue in chart version 1.0.0:
```
cd bitnami/charts
helm template --set exporter.enabled=true --set authentication.enabled=false .
```
See duplicate keys in `livenessProbe` / `readinessProbe` in `solr-exporter` container.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
Fix duplicate properties

**Possible drawbacks**
n/a

**Applicable issues**
n/a

**Additional information**
n/a

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
