### PR TITLE
[bitnami/keycloak] Add support for ingressClassName

### DIFF
--- a/bitnami/keycloak/Chart.lock
+++ b/bitnami/keycloak/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.6.1
+  version: 1.7.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.5.0
-digest: sha256:8ddf8e5a5a40c9008f20388c517a745c4e929130472245723dafa586b911d0c8
-generated: "2021-06-18T03:36:17.84293623Z"
+  version: 10.5.2
+digest: sha256:fdd07b1172617d4eefa2de7ee90b8684e3550febec427753719691086958561a
+generated: "2021-07-06T08:23:52.052589+02:00"

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 3.1.1
+version: 3.2.0

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -197,6 +197,7 @@ The following tables lists the configurable parameters of the Keycloak chart and
 | `service.annotations`              | Annotations for Keycloak service                                                  | `{}` (evaluated as a template) |
 | `ingress.enabled`                  | Enable ingress controller resource                                                | `false`                        |
 | `ingress.apiVersion`               | Force Ingress API version (automatically detected if not set)                     | ``                             |
+| `ingress.ingressClassName`         | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)     | `nil`                          |
 | `ingress.path`                     | Ingress path                                                                      | `/`                            |
 | `ingress.pathType`                 | Ingress path type                                                                 | `ImplementationSpecific`       |
 | `ingress.certManager`              | Add annotations for cert-manager                                                  | `false`                        |

--- a/bitnami/keycloak/templates/ingress.yaml
+++ b/bitnami/keycloak/templates/ingress.yaml
@@ -22,6 +22,9 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
+  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- end }}
   rules:
     {{- if .Values.ingress.path }}
     - http:

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -490,6 +490,12 @@ ingress:
   ##
   apiVersion:
 
+  ## IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)
+  ## This is supported in Kubernetes 1.18+ and required if you have more than one IngressClass marked as the default for your cluster .
+  ## ref: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
+  ##
+  ingressClassName:
+
   ## Ingress Path
   ##
   path: /


### PR DESCRIPTION
**Description of the change**

Adds support for ingressClassname for the Keycloak chart, as requested in https://github.com/bitnami/charts/issues/5514#issuecomment-872128727

**Benefits**

Additional feature.

**Possible drawbacks**

None known.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
