### PR TITLE
[bitnami/thanos] Common labels thanos

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 5.0.0
+version: 5.1.0

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -98,6 +98,7 @@ The following tables lists the configurable parameters of the Thanos chart and t
 | `image.pullSecrets`           | Specify docker-registry secret names as an array                                          | `[]` (does not add image pull secrets to deployed pods) |
 | `nameOverride`                | String to partially override common.names.fullname                                        | `nil`                                                   |
 | `fullnameOverride`            | String to fully override common.names.fullname                                            | `nil`                                                   |
+| `commonLabels`                | Labels to add to all deployed objects                                                     | `{}`                                                    |
 | `clusterDomain`               | Default Kubernetes cluster domain                                                         | `cluster.local`                                         |
 | `objstoreConfig`              | [Objstore configuration](https://thanos.io/storage.md/#configuration)                     | `nil`                                                   |
 | `indexCacheConfig`            | [Index cache configuration](https://thanos.io/components/store.md/#memcached-index-cache) | `nil`                                                   |
@@ -851,7 +852,7 @@ Please note if you have changes in the `securityContext` fields those need to be
 # ...
 - securityContext:
 + podSecurityContext:
-# ... 
+# ...
 ```
 
 Other than that a new `securityContext` interface for containers got introduced `containerSecurityContext`. It's default is enabled so if you do not need it you need to opt out of it.

--- a/bitnami/thanos/templates/bucketweb/deployment.yaml
+++ b/bitnami/thanos/templates/bucketweb/deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-bucketweb
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: bucketweb
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.bucketweb.replicaCount }}
   strategy:
@@ -19,7 +22,10 @@ spec:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: bucketweb
-        {{- if and .Values.bucketweb.enabled .Values.bucketweb.podLabels }}
+        {{- if .Values.commonLabels }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.bucketweb.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.bucketweb.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
@@ -56,7 +62,7 @@ spec:
       containers:
         {{- if .Values.bucketweb.extraContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.bucketweb.extraContainers "context" $) | nindent 8 }}
-        {{- end }}      
+        {{- end }}
         - name: bucketweb
           image: {{ include "thanos.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
@@ -89,7 +95,7 @@ spec:
               containerPort: 8080
               protocol: TCP
           {{- if .Values.bucketweb.livenessProbe.enabled }}
-          livenessProbe: 
+          livenessProbe:
             httpGet:
               path: /-/healthy
               port: http
@@ -100,7 +106,7 @@ spec:
             failureThreshold: {{ .Values.bucketweb.livenessProbe.failureThreshold }}
           {{- end }}
           {{- if .Values.bucketweb.readinessProbe.enabled }}
-          readinessProbe: 
+          readinessProbe:
             httpGet:
               path: /-/ready
               port: http

--- a/bitnami/thanos/templates/bucketweb/ingress.yaml
+++ b/bitnami/thanos/templates/bucketweb/ingress.yaml
@@ -4,6 +4,10 @@ kind: Ingress
 metadata:
   name: {{ include "common.names.fullname" . }}-bucketweb
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: bucketweb
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   annotations:
     {{- if .Values.bucketweb.ingress.certManager }}
     kubernetes.io/tls-acme: "true"

--- a/bitnami/thanos/templates/bucketweb/pdb.yaml
+++ b/bitnami/thanos/templates/bucketweb/pdb.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-bucketweb
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: bucketweb
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   {{- if .Values.bucketweb.pdb.minAvailable }}
   minAvailable: {{ .Values.bucketweb.pdb.minAvailable }}

--- a/bitnami/thanos/templates/bucketweb/service.yaml
+++ b/bitnami/thanos/templates/bucketweb/service.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-bucketweb
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: bucketweb
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.bucketweb.service.annotations }}
   annotations: {{- include "common.tplvalues.render" (dict "value" .Values.bucketweb.service.annotations "context" $) | nindent 4 }}
   {{- end }}

--- a/bitnami/thanos/templates/bucketweb/serviceaccount.yaml
+++ b/bitnami/thanos/templates/bucketweb/serviceaccount.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "thanos.serviceaccount.name" (dict "component" "bucketweb" "context" $) }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: bucketweb
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.bucketweb.serviceAccount.annotations }}
   annotations:
     {{- include "common.tplvalues.render" ( dict "value" .Values.bucketweb.serviceAccount.annotations "context" $) | nindent 4 }}

--- a/bitnami/thanos/templates/bucketweb/servicemonitor.yaml
+++ b/bitnami/thanos/templates/bucketweb/servicemonitor.yaml
@@ -8,9 +8,12 @@ metadata:
   {{- end }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: bucketweb
-{{- if .Values.metrics.serviceMonitor.labels }}
-{{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
-{{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}

--- a/bitnami/thanos/templates/bucketweb/tls-secrets.yaml
+++ b/bitnami/thanos/templates/bucketweb/tls-secrets.yaml
@@ -5,6 +5,10 @@ kind: Secret
 metadata:
   name: {{ include "common.names.fullname" $ }}-bucketweb
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
+    app.kubernetes.io/component: bucketweb
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .certificate | b64enc }}

--- a/bitnami/thanos/templates/compactor/deployment.yaml
+++ b/bitnami/thanos/templates/compactor/deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-compactor
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: compactor
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   replicas: 1
   strategy:
@@ -19,7 +22,10 @@ spec:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: compactor
-        {{- if and .Values.compactor.enabled .Values.compactor.podLabels }}
+        {{- if .Values.commonLabels }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.compactor.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.compactor.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
@@ -101,7 +107,7 @@ spec:
               containerPort: 10902
               protocol: TCP
           {{- if .Values.compactor.livenessProbe.enabled }}
-          livenessProbe: 
+          livenessProbe:
             httpGet:
               path: /-/healthy
               port: http
@@ -112,7 +118,7 @@ spec:
             failureThreshold: {{ .Values.compactor.livenessProbe.failureThreshold }}
           {{- end }}
           {{- if .Values.compactor.readinessProbe.enabled }}
-          readinessProbe: 
+          readinessProbe:
             httpGet:
               path: /-/ready
               port: http

--- a/bitnami/thanos/templates/compactor/pvc.yaml
+++ b/bitnami/thanos/templates/compactor/pvc.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-compactor
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: compactor
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   accessModes:
   {{- range .Values.compactor.persistence.accessModes }}

--- a/bitnami/thanos/templates/compactor/service.yaml
+++ b/bitnami/thanos/templates/compactor/service.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-compactor
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: compactor
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.compactor.service.annotations }}
   annotations: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.service.annotations "context" $) | nindent 4 }}
   {{- end }}

--- a/bitnami/thanos/templates/compactor/serviceaccount.yaml
+++ b/bitnami/thanos/templates/compactor/serviceaccount.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "thanos.serviceaccount.name" (dict "component" "compactor" "context" $) }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: compactor
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.compactor.serviceAccount.annotations }}
   annotations:
     {{- include "common.tplvalues.render" ( dict "value" .Values.compactor.serviceAccount.annotations "context" $) | nindent 4 }}

--- a/bitnami/thanos/templates/compactor/servicemonitor.yaml
+++ b/bitnami/thanos/templates/compactor/servicemonitor.yaml
@@ -8,9 +8,12 @@ metadata:
   {{- end }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: compactor
-{{- if .Values.metrics.serviceMonitor.labels }}
-{{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
-{{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}

--- a/bitnami/thanos/templates/objstore-secret.yaml
+++ b/bitnami/thanos/templates/objstore-secret.yaml
@@ -4,6 +4,9 @@ kind: Secret
 metadata:
   name: {{ include "common.names.fullname" . }}-objstore-secret
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 data:
   objstore.yml: |-
     {{- include "common.tplvalues.render" (dict "value" .Values.objstoreConfig "context" $) | b64enc | nindent 4 }}

--- a/bitnami/thanos/templates/query-frontend/configmap.yaml
+++ b/bitnami/thanos/templates/query-frontend/configmap.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-query-frontend-configmap
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query-frontend
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 data:
   config.yml: |-
     {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.config "context" $) | nindent 4 }}

--- a/bitnami/thanos/templates/query-frontend/deployment.yaml
+++ b/bitnami/thanos/templates/query-frontend/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-query-frontend
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query-frontend
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.queryFrontend.replicaCount }}
   strategy:
@@ -20,7 +23,10 @@ spec:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: query-frontend
-        {{- if and .Values.queryFrontend.enabled .Values.queryFrontend.podLabels }}
+        {{- if .Values.commonLabels }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.queryFrontend.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.podLabels "context" $) | nindent 8 }}
         {{- end }}
       {{- if or .Values.queryFrontend.podAnnotations (include "thanos.queryFrontend.createConfigmap" .) }}
@@ -61,7 +67,7 @@ spec:
       containers:
         {{- if .Values.queryFrontend.extraContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.extraContainers "context" $) | nindent 8 }}
-        {{- end }}           
+        {{- end }}
         - name: query-frontend
           image: {{ include "thanos.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
@@ -89,7 +95,7 @@ spec:
               containerPort: 10902
               protocol: TCP
           {{- if .Values.queryFrontend.livenessProbe.enabled }}
-          livenessProbe: 
+          livenessProbe:
             httpGet:
               path: /-/healthy
               port: http
@@ -100,7 +106,7 @@ spec:
             failureThreshold: {{ .Values.queryFrontend.livenessProbe.failureThreshold }}
           {{- end }}
           {{- if .Values.queryFrontend.readinessProbe.enabled }}
-          readinessProbe: 
+          readinessProbe:
             httpGet:
               path: /-/ready
               port: http

--- a/bitnami/thanos/templates/query-frontend/hpa.yaml
+++ b/bitnami/thanos/templates/query-frontend/hpa.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-query-frontend
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query-frontend
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}

--- a/bitnami/thanos/templates/query-frontend/ingress.yaml
+++ b/bitnami/thanos/templates/query-frontend/ingress.yaml
@@ -4,6 +4,10 @@ kind: Ingress
 metadata:
   name: {{ include "common.names.fullname" . }}-query-frontend
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: query-frontend
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   annotations:
     {{- if .Values.queryFrontend.ingress.certManager }}
     kubernetes.io/tls-acme: "true"

--- a/bitnami/thanos/templates/query-frontend/pdb.yaml
+++ b/bitnami/thanos/templates/query-frontend/pdb.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-query-frontend
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query-frontend
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   {{- if .Values.queryFrontend.pdb.minAvailable }}
   minAvailable: {{ .Values.queryFrontend.pdb.minAvailable }}

--- a/bitnami/thanos/templates/query-frontend/psp-clusterrole.yaml
+++ b/bitnami/thanos/templates/query-frontend/psp-clusterrole.yaml
@@ -3,6 +3,11 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname" . }}-query-frontend
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: query-frontend
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 rules:
 - apiGroups: ['policy']
   resources: ['podsecuritypolicies']

--- a/bitnami/thanos/templates/query-frontend/psp-clusterrolebinding.yaml
+++ b/bitnami/thanos/templates/query-frontend/psp-clusterrolebinding.yaml
@@ -3,6 +3,11 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "common.names.fullname" . }}-query-frontend
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: query-frontend
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 roleRef:
   kind: ClusterRole
   name: {{ include "common.names.fullname" . }}-query-frontend

--- a/bitnami/thanos/templates/query-frontend/psp.yaml
+++ b/bitnami/thanos/templates/query-frontend/psp.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-query-frontend
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query-frontend
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   fsGroup:
     rule: RunAsAny

--- a/bitnami/thanos/templates/query-frontend/service.yaml
+++ b/bitnami/thanos/templates/query-frontend/service.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-query-frontend
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query-frontend
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.queryFrontend.service.annotations }}
   annotations: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.service.annotations "context" $) | nindent 4 }}
   {{- end }}

--- a/bitnami/thanos/templates/query-frontend/serviceaccount.yaml
+++ b/bitnami/thanos/templates/query-frontend/serviceaccount.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "thanos.serviceaccount.name" (dict "component" "query-frontend" "context" $) }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query-frontend
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.queryFrontend.serviceAccount.annotations }}
   annotations:
     {{ include "common.tplvalues.render" ( dict "value" .Values.queryFrontend.serviceAccount.annotations "context" $) | nindent 4 }}

--- a/bitnami/thanos/templates/query-frontend/servicemonitor.yaml
+++ b/bitnami/thanos/templates/query-frontend/servicemonitor.yaml
@@ -8,9 +8,12 @@ metadata:
   {{- end }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query-frontend
-{{- if .Values.metrics.serviceMonitor.labels }}
-{{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
-{{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}

--- a/bitnami/thanos/templates/query-frontend/tls-secrets.yaml
+++ b/bitnami/thanos/templates/query-frontend/tls-secrets.yaml
@@ -5,6 +5,10 @@ kind: Secret
 metadata:
   name: {{ include "common.names.fullname" . }}-query-frontend
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
+    app.kubernetes.io/component: query-frontend
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .certificate | b64enc }}

--- a/bitnami/thanos/templates/query/deployment.yaml
+++ b/bitnami/thanos/templates/query/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-query
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ $query.replicaCount }}
   strategy:
@@ -20,7 +23,10 @@ spec:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: query
-        {{- if and $query.enabled $query.podLabels }}
+        {{- if .Values.commonLabels }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 8 }}
+        {{- end }}
+        {{- if $query.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" $query.podLabels "context" $) | nindent 8 }}
         {{- end }}
       {{- if or (include "thanos.query.createSDConfigmap" .) $query.existingSDConfigmap $query.podAnnotations }}
@@ -61,7 +67,7 @@ spec:
       containers:
         {{- if $query.extraContainers }}
         {{- include "common.tplvalues.render" (dict "value" $query.extraContainers "context" $) | nindent 8 }}
-        {{- end }}         
+        {{- end }}
         - name: query
           image: {{ include "thanos.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
@@ -149,7 +155,7 @@ spec:
               containerPort: 10901
               protocol: TCP
           {{- if $query.livenessProbe.enabled }}
-          livenessProbe: 
+          livenessProbe:
             httpGet:
               path: /-/healthy
               port: http
@@ -160,7 +166,7 @@ spec:
             failureThreshold: {{ $query.livenessProbe.failureThreshold }}
           {{- end }}
           {{- if $query.readinessProbe.enabled }}
-          readinessProbe: 
+          readinessProbe:
             httpGet:
               path: /-/ready
               port: http

--- a/bitnami/thanos/templates/query/hpa.yaml
+++ b/bitnami/thanos/templates/query/hpa.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-query
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
@@ -26,4 +29,4 @@ spec:
         name: cpu
         targetAverageUtilization: {{ $query.autoscaling.targetCPU }}
     {{- end }}
-{{- end }}    
+{{- end }}

--- a/bitnami/thanos/templates/query/ingress-grpc.yaml
+++ b/bitnami/thanos/templates/query/ingress-grpc.yaml
@@ -5,6 +5,10 @@ kind: Ingress
 metadata:
   name: {{ include "common.names.fullname" . }}-grpc
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: query
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   annotations:
     {{- if $query.ingress.grpc.certManager }}
     kubernetes.io/tls-acme: "true"

--- a/bitnami/thanos/templates/query/ingress.yaml
+++ b/bitnami/thanos/templates/query/ingress.yaml
@@ -5,6 +5,10 @@ kind: Ingress
 metadata:
   name: {{ include "common.names.fullname" . }}-query
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: query
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   annotations:
     {{- if $query.ingress.certManager }}
     kubernetes.io/tls-acme: "true"

--- a/bitnami/thanos/templates/query/pdb.yaml
+++ b/bitnami/thanos/templates/query/pdb.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-query
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   {{- if $query.pdb.minAvailable }}
   minAvailable: {{ $query.pdb.minAvailable }}

--- a/bitnami/thanos/templates/query/psp-clusterrole.yaml
+++ b/bitnami/thanos/templates/query/psp-clusterrole.yaml
@@ -4,6 +4,11 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname" . }}-query
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: query
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 rules:
 - apiGroups: ['policy']
   resources: ['podsecuritypolicies']

--- a/bitnami/thanos/templates/query/psp-clusterrolebinding.yaml
+++ b/bitnami/thanos/templates/query/psp-clusterrolebinding.yaml
@@ -4,6 +4,11 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "common.names.fullname" . }}-query
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: query
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 roleRef:
   kind: ClusterRole
   name: {{ include "common.names.fullname" . }}-query

--- a/bitnami/thanos/templates/query/psp.yaml
+++ b/bitnami/thanos/templates/query/psp.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-query
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   fsGroup:
     rule: RunAsAny

--- a/bitnami/thanos/templates/query/sd-configmap.yaml
+++ b/bitnami/thanos/templates/query/sd-configmap.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-query-sd-configmap
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 data:
   servicediscovery.yml: |-
     {{- include "common.tplvalues.render" (dict "value" $query.sdConfig "context" $) | nindent 4 }}

--- a/bitnami/thanos/templates/query/service.yaml
+++ b/bitnami/thanos/templates/query/service.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-query
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if $query.service.annotations }}
   annotations: {{- include "common.tplvalues.render" (dict "value" $query.service.annotations "context" $) | nindent 4 }}
   {{- end }}
@@ -42,7 +45,7 @@ spec:
       {{- else if eq $query.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
-  selector: 
+  selector:
     {{- if $query.service.labelSelectorsOverride }}
     {{- include "common.tplvalues.render" (dict "value" $query.service.labelSelectorsOverride "context" $) | nindent 4 }}
     {{- else }}

--- a/bitnami/thanos/templates/query/serviceaccount.yaml
+++ b/bitnami/thanos/templates/query/serviceaccount.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ include "thanos.serviceaccount.name" (dict "component" "query" "context" $) }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if $query.serviceAccount.annotations }}
   annotations:
     {{ include "common.tplvalues.render" ( dict "value" $query.serviceAccount.annotations "context" $) | nindent 4 }}

--- a/bitnami/thanos/templates/query/servicemonitor.yaml
+++ b/bitnami/thanos/templates/query/servicemonitor.yaml
@@ -9,9 +9,12 @@ metadata:
   {{- end }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query
-{{- if .Values.metrics.serviceMonitor.labels }}
-{{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
-{{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}

--- a/bitnami/thanos/templates/query/tls-client-secret.yaml
+++ b/bitnami/thanos/templates/query/tls-client-secret.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ include "common.secrets.name" (dict "existingSecret" .Values.query.grpcTLS.server.existingSecret "defaultNameSuffix" "query-tls-client" "context" $) }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 type: Opaque
 data:
 {{- if $query.grpcTLS.client.cert }}

--- a/bitnami/thanos/templates/query/tls-secrets.yaml
+++ b/bitnami/thanos/templates/query/tls-secrets.yaml
@@ -6,6 +6,10 @@ kind: Secret
 metadata:
   name: {{ include "common.names.fullname" $ }}-query
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
+    app.kubernetes.io/component: query
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .certificate | b64enc }}

--- a/bitnami/thanos/templates/query/tls-server-secret.yaml
+++ b/bitnami/thanos/templates/query/tls-server-secret.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ include "common.secrets.name" (dict "existingSecret" .Values.query.grpcTLS.server.existingSecret "defaultNameSuffix" "query-tls-server" "context" $) }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 type: Opaque
 data:
   tls-cert: {{ $query.grpcTLS.server.cert | b64enc | quote }}

--- a/bitnami/thanos/templates/receive/configmap.yaml
+++ b/bitnami/thanos/templates/receive/configmap.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-receive
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: receive
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 data:
   hashrings.json: |-
     {{- include "common.tplvalues.render" (dict "value" (include "thanos.receive.config" .) "context" .) | nindent 4 }}

--- a/bitnami/thanos/templates/receive/hpa.yaml
+++ b/bitnami/thanos/templates/receive/hpa.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-receive
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: receive
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
@@ -25,4 +28,4 @@ spec:
         name: cpu
         targetAverageUtilization: {{ .Values.receive.autoscaling.targetCPU }}
     {{- end }}
-{{- end }}    
+{{- end }}

--- a/bitnami/thanos/templates/receive/ingress.yaml
+++ b/bitnami/thanos/templates/receive/ingress.yaml
@@ -4,6 +4,10 @@ kind: Ingress
 metadata:
   name: {{ include "common.names.fullname" . }}-receive
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: receive
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   annotations:
     {{- if .Values.receive.ingress.certManager }}
     kubernetes.io/tls-acme: "true"

--- a/bitnami/thanos/templates/receive/pdb.yaml
+++ b/bitnami/thanos/templates/receive/pdb.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-receive
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: receive
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   {{- if .Values.receive.pdb.minAvailable }}
   minAvailable: {{ .Values.receive.pdb.minAvailable }}

--- a/bitnami/thanos/templates/receive/service-headless.yaml
+++ b/bitnami/thanos/templates/receive/service-headless.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-receive-headless
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: receive
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/bitnami/thanos/templates/receive/service.yaml
+++ b/bitnami/thanos/templates/receive/service.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-receive
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: receive
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.receive.service.annotations }}
   annotations: {{- include "common.tplvalues.render" (dict "value" .Values.receive.service.annotations "context" $) | nindent 4 }}
   {{- end }}
@@ -50,7 +53,7 @@ spec:
       {{- else if eq .Values.receive.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
-  selector: 
+  selector:
     {{- if .Values.receive.service.labelSelectorsOverride }}
     {{- include "common.tplvalues.render" (dict "value" .Values.receive.service.labelSelectorsOverride "context" $) | nindent 4 }}
     {{- else }}

--- a/bitnami/thanos/templates/receive/serviceaccount.yaml
+++ b/bitnami/thanos/templates/receive/serviceaccount.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "thanos.serviceaccount.name" (dict "component" "receive" "context" $) }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: receive
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.receive.serviceAccount.annotations }}
   annotations:
     {{- include "common.tplvalues.render" ( dict "value" .Values.receive.serviceAccount.annotations "context" $) | nindent 4 }}

--- a/bitnami/thanos/templates/receive/servicemonitor.yaml
+++ b/bitnami/thanos/templates/receive/servicemonitor.yaml
@@ -8,9 +8,12 @@ metadata:
   {{- end }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: receive
-{{- if .Values.metrics.serviceMonitor.labels }}
-{{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
-{{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}

--- a/bitnami/thanos/templates/receive/statefulset.yaml
+++ b/bitnami/thanos/templates/receive/statefulset.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-receive
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: receive
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.receive.replicaCount }}
   podManagementPolicy: {{ .Values.receive.podManagementPolicy }}
@@ -21,7 +24,10 @@ spec:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: receive
-        {{- if and .Values.receive.enabled .Values.receive.podLabels }}
+        {{- if .Values.commonLabels }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.receive.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.receive.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
@@ -61,7 +67,7 @@ spec:
       containers:
         {{- if .Values.receive.extraContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.receive.extraContainers "context" $) | nindent 8 }}
-        {{- end }}         
+        {{- end }}
         - name: receive
           image: {{ include "thanos.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
@@ -118,7 +124,7 @@ spec:
               name: remote-write
               protocol: TCP
           {{- if .Values.receive.livenessProbe.enabled }}
-          livenessProbe: 
+          livenessProbe:
             httpGet:
               path: /-/healthy
               port: http
@@ -129,7 +135,7 @@ spec:
             failureThreshold: {{ .Values.receive.livenessProbe.failureThreshold }}
           {{- end }}
           {{- if .Values.receive.readinessProbe.enabled }}
-          readinessProbe: 
+          readinessProbe:
             httpGet:
               path: /-/ready
               port: http

--- a/bitnami/thanos/templates/receive/tls-secrets.yaml
+++ b/bitnami/thanos/templates/receive/tls-secrets.yaml
@@ -5,6 +5,10 @@ kind: Secret
 metadata:
   name: {{ include "common.names.fullname" $ }}-receive
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
+    app.kubernetes.io/component: receive
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .certificate | b64enc }}

--- a/bitnami/thanos/templates/receive/tls-server-secret.yaml
+++ b/bitnami/thanos/templates/receive/tls-server-secret.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-receive-tls-server
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: receive
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 type: Opaque
 data:
   cert.pem: {{ .Values.receive.grpc.server.cert | b64enc | quote }}

--- a/bitnami/thanos/templates/ruler/configmap.yaml
+++ b/bitnami/thanos/templates/ruler/configmap.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-ruler-configmap
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: ruler
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 data:
   ruler.yml: |-
     {{- include "common.tplvalues.render" (dict "value" .Values.ruler.config "context" $) | nindent 4 }}

--- a/bitnami/thanos/templates/ruler/ingress.yaml
+++ b/bitnami/thanos/templates/ruler/ingress.yaml
@@ -4,6 +4,10 @@ kind: Ingress
 metadata:
   name: {{ include "common.names.fullname" . }}-ruler
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: ruler
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   annotations:
     {{- if .Values.ruler.ingress.certManager }}
     kubernetes.io/tls-acme: "true"

--- a/bitnami/thanos/templates/ruler/pdb.yaml
+++ b/bitnami/thanos/templates/ruler/pdb.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-ruler
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: ruler
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   {{- if .Values.ruler.pdb.minAvailable }}
   minAvailable: {{ .Values.ruler.pdb.minAvailable }}

--- a/bitnami/thanos/templates/ruler/secret.yaml
+++ b/bitnami/thanos/templates/ruler/secret.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-ruler-alertmanagers-config
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: ruler
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 data:
   alertmanagers_config.yml: |-
     {{- include "common.tplvalues.render" (dict "value" .Values.ruler.alertmanagersConfig "context" $) | b64enc | nindent 4 }}

--- a/bitnami/thanos/templates/ruler/service-headless.yaml
+++ b/bitnami/thanos/templates/ruler/service-headless.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-ruler-headless
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: ruler
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/bitnami/thanos/templates/ruler/service.yaml
+++ b/bitnami/thanos/templates/ruler/service.yaml
@@ -8,6 +8,9 @@ metadata:
     {{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
     prometheus-operator/monitor: 'true'
     {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.ruler.service.annotations }}
   annotations: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.service.annotations "context" $) | nindent 4 }}
   {{- end }}

--- a/bitnami/thanos/templates/ruler/serviceaccount.yaml
+++ b/bitnami/thanos/templates/ruler/serviceaccount.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "thanos.serviceaccount.name" (dict "component" "ruler" "context" $) }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: ruler
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.ruler.serviceAccount.annotations }}
   annotations:
     {{- include "common.tplvalues.render" ( dict "value" .Values.ruler.serviceAccount.annotations "context" $) | nindent 4 }}

--- a/bitnami/thanos/templates/ruler/servicemonitor.yaml
+++ b/bitnami/thanos/templates/ruler/servicemonitor.yaml
@@ -8,9 +8,12 @@ metadata:
   {{- end }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: ruler
-{{- if .Values.metrics.serviceMonitor.labels }}
-{{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
-{{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}

--- a/bitnami/thanos/templates/ruler/statefulset.yaml
+++ b/bitnami/thanos/templates/ruler/statefulset.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-ruler
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: ruler
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.ruler.replicaCount }}
   podManagementPolicy: {{ .Values.ruler.podManagementPolicy }}
@@ -22,7 +25,10 @@ spec:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: ruler
-        {{- if and .Values.ruler.enabled .Values.ruler.podLabels }}
+        {{- if .Values.commonLabels }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.ruler.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.ruler.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
@@ -77,7 +83,7 @@ spec:
       containers:
         {{- if .Values.ruler.extraContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.ruler.extraContainers  "context" $) | nindent 8 }}
-        {{- end }}         
+        {{- end }}
         - name: ruler
           image: {{ include "thanos.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
@@ -128,7 +134,7 @@ spec:
               containerPort: 10901
               protocol: TCP
           {{- if .Values.ruler.livenessProbe.enabled }}
-          livenessProbe: 
+          livenessProbe:
             httpGet:
               path: /-/healthy
               port: http
@@ -139,7 +145,7 @@ spec:
             failureThreshold: {{ .Values.ruler.livenessProbe.failureThreshold }}
           {{- end }}
           {{- if .Values.ruler.readinessProbe.enabled }}
-          readinessProbe: 
+          readinessProbe:
             httpGet:
               path: /-/ready
               port: http

--- a/bitnami/thanos/templates/storegateway/configmap.yaml
+++ b/bitnami/thanos/templates/storegateway/configmap.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-storegateway-configmap
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: storegateway
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 data:
   config.yml: |-
     {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.config "context" $) | nindent 4 }}

--- a/bitnami/thanos/templates/storegateway/hpa.yaml
+++ b/bitnami/thanos/templates/storegateway/hpa.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-storegateway
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: storegateway
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/bitnami/thanos/templates/storegateway/pdb.yaml
+++ b/bitnami/thanos/templates/storegateway/pdb.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-storegateway
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: storegateway
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   {{- if .Values.storegateway.pdb.minAvailable }}
   minAvailable: {{ .Values.storegateway.pdb.minAvailable }}

--- a/bitnami/thanos/templates/storegateway/service-headless.yaml
+++ b/bitnami/thanos/templates/storegateway/service-headless.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-storegateway-headless
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: storegateway
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/bitnami/thanos/templates/storegateway/service.yaml
+++ b/bitnami/thanos/templates/storegateway/service.yaml
@@ -8,6 +8,9 @@ metadata:
     {{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
     prometheus-operator/monitor: 'true'
     {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.storegateway.service.annotations }}
   annotations: {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.service.annotations "context" $) | nindent 4 }}
   {{- end }}

--- a/bitnami/thanos/templates/storegateway/serviceaccount.yaml
+++ b/bitnami/thanos/templates/storegateway/serviceaccount.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "thanos.serviceaccount.name" (dict "component" "storegateway" "context" $) }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: storegateway
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.storegateway.serviceAccount.annotations }}
   annotations:
     {{- include "common.tplvalues.render" ( dict "value" .Values.storegateway.serviceAccount.annotations "context" $) | nindent 4 }}

--- a/bitnami/thanos/templates/storegateway/servicemonitor.yaml
+++ b/bitnami/thanos/templates/storegateway/servicemonitor.yaml
@@ -8,9 +8,12 @@ metadata:
   {{- end }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: storegateway
-{{- if .Values.metrics.serviceMonitor.labels }}
-{{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
-{{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}

--- a/bitnami/thanos/templates/storegateway/statefulset.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}-storegateway
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: storegateway
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.storegateway.replicaCount }}
   podManagementPolicy: {{ .Values.storegateway.podManagementPolicy }}
@@ -21,7 +24,10 @@ spec:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: storegateway
-        {{- if and .Values.storegateway.enabled .Values.storegateway.podLabels }}
+        {{- if .Values.commonLabels }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.storegateway.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
@@ -125,7 +131,7 @@ spec:
               containerPort: 10901
               protocol: TCP
           {{- if .Values.storegateway.livenessProbe.enabled }}
-          livenessProbe: 
+          livenessProbe:
             httpGet:
               path: /-/healthy
               port: http
@@ -136,7 +142,7 @@ spec:
             failureThreshold: {{ .Values.storegateway.livenessProbe.failureThreshold }}
           {{- end }}
           {{- if .Values.storegateway.readinessProbe.enabled }}
-          readinessProbe: 
+          readinessProbe:
             httpGet:
               path: /-/ready
               port: http

--- a/bitnami/thanos/templates/storegateway/tls-server-secret.yaml
+++ b/bitnami/thanos/templates/storegateway/tls-server-secret.yaml
@@ -4,7 +4,10 @@ kind: Secret
 metadata:
   name: {{ printf "%s-store-tls-server" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: store
+    app.kubernetes.io/component: storegateway
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 type: Opaque
 data:
   tls-cert: {{ .Values.storegateway.grpc.tls.cert | b64enc | quote }}

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -37,6 +37,10 @@ image:
 ##
 # fullnameOverride:
 
+## Add labels to all the deployed resources
+##
+commonLabels: {}
+
 ## Kubernetes Cluster Domain
 ##
 clusterDomain: cluster.local


### PR DESCRIPTION
**Description of the change**

Addition of commonLabels field, to be able to apply this two elements to all manifests of the chart.

**Benefits**

We can now apply Labels for all k8s ressources deployed by this chart.

None

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
