### PR TITLE
[bitnami/mongodb-sharded] Fix issue when setting a custom service name

### DIFF
--- a/bitnami/mongodb-sharded/Chart.lock
+++ b/bitnami/mongodb-sharded/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.6.1
-digest: sha256:a5d7f7f9655fe533e46082b3a509cdc21c9bc267fbe24d8484a5e70fe09e6aef
-generated: "2021-06-20T06:58:35.931587698Z"
+  version: 1.7.0
+digest: sha256:6786bc7fdfc6e4038fd28819c2b07339f232282dbaeab21de8064aaa6814a8d1
+generated: "2021-07-07T15:32:21.159182482Z"

--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb-sharded
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb-sharded
   - https://mongodb.org
-version: 3.7.0
+version: 3.7.1

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -54,7 +54,7 @@ spec:
       nodeSelector: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.dataNode.nodeSelector "context" (set $ "dataNodeLoopId" $i)) | nindent 8 }}
       {{- end }}
       {{- if $.Values.shardsvr.dataNode.tolerations }}
-      tolerations: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.dataNode.tolerations "context" (set $ "dataNodeLoopId" $i)) | nindent 8 }}      
+      tolerations: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.dataNode.tolerations "context" (set $ "dataNodeLoopId" $i)) | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "mongodb-sharded.serviceAccountName" (dict "value" $.Values.shardsvr.dataNode.serviceAccount "context" $) }}
       {{- if $.Values.shardsvr.dataNode.priorityClassName }}
@@ -118,7 +118,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: MONGODB_MONGOS_HOST
-              value: {{ include "common.names.fullname" $ }}
+              value: {{ include "mongodb-sharded.serviceName" $ }}
             - name: MONGODB_INITIAL_PRIMARY_HOST
               value: {{ printf "%s-shard%d-data-0.%s-headless.%s.svc.%s" (include "common.names.fullname" $ ) $i (include "common.names.fullname" $ ) $.Release.Namespace $.Values.clusterDomain }}
             - name: MONGODB_REPLICA_SET_NAME

--- a/bitnami/mongodb-sharded/values.yaml
+++ b/bitnami/mongodb-sharded/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/mongodb-sharded
-  tag: 4.4.6-debian-10-r36
+  tag: 4.4.6-debian-10-r40
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -956,7 +956,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r112
+    tag: 10-debian-10-r126
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -1061,7 +1061,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mongodb-exporter
-    tag: 0.11.2-debian-10-r197
+    tag: 0.11.2-debian-10-r212
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**

`MONGODB_MONGOS_HOST` variable was hardcoded to `common.names.fullname` but there is a template used to generate the service name based on the custom name specified in the values or the general fullname:
```
 {{/*
 Returns the proper Service name depending on if an explicit service name is set
 in the values file. If the name is not explicitly set it will take the "common.names.fullname"
 */}}
 {{- define "mongodb-sharded.serviceName" -}}
   {{- if .Values.service.name -}}
     {{ .Values.service.name }}
   {{- else -}}
     {{ include "common.names.fullname" .}}
   {{- end -}}
 {{- end -}}
```

This template is used everywhere except in the `MONGODB_MONGOS_HOST` env. variable, causing an issue when deploying the chart with a custom service name:
```console
$ kubectl get pods
NAME                                   READY   STATUS             RESTARTS   AGE
mongo-mongodb-sharded-configsvr-0     1/1     Running            0          22m
mongo-mongodb-sharded-mongos-0        1/1     Running            0          22m
mongo-mongodb-sharded-shard0-data-0   0/1     Running            8          22m
mongo-mongodb-sharded-shard1-data-0   0/1     Running            8          22m

$ kubectl logs -f mongo-mongodb-sharded-shard1-data-0
 09:25:09.54 INFO  ==> Setting node as primary
mongodb 09:25:09.57
mongodb 09:25:09.58 Welcome to the Bitnami mongodb-sharded container
mongodb 09:25:09.58 Subscribe to project updates by watching https://github.com/bitnami/bitnami-docker-mongodb-sharded
mongodb 09:25:09.58 Submit issues and feature requests at https://github.com/bitnami/bitnami-docker-mongodb-sharded/issues
mongodb 09:25:09.58
mongodb 09:25:09.58 INFO  ==> ** Starting MongoDB Sharded setup **
mongodb 09:25:09.61 INFO  ==> Validating settings in MONGODB_* env vars...
mongodb 09:25:09.63 INFO  ==> Initializing MongoDB Sharded...
mongodb 09:25:09.65 INFO  ==> Writing keyfile for replica set authentication...
mongodb 09:25:09.66 INFO  ==> Enabling authentication...
mongodb 09:25:09.67 INFO  ==> Deploying MongoDB Sharded with persisted data...
mongodb 09:25:09.68 INFO  ==> Trying to connect to MongoDB server my-service-name...
cannot resolve host "my-new-service": lookup my-new-service on 10.30.240.10:53: no such host
cannot resolve host "my-new-service": lookup my-new-service on 10.30.240.10:53: no such host
cannot resolve host "my-new-service": lookup my-new-service on 10.30.240.10:53: no such host
cannot resolve host "my-new-service": lookup my-new-service on 10.30.240.10:53: no such host
```

With the fix in this PR, the `MONGODB_MONGOS_HOST` env. variable is going to use the custom service name if provided or the common one if not. With those changes, everything is up and running:
```console
$ kubectl get pods
NAME                                   READY   STATUS    RESTARTS   AGE
mongo3-mongodb-sharded-configsvr-0     1/1     Running   0          22m
mongo3-mongodb-sharded-mongos-0        1/1     Running   0          22m
mongo3-mongodb-sharded-shard0-data-0   1/1     Running   0          22m
mongo3-mongodb-sharded-shard1-data-0   1/1     Running   0          22m
```

**Applicable issues**

  - fixes #6808

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])