### PR TITLE
[bitnami/redis] Specify master replicas to be 1

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -25,4 +25,4 @@ name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 14.6.4
+version: 14.6.5

--- a/bitnami/redis/templates/master/statefulset.yaml
+++ b/bitnami/redis/templates/master/statefulset.yaml
@@ -13,6 +13,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  replicas: 1
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: master


### PR DESCRIPTION
**Description of the change**

Specify explicitly the default replicas (1) for Redis master instead of leaving it implicit

**Benefits**

  + If we omit to specify the replicas it is defaulted to 1.
    By omitting the value, an issue arise if an operator scale (down/up)
    the replicaset and after try to re-apply the helm chart in order to
    revert operations. In the case the replicas value is omitted
    helm/kube will not scale back the replicaset to its original default
    value.

  + This PR intends to paliate to the above issue. It just adds
    replicas in the chart, so Helm/Kube will re-adjust/scale the
    replicaset even if changed by an operator.

**Possible drawbacks**

Replicaset will be re-scaled every time the chart is applied if not at the default value, but that's the desired behavior


**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
