### PR TITLE
[bitnami/mongodb] commonLabels

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 10.20.5
+version: 10.21.0

--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -92,7 +92,8 @@ The following tables lists the configurable parameters of the MongoDB&reg; chart
 | `architecture`           | MongoDB&reg; architecture (`standalone` or `replicaset`)                                                                      | `standalone`                                   |
 | `hostAliases`            | Add deployment host aliases                                                                                                   | `[]`                                           |
 | `useStatefulSet`         | Set to true to use a StatefulSet instead of a Deployment (only when `architecture=standalone`)                                | `false`                                        |
-| `commonAnnotations`      | Annotations to be added to all Mongo resources                                                                                     | `{}`                                                    |
+| `commonAnnotations`      | Annotations to be added to all Mongo resources                                                                                     | `{}`
+| `commonLabels`           | Labels to be added to all Mongo resources                                                                                     | `{}`                                                    |
 | `auth.enabled`           | Enable authentication                                                                                                         | `true`                                         |
 | `auth.rootPassword`      | MongoDB&reg; admin password                                                                                                   | _random 10 character long alphanumeric string_ |
 | `auth.username`          | MongoDB&reg; custom user (mandatory if `auth.database` is set)                                                                | `nil`                                          |

--- a/bitnami/mongodb/templates/arbiter/configmap.yaml
+++ b/bitnami/mongodb/templates/arbiter/configmap.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "mongodb.namespace" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: arbiter
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 data:
   mongodb.conf: |-
     {{- include "common.tplvalues.render" (dict "value" .Values.arbiter.configuration "context" $) | nindent 4 }}

--- a/bitnami/mongodb/templates/arbiter/headless-svc.yaml
+++ b/bitnami/mongodb/templates/arbiter/headless-svc.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "mongodb.namespace" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: arbiter
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.service.annotations }}
   annotations: {{- include "common.tplvalues.render" (dict "value" .Values.service.annotations "context" $) | nindent 4 }}
   {{- end }}

--- a/bitnami/mongodb/templates/arbiter/pdb.yaml
+++ b/bitnami/mongodb/templates/arbiter/pdb.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "mongodb.namespace" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: arbiter
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   {{- if .Values.arbiter.pdb.minAvailable }}
   minAvailable: {{ .Values.arbiter.pdb.minAvailable }}

--- a/bitnami/mongodb/templates/arbiter/statefulset.yaml
+++ b/bitnami/mongodb/templates/arbiter/statefulset.yaml
@@ -9,6 +9,9 @@ metadata:
     {{- if .Values.arbiter.labels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.arbiter.labels "context" $) | nindent 4 }}
     {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
     {{- if .Values.arbiter.annotations }}
   annotations: {{- include "common.tplvalues.render" (dict "value" .Values.arbiter.annotations "context" $) | nindent 4 }}
   {{- end }}

--- a/bitnami/mongodb/templates/configmap.yaml
+++ b/bitnami/mongodb/templates/configmap.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "mongodb.namespace" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: mongodb
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/mongodb/templates/hidden/configmap.yml
+++ b/bitnami/mongodb/templates/hidden/configmap.yml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "mongodb.namespace" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: hidden
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 data:
   mongodb.conf: |-
     {{- include "common.tplvalues.render" (dict "value" .Values.hidden.configuration "context" $) | nindent 4 }}

--- a/bitnami/mongodb/templates/hidden/external-access-svc.yaml
+++ b/bitnami/mongodb/templates/hidden/external-access-svc.yaml
@@ -14,6 +14,9 @@ metadata:
   namespace: {{ include "mongodb.namespace" $ }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: hidden
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
     pod: {{ $targetPod }}
   {{- if $root.Values.externalAccess.hidden.service.annotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $root.Values.externalAccess.hidden.service.annotations "context" $) | nindent 4 }}

--- a/bitnami/mongodb/templates/hidden/headless-svc.yaml
+++ b/bitnami/mongodb/templates/hidden/headless-svc.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "mongodb.namespace" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: hidden
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.service.annotations }}
   annotations: {{- include "common.tplvalues.render" (dict "value" .Values.service.annotations "context" $) | nindent 4 }}
   {{- end }}

--- a/bitnami/mongodb/templates/hidden/pdb.yaml
+++ b/bitnami/mongodb/templates/hidden/pdb.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "mongodb.namespace" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: hidden
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   {{- if .Values.hidden.pdb.minAvailable }}
   minAvailable: {{ .Values.hidden.pdb.minAvailable }}

--- a/bitnami/mongodb/templates/hidden/statefulset.yaml
+++ b/bitnami/mongodb/templates/hidden/statefulset.yaml
@@ -12,6 +12,9 @@ metadata:
     {{- if .Values.hidden.labels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.hidden.labels "context" $) | nindent 4 }}
     {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.hidden.annotations }}
   annotations: {{- include "common.tplvalues.render" (dict "value" .Values.hidden.annotations "context" $) | nindent 4 }}
   {{- end }}

--- a/bitnami/mongodb/templates/initialization-configmap.yaml
+++ b/bitnami/mongodb/templates/initialization-configmap.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "mongodb.namespace" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: mongodb
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/mongodb/templates/metrics-svc.yaml
+++ b/bitnami/mongodb/templates/metrics-svc.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "mongodb.namespace" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: metrics
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.metrics.service.annotations }}
   annotations: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.service.annotations "context" $) | nindent 4 }}
   {{- end }}

