### PR TITLE
[bitnami/redis]: Add an extra VolumeMount to the metrics sidecar

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -25,4 +25,4 @@ name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 14.8.4
+version: 14.8.5

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -370,6 +370,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.image.pullSecrets`                  | Redis(TM) Exporter image pull secrets                                                            | `[]`                     |
 | `metrics.redisTargetHost`                    | A way to specify an alternative Redis(TM) hostname                                               | `localhost`              |
 | `metrics.extraArgs`                          | Extra arguments for Redis(TM) exporter, for example:                                             | `{}`                     |
+| `metrics.extraVolumes`                       | Optionally specify extra list of additional volumes for the Redis(TM) metrics sidecar             | `[]`            |
+| `metrics.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the Redis(TM) metrics sidecar        | `[]`            |
 | `metrics.containerSecurityContext.enabled`   | Enabled Redis(TM) exporter containers' Security Context                                          | `true`                   |
 | `metrics.containerSecurityContext.runAsUser` | Set Redis(TM) exporter containers' Security Context runAsUser                                    | `1001`                   |
 | `metrics.resources.limits`                   | The resources limits for the Redis(TM) exporter container                                        | `{}`                     |

--- a/bitnami/redis/templates/master/statefulset.yaml
+++ b/bitnami/redis/templates/master/statefulset.yaml
@@ -290,6 +290,11 @@ spec:
               mountPath: /opt/bitnami/redis/certs
               readOnly: true
             {{- end }}
+            {{- if .Values.metrics.extraArgs.script }}
+            - name: {{ printf "%s-metrics-script-file" (include "common.names.fullname" .) }}
+              mountPath: {{ printf "/mnt/%s/" (include "common.names.name" .) }}
+              readOnly: true
+            {{- end }}
         {{- end }}
         {{- if .Values.master.sidecars }}
         {{- include "common.tplvalues.render" (dict "value" .Values.master.sidecars "context" $) | nindent 8 }}
@@ -383,6 +388,9 @@ spec:
         {{- end }}
         {{- if .Values.master.extraVolumes }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.master.extraVolumes "context" $ ) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.metrics.extraVolumes }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.extraVolumes "context" $ ) | nindent 8 }}
         {{- end }}
   {{- if not .Values.master.persistence.enabled }}
         - name: redis-data

--- a/bitnami/redis/templates/master/statefulset.yaml
+++ b/bitnami/redis/templates/master/statefulset.yaml
@@ -290,10 +290,8 @@ spec:
               mountPath: /opt/bitnami/redis/certs
               readOnly: true
             {{- end }}
-            {{- if .Values.metrics.extraArgs.script }}
-            - name: {{ printf "%s-metrics-script-file" (include "common.names.fullname" .) }}
-              mountPath: {{ printf "/mnt/%s/" (include "common.names.name" .) }}
-              readOnly: true
+            {{- if .Values.metrics.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.extraVolumeMounts "context" $ ) | nindent 12 }}
             {{- end }}
         {{- end }}
         {{- if .Values.master.sidecars }}

--- a/bitnami/redis/templates/replicas/statefulset.yaml
+++ b/bitnami/redis/templates/replicas/statefulset.yaml
@@ -300,10 +300,8 @@ spec:
               mountPath: /opt/bitnami/redis/certs
               readOnly: true
             {{- end }}
-            {{- if .Values.metrics.extraArgs.script }}
-            - name: {{ printf "%s-metrics-script-file" (include "common.names.fullname" .) }}
-              mountPath: {{ printf "/mnt/%s/" (include "common.names.name" .) }}
-              readOnly: true
+            {{- if .Values.metrics.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.extraVolumeMounts "context" $ ) | nindent 12 }}
             {{- end }}
         {{- end }}
         {{- if .Values.replica.sidecars }}

--- a/bitnami/redis/templates/replicas/statefulset.yaml
+++ b/bitnami/redis/templates/replicas/statefulset.yaml
@@ -300,6 +300,11 @@ spec:
               mountPath: /opt/bitnami/redis/certs
               readOnly: true
             {{- end }}
+            {{- if .Values.metrics.extraArgs.script }}
+            - name: {{ printf "%s-metrics-script-file" (include "common.names.fullname" .) }}
+              mountPath: {{ printf "/mnt/%s/" (include "common.names.name" .) }}
+              readOnly: true
+            {{- end }}
         {{- end }}
         {{- if .Values.replica.sidecars }}
         {{- include "common.tplvalues.render" (dict "value" .Values.replica.sidecars "context" $) | nindent 8 }}
@@ -391,6 +396,9 @@ spec:
         {{- end }}
         {{- if .Values.replica.extraVolumes }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.replica.extraVolumes "context" $ ) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.metrics.extraVolumes }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.extraVolumes "context" $ ) | nindent 8 }}
         {{- end }}
   {{- if not .Values.replica.persistence.enabled }}
         - name: redis-data

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -1134,6 +1134,7 @@ metrics:
   ##
   extraVolumes: []
   ## @param metrics.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the Redis(TM) metrics sidecar
+  ##
   extraVolumeMounts: []
   ## Redis(TM) exporter resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -1130,6 +1130,11 @@ metrics:
   containerSecurityContext:
     enabled: true
     runAsUser: 1001
+  ## @param metrics.extraVolumes Optionally specify extra list of additional volumes for the Redis(TM) metrics sidecar
+  ##
+  extraVolumes: []
+  ## @param metrics.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the Redis(TM) metrics sidecar
+  extraVolumeMounts: []
   ## Redis(TM) exporter resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ## @param metrics.resources.limits The resources limits for the Redis(TM) exporter container


### PR DESCRIPTION
If `metrics.extraArgs.script` is defined, add an extra VolumeMount to the metrics sidecar containers to ensure they can see it.  The responsibility of providing the volume and script is on the chart.

This was not added to the sentinel sidecar, as that is apparently going away.

Fixes issue: https://github.com/bitnami/charts/issues/6792

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
