### PR TITLE
[bitnami/elasticsearch] Add suppor for custom sidecars and init containers

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/bitnami-docker-elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 15.7.1
+version: 15.8.0

--- a/bitnami/elasticsearch/README.md
+++ b/bitnami/elasticsearch/README.md
@@ -144,6 +144,8 @@ The following table lists the configurable parameters of the Elasticsearch chart
 | `master.customStartupProbe`                       | Override default startup probe                                                                                                                                    | `{}`                                                         |
 | `master.customLivenessProbe`                      | Override default liveness probe                                                                                                                                   | `{}`                                                         |
 | `master.customReadinessProbe`                     | Override default readiness probe                                                                                                                                  | `{}`                                                         |
+| `master.initContainers`                           | Add additional init containers to the Elasticsearch master-eligible pods                                                                                          | `{}` (evaluated as a template)                               |
+| `master.sidecars`                                 | Add additional sidecar containers to the  Elasticsearch master-eligible pods                                                                                      | `{}` (evaluated as a template)                               |
 | `master.serviceAccount.create`                    | Enable creation of ServiceAccount for the master node                                                                                                             | `false`                                                      |
 | `master.serviceAccount.name`                      | Name of the created serviceAccount                                                                                                                                | Generated using the `elasticsearch.master.fullname` template |
 | `master.autoscaling.enabled`                      | Enable autoscaling for master replicas                                                                                                                            | `false`                                                      |
@@ -200,6 +202,8 @@ The following table lists the configurable parameters of the Elasticsearch chart
 | `coordinating.customStartupProbe`                 | Override default startup probe                                                                                                                                    | `{}`                                                         |
 | `coordinating.customLivenessProbe`                | Override default liveness probe                                                                                                                                   | `{}`                                                         |
 | `coordinating.customReadinessProbe`               | Override default readiness probe                                                                                                                                  | `{}`                                                         |
+| `coordinating.initContainers`                     | Add additional init containers to the Elasticsearch coordinating-only pods                                                                                        | `{}` (evaluated as a template)                               |
+| `coordinating.sidecars`                           | Add additional sidecar containers to the  Elasticsearch coordinating-only pods                                                                                    | `{}` (evaluated as a template)                               |
 | `coordinating.serviceAccount.create`              | Enable creation of ServiceAccount for the coordinating-only node                                                                                                  | `false`                                                      |
 | `coordinating.serviceAccount.name`                | Name of the created serviceAccount                                                                                                                                | Generated using the `elasticsearch.coordinating.fullname`    |
 | `coordinating.autoscaling.enabled`                | Enable autoscaling for coordinating replicas                                                                                                                      | `false`                                                      |
@@ -261,6 +265,8 @@ The following table lists the configurable parameters of the Elasticsearch chart
 | `data.readinessProbe.timeoutSeconds`              | When the probe times out (data nodes pod)                                                                                                                         | `5`                                                          |
 | `data.readinessProbe.successThreshold`            | Minimum consecutive successes for the probe to be considered successful after having failed (data nodes pod)                                                      | `1`                                                          |
 | `data.readinessProbe.failureThreshold`            | Minimum consecutive failures for the probe to be considered failed after having succeeded                                                                         | `5`                                                          |
+| `data.initContainers`                             | Add additional init containers to the Elasticsearch data pods                                                                                                     | `{}` (evaluated as a template)                               |
+| `data.sidecars`                                   | Add additional sidecar containers to the  Elasticsearch data pods                                                                                                 | `{}` (evaluated as a template)                               |
 | `data.serviceAccount.create`                      | Enable creation of ServiceAccount for the data node                                                                                                               | `false`                                                      |
 | `data.serviceAccount.name`                        | Name of the created serviceAccount                                                                                                                                | Generated using the `elasticsearch.data.fullname` template   |
 | `data.autoscaling.enabled`                        | Enable autoscaling for data replicas                                                                                                                              | `false`                                                      |
