### PR TITLE
[bitnami/wordpress] Add support for ingressClassName

### DIFF
--- a/bitnami/wordpress/Chart.lock
+++ b/bitnami/wordpress/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 9.3.16
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
-  version: 5.13.1
+  version: 5.13.3
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.6.1
-digest: sha256:8a7c45c9da427ca76b18a64b6ac12ce67af6918f74df5a0629ca4f6e83e690fb
-generated: "2021-06-30T23:35:40.098128654Z"
+  version: 1.7.0
+digest: sha256:68fb44995a47ac6187e171ed1215edf819df412b670ad17045dbfb2fbcc89293
+generated: "2021-07-06T08:14:12.179974+02:00"

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -35,4 +35,4 @@ name: wordpress
 sources:
   - https://github.com/bitnami/bitnami-docker-wordpress
   - https://wordpress.org/
-version: 11.0.18
+version: 11.1.0

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -195,6 +195,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ingress.certManager`              | Add the corresponding annotations for cert-manager integration                                        | `false`                  |
 | `ingress.pathType`                 | Ingress path type                                                                                     | `ImplementationSpecific` |
 | `ingress.apiVersion`               | Force Ingress API version (automatically detected if not set)                                         | `nil`                    |
+| `ingress.ingressClassName`         | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                         | `nil`                    |
 | `ingress.hostname`                 | Default host for the ingress record                                                                   | `wordpress.local`        |
 | `ingress.path`                     | Default path for the ingress record                                                                   | `/`                      |
 | `ingress.annotations`              | Additional custom annotations for the ingress record                                                  | `{}`                     |

--- a/bitnami/wordpress/templates/ingress.yaml
+++ b/bitnami/wordpress/templates/ingress.yaml
@@ -19,6 +19,9 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
 spec:
+  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- end }}
   rules:
     {{- if .Values.ingress.hostname }}
     - host: {{ .Values.ingress.hostname | quote }}

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -508,6 +508,11 @@ ingress:
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
   apiVersion:
+  ## @param ingress.ingressClassName IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)
+  ## This is supported in Kubernetes 1.18+ and required if you have more than one IngressClass marked as the default for your cluster .
+  ## ref: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
+  ##
+  ingressClassName:
   ## @param ingress.hostname Default host for the ingress record
   ##
   hostname: wordpress.local


### PR DESCRIPTION
**Description of the change**

Reopens #5522

**Benefits**

Adds support for IngressClassName and updates common to version 1.7.0

**Possible drawbacks**

None known.

**Applicable issues**

  - fixes #5514

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