--- a/bitnami/mongodb/templates/prometheusrule.yaml
+++ b/bitnami/mongodb/templates/prometheusrule.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "mongodb.fullname" . }}
   namespace: {{ include "mongodb.prometheusRule.namespace" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
     {{- if .Values.metrics.prometheusRule.additionalLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.metrics.prometheusRule.additionalLabels "context" $) | nindent 4 }}
     {{- end }}

--- a/bitnami/mongodb/templates/replicaset/external-access-svc.yaml
+++ b/bitnami/mongodb/templates/replicaset/external-access-svc.yaml
@@ -14,6 +14,9 @@ metadata:
   namespace: {{ include "mongodb.namespace" $ }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: mongodb
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
     pod: {{ $targetPod }}
   {{- if $root.Values.externalAccess.service.annotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $root.Values.externalAccess.service.annotations "context" $) | nindent 4 }}

--- a/bitnami/mongodb/templates/replicaset/headless-svc.yaml
+++ b/bitnami/mongodb/templates/replicaset/headless-svc.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "mongodb.namespace" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: mongodb
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if or .Values.service.annotations .Values.commonAnnotations }}
   annotations:
     {{- if .Values.service.annotations }}

--- a/bitnami/mongodb/templates/replicaset/pdb.yaml
+++ b/bitnami/mongodb/templates/replicaset/pdb.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "mongodb.namespace" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: mongodb
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/mongodb/templates/replicaset/scripts-configmap.yaml
+++ b/bitnami/mongodb/templates/replicaset/scripts-configmap.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "mongodb.namespace" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: mongodb
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -9,6 +9,9 @@ metadata:
   namespace: {{ include "mongodb.namespace" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: mongodb
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
     {{- if .Values.labels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.labels "context" $) | nindent 4 }}
     {{- end }}

--- a/bitnami/mongodb/templates/replicaset/svc.yaml
+++ b/bitnami/mongodb/templates/replicaset/svc.yaml
@@ -15,6 +15,9 @@ metadata:
   namespace: {{ include "mongodb.namespace" $ }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: mongodb
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if $root.Values.service.annotations }}
   annotations: {{- include "common.tplvalues.render" (dict "value" $root.Values.service.annotations "context" $) | nindent 4 }}
   {{- end }}

--- a/bitnami/mongodb/templates/role.yaml
+++ b/bitnami/mongodb/templates/role.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "mongodb.fullname" . }}
   namespace: {{ include "mongodb.namespace" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+  {{- if .Values.commonLabels }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups:
       - ""

--- a/bitnami/mongodb/templates/rolebinding.yaml
+++ b/bitnami/mongodb/templates/rolebinding.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "mongodb.fullname" . }}
   namespace: {{ include "mongodb.namespace" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+  {{- if .Values.commonLabels }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
 roleRef:
   kind: Role
   name: {{ include "mongodb.fullname" . }}

--- a/bitnami/mongodb/templates/secrets-ca.yaml
+++ b/bitnami/mongodb/templates/secrets-ca.yaml
@@ -11,6 +11,9 @@ metadata:
   labels:
    {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: mongodb
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/mongodb/templates/secrets.yaml
+++ b/bitnami/mongodb/templates/secrets.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ template "mongodb.namespace" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: mongodb
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/mongodb/templates/serviceaccount.yaml
+++ b/bitnami/mongodb/templates/serviceaccount.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "mongodb.serviceAccountName" . }}
   namespace: {{ include "mongodb.namespace" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+  {{- if .Values.commonLabels }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
   {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
   annotations:
     {{- if .Values.serviceAccount.annotations }}

--- a/bitnami/mongodb/templates/servicemonitor.yaml
+++ b/bitnami/mongodb/templates/servicemonitor.yaml
@@ -8,6 +8,9 @@ metadata:
     {{- if .Values.metrics.serviceMonitor.additionalLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.additionalLabels "context" $) | nindent 4 }}
     {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/mongodb/templates/standalone/dep-sts.yaml
+++ b/bitnami/mongodb/templates/standalone/dep-sts.yaml
@@ -9,6 +9,9 @@ metadata:
     {{- if .Values.labels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.labels "context" $) | nindent 4 }}
     {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if or .Values.annotations .Values.commonAnnotations }}
   annotations:
     {{- if .Values.annotations }}
@@ -38,6 +41,9 @@ spec:
         app.kubernetes.io/component: mongodb
         {{- if .Values.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.commonLabels }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 8 }}
         {{- end }}
       {{- if or (include "mongodb.createConfigmap" .) .Values.podAnnotations }}
       annotations:

--- a/bitnami/mongodb/templates/standalone/pvc.yaml
+++ b/bitnami/mongodb/templates/standalone/pvc.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "mongodb.namespace" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: mongodb
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/mongodb/templates/standalone/svc.yaml
+++ b/bitnami/mongodb/templates/standalone/svc.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "mongodb.namespace" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: mongodb
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if or .Values.service.annotations .Values.commonAnnotations }}
   annotations:
     {{- if .Values.service.annotations }}

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -80,6 +80,10 @@ clusterDomain: cluster.local
 ##
 extraDeploy: []
 
+## Add labels to all the deployed resources (sub-charts are not considered). Evaluated as a template
+##
+commonLabels: {}
+
 ## Common annotations to add to all Mongo resources (sub-charts are not considered). Evaluated as a template
 ##
 commonAnnotations: {}


### PR DESCRIPTION
**Description of the change**

Lot of chart proposes commonLabels.

Here are some example:
https://github.com/bitnami/charts/blob/master/bitnami/redis/values.yaml#L35
https://github.com/bitnami/charts/blob/master/bitnami/memcached/values.yaml#L44

**Benefits**

* Add globalLabels to MongoDB charts that will be added to all objects
* Harmonization with other charts

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X ] Variables are documented in the README.md
- [ X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