@@ -312,6 +318,8 @@ The following table lists the configurable parameters of the Elasticsearch chart
 | `ingest.affinity`                                 | Ingest Affinity for pod assignment                                                                                                                                | `{}` (evaluated as a template)                               |
 | `ingest.nodeSelector`                             | Ingest Node labels for pod assignment                                                                                                                             | `{}` (evaluated as a template)                               |
 | `ingest.tolerations`                              | Ingest Tolerations for pod assignment                                                                                                                             | `[]` (evaluated as a template)                               |
+| `ingest.initContainers`                           | Add additional init containers to the Elasticsearch ingest pods                                                                                                   | `{}` (evaluated as a template)                               |
+| `ingest.sidecars`                                 | Add additional sidecar containers to the  Elasticsearch ingest pods                                                                                               | `{}` (evaluated as a template)                               |
 | `ingest.readinessProbe.enabled`                   | Enable/disable the readiness probe (ingest nodes pod)                                                                                                             | `true`                                                       |
 | `ingest.readinessProbe.initialDelaySeconds`       | Delay before readiness probe is initiated (ingest nodes pod)                                                                                                      | `90`                                                         |
 | `ingest.readinessProbe.periodSeconds`             | How often to perform the probe (ingest nodes pod)                                                                                                                 | `10`                                                         |
@@ -359,7 +367,8 @@ The following table lists the configurable parameters of the Elasticsearch chart
 | `curator.priorityClassName`                       | priorityClassName                                                                                                                                                 | `nil`                                                        |
 | `curator.extraVolumes`                            | Extra volumes                                                                                                                                                     |                                                              |
 | `curator.extraVolumeMounts`                       | Mount extra volume(s),                                                                                                                                            |                                                              |
-| `curator.extraInitContainers`                     | Init containers to add to the cronjob container                                                                                                                   | `{}`                                                         |
+| `curator.initContainers`                          | Add additional init containers to the Elasticsearch Curator pods                                                                                                  | `{}` (evaluated as a template)                               |
+| `curator.sidecars`                                | Add additional sidecar containers to the  Elasticsearch Curator pods                                                                                              | `{}` (evaluated as a template)                               |
 | `curator.envFromSecrets`                          | Environment variables from secrets to the cronjob container                                                                                                       | `{}`                                                         |
 | `curator.envFromSecrets.*.from.secret`            | - `secretKeyRef.name` used for environment variable                                                                                                               |                                                              |
 | `curator.envFromSecrets.*.from.key`               | - `secretKeyRef.key` used for environment variable                                                                                                                |                                                              |
@@ -521,6 +530,32 @@ extraVolumeMounts:
   - name: snapshot-repository
     mountPath: /snapshots
 snapshotRepoPath: "/snapshots"
