### PR TITLE
[bitnami/mongodb] Specify standalone replicas to be 1

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 10.21.0
+version: 10.21.1

--- a/bitnami/mongodb/templates/standalone/dep-sts.yaml
+++ b/bitnami/mongodb/templates/standalone/dep-sts.yaml
@@ -22,6 +22,7 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
+  replicas: 1
   {{- if .Values.useStatefulSet }}
   serviceName: {{ include "mongodb.fullname" . }}
   updateStrategy:


### PR DESCRIPTION
**Description of the change**

Specify explicitly the default replicas (1) for standalone mongo instead of leaving it implicit

P.s: Found the same issue than yesterday, PR for Redis master

**Benefits**

  + If we omit to specify the replicas it is defaulted to 1.
    By omitting the value, an issue arise if an operator scale (down/up)
    the replicaset and after try to re-apply the helm chart in order to
    revert operations. In the case the replicas value is omitted
    helm/kube will not scale back the replicaset to its original default
    value.

  + This PR intends to paliate to the above issue. It just adds
    replicas in the chart, so Helm/Kube will re-adjust/scale the
    replicaset even if changed by an operator.

**Possible drawbacks**

Replicaset will be re-scaled every time the chart is applied if not at the default value, but that's the desired behavior


**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
