### PR TITLE
[bitnami/nginx] Fix missing whitespace in template

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -25,4 +25,4 @@ name: nginx
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx
   - http://www.nginx.org
-version: 9.3.4
+version: 9.3.5

--- a/bitnami/nginx/templates/_helpers.tpl
+++ b/bitnami/nginx/templates/_helpers.tpl
@@ -51,10 +51,10 @@ Return the volume to use to mount the static site in the NGINX container
 emptyDir: {}
 {{- else if .Values.staticSiteConfigmap }}
 configMap:
-  name: {{- printf "%s" (tpl .Values.staticSiteConfigmap $) -}}
+  name: {{ printf "%s" (tpl .Values.staticSiteConfigmap $) -}}
 {{- else if .Values.staticSitePVC }}
 persistentVolumeClaim:
-  claimName: {{- printf "%s" (tpl .Values.staticSitePVC $) -}}
+  claimName: {{ printf "%s" (tpl .Values.staticSitePVC $) -}}
 {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Fix templating. Removing whitespace after yaml `key:` causes issues.

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