+```
+
+### Sidecars and Init Containers
+
+If you have a need for additional containers to run within the same pod as Elasticsearch components (e.g. an additional metrics or logging exporter), you can do so via the `XXX.sidecars` parameter(s), where XXX is placeholder you need to replace with the actual component(s). Simply define your container according to the Kubernetes container spec.
+
+
+```yaml
+sidecars:
+  - name: your-image-name
+    image: your-image
+    imagePullPolicy: Always
+    ports:
+      - name: portname
+       containerPort: 1234
+```
+
+Similarly, you can add extra init containers using the `initContainers` parameter.
+
+```yaml
+initContainers:
+  - name: your-image-name
+    image: your-image
+    imagePullPolicy: Always
+    ports:
+      - name: portname
 ```
 
 ### Setting Pod's affinity

--- a/bitnami/elasticsearch/templates/coordinating-deploy.yaml
+++ b/bitnami/elasticsearch/templates/coordinating-deploy.yaml
@@ -55,7 +55,7 @@ spec:
       securityContext:
         fsGroup: {{ .Values.coordinating.securityContext.fsGroup }}
       {{- end }}
-      {{- if .Values.sysctlImage.enabled }}
+      {{- if or .Values.coordinating.initContainers .Values.sysctlImage.enabled }}
       ## Image that performs the sysctl operation to modify Kernel settings (needed sometimes to avoid boot errors)
       initContainers:
         - name: sysctl
@@ -71,6 +71,9 @@ spec:
           {{- if .Values.sysctlImage.resources }}
           resources: {{- toYaml .Values.sysctlImage.resources | nindent 12 }}
           {{- end }}
+        {{- if .Values.coordinating.initContainers }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.coordinating.initContainers "context" $) | nindent 8 }}
+        {{- end }}
       {{- end }}
       containers:
         - name: elasticsearch
@@ -188,6 +191,9 @@ spec:
             - name: custom-init-scripts-secret
               mountPath: /docker-entrypoint-initdb.d/init-scripts-secret
             {{- end }}
+        {{- if .Values.coordinating.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.coordinating.sidecars "context" $) | nindent 8 }}
+        {{- end }}
       volumes:
         {{- if or .Values.config .Values.extraConfig }}
         - name: config

--- a/bitnami/elasticsearch/templates/cronjob.yaml
+++ b/bitnami/elasticsearch/templates/cronjob.yaml
@@ -53,12 +53,9 @@ spec:
           priorityClassName: {{ .Values.curator.priorityClassName | quote }}
           {{- end }}
 {{- include "elasticsearch.imagePullSecrets" . | indent 10 }}
-          {{- if .Values.curator.extraInitContainers }}
-          initContainers:
-            {{- range $key, $value := .Values.curator.extraInitContainers }}
-            - name: "{{ $key }}"
-            {{- toYaml $value | nindent 14 }}
-            {{- end }}
+          {{- $initContainers := coalesce .Values.curator.initContainers .Values.curator.extraInitContainers -}}
+          {{- if $initContainers }}
+          initContainers: {{- include "common.tplvalues.render" (dict "value" $initContainers "context" $) | nindent 8 }}
           {{- end }}
           {{- if .Values.curator.schedulerName }}
           schedulerName: {{ .Values.curator.schedulerName }}
@@ -120,4 +117,7 @@ spec:
               {{- if .Values.curator.resources }}
               resources: {{- toYaml .Values.curator.resources | nindent 16 }}
               {{- end }}
+        {{- if .Values.curator.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.curator.sidecars "context" $) | nindent 8 }}
+        {{- end }}
 {{- end }}

--- a/bitnami/elasticsearch/templates/data-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/data-statefulset.yaml
@@ -60,7 +60,7 @@ spec:
       securityContext:
         fsGroup: {{ .Values.data.securityContext.fsGroup }}
       {{- end }}
-      {{- if or .Values.sysctlImage.enabled (and .Values.volumePermissions.enabled .Values.data.persistence.enabled) }}
+      {{- if or .Values.data.initContainers .Values.sysctlImage.enabled (and .Values.volumePermissions.enabled .Values.data.persistence.enabled) }}
       initContainers:
         {{- if .Values.sysctlImage.enabled }}
         ## Image that performs the sysctl operation to modify Kernel settings (needed sometimes to avoid boot errors)
@@ -95,6 +95,9 @@ spec:
           volumeMounts:
             - name: data
               mountPath: "/bitnami/elasticsearch/data"
+        {{- end }}
+        {{- if .Values.data.initContainers }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.data.initContainers "context" $) | nindent 8 }}
         {{- end }}
       {{- end }}
       containers:
@@ -217,6 +220,9 @@ spec:
             - name: custom-init-scripts-secret
               mountPath: /docker-entrypoint-initdb.d/init-scripts-secret
             {{- end }}
+        {{- if .Values.data.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.data.sidecars "context" $) | nindent 8 }}
+        {{- end }}
       volumes:
         {{- if or .Values.config .Values.extraConfig }}
         - name: "config"

--- a/bitnami/elasticsearch/templates/ingest-deploy.yaml
+++ b/bitnami/elasticsearch/templates/ingest-deploy.yaml
@@ -50,7 +50,7 @@ spec:
       securityContext:
         fsGroup: {{ .Values.ingest.securityContext.fsGroup }}
       {{- end }}
-      {{- if .Values.sysctlImage.enabled }}
+      {{- if or .Values.ingest.initContainers  .Values.sysctlImage.enabled }}
       ## Image that performs the sysctl operation to modify Kernel settings (needed sometimes to avoid boot errors)
       initContainers:
         - name: sysctl
@@ -66,6 +66,9 @@ spec:
           {{- if .Values.sysctlImage.resources }}
           resources: {{- toYaml .Values.sysctlImage.resources | nindent 12 }}
           {{- end }}
+        {{- if .Values.ingest.initContainers }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.ingest.initContainers "context" $) | nindent 8 }}
+        {{- end }}
       {{- end }}
       containers:
         - name: elasticsearch
@@ -183,6 +186,9 @@ spec:
             - name: custom-init-scripts-secret
               mountPath: /docker-entrypoint-initdb.d/init-scripts-secret
             {{- end }}
+        {{- if .Values.ingest.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.ingest.sidecars "context" $) | nindent 8 }}
+        {{- end }}
       volumes:
         {{- if or .Values.config .Values.extraConfig }}
         - name: config

--- a/bitnami/elasticsearch/templates/master-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/master-statefulset.yaml
@@ -57,7 +57,7 @@ spec:
       securityContext:
         fsGroup: {{ .Values.master.securityContext.fsGroup }}
       {{- end }}
-      {{- if or .Values.sysctlImage.enabled (and .Values.volumePermissions.enabled .Values.master.persistence.enabled) }}
+      {{- if or .Values.master.initContainers .Values.sysctlImage.enabled (and .Values.volumePermissions.enabled .Values.master.persistence.enabled) }}
       initContainers:
         {{- if .Values.sysctlImage.enabled }}
         ## Image that performs the sysctl operation to modify Kernel settings (needed sometimes to avoid boot errors)
@@ -92,6 +92,9 @@ spec:
           volumeMounts:
             - name: data
               mountPath: "/bitnami/elasticsearch/data"
+        {{- end }}
+        {{- if .Values.master.initContainers }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.master.initContainers "context" $) | nindent 8 }}
         {{- end }}
       {{- end }}
       containers:
@@ -220,6 +223,9 @@ spec:
             - name: custom-init-scripts-secret
               mountPath: /docker-entrypoint-initdb.d/init-scripts-secret
             {{- end }}
+        {{- if .Values.master.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.master.sidecars "context" $) | nindent 8 }}
+        {{- end }}
       volumes:
         {{- if or .Values.config .Values.extraConfig }}
         - name: config

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -327,6 +327,14 @@ master:
   ##
   customReadinessProbe: {}
 
+  ## Extra init containers to add to the Elasticsearch master-eligible pod(s)
+  ##
+  initContainers: []
+
+  ## Extra sidecar containers to add to the Elasticsearch master-eligible pod(s)
+  ##
+  sidecars: []
+
   ## Enable persistence using Persistent Volume Claims
   ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
   ##
@@ -545,6 +553,15 @@ coordinating:
   ## Custom Rediness probes coordinating-only containers
   ##
   customReadinessProbe: {}
+
+  ## Extra init containers to add to the Elasticsearch coordinating-only pod(s)
+  ##
+  initContainers: []
+
+  ## Extra sidecar containers to add to the Elasticsearch coordinating-only pod(s)
+  ##
+  sidecars: []
+
   ## Service parameters for coordinating-only node(s)
   ##
   service:
@@ -721,6 +738,15 @@ data:
   ## Custom Rediness probes data containers
   ##
   customReadinessProbe: {}
+
+  ## Extra init containers to add to the Elasticsearch data pod(s)
+  ##
+  initContainers: []
+
+  ## Extra sidecar containers to add to the Elasticsearch data pod(s)
+  ##
+  sidecars: []
+
   ## Enable persistence using Persistent Volume Claims
   ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
   ##
@@ -911,6 +937,15 @@ ingest:
   ## Custom Rediness probes ingest containers
   ##
   customReadinessProbe: {}
+
+  ## Extra init containers to add to the Elasticsearch ingest pod(s)
+  ##
+  initContainers: []
+
+  ## Extra sidecar containers to add to the Elasticsearch ingest pod(s)
+  ##
+  sidecars: []
+
   ## Service parameters for ingest node(s)
   ##
   service:
@@ -1123,41 +1158,47 @@ curator:
   #     mountPath: /certs
   #     readOnly: true
 
-  ## Add your own init container or uncomment and modify the given example.
+  ## Extra init containers to add to the Elasticsearch ingest pod(s)
+  ## Example to configure S3 repository waiting for ES to be reachable:
+  ## elasticsearch-s3-repository:
+  ##   image: bitnami/bitnami-shell:latest
+  ##   imagePullPolicy: Always
+  ##   command:
+  ##     - /bin/bash
+  ##   args:
+  ##     - c
+  ##     - |
+  ##       ES_HOST=elasticsearch
+  ##       ES_PORT=9200
+  ##       ES_REPOSITORY=backup
+  ##       S3_REGION=us-east-1
+  ##       S3_BUCKET=bucket
+  ##       S3_BASE_PATH=backup
+  ##       S3_COMPRESS=true
+  ##       S3_STORAGE_CLASS=standard
+  ##       install_packages curl && \
+  ##       ( counter=0; while (( counter++ < 120 )); do curl -s http://${ES_HOST}:${ES_PORT} >/dev/null 2>&1 && break; echo "Waiting for elasticsearch $counter/120"; sleep 1; done ) && \
+  ##       cat <<EOF | curl -sS -XPUT -H "Content-Type: application/json" -d @- http://${ES_HOST}:${ES_PORT}/_snapshot/${ES_REPOSITORY} \
+  ##       {
+  ##         "type": "s3",
+  ##         "settings": {
+  ##           "bucket": "${S3_BUCKET}",
+  ##           "base_path": "${S3_BASE_PATH}",
+  ##           "region": "${S3_REGION}",
+  ##           "compress": "${S3_COMPRESS}",
+  ##           "storage_class": "${S3_STORAGE_CLASS}"
+  ##         }
+  ##       }
   ##
-  extraInitContainers: {}
-  ## Don't configure S3 repository till Elasticsearch is reachable.
-  ## Ensure that it is available at http://elasticsearch:9200
+  initContainers: []
+
+  ## DEPRECATED. Use `curator.initContainers` instead
   ##
-  # elasticsearch-s3-repository:
-  #   image: bitnami/minideb
-  #   imagePullPolicy: "IfNotPresent"
-  #   command:
-  #   - "/bin/bash"
-  #   - "-c"
-  #   args:
-  #   - |
-  #     ES_HOST=elasticsearch
-  #     ES_PORT=9200
-  #     ES_REPOSITORY=backup
-  #     S3_REGION=us-east-1
-  #     S3_BUCKET=bucket
-  #     S3_BASE_PATH=backup
-  #     S3_COMPRESS=true
-  #     S3_STORAGE_CLASS=standard
-  #     install_packages curl && \
-  #     ( counter=0; while (( counter++ < 120 )); do curl -s http://${ES_HOST}:${ES_PORT} >/dev/null 2>&1 && break; echo "Waiting for elasticsearch $counter/120"; sleep 1; done ) && \
-  #     cat <<EOF | curl -sS -XPUT -H "Content-Type: application/json" -d @- http://${ES_HOST}:${ES_PORT}/_snapshot/${ES_REPOSITORY} \
-  #     {
-  #       "type": "s3",
-  #       "settings": {
-  #         "bucket": "${S3_BUCKET}",
-  #         "base_path": "${S3_BASE_PATH}",
-  #         "region": "${S3_REGION}",
-  #         "compress": "${S3_COMPRESS}",
-  #         "storage_class": "${S3_STORAGE_CLASS}"
-  #       }
-  #     }
+  extraInitContainers: []
+
+  ## Extra sidecar containers to add to the Elasticsearch ingest pod(s)
+  ##
+  sidecars: []
 
 ## Elasticsearch Prometheus exporter configuration
 ## ref: https://hub.docker.com/r/bitnami/elasticsearch-exporter/tags/


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR adds support for adding custom init container and sidecar containers to Elasticsearch components.

**Benefits**

Flexibility

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/6790

**Additional information**

N/A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
