### PR TITLE
[bitnami/*] Avoid creating PVC when unneeded

### DIFF
--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-discourse
   - https://github.com/spinnaker
   - https://www.discourse.org/
-version: 4.2.1
+version: 4.2.2

--- a/bitnami/discourse/templates/pvc.yaml
+++ b/bitnami/discourse/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+{{- if and (include "discourse.host" .) .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -33,4 +33,4 @@ name: ghost
 sources:
   - https://github.com/bitnami/bitnami-docker-ghost
   - http://www.ghost.org/
-version: 13.0.16
+version: 13.0.17

--- a/bitnami/ghost/templates/pvc.yaml
+++ b/bitnami/ghost/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+{{- if and (include "ghost.host" .) .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/bitnami/magento/Chart.yaml
+++ b/bitnami/magento/Chart.yaml
@@ -35,4 +35,4 @@ name: magento
 sources:
   - https://github.com/bitnami/bitnami-docker-magento
   - https://magento.com/
-version: 18.1.3
+version: 18.1.4

--- a/bitnami/magento/templates/pvc.yaml
+++ b/bitnami/magento/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+{{- if and (include "magento.host" .) .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/bitnami/mediawiki/Chart.yaml
+++ b/bitnami/mediawiki/Chart.yaml
@@ -32,4 +32,4 @@ name: mediawiki
 sources:
   - https://github.com/bitnami/bitnami-docker-mediawiki
   - http://www.mediawiki.org/
-version: 12.3.2
+version: 12.3.3

--- a/bitnami/mediawiki/templates/mediawiki-pvc.yaml
+++ b/bitnami/mediawiki/templates/mediawiki-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+{{- if (include "mediawiki.host" .) and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/bitnami/mediawiki/templates/mediawiki-pvc.yaml
+++ b/bitnami/mediawiki/templates/mediawiki-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if (include "mediawiki.host" .) and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+{{- if and (include "mediawiki.host" .) .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/bitnami/opencart/Chart.yaml
+++ b/bitnami/opencart/Chart.yaml
@@ -29,4 +29,4 @@ name: opencart
 sources:
   - https://github.com/bitnami/bitnami-docker-opencart
   - https://opencart.com/
-version: 10.0.14
+version: 10.0.15

--- a/bitnami/opencart/templates/pvc.yaml
+++ b/bitnami/opencart/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+{{- if and (include "opencart.host" .) .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/bitnami/owncloud/Chart.yaml
+++ b/bitnami/owncloud/Chart.yaml
@@ -31,4 +31,4 @@ name: owncloud
 sources:
   - https://github.com/bitnami/bitnami-docker-owncloud
   - https://owncloud.org/
-version: 10.2.17
+version: 10.2.18

--- a/bitnami/owncloud/templates/pvc.yaml
+++ b/bitnami/owncloud/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+{{- if and (include "owncloud.host" .) .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/bitnami/phabricator/Chart.yaml
+++ b/bitnami/phabricator/Chart.yaml
@@ -37,4 +37,4 @@ name: phabricator
 sources:
   - https://github.com/bitnami/bitnami-docker-phabricator
   - https://www.phacility.com/phabricator/
-version: 11.0.21
+version: 11.0.22

--- a/bitnami/phabricator/templates/pvc.yaml
+++ b/bitnami/phabricator/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+{{- if and (include "phabricator.host" .) .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/bitnami/suitecrm/Chart.yaml
+++ b/bitnami/suitecrm/Chart.yaml
@@ -29,4 +29,4 @@ name: suitecrm
 sources:
   - https://github.com/bitnami/bitnami-docker-suitecrm
   - https://www.suitecrm.com/
-version: 9.3.13
+version: 9.3.14

--- a/bitnami/suitecrm/templates/pvc.yaml
+++ b/bitnami/suitecrm/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+{{- if and (include "suitecrm.host" .) .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

There are several apps that requires the external hostname (or IP) to be passed during the chart installation to configure the app properly.

Currently, we're not creating the **deployment** when we detect this happens (while installing other manifests such as the database ones), and show a warning in the **NOTES.txt** explaining the steps to follow to complete the installation. This is done to avoid users to face weird issues and `Crashloopbackoff` errors.

When you install the chart using `--wait` flag, it waits for every resource to be ready. While we're not creating the  **deployment** manifests as I mention before, we are creating the associated PVC manifests. These PVC(s) remain as "Pending" since the pods that are supposed to use them are never created, therefore the `helm install --wait ...` fails.

**Benefits**

`helm install --wait ...` works properly even if the external hostname is not provided.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
