### PR TITLE
[bitnami/*] Adapt values.yaml of Nginx Ingress Controller, Node and Node Exporter charts

### DIFF
--- a/.github/workflows/generate-chart-readme.yml
+++ b/.github/workflows/generate-chart-readme.yml
@@ -27,6 +27,9 @@ on:
       - 'bitnami/metrics-server/values.yaml'
       - 'bitnami/minio/values.yaml'
       - 'bitnami/mongodb/values.yaml'
+      - 'bitnami/nginx-ingress-controller/values.yaml'
+      - 'bitnami/node/values.yaml'
+      - 'bitnami/node-exporter/values.yaml'
 
 jobs:
   generate-chart-readme:

--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -26,4 +26,4 @@ name: nginx-ingress-controller
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx-ingress-controller
   - https://github.com/kubernetes/ingress-nginx
-version: 7.6.14
+version: 7.6.15

--- a/bitnami/nginx-ingress-controller/README.md
+++ b/bitnami/nginx-ingress-controller/README.md
@@ -47,208 +47,242 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Parameters
 
-The following tables lists the configurable parameters of the Nginx Ingress Controller chart chart and their default values per section/component:
-
 ### Global parameters
 
-| Parameter                 | Description                                     | Default                                                 |
-|---------------------------|-------------------------------------------------|---------------------------------------------------------|
-| `global.imageRegistry`    | Global Docker image registry                    | `nil`                                                   |
-| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
+| Name                      | Description                                     | Value |
+| ------------------------- | ----------------------------------------------- | ----- |
+| `global.imageRegistry`    | Global Docker image registry                    | `nil` |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
+
 
 ### Common parameters
 
-| Parameter           | Description                                        | Default                        |
-|---------------------|----------------------------------------------------|--------------------------------|
-| `nameOverride`      | String to partially override common.names.fullname | `nil`                          |
-| `fullnameOverride`  | String to fully override common.names.fullname     | `nil`                          |
-| `commonLabels`      | Labels to add to all deployed objects              | `{}`                           |
-| `commonAnnotations` | Annotations to add to all deployed objects         | `{}`                           |
-| `extraDeploy`       | Array of extra objects to deploy with the release  | `[]` (evaluated as a template) |
+| Name                | Description                                        | Value |
+| ------------------- | -------------------------------------------------- | ----- |
+| `nameOverride`      | String to partially override common.names.fullname | `nil` |
+| `fullnameOverride`  | String to fully override common.names.fullname     | `nil` |
+| `commonLabels`      | Add labels to all the deployed resources           | `{}`  |
+| `commonAnnotations` | Add annotations to all the deployed resources      | `{}`  |
+| `extraDeploy`       | Array of extra objects to deploy with the release  | `[]`  |
+
 
 ### Nginx Ingress Controller parameters
 
-| Parameter                     | Description                                                                                                                                        | Default                                                 |
-|-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `image.registry`              | Nginx Ingress Controller image registry                                                                                                            | `docker.io`                                             |
-| `image.repository`            | Nginx Ingress Controller image name                                                                                                                | `bitnami/nginx-ingress-controller`                      |
-| `image.tag`                   | Nginx Ingress Controller image tag                                                                                                                 | `{TAG_NAME}`                                            |
-| `image.pullPolicy`            | Image pull policy                                                                                                                                  | `IfNotPresent`                                          |
-| `image.pullSecrets`           | Specify docker-registry secret names as an array                                                                                                   | `[]` (does not add image pull secrets to deployed pods) |
-| `containerPorts.http`         | The port that the controller container listens on for HTTP connections.                                                                            | `80`                                                    |
-| `containerPorts.https`        | The port that the controller container listens on for HTTPS connections.                                                                           | `443`                                                   |
-| `config`                      | Nginx ConfigMap entries                                                                                                                            | `{}`                                                    |
-| `addHeaders`                  | Custom headers to be added before sending responses to the client                                                                                  | `{}`                                                    |
-| `proxySetHeaders`             | Custom headers to be added before sending request to the backends for NGINX                                                                        | `{}`                                                    |
-| `reportNodeInternalIp`        | If using `hostNetwork=true`, setting `reportNodeInternalIp=true`, will pass the flag `report-node-internal-ip-address` to Nginx Ingress Controller | `ClusterFirst`                                          |
-| `defaultBackendService`       | Default 404 backend service; required only if `defaultBackend.enabled = false`                                                                     | `""`                                                    |
-| `electionID`                  | Election ID to use for the status update                                                                                                           | `ingress-controller-leader`                             |
-| `ingressClass`                | Name of the ingress class to route through this controller                                                                                         | `nginx`                                                 |
-| `publishService.enabled`      | Set the endpoint records on the Ingress objects to reflect those on the service                                                                    | `false`                                                 |
-| `publishService.pathOverride` | Override of the default publish-service name                                                                                                       | `""`                                                    |
-| `hostAliases`                 | Add deployment host aliases                                                                                                                        | `[]`                                                    |
-| `scope.enabled`               | Limit the scope of the ingress controller                                                                                                          | `false` (watch all namespaces)                          |
-| `scope.namespace`             | Namespace to watch for ingress                                                                                                                     | `""` (use the release namespace)                        |
-| `configMapNamespace`          | The nginx-configmap namespace name                                                                                                                 | `""`                                                    |
-| `tcpConfigMapNamespace`       | The tcp-services-configmap namespace name                                                                                                          | `""`                                                    |
-| `udpConfigMapNamespace`       | The udp-services-configmap namespace name                                                                                                          | `""`                                                    |
-| `dhparam`                     | A base64 Diffie-Helman parameter                                                                                                                   | `nil`                                                   |
-| `tcp`                         | TCP service key:value pairs                                                                                                                        | `{}`                                                    |
-| `udp`                         | UDP service key:value pairs                                                                                                                        | `{}`                                                    |
-| `maxmindLicenseKey`           | Maxmind license key to download GeoLite2 Databases                                                                                                 | `""`                                                    |
-| `command`                     | Override default container command (useful when using custom images)                                                                               | `nil`                                                   |
-| `args`                        | Override default container args (useful when using custom images)                                                                                  | `nil`                                                   |
-| `extraArgs`                   | Additional command line arguments to pass to Nginx Ingress container                                                                               | `{}`                                                    |
-| `extraEnvVars`                | Extra environment variables to be set on Nginx Ingress container                                                                                   | `[]`                                                    |
-| `extraEnvVarsCM`              | Name of existing ConfigMap containing extra env vars                                                                                               | `nil`                                                   |
-| `extraEnvVarsSecret`          | Name of existing Secret containing extra env vars                                                                                                  | `nil`                                                   |
+| Name                          | Description                                                                                                                                        | Value                              |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| `image.registry`              | Nginx Ingress Controller image registry                                                                                                            | `docker.io`                        |
+| `image.repository`            | Nginx Ingress Controller image repository                                                                                                          | `bitnami/nginx-ingress-controller` |
+| `image.tag`                   | Nginx Ingress Controller image tag (immutable tags are recommended)                                                                                | `0.47.0-debian-10-r25`             |
+| `image.pullPolicy`            | Nginx Ingress Controller image pull policy                                                                                                         | `IfNotPresent`                     |
+| `image.pullSecrets`           | Specify docker-registry secret names as an array                                                                                                   | `[]`                               |
+| `containerPorts`              | Controller container ports to open                                                                                                                 | `{}`                               |
+| `hostAliases`                 | Deployment pod host aliases                                                                                                                        | `[]`                               |
+| `config`                      | Custom configuration options for NGINX                                                                                                             | `{}`                               |
+| `proxySetHeaders`             | Custom headers before sending traffic to backends                                                                                                  | `{}`                               |
+| `addHeaders`                  | Custom headers before sending response traffic to the client                                                                                       | `{}`                               |
+| `defaultBackendService`       | Default 404 backend service; required only if `defaultBackend.enabled = false`                                                                     | `""`                               |
+| `electionID`                  | Election ID to use for status update                                                                                                               | `ingress-controller-leader`        |
+| `reportNodeInternalIp`        | If using `hostNetwork=true`, setting `reportNodeInternalIp=true`, will pass the flag `report-node-internal-ip-address` to Nginx Ingress Controller | `false`                            |
+| `ingressClass`                | Name of the ingress class to route through this controller                                                                                         | `nginx`                            |
+| `publishService.enabled`      | Set the endpoint records on the Ingress objects to reflect those on the service                                                                    | `false`                            |
+| `publishService.pathOverride` | Allows overriding of the publish service to bind to                                                                                                | `""`                               |
+| `scope.enabled`               | Limit the scope of the controller. Defaults to `.Release.Namespace`                                                                                | `false`                            |
+| `configMapNamespace`          | Allows customization of the configmap / nginx-configmap namespace                                                                                  | `""`                               |
+| `tcpConfigMapNamespace`       | Allows customization of the tcp-services-configmap namespace                                                                                       | `""`                               |
+| `udpConfigMapNamespace`       | Allows customization of the udp-services-configmap namespace                                                                                       | `""`                               |
+| `maxmindLicenseKey`           | License key used to download Geolite2 database                                                                                                     | `""`                               |
+| `dhParam`                     | A base64ed Diffie-Hellman parameter                                                                                                                | `nil`                              |
+| `tcp`                         | TCP service key:value pairs                                                                                                                        | `""`                               |
+| `udp`                         | UDP service key:value pairs                                                                                                                        | `""`                               |
+| `command`                     | Override default container command (useful when using custom images)                                                                               | `[]`                               |
+| `args`                        | Override default container args (useful when using custom images)                                                                                  | `[]`                               |
+| `extraArgs`                   | Additional command line arguments to pass to nginx-ingress-controller                                                                              | `{}`                               |
+| `extraEnvVars`                | Extra environment variables to be set on Nginx Ingress container                                                                                   | `[]`                               |
+| `extraEnvVarsCM`              | Name of a existing ConfigMap containing extra environment variables                                                                                | `nil`                              |
+| `extraEnvVarsSecret`          | Name of a existing Secret containing extra environment variables                                                                                   | `nil`                              |
+
 
 ### Nginx Ingress deployment / daemonset parameters
 
-| Parameter                       | Description                                                                                             | Default                        |
-|---------------------------------|---------------------------------------------------------------------------------------------------------|--------------------------------|
-| `kind`                          | Install as Deployment or DaemonSet                                                                      | `Deployment`                   |
-| `replicaCount`                  | Desired number of Controller pods                                                                       | `1`                            |
-| `daemonset.useHostPort`         | If `kind` is `DaemonSet`, this will enable `hostPort` for `TCP/80` and `TCP/443`                        | `false`                        |
-| `daemonset.hostPorts.http`      | If `daemonset.useHostPort` is `true` and this is non-empty, it sets the hostPort                        | `"80"`                         |
-| `daemonset.hostPorts.https`     | If `daemonset.useHostPort` is `true` and this is non-empty, it sets the hostPort                        | `"443"`                        |
-| `hostNetwork`                   | If the nginx deployment / daemonset should run on the host's network namespace                          | `false`                        |
-| `dnsPolicy`                     | If using `hostNetwork=true`, change to `ClusterFirstWithHostNet`                                        | `ClusterFirst`                 |
-| `podSecurityContext`            | Controller pods' Security Context                                                                       | Check `values.yaml` file       |
-| `containerSecurityContext`      | Controller containers' Security Context                                                                 | Check `values.yaml` file       |
-| `resources.limits`              | The resources limits for the Controller container                                                       | `{}`                           |
-| `resources.requests`            | The requested resources for the Controller container                                                    | `{}`                           |
-| `livenessProbe`                 | Liveness probe configuration for Controller                                                             | Check `values.yaml` file       |
-| `readinessProbe`                | Readiness probe configuration for Controller                                                            | Check `values.yaml` file       |
-| `customLivenessProbe`           | Override default liveness probe                                                                         | `nil`                          |
-| `customReadinessProbe`          | Override default readiness probe                                                                        | `nil`                          |
-| `revisionHistoryLimit`          | The number of old history to retain to allow rollback.                                                  | `10`                           |
-| `updateStrategy`                | Strategy to use to update Pods                                                                          | Check `values.yaml` file       |
-| `podAffinityPreset`             | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                     | `""`                           |
-| `podAntiAffinityPreset`         | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                | `soft`                         |
-| `nodeAffinityPreset.type`       | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`               | `""`                           |
-| `nodeAffinityPreset.key`        | Node label key to match. Ignored if `affinity` is set.                                                  | `""`                           |
-| `nodeAffinityPreset.values`     | Node label values to match. Ignored if `affinity` is set.                                               | `[]`                           |
-| `affinity`                      | Affinity for pod assignment                                                                             | `{}` (evaluated as a template) |
-| `nodeSelector`                  | Node labels for pod assignment                                                                          | `{}` (evaluated as a template) |
-| `tolerations`                   | Tolerations for pod assignment                                                                          | `[]` (evaluated as a template) |
-| `podLabels`                     | Extra labels for Controller pods                                                                        | `{}` (evaluated as a template) |
-| `podAnnotations`                | Annotations for Controller pods                                                                         | `{}` (evaluated as a template) |
-| `priorityClassName`             | Controller priorityClassName                                                                            | `nil`                          |
-| `lifecycle`                     | LifecycleHooks to set additional configuration at startup.                                              | `{}` (evaluated as a template) |
-| `terminationGracePeriodSeconds` | How many seconds to wait before terminating a pod                                                       | `60`                           |
-| `topologySpreadConstraints`     | Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in | `{}`                           |
-| `minReadySeconds`               | How many seconds a pod needs to be ready before killing the next, during update                         | `0`                            |
-| `extraVolumeMounts`             | Optionally specify extra list of additional volumeMounts for Controller container(s)                    | `[]`                           |
-| `extraVolumes`                  | Optionally specify extra list of additional volumes for Controller pods                                 | `[]`                           |
-| `initContainers`                | Add additional init containers to the Controller pods                                                   | `{}` (evaluated as a template) |
-| `sidecars`                      | Add additional sidecar containers to the Controller pods                                                | `{}` (evaluated as a template) |
+| Name                                                | Description                                                                                             | Value          |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | -------------- |
+| `kind`                                              | Install as Deployment or DaemonSet                                                                      | `Deployment`   |
+| `daemonset.useHostPort`                             | If `kind` is `DaemonSet`, this will enable `hostPort` for `TCP/80` and `TCP/443`                        | `false`        |
+| `daemonset.hostPorts`                               | HTTP and HTTPS ports                                                                                    | `{}`           |
+| `replicaCount`                                      | Desired number of Controller pods                                                                       | `1`            |
+| `updateStrategy`                                    | Strategy to use to update Pods                                                                          | `{}`           |
+| `revisionHistoryLimit`                              | The number of old history to retain to allow rollback                                                   | `10`           |
+| `podSecurityContext.enabled`                        | Enable Controller pods' Security Context                                                                | `true`         |
+| `podSecurityContext.fsGroup`                        | Group ID for the container filesystem                                                                   | `1001`         |
+| `containerSecurityContext.enabled`                  | Enable Controller containers' Security Context                                                          | `true`         |
+| `containerSecurityContext.allowPrivilegeEscalation` | Switch to allow priviledge escalation on the Controller container                                       | `true`         |
+| `containerSecurityContext.runAsUser`                | User ID for the Controller container                                                                    | `1001`         |
+| `containerSecurityContext.capabilities.drop`        | Linux Kernel capabilities that should be dropped                                                        | `[]`           |
+| `containerSecurityContext.capabilities.add`         | Linux Kernel capabilities that should be added                                                          | `[]`           |
+| `minReadySeconds`                                   | How many seconds a pod needs to be ready before killing the next, during update                         | `0`            |
+| `resources.limits`                                  | The resources limits for the Controller container                                                       | `{}`           |
+| `resources.requests`                                | The requested resources for the Controller container                                                    | `{}`           |
+| `livenessProbe.enabled`                             | Enable livenessProbe                                                                                    | `true`         |
+| `livenessProbe.httpGet.path`                        | Request path for livenessProbe                                                                          | `/healthz`     |
+| `livenessProbe.httpGet.port`                        | Port for livenessProbe                                                                                  | `10254`        |
+| `livenessProbe.httpGet.scheme`                      | Scheme for livenessProbe                                                                                | `HTTP`         |
+| `livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                                 | `10`           |
+| `livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                                        | `10`           |
+| `livenessProbe.timeoutSeconds`                      | Timeout seconds for livenessProbe                                                                       | `1`            |
+| `livenessProbe.failureThreshold`                    | Failure threshold for livenessProbe                                                                     | `3`            |
+| `livenessProbe.successThreshold`                    | Success threshold for livenessProbe                                                                     | `1`            |
+| `readinessProbe.enabled`                            | Enable readinessProbe                                                                                   | `true`         |
+| `readinessProbe.httpGet.path`                       | Request path for readinessProbe                                                                         | `/healthz`     |
+| `readinessProbe.httpGet.port`                       | Port for readinessProbe                                                                                 | `10254`        |
+| `readinessProbe.httpGet.scheme`                     | Scheme for readinessProbe                                                                               | `HTTP`         |
+| `readinessProbe.initialDelaySeconds`                | Initial delay seconds for readinessProbe                                                                | `10`           |
+| `readinessProbe.periodSeconds`                      | Period seconds for readinessProbe                                                                       | `10`           |
+| `readinessProbe.timeoutSeconds`                     | Timeout seconds for readinessProbe                                                                      | `1`            |
+| `readinessProbe.failureThreshold`                   | Failure threshold for readinessProbe                                                                    | `3`            |
+| `readinessProbe.successThreshold`                   | Success threshold for readinessProbe                                                                    | `1`            |
+| `customLivenessProbe`                               | Override default liveness probe                                                                         | `{}`           |
+| `customReadinessProbe`                              | Override default readiness probe                                                                        | `{}`           |
+| `lifecycle`                                         | LifecycleHooks to set additional configuration at startup                                               | `{}`           |
+| `podLabels`                                         | Extra labels for Controller pods                                                                        | `{}`           |
+| `podAnnotations`                                    | Annotations for Controller pods                                                                         | `{}`           |
+| `priorityClassName`                                 | Controller priorityClassName                                                                            | `""`           |
+| `hostNetwork`                                       | If the Nginx deployment / daemonset should run on the host's network namespace                          | `false`        |
+| `dnsPolicy`                                         | By default, while using host network, name resolution uses the host's DNS                               | `ClusterFirst` |
+| `terminationGracePeriodSeconds`                     | How many seconds to wait before terminating a pod                                                       | `60`           |
+| `podAffinityPreset`                                 | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                     | `""`           |
+| `podAntiAffinityPreset`                             | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                | `soft`         |
+| `nodeAffinityPreset.type`                           | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`               | `""`           |
+| `nodeAffinityPreset.key`                            | Node label key to match. Ignored if `affinity` is set.                                                  | `""`           |
+| `nodeAffinityPreset.values`                         | Node label values to match. Ignored if `affinity` is set.                                               | `[]`           |
+| `affinity`                                          | Affinity for pod assignment. Evaluated as a template.                                                   | `{}`           |
+| `nodeSelector`                                      | Node labels for pod assignment. Evaluated as a template.                                                | `{}`           |
+| `tolerations`                                       | Tolerations for pod assignment. Evaluated as a template.                                                | `[]`           |
+| `extraVolumes`                                      | Optionally specify extra list of additional volumes for Controller pods                                 | `[]`           |
+| `extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for Controller container(s)                    | `[]`           |
+| `initContainers`                                    | Add init containers to the controller pods                                                              | `{}`           |
+| `sidecars`                                          | Add sidecars to the controller pods.                                                                    | `{}`           |
+| `customTemplate`                                    | Override NGINX template                                                                                 | `{}`           |
+| `topologySpreadConstraints`                         | Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in | `[]`           |
+| `podSecurityPolicy.enabled`                         | If true, create & use Pod Security Policy resources                                                     | `false`        |
+
 
 ### Default backend parameters
 
-| Parameter                                  | Description                                                                               | Default                                                 |
-|--------------------------------------------|-------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `defaultBackend.enabled`                   | Enable a default backend based on NGINX                                                   | `true`                                                  |
-| `defaultBackend.image.registry`            | Default backend image registry                                                            | `docker.io`                                             |
-| `defaultBackend.hostAliases`               | Add deployment host aliases                                                               | `[]`                                                    |
-| `defaultBackend.image.repository`          | Default backend image name                                                                | `bitnami/nginx`                                         |
-| `defaultBackend.image.tag`                 | Default backend image tag                                                                 | `{TAG_NAME}`                                            |
-| `defaultBackend.image.pullPolicy`          | Image pull policy                                                                         | `IfNotPresent`                                          |
-| `defaultBackend.image.pullSecrets`         | Specify docker-registry secret names as an array                                          | `[]` (does not add image pull secrets to deployed pods) |
-| `defaultBackend.extraArgs`                 | Additional command line arguments to pass to NGINX container                              | `{}`                                                    |
-| `defaultBackend.containerPort`             | HTTP container port number                                                                | `8080`                                                  |
-| `defaultBackend.serverBlockConfig`         | NGINX backend default server block configuration                                          | Check `values.yaml` file                                |
-| `defaultBackend.replicaCount`              | Desired number of default backend pods                                                    | `1`                                                     |
-| `defaultBackend.podSecurityContext`        | Default backend pods' Security Context                                                    | Check `values.yaml` file                                |
-| `defaultBackend.containerSecurityContext`  | Default backend containers' Security Context                                              | Check `values.yaml` file                                |
-| `defaultBackend.resources.limits`          | The resources limits for the Default backend container                                    | `{}`                                                    |
-| `defaultBackend.resources.requests`        | The requested resources for the Default backend container                                 | `{}`                                                    |
-| `defaultBackend.livenessProbe`             | Liveness probe configuration for Default backend                                          | Check `values.yaml` file                                |
-| `defaultBackend.readinessProbe`            | Readiness probe configuration for Default backend                                         | Check `values.yaml` file                                |
-| `defaultBackend.customLivenessProbe`       | Override default liveness probe                                                           | `nil`                                                   |
-| `defaultBackend.customReadinessProbe`      | Override default readiness probe                                                          | `nil`                                                   |
-| `defaultBackend.podAffinityPreset`         | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                                                    |
-| `defaultBackend.podAntiAffinityPreset`     | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                                  |
-| `defaultBackend.nodeAffinityPreset.type`   | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                                                    |
-| `defaultBackend.nodeAffinityPreset.key`    | Node label key to match. Ignored if `affinity` is set.                                    | `""`                                                    |
-| `defaultBackend.nodeAffinityPreset.values` | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                                                    |
-| `defaultBackend.affinity`                  | Affinity for pod assignment                                                               | `{}` (evaluated as a template)                          |
-| `defaultBackend.nodeSelector`              | Node labels for pod assignment                                                            | `{}` (evaluated as a template)                          |
-| `defaultBackend.tolerations`               | Tolerations for pod assignment                                                            | `[]` (evaluated as a template)                          |
-| `defaultBackend.podLabels`                 | Extra labels for Controller pods                                                          | `{}` (evaluated as a template)                          |
-| `defaultBackend.podAnnotations`            | Annotations for Controller pods                                                           | `{}` (evaluated as a template)                          |
-| `customTemplate.configMapName`             | ConfigMap containing a custom NGINX template                                              | `""`                                                    |
-| `customTemplate.configMapKey`              | ConfigMap key containing the NGINX template                                               | `""`                                                    |
+| Name                                                | Description                                                                               | Value                 |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------- | --------------------- |
+| `defaultBackend.enabled`                            | Enable a default backend based on NGINX                                                   | `true`                |
+| `defaultBackend.hostAliases`                        | Add deployment host aliases                                                               | `[]`                  |
+| `defaultBackend.image.registry`                     | Default backend image registry                                                            | `docker.io`           |
+| `defaultBackend.image.repository`                   | Default backend image repository                                                          | `bitnami/nginx`       |
+| `defaultBackend.image.tag`                          | Default backend image tag (immutable tags are recommended)                                | `1.21.1-debian-10-r1` |
+| `defaultBackend.image.pullPolicy`                   | Image pull policy                                                                         | `IfNotPresent`        |
+| `defaultBackend.image.pullSecrets`                  | Specify docker-registry secret names as an array                                          | `[]`                  |
+| `defaultBackend.extraArgs`                          | Additional command line arguments to pass to Nginx container                              | `{}`                  |
+| `defaultBackend.containerPort`                      | HTTP container port number                                                                | `8080`                |
+| `defaultBackend.serverBlockConfig`                  | NGINX backend default server block configuration                                          | `""`                  |
+| `defaultBackend.replicaCount`                       | Desired number of default backend pods                                                    | `1`                   |
+| `defaultBackend.podSecurityContext.enabled`         | Enable Default backend pods' Security Context                                             | `true`                |
+| `defaultBackend.podSecurityContext.fsGroup`         | Group ID for the container filesystem                                                     | `1001`                |
+| `defaultBackend.containerSecurityContext.enabled`   | Enable Default backend containers' Security Context                                       | `true`                |
+| `defaultBackend.containerSecurityContext.runAsUser` | User ID for the Default backend container                                                 | `1001`                |
+| `defaultBackend.resources.limits`                   | The resources limits for the Default backend container                                    | `{}`                  |
+| `defaultBackend.resources.requests`                 | The requested resources for the Default backend container                                 | `{}`                  |
+| `defaultBackend.livenessProbe.enabled`              | Enable livenessProbe                                                                      | `true`                |
+| `defaultBackend.livenessProbe.httpGet.path`         | Request path for livenessProbe                                                            | `/healthz`            |
+| `defaultBackend.livenessProbe.httpGet.port`         | Port for livenessProbe                                                                    | `http`                |
+| `defaultBackend.livenessProbe.httpGet.scheme`       | Scheme for livenessProbe                                                                  | `HTTP`                |
+| `defaultBackend.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                   | `30`                  |
+| `defaultBackend.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                          | `10`                  |
+| `defaultBackend.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                         | `5`                   |
+| `defaultBackend.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                       | `3`                   |
+| `defaultBackend.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                       | `1`                   |
+| `defaultBackend.readinessProbe.enabled`             | Enable readinessProbe                                                                     | `true`                |
+| `defaultBackend.readinessProbe.httpGet.path`        | Request path for readinessProbe                                                           | `/healthz`            |
+| `defaultBackend.readinessProbe.httpGet.port`        | Port for readinessProbe                                                                   | `http`                |
+| `defaultBackend.readinessProbe.httpGet.scheme`      | Scheme for readinessProbe                                                                 | `HTTP`                |
+| `defaultBackend.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                  | `0`                   |
+| `defaultBackend.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                         | `5`                   |
+| `defaultBackend.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                        | `5`                   |
+| `defaultBackend.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                      | `6`                   |
+| `defaultBackend.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                      | `1`                   |
+| `defaultBackend.podLabels`                          | Extra labels for Controller pods                                                          | `{}`                  |
+| `defaultBackend.podAnnotations`                     | Annotations for Controller pods                                                           | `{}`                  |
+| `defaultBackend.priorityClassName`                  | priorityClassName                                                                         | `""`                  |
+| `defaultBackend.podAffinityPreset`                  | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                  |
+| `defaultBackend.podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                |
+| `defaultBackend.nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                  |
+| `defaultBackend.nodeAffinityPreset.key`             | Node label key to match. Ignored if `affinity` is set.                                    | `""`                  |
+| `defaultBackend.nodeAffinityPreset.values`          | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                  |
+| `defaultBackend.affinity`                           | Affinity for pod assignment                                                               | `{}`                  |
+| `defaultBackend.nodeSelector`                       | Node labels for pod assignment                                                            | `{}`                  |
+| `defaultBackend.tolerations`                        | Tolerations for pod assignment                                                            | `[]`                  |
+| `defaultBackend.service.type`                       | Kubernetes Service type for default backend                                               | `ClusterIP`           |
+| `defaultBackend.service.port`                       | Default backend service port                                                              | `80`                  |
+| `defaultBackend.pdb.create`                         | Enable/disable a Pod Disruption Budget creation for Default backend                       | `false`               |
+| `defaultBackend.pdb.minAvailable`                   | Minimum number/percentage of Default backend pods that should remain scheduled            | `1`                   |
+| `defaultBackend.pdb.maxUnavailable`                 | Maximum number/percentage of Default backend pods that may be made unavailable            | `nil`                 |
 
-### Exposure parameters
 
-| Parameter                          | Description                                                                                                                            | Default        |
-|------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|----------------|
+### Traffic exposure parameters
+
+| Name                               | Description                                                                                                                            | Value          |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
 | `service.type`                     | Kubernetes Service type for Controller                                                                                                 | `LoadBalancer` |
+| `service.ports`                    | Service ports                                                                                                                          | `{}`           |
+| `service.targetPorts`              | Map the controller service HTTP/HTTPS port                                                                                             | `{}`           |
+| `service.nodePorts`                | Specify the nodePort value(s) for the LoadBalancer and NodePort service types.                                                         | `{}`           |
 | `service.annotations`              | Annotations for controller service                                                                                                     | `{}`           |
 | `service.labels`                   | Labels for controller service                                                                                                          | `{}`           |
-| `service.loadBalancerIP`           | Kubernetes LoadBalancerIP to request for Controller                                                                                    | `nil`          |
-| `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported)                                                                        | `[]`           |
+| `service.clusterIP`                | Controller Internal Cluster Service IP (optional)                                                                                      | `nil`          |
 | `service.externalIPs`              | Controller Service external IP addresses                                                                                               | `[]`           |
-| `service.clusterIP`                | Controller Internal Cluster Service IP                                                                                                 | `""`           |
-| `service.omitClusterIP`            | To omit the `ClusterIP` from the controller service                                                                                    | `false`        |
-| `service.ports.http`               | Controller Service HTTP port                                                                                                           | `80`           |
-| `service.ports.https`              | Controller Service HTTPS port                                                                                                          | `443`           |
-| `service.targetPorts.http`         | Map the controller service HTTP port                                                                                                   | `http`         |
-| `service.targetPorts.https`        | Map the controller service HTTPS port                                                                                                  | `https`        |
-| `service.externalTrafficPolicy`    | Enable client source IP preservation                                                                                                   | `Cluster`      |
-| `service.nodePorts.http`           | Kubernetes http node port for Controller                                                                                               | `""`           |
-| `service.nodePorts.https`          | Kubernetes https node port for Controller                                                                                              | `""`           |
-| `service.nodePorts.tcp`            | Sets the nodePort for an entry referenced by its key from `tcp`                                                                        | `{}`           |
-| `service.nodePorts.udp`            | Sets the nodePort for an entry referenced by its key from `udp`                                                                        | `{}`           |
-| `service.healthCheckNodePort`      | Set this to the managed health-check port the kube-proxy will expose. If blank, a random port in the `NodePort` range will be assigned | `""`           |
-| `defaultBackend.service.type`      | Kubernetes Service type for default backend                                                                                            | `ClusterIP`    |
-| `defaultBackend.service.port`      | Default backend service port                                                                                                           | `80`           |
+| `service.loadBalancerIP`           | Kubernetes LoadBalancerIP to request for Controller (optional, cloud specific)                                                         | `nil`          |
+| `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported)                                                                        | `[]`           |
+| `service.externalTrafficPolicy`    | Set external traffic policy to: "Local" to preserve source IP on providers supporting it                                               | `""`           |
+| `service.healthCheckNodePort`      | Set this to the managed health-check port the kube-proxy will expose. If blank, a random port in the `NodePort` range will be assigned | `0`            |
+
 
 ### RBAC parameters
 
-| Parameter                    | Description                                                 | Default                                              |
-|------------------------------|-------------------------------------------------------------|------------------------------------------------------|
-| `serviceAccount.create`      | Enable the creation of a ServiceAccount for Controller pods | `true`                                               |
-| `serviceAccount.name`        | Name of the created ServiceAccount                          | Generated using the `common.names.fullname` template |
-| `serviceAccount.annotations` | Annotations for service account.                            | `{}`                                                 |
-| `rbac.create`                | Whether to create & use RBAC resources or not               | `false`                                              |
+| Name                         | Description                                                 | Value  |
+| ---------------------------- | ----------------------------------------------------------- | ------ |
+| `serviceAccount.create`      | Enable the creation of a ServiceAccount for Controller pods | `true` |
+| `serviceAccount.name`        | Name of the created ServiceAccount                          | `nil`  |
+| `serviceAccount.annotations` | Annotations for service account.                            | `{}`   |
+| `rbac.create`                | Specifies whether RBAC rules should be created              | `true` |
+
 
 ### Other parameters
 
-| Parameter                           | Description                                                                    | Default |
-|-------------------------------------|--------------------------------------------------------------------------------|---------|
-| `pdb.create`                        | Enable/disable a Pod Disruption Budget creation for Controller                 | `false` |
-| `pdb.minAvailable`                  | Minimum number/percentage of Controller pods that should remain scheduled      | `1`     |
-| `pdb.maxUnavailable`                | Maximum number/percentage of Controller pods that may be made unavailable      | `nil`   |
-| `defaultBackend.pdb.create`         | Enable/disable a Pod Disruption Budget creation for Default backend            | `false` |
-| `defaultBackend.pdb.minAvailable`   | Minimum number/percentage of Default backend pods that should remain scheduled | `1`     |
-| `defaultBackend.pdb.maxUnavailable` | Maximum number/percentage of Default backend pods that may be made unavailable | `nil`   |
-| `autoscaling.enabled`               | Enable autoscaling for Controller                                              | `false` |
-| `autoscaling.minReplicas`           | Minimum number of Controller replicas                                          | `1`     |
-| `autoscaling.maxReplicas`           | Maximum number of Controller replicas                                          | `11`    |
-| `autoscaling.targetCPU`             | Target CPU utilization percentage                                              | `nil`   |
-| `autoscaling.targetMemory`          | Target Memory utilization percentage                                           | `nil`   |
+| Name                       | Description                                                               | Value   |
+| -------------------------- | ------------------------------------------------------------------------- | ------- |
+| `pdb.create`               | Enable/disable a Pod Disruption Budget creation for Controller            | `false` |
+| `pdb.minAvailable`         | Minimum number/percentage of Controller pods that should remain scheduled | `1`     |
+| `pdb.maxUnavailable`       | Maximum number/percentage of Controller pods that may be made unavailable | `nil`   |
+| `autoscaling.enabled`      | Enable autoscaling for Controller                                         | `false` |
+| `autoscaling.minReplicas`  | Minimum number of Controller replicas                                     | `1`     |
+| `autoscaling.maxReplicas`  | Maximum number of Controller replicas                                     | `11`    |
+| `autoscaling.targetCPU`    | Target CPU utilization percentage                                         | `nil`   |
+| `autoscaling.targetMemory` | Target Memory utilization percentage                                      | `nil`   |
+
 
 ### Metrics parameters
 
-| Parameter                                 | Description                                                                   | Default                                                      |
-|-------------------------------------------|-------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `metrics.enabled`                         | Enable exposing Controller statistics                                         | `false`                                                      |
-| `metrics.service.type`                    | Type of Prometheus metrics service to create                                  | `ClusterIP`                                                  |
-| `metrics.service.port`                    | Service HTTP management port                                                  | `9913`                                                       |
-| `metrics.service.annotations`             | Annotations for enabling prometheus to access the metrics endpoints           | `{prometheus.io/scrape: "true", prometheus.io/port: "9913"}` |
-| `metrics.serviceMonitor.enabled`          | Create ServiceMonitor resource for scraping metrics using PrometheusOperator  | `false`                                                      |
-| `metrics.serviceMonitor.namespace`        | Namespace which Prometheus is running in                                      | `nil`                                                        |
-| `metrics.serviceMonitor.interval`         | Interval at which metrics should be scraped                                   | `30s`                                                        |
-| `metrics.serviceMonitor.scrapeTimeout`    | Specify the timeout after which the scrape is ended                           | `nil`                                                        |
-| `metrics.serviceMonitor.relabellings`     | Specify Metric Relabellings to add to the scrape endpoint                     | `nil`                                                        |
-| `metrics.serviceMonitor.honorLabels`      | honorLabels chooses the metric's labels on collisions with target labels.     | `false`                                                      |
-| `metrics.serviceMonitor.additionalLabels` | Used to pass Labels that are required by the Installed Prometheus Operator    | `{}`                                                         |
-| `metrics.prometheusRule.enabled`          | Create PrometheusRules resource for scraping metrics using PrometheusOperator | `false`                                                      |
-| `metrics.prometheusRule.additionalLabels` | Used to pass Labels that are required by the Installed Prometheus Operator    | `{}`                                                         |
-| `metrics.prometheusRule.namespace`        | Namespace which Prometheus is running in                                      | `nil`                                                        |
-| `metrics.prometheusRule.rules`            | Rules to be prometheus in YAML format, check values for an example.           | `[]`                                                         |
+| Name                                      | Description                                                                   | Value       |
+| ----------------------------------------- | ----------------------------------------------------------------------------- | ----------- |
+| `metrics.enabled`                         | Enable exposing Controller statistics                                         | `false`     |
+| `metrics.service.type`                    | Type of Prometheus metrics service to create                                  | `ClusterIP` |
+| `metrics.service.port`                    | Service HTTP management port                                                  | `9913`      |
+| `metrics.service.annotations`             | Annotations for the Prometheus exporter service                               | `{}`        |
+| `metrics.serviceMonitor.enabled`          | Create ServiceMonitor resource for scraping metrics using PrometheusOperator  | `false`     |
+| `metrics.serviceMonitor.namespace`        | Namespace in which Prometheus is running                                      | `nil`       |
+| `metrics.serviceMonitor.interval`         | Interval at which metrics should be scraped                                   | `30s`       |
+| `metrics.serviceMonitor.scrapeTimeout`    | Specify the timeout after which the scrape is ended                           | `nil`       |
+| `metrics.serviceMonitor.selector`         | ServiceMonitor selector labels                                                | `{}`        |
+| `metrics.prometheusRule.enabled`          | Create PrometheusRules resource for scraping metrics using PrometheusOperator | `false`     |
+| `metrics.prometheusRule.additionalLabels` | Used to pass Labels that are required by the Installed Prometheus Operator    | `{}`        |
+| `metrics.prometheusRule.namespace`        | Namespace which Prometheus is running in                                      | `""`        |
+| `metrics.prometheusRule.rules`            | Rules to be prometheus in YAML format, check values for an example            | `[]`        |
+
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/nginx-ingress-controller/values.yaml
+++ b/bitnami/nginx-ingress-controller/values.yaml
@@ -1,14 +1,26 @@
+## @section Global parameters
 ## Global Docker image parameters
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value
-## Current available global Docker image parameters: imageRegistry and imagePullSecrets
+## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
+
+## @param global.imageRegistry Global Docker image registry
+## @param global.imagePullSecrets Global Docker registry secret names as an array
 ##
-# global:
-#   imageRegistry: myRegistryName
-#   imagePullSecrets:
-#     - myRegistryKeySecretName
+global:
+  imageRegistry:
+  ## E.g.
+  ## imagePullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
 
 ## Bitnami NGINX Ingress controller image version
 ## ref: https://hub.docker.com/r/bitnami/nginx-ingress-controller/tags/
+## @param image.registry Nginx Ingress Controller image registry
+## @param image.repository Nginx Ingress Controller image repository
+## @param image.tag Nginx Ingress Controller image tag (immutable tags are recommended)
+## @param image.pullPolicy Nginx Ingress Controller image pull policy
+## @param image.pullSecrets Specify docker-registry secret names as an array
 ##
 image:
   registry: docker.io
@@ -28,61 +40,62 @@ image:
   ##
   pullSecrets: []
 
-## String to partially override nginx-ingress-controller.fullname template (will maintain the release name)
+## @param nameOverride String to partially override common.names.fullname
 ##
-# nameOverride:
+nameOverride:
 
-## String to fully override nginx-ingress-controller.fullname template
+## @param fullnameOverride String to fully override common.names.fullname
 ##
-# fullnameOverride:
+fullnameOverride:
 
-## Add labels to all the deployed resources
+## @param commonLabels Add labels to all the deployed resources
 ##
 commonLabels: {}
 
-## Add annotations to all the deployed resources
+## @param commonAnnotations Add annotations to all the deployed resources
 ##
 commonAnnotations: {}
 
-## Extra objects to deploy (value evaluated as a template)
+## @param extraDeploy Array of extra objects to deploy with the release
 ##
 extraDeploy: []
 
-## Deployment pod host aliases
+## @param hostAliases Deployment pod host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
 hostAliases: []
 
-## Custom configuration options for NGINX
+## @param config Custom configuration options for NGINX
 ## ref: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
 ##
 config: {}
 
-## Custom headers before sending traffic to backends
+## @param proxySetHeaders Custom headers before sending traffic to backends
 ## ref: https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers
 ##
 proxySetHeaders: {}
 
-## Custom headers before sending response traffic to the client
+## @param addHeaders Custom headers before sending response traffic to the client
 ## ref: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#add-headers
 ##
 addHeaders: {}
 
-## Required only if defaultBackend.enabled = false
+## @param defaultBackendService Default 404 backend service; required only if `defaultBackend.enabled = false`
 ## Must be <namespace>/<service_name>
 ##
 defaultBackendService: ''
 
-## Election ID to use for status update
+## @param electionID Election ID to use for status update
 ##
 electionID: ingress-controller-leader
 
+## @param reportNodeInternalIp If using `hostNetwork=true`, setting `reportNodeInternalIp=true`, will pass the flag `report-node-internal-ip-address` to Nginx Ingress Controller
 ## Bare-metal considerations via the host network
 ## ref: https://kubernetes.github.io/ingress-nginx/deploy/baremetal/#via-the-host-network
 ##
 reportNodeInternalIp: false
 
-## Name of the ingress class to route through this controller
+## @param ingressClass Name of the ingress class to route through this controller
 ##
 ingressClass: nginx
 
@@ -90,88 +103,95 @@ ingressClass: nginx
 ## the ingress will be bound to via DNS
 ##
 publishService:
+  ## @param publishService.enabled Set the endpoint records on the Ingress objects to reflect those on the service
+  ##
   enabled: false
-  ## Allows overriding of the publish service to bind to
+  ## @param publishService.pathOverride Allows overriding of the publish service to bind to
   ## Must be <namespace>/<service_name>
   ##
   pathOverride: ''
 
-## Limit the scope of the controller
-## Defaults to `.Release.Namespace`
+## @param scope.enabled Limit the scope of the controller. Defaults to `.Release.Namespace`
 ##
 scope:
   enabled: false
 
-## Allows customization of the configmap / nginx-configmap namespace
+## @param configMapNamespace Allows customization of the configmap / nginx-configmap namespace
 ## Defaults to .Release.Namespace
 ##
 configMapNamespace: ''
 
-## Allows customization of the tcp-services-configmap namespace
+## @param tcpConfigMapNamespace Allows customization of the tcp-services-configmap namespace
 ## Defaults to .Release.Namespace
 ##
 tcpConfigMapNamespace: ''
 
-## Allows customization of the udp-services-configmap namespace
+## @param udpConfigMapNamespace Allows customization of the udp-services-configmap namespace
 ## Defaults to .Release.Namespace
 ##
 udpConfigMapNamespace: ''
 
-## License key used to download Geolite2 database
+## @param maxmindLicenseKey License key used to download Geolite2 database
 ##
 maxmindLicenseKey: ''
 
-# A base64ed Diffie-Hellman parameter
-# This can be generated with: openssl dhparam 4096 2> /
-# Ref: https://github.com/krmichel/ingress-nginx/blob/master/docs/examples/customization/ssl-dh-param
+## @param dhParam A base64ed Diffie-Hellman parameter
+## This can be generated with: openssl dhparam 4096 2> /
+## Ref: https://github.com/krmichel/ingress-nginx/blob/master/docs/examples/customization/ssl-dh-param
 dhParam:
 
-## TCP service key:value pairs
+## @param tcp TCP service key:value pairs
 ## ref: https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/tcp
+## e.g:
+## tcp:
+##   8080: "default/example-tcp-svc:9000"
 ##
 tcp: {}
-#  8080: "default/example-tcp-svc:9000"
 
-## UDP service key:value pairs
+## @param udp UDP service key:value pairs
 ## ref: https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/udp
+## e.g:
+## udp:
+##   53: "kube-system/kube-dns:53"
 ##
 udp: {}
-#  53: "kube-system/kube-dns:53"
 
-## DaemonSet or Deployment
+## @param kind Install as Deployment or DaemonSet
 ##
 kind: Deployment
 
 ## Daemonset configuration
 ##
 daemonset:
-  ## Use hostPort for NGINX Ingress Controller
+  ## @param daemonset.useHostPort If `kind` is `DaemonSet`, this will enable `hostPort` for `TCP/80` and `TCP/443`
   ##
   useHostPort: false
 
-  ## HTTP and HTTPS ports
+  ## @param daemonset.hostPorts [object] HTTP and HTTPS ports
   ##
   hostPorts:
     http: 80
     https: 443
 
-## Number of replicas
+## @param replicaCount Desired number of Controller pods
 ##
 replicaCount: 1
 
-## Command and args for running the container (set to default if not set). Use array form
+## @param command Override default container command (useful when using custom images)
 ##
 command: []
+## @param args Override default container args (useful when using custom images)
+##
 args: []
 
-## Additional command line arguments to pass to nginx-ingress-controller
+## @param extraArgs Additional command line arguments to pass to nginx-ingress-controller
 ## E.g. to specify the default SSL certificate you can use
 ## extraArgs:
 ##   default-ssl-certificate: "<namespace>/<secret_name>"
 ##
 extraArgs: {}
 
-## Additional environment variables to set
+## @param extraEnvVars Extra environment variables to be set on Nginx Ingress container
 ## E.g:
 ## extraEnvs:
 ##   - name: FOO
@@ -182,32 +202,34 @@ extraArgs: {}
 ##
 extraEnvVars: []
 
-## Name of a ConfigMap containing extra env vars
+## @param extraEnvVarsCM Name of a existing ConfigMap containing extra environment variables
 ##
 extraEnvVarsCM:
 
-## Secret with extra environment variables
+## @param extraEnvVarsSecret Name of a existing Secret containing extra environment variables
 ##
 extraEnvVarsSecret:
 
-## Controller container ports to open
+## @param containerPorts [object] Controller container ports to open
 ##
 containerPorts:
   http: 80
   https: 443
   metrics: 10254
 
-## updateStrategy
+## @param updateStrategy Strategy to use to update Pods
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
 ##
 updateStrategy: {}
 
-## Rollback limit
+## @param revisionHistoryLimit The number of old history to retain to allow rollback
 ##
 revisionHistoryLimit: 10
 
 ## Controller pods' Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+## @param podSecurityContext.enabled Enable Controller pods' Security Context
+## @param podSecurityContext.fsGroup Group ID for the container filesystem
 ##
 podSecurityContext:
   enabled: true
@@ -215,6 +237,11 @@ podSecurityContext:
 
 ## Controller containers' Security Context (only main container)
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+## @param containerSecurityContext.enabled Enable Controller containers' Security Context
+## @param containerSecurityContext.allowPrivilegeEscalation Switch to allow priviledge escalation on the Controller container
+## @param containerSecurityContext.runAsUser User ID for the Controller container
+## @param containerSecurityContext.capabilities.drop [array] Linux Kernel capabilities that should be dropped
+## @param containerSecurityContext.capabilities.add [array] Linux Kernel capabilities that should be added
 ##
 containerSecurityContext:
   enabled: true
@@ -224,27 +251,42 @@ containerSecurityContext:
     drop: ["ALL"]
     add: ["NET_BIND_SERVICE"]
 
-## minReadySeconds to avoid killing pods before we are ready
+## @param minReadySeconds How many seconds a pod needs to be ready before killing the next, during update
 ##
 minReadySeconds: 0
 
 ## Controller containers' resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources
+## We usually recommend not to specify default resources and to leave this as a conscious
+## choice for the user. This also increases chances charts run on environments with little
+## resources, such as Minikube. If you do want to specify resources, uncomment the following
+## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+## @param resources.limits The resources limits for the Controller container
+## @param resources.requests The requested resources for the Controller container
 ##
 resources:
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ## Example:
+  ## limits:
+  ##    cpu: 250m
+  ##    memory: 256Mi
   limits: {}
-  #   cpu: 250m
-  #   memory: 256Mi
+  ## Examples:
+  ## requests:
+  ##    cpu: 250m
+  ##    memory: 256Mi
   requests: {}
-  #   cpu: 250m
-  #   memory: 256Mi
 
-## Controller containers' liveness and readiness probes. Evaluated as a template.
+## Controller containers' liveness probe. Evaluated as a template.
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+## @param livenessProbe.enabled Enable livenessProbe
+## @param livenessProbe.httpGet.path Request path for livenessProbe
+## @param livenessProbe.httpGet.port Port for livenessProbe
+## @param livenessProbe.httpGet.scheme Scheme for livenessProbe
+## @param livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+## @param livenessProbe.periodSeconds Period seconds for livenessProbe
+## @param livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+## @param livenessProbe.failureThreshold Failure threshold for livenessProbe
+## @param livenessProbe.successThreshold Success threshold for livenessProbe
 ##
 livenessProbe:
   enabled: true
@@ -257,6 +299,18 @@ livenessProbe:
   periodSeconds: 10
   successThreshold: 1
   timeoutSeconds: 1
+## Controller containers' readiness probe. Evaluated as a template.
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+## @param readinessProbe.enabled Enable readinessProbe
+## @param readinessProbe.httpGet.path Request path for readinessProbe
+## @param readinessProbe.httpGet.port Port for readinessProbe
+## @param readinessProbe.httpGet.scheme Scheme for readinessProbe
+## @param readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+## @param readinessProbe.periodSeconds Period seconds for readinessProbe
+## @param readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+## @param readinessProbe.failureThreshold Failure threshold for readinessProbe
+## @param readinessProbe.successThreshold Success threshold for readinessProbe
+##
 readinessProbe:
   enabled: true
   httpGet:
@@ -269,75 +323,72 @@ readinessProbe:
   successThreshold: 1
   timeoutSeconds: 1
 
-## Custom Liveness probes for Controller
+## @param customLivenessProbe Override default liveness probe
 ##
 customLivenessProbe: {}
 
-## Custom Rediness probes Controller
+## @param customReadinessProbe Override default readiness probe
 ##
 customReadinessProbe: {}
 
-## Container lifecycle
+## @param lifecycle LifecycleHooks to set additional configuration at startup
 ##
 lifecycle: {}
 
-## Pod extra labels
+## @param podLabels Extra labels for Controller pods
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ##
 podLabels: {}
 
-## Pod annotations
+## @param podAnnotations Annotations for Controller pods
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 ##
 podAnnotations: {}
 
-## priorityClassName
+## @param priorityClassName Controller priorityClassName
 ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
 ##
 priorityClassName: ''
 
-## Required on CNI based K8s installations, since CNI and hostport don't mix yet.
+## @param hostNetwork If the Nginx deployment / daemonset should run on the host's network namespace
+## Required on CNI based K8s installations, since CNI and hostport don't mix yet
 ## Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920 is merged
 ##
 hostNetwork: false
 
-## Optionally, change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true'.
-## By default, while using host network, name resolution uses the host's DNS. If you wish nginx-controller
-## to keep resolving names inside the k8s network, use ClusterFirstWithHostNet.
+## @param dnsPolicy By default, while using host network, name resolution uses the host's DNS
+## Optionally, change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true' if you wish nginx-controller
+## to keep resolving names inside the Kubernetes network
 ##
 dnsPolicy: ClusterFirst
 
-## terminationGracePeriodSeconds
+## @param terminationGracePeriodSeconds How many seconds to wait before terminating a pod
 ##
 terminationGracePeriodSeconds: 60
 
-## Pod affinity preset
+## @param podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
 ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
-## Allowed values: soft, hard
 ##
 podAffinityPreset: ""
 
-## Pod anti-affinity preset
+## @param podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
 ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
-## Allowed values: soft, hard
 ##
 podAntiAffinityPreset: soft
 
 ## Node affinity preset
 ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
-## Allowed values: soft, hard
 ##
 nodeAffinityPreset:
-  ## Node affinity type
-  ## Allowed values: soft, hard
+  ## @param nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
   ##
   type: ""
-  ## Node label key to match
+  ## @param nodeAffinityPreset.key Node label key to match. Ignored if `affinity` is set.
   ## E.g.
   ## key: "kubernetes.io/e2e-az-name"
   ##
   key: ""
-  ## Node label values to match
+  ## @param nodeAffinityPreset.values Node label values to match. Ignored if `affinity` is set.
   ## E.g.
   ## values:
   ##   - e2e-az1
@@ -345,31 +396,31 @@ nodeAffinityPreset:
   ##
   values: []
 
-## Affinity for pod assignment. Evaluated as a template.
+## @param affinity Affinity for pod assignment. Evaluated as a template.
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 ## Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
 ##
 affinity: {}
 
-## Node labels for pod assignment. Evaluated as a template.
+## @param nodeSelector Node labels for pod assignment. Evaluated as a template.
 ## ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##
 nodeSelector: {}
 
-## Tolerations for pod assignment. Evaluated as a template.
+## @param tolerations Tolerations for pod assignment. Evaluated as a template.
 ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
 tolerations: []
 
-## Extra volumes to add to the deployment
+## @param extraVolumes Optionally specify extra list of additional volumes for Controller pods
 ##
 extraVolumes: []
 
-## Extra volume mounts to add to the container
+## @param extraVolumeMounts Optionally specify extra list of additional volumeMounts for Controller container(s)
 ##
 extraVolumeMounts: []
 
-## Add init containers to the controller pods.
+## @param initContainers Add init containers to the controller pods
 ## Example:
 ## initContainers:
 ##   - name: your-image-name
@@ -381,7 +432,7 @@ extraVolumeMounts: []
 ##
 initContainers: {}
 
-## Add sidecars to the controller pods.
+## @param sidecars Add sidecars to the controller pods.
 ## Example:
 ## sidecars:
 ##   - name: your-image-name
@@ -393,7 +444,7 @@ initContainers: {}
 ##
 sidecars: {}
 
-## Override NGINX template
+## @param customTemplate [object] Override NGINX template
 ##
 customTemplate:
   configMapName: ''
@@ -402,21 +453,23 @@ customTemplate:
 ## Service parameters
 ##
 service:
-  ## Service type
+  ## @param service.type Kubernetes Service type for Controller
   ##
   type: LoadBalancer
 
-  ## Service ports
+  ## @param service.ports [object] Service ports
   ##
   ports:
     http: 80
     https: 443
 
+  ## @param service.targetPorts [object] Map the controller service HTTP/HTTPS port
+  ##
   targetPorts:
     http: http
     https: https
 
-  ## Specify the nodePort value(s) for the LoadBalancer and NodePort service types.
+  ## @param service.nodePorts [object] Specify the nodePort value(s) for the LoadBalancer and NodePort service types.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
   ##
   nodePorts:
@@ -425,40 +478,43 @@ service:
     tcp: {}
     udp: {}
 
-  ## Provide any additional annotations which may be required. This can be used to
-  ## set the LoadBalancer service type to internal only.
+  ## @param service.annotations Annotations for controller service
+  ## This can be used to set the LoadBalancer service type to internal only.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
   ##
   annotations: {}
-  ## Provide any additional label which may be required.
+  ## @param service.labels Labels for controller service
   ##
   labels: {}
 
-  ## clusterIP (optional)
+  ## @param service.clusterIP Controller Internal Cluster Service IP (optional)
   ##
-  # clusterIP:
+  clusterIP:
 
-  ## List of IP addresses at which the controller services are available
+  ## @param service.externalIPs Controller Service external IP addresses
   ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
   ##
   externalIPs: []
 
-  ## loadBalancerIP (optional, cloud specific)
+  ## @param service.loadBalancerIP Kubernetes LoadBalancerIP to request for Controller (optional, cloud specific)
   ## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
   ##
-  # loadBalancerIP:
-  ## Load Balancer sources
+  loadBalancerIP:
+  ## @param service.loadBalancerSourceRanges List of IP CIDRs allowed access to load balancer (if supported)
   ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
   ##
   loadBalancerSourceRanges: []
 
-  ## Set external traffic policy to: "Local" to preserve source IP on providers supporting it
+  ## @param service.externalTrafficPolicy Set external traffic policy to: "Local" to preserve source IP on providers supporting it
+  ## Enable client source IP preservation
   ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
   ##
   externalTrafficPolicy: ''
+  ## @param service.healthCheckNodePort Set this to the managed health-check port the kube-proxy will expose. If blank, a random port in the `NodePort` range will be assigned
+  ##
   healthCheckNodePort: 0
 
-## Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in.
+## @param topologySpreadConstraints Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in
 ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
 ##
 ## topologySpreadConstraints:
@@ -475,7 +531,7 @@ topologySpreadConstraints: []
 ## Ref: https://kubernetes.io/docs/admin/authorization/rbac/
 ##
 rbac:
-  ## Specifies whether RBAC rules should be created
+  ## @param rbac.create Specifies whether RBAC rules should be created
   ##
   create: true
 
@@ -483,14 +539,14 @@ rbac:
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 ##
 serviceAccount:
-  ## Specifies whether a ServiceAccount should be created
+  ## @param serviceAccount.create Enable the creation of a ServiceAccount for Controller pods
   ##
   create: true
-  ## The name of the ServiceAccount to use.
+  ## @param serviceAccount.name Name of the created ServiceAccount
   ## If not set and create is true, a name is generated using the metrics-server.fullname template
-  # name:
+  name:
 
-  ## Annotations for service account. Evaluated as a template.
+  ## @param serviceAccount.annotations Annotations for service account.
   ## Only used if `create` is `true`.
   ##
   annotations: {}
@@ -499,24 +555,31 @@ serviceAccount:
 ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
 ##
 pdb:
+  ## @param pdb.create Enable/disable a Pod Disruption Budget creation for Controller
+  ##
   create: false
-  ## Min number of pods that must still be available after the eviction
+  ## @param pdb.minAvailable Minimum number/percentage of Controller pods that should remain scheduled
   ##
   minAvailable: 1
-  ## Max number of pods that can be unavailable after the eviction
+  ## @param pdb.maxUnavailable Maximum number/percentage of Controller pods that may be made unavailable
   ##
-  # maxUnavailable: 1
+  maxUnavailable:
 
 ## Controller Autoscaling configuration
+## @param autoscaling.enabled Enable autoscaling for Controller
+## @param autoscaling.minReplicas Minimum number of Controller replicas
+## @param autoscaling.maxReplicas Maximum number of Controller replicas
+## @param autoscaling.targetCPU Target CPU utilization percentage
+## @param autoscaling.targetMemory Target Memory utilization percentage
 ##
 autoscaling:
   enabled: false
   minReplicas: 1
   maxReplicas: 11
-  # targetCPU: 50
-  # targetMemory: 50
+  targetCPU:
+  targetMemory:
 
-## If true, create & use Pod Security Policy resources
+## @param podSecurityPolicy.enabled If true, create & use Pod Security Policy resources
 ## https://kubernetes.io/docs/concepts/policy/pod-security-policy/
 ##
 podSecurityPolicy:
@@ -525,15 +588,20 @@ podSecurityPolicy:
 ## Default 404 backend
 ##
 defaultBackend:
-  ## If false, defaultBackendService must be provided
+  ## @param defaultBackend.enabled Enable a default backend based on NGINX
   ##
   enabled: true
-  ## Deployment pod host aliases
+  ## @param defaultBackend.hostAliases Add deployment host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
   hostAliases: []
   ## Bitnami NGINX image
   ## ref: https://hub.docker.com/r/bitnami/nginx/tags/
+  ## @param defaultBackend.image.registry Default backend image registry
+  ## @param defaultBackend.image.repository Default backend image repository
+  ## @param defaultBackend.image.tag Default backend image tag (immutable tags are recommended)
+  ## @param defaultBackend.image.pullPolicy Image pull policy
+  ## @param defaultBackend.image.pullSecrets Specify docker-registry secret names as an array
   ##
   image:
     registry: docker.io
@@ -553,12 +621,14 @@ defaultBackend:
     ##
     pullSecrets: []
 
-  ## Additional command line arguments to pass to NGINX backend
+  ## @param defaultBackend.extraArgs Additional command line arguments to pass to Nginx container
   ##
   extraArgs: {}
+  ## @param defaultBackend.containerPort HTTP container port number
+  ##
   containerPort: 8080
 
-  ## NGINX backend default server block configuration
+  ## @param defaultBackend.serverBlockConfig NGINX backend default server block configuration
   ## Should be compliant with: https://kubernetes.github.io/ingress-nginx/user-guide/default-backend/
   ##
   serverBlockConfig: |-
@@ -570,12 +640,14 @@ defaultBackend:
       return 404;
     }
 
-  ## Number of replicas
+  ## @param defaultBackend.replicaCount Desired number of default backend pods
   ##
   replicaCount: 1
 
   ## Default backend pods' Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  ## @param defaultBackend.podSecurityContext.enabled Enable Default backend pods' Security Context
+  ## @param defaultBackend.podSecurityContext.fsGroup Group ID for the container filesystem
   ##
   podSecurityContext:
     enabled: true
@@ -583,6 +655,8 @@ defaultBackend:
 
   ## Default backend containers' Security Context (only main container)
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  ## @param defaultBackend.containerSecurityContext.enabled Enable Default backend containers' Security Context
+  ## @param defaultBackend.containerSecurityContext.runAsUser User ID for the Default backend container
   ##
   containerSecurityContext:
     enabled: true
@@ -590,21 +664,36 @@ defaultBackend:
 
   ## Default backend containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources
+  ## We usually recommend not to specify default resources and to leave this as a conscious
+  ## choice for the user. This also increases chances charts run on environments with little
+  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ## @param defaultBackend.resources.limits The resources limits for the Default backend container
+  ## @param defaultBackend.resources.requests The requested resources for the Default backend container
   ##
   resources:
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    ## Example:
+    ## limits:
+    ##    cpu: 250m
+    ##    memory: 256Mi
     limits: {}
-    #   cpu: 250m
-    #   memory: 256Mi
+    ## Examples:
+    ## requests:
+    ##    cpu: 250m
+    ##    memory: 256Mi
     requests: {}
-    #   cpu: 250m
-    #   memory: 256Mi
 
-  ## Default backend containers' liveness and readiness probes. Evaluated as a template.
+  ## Default backend containers' liveness probe. Evaluated as a template.
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ## @param defaultBackend.livenessProbe.enabled Enable livenessProbe
+  ## @param defaultBackend.livenessProbe.httpGet.path Request path for livenessProbe
+  ## @param defaultBackend.livenessProbe.httpGet.port Port for livenessProbe
+  ## @param defaultBackend.livenessProbe.httpGet.scheme Scheme for livenessProbe
+  ## @param defaultBackend.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+  ## @param defaultBackend.livenessProbe.periodSeconds Period seconds for livenessProbe
+  ## @param defaultBackend.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+  ## @param defaultBackend.livenessProbe.failureThreshold Failure threshold for livenessProbe
+  ## @param defaultBackend.livenessProbe.successThreshold Success threshold for livenessProbe
   ##
   livenessProbe:
     enabled: true
@@ -617,6 +706,18 @@ defaultBackend:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 5
+  ## Default backend containers' readiness probe. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ## @param defaultBackend.readinessProbe.enabled Enable readinessProbe
+  ## @param defaultBackend.readinessProbe.httpGet.path Request path for readinessProbe
+  ## @param defaultBackend.readinessProbe.httpGet.port Port for readinessProbe
+  ## @param defaultBackend.readinessProbe.httpGet.scheme Scheme for readinessProbe
+  ## @param defaultBackend.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+  ## @param defaultBackend.readinessProbe.periodSeconds Period seconds for readinessProbe
+  ## @param defaultBackend.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+  ## @param defaultBackend.readinessProbe.failureThreshold Failure threshold for readinessProbe
+  ## @param defaultBackend.readinessProbe.successThreshold Success threshold for readinessProbe
+  ##
   readinessProbe:
     enabled: true
     httpGet:
@@ -629,48 +730,44 @@ defaultBackend:
     successThreshold: 1
     timeoutSeconds: 5
 
-  ## Pod extra labels
+  ## @param defaultBackend.podLabels Extra labels for Controller pods
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   ##
   podLabels: {}
 
-  ## Pod annotations
+  ## @param defaultBackend.podAnnotations Annotations for Controller pods
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##
   podAnnotations: {}
 
-  ## priorityClassName
+  ## @param defaultBackend.priorityClassName priorityClassName
   ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
   ##
   priorityClassName: ''
 
-  ## Pod affinity preset
+  ## @param defaultBackend.podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
-  ## Allowed values: soft, hard
   ##
   podAffinityPreset: ""
 
-  ## Pod anti-affinity preset
+  ## @param defaultBackend.podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
-  ## Allowed values: soft, hard
   ##
   podAntiAffinityPreset: soft
 
   ## Node affinity preset
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
-  ## Allowed values: soft, hard
   ##
   nodeAffinityPreset:
-    ## Node affinity type
-    ## Allowed values: soft, hard
+    ## @param defaultBackend.nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
     ##
     type: ""
-    ## Node label key to match
+    ## @param defaultBackend.nodeAffinityPreset.key Node label key to match. Ignored if `affinity` is set.
     ## E.g.
     ## key: "kubernetes.io/e2e-az-name"
     ##
     key: ""
-    ## Node label values to match
+    ## @param defaultBackend.nodeAffinityPreset.values Node label values to match. Ignored if `affinity` is set.
     ## E.g.
     ## values:
     ##   - e2e-az1
@@ -678,18 +775,18 @@ defaultBackend:
     ##
     values: []
 
-  ## Affinity for pod assignment. Evaluated as a template.
+  ## @param defaultBackend.affinity Affinity for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ## Note: defaultBackend.podAffinityPreset, defaultBackend.podAntiAffinityPreset, and defaultBackend.nodeAffinityPreset will be ignored when it's set
   ##
   affinity: {}
 
-  ## Node labels for pod assignment. Evaluated as a template.
+  ## @param defaultBackend.nodeSelector Node labels for pod assignment
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
   nodeSelector: {}
 
-  ## Tolerations for pod assignment. Evaluated as a template.
+  ## @param defaultBackend.tolerations Tolerations for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
   tolerations: []
@@ -697,10 +794,10 @@ defaultBackend:
   ## Default backend Service parameters
   ##
   service:
-    ## Service type
+    ## @param defaultBackend.service.type Kubernetes Service type for default backend
     ##
     type: ClusterIP
-    ## Service port
+    ## @param defaultBackend.service.port Default backend service port
     ##
     port: 80
 
@@ -708,29 +805,33 @@ defaultBackend:
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   ##
   pdb:
+    ## @param defaultBackend.pdb.create Enable/disable a Pod Disruption Budget creation for Default backend
+    ##
     create: false
-    ## Min number of pods that must still be available after the eviction
+    ## @param defaultBackend.pdb.minAvailable Minimum number/percentage of Default backend pods that should remain scheduled
     ##
     minAvailable: 1
-    ## Max number of pods that can be unavailable after the eviction
+    ## @param defaultBackend.pdb.maxUnavailable Maximum number/percentage of Default backend pods that may be made unavailable
     ##
-    # maxUnavailable: 1
+    maxUnavailable: 1
 
 ## Prometheus exporter parameters
 ##
 metrics:
+  ## @param metrics.enabled Enable exposing Controller statistics
+  ##
   enabled: false
 
   ## Prometheus exporter service parameters
   ##
   service:
-    ## Prometheus exporter service type
+    ## @param metrics.service.type Type of Prometheus metrics service to create
     ##
     type: ClusterIP
-    ## Prometheus exporter port
+    ## @param metrics.service.port Service HTTP management port
     ##
     port: 9913
-    ## Annotations for the Prometheus exporter service
+    ## @param metrics.service.annotations [object] Annotations for the Prometheus exporter service
     ##
     annotations:
       prometheus.io/scrape: "true"
@@ -739,24 +840,34 @@ metrics:
   ## Prometheus Operator ServiceMonitor configuration
   ##
   serviceMonitor:
-    enabled: false
-    ## Namespace in which Prometheus is running
+    ## @param metrics.serviceMonitor.enabled Create ServiceMonitor resource for scraping metrics using PrometheusOperator
     ##
-    # namespace: monitoring
-    ## Interval at which metrics should be scraped.
+    enabled: false
+    ## @param metrics.serviceMonitor.namespace Namespace in which Prometheus is running
+    ##
+    namespace:
+    ## @param metrics.serviceMonitor.interval Interval at which metrics should be scraped
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
     ##
     interval: 30s
-    ## Timeout after which the scrape is ended
+    ## @param metrics.serviceMonitor.scrapeTimeout Specify the timeout after which the scrape is ended
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ## e.g:
+    ## scrapeTimeout: 10s
     ##
-    # scrapeTimeout: 10s
-    ## ServiceMonitor selector labels
+    scrapeTimeout:
+    ## @param metrics.serviceMonitor.selector ServiceMonitor selector labels
     ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
+    ## e.g:
+    ## selector:
+    ##   prometheus: my-prometheus
     ##
-    # selector:
-    #   prometheus: my-prometheus
-
+    selector: {}
+  ## @param metrics.prometheusRule.enabled Create PrometheusRules resource for scraping metrics using PrometheusOperator
+  ## @param metrics.prometheusRule.additionalLabels Used to pass Labels that are required by the Installed Prometheus Operator
+  ## @param metrics.prometheusRule.namespace Namespace which Prometheus is running in
+  ## @param metrics.prometheusRule.rules Rules to be prometheus in YAML format, check values for an example
+  ##
   prometheusRule:
     enabled: false
     additionalLabels: {}

--- a/bitnami/nginx-ingress-controller/values.yaml
+++ b/bitnami/nginx-ingress-controller/values.yaml
@@ -14,6 +14,26 @@ global:
   ##
   imagePullSecrets: []
 
+## @section Common parameters
+
+## @param nameOverride String to partially override common.names.fullname
+##
+nameOverride:
+## @param fullnameOverride String to fully override common.names.fullname
+##
+fullnameOverride:
+## @param commonLabels Add labels to all the deployed resources
+##
+commonLabels: {}
+## @param commonAnnotations Add annotations to all the deployed resources
+##
+commonAnnotations: {}
+## @param extraDeploy Array of extra objects to deploy with the release
+##
+extraDeploy: []
+
+## @section Nginx Ingress Controller parameters
+
 ## Bitnami NGINX Ingress controller image version
 ## ref: https://hub.docker.com/r/bitnami/nginx-ingress-controller/tags/
 ## @param image.registry Nginx Ingress Controller image registry
@@ -39,66 +59,43 @@ image:
   ##   - myRegistryKeySecretName
   ##
   pullSecrets: []
-
-## @param nameOverride String to partially override common.names.fullname
+## @param containerPorts [object] Controller container ports to open
 ##
-nameOverride:
-
-## @param fullnameOverride String to fully override common.names.fullname
-##
-fullnameOverride:
-
-## @param commonLabels Add labels to all the deployed resources
-##
-commonLabels: {}
-
-## @param commonAnnotations Add annotations to all the deployed resources
-##
-commonAnnotations: {}
-
-## @param extraDeploy Array of extra objects to deploy with the release
-##
-extraDeploy: []
-
+containerPorts:
+  http: 80
+  https: 443
+  metrics: 10254
 ## @param hostAliases Deployment pod host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
 hostAliases: []
-
 ## @param config Custom configuration options for NGINX
 ## ref: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
 ##
 config: {}
-
 ## @param proxySetHeaders Custom headers before sending traffic to backends
 ## ref: https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers
 ##
 proxySetHeaders: {}
-
 ## @param addHeaders Custom headers before sending response traffic to the client
 ## ref: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#add-headers
 ##
 addHeaders: {}
-
 ## @param defaultBackendService Default 404 backend service; required only if `defaultBackend.enabled = false`
 ## Must be <namespace>/<service_name>
 ##
 defaultBackendService: ''
-
 ## @param electionID Election ID to use for status update
 ##
 electionID: ingress-controller-leader
-
 ## @param reportNodeInternalIp If using `hostNetwork=true`, setting `reportNodeInternalIp=true`, will pass the flag `report-node-internal-ip-address` to Nginx Ingress Controller
 ## Bare-metal considerations via the host network
 ## ref: https://kubernetes.github.io/ingress-nginx/deploy/baremetal/#via-the-host-network
 ##
 reportNodeInternalIp: false
-
 ## @param ingressClass Name of the ingress class to route through this controller
 ##
 ingressClass: nginx
-
 ## Allows customization of the external service
 ## the ingress will be bound to via DNS
 ##
@@ -110,36 +107,29 @@ publishService:
   ## Must be <namespace>/<service_name>
   ##
   pathOverride: ''
-
 ## @param scope.enabled Limit the scope of the controller. Defaults to `.Release.Namespace`
 ##
 scope:
   enabled: false
-
 ## @param configMapNamespace Allows customization of the configmap / nginx-configmap namespace
 ## Defaults to .Release.Namespace
 ##
 configMapNamespace: ''
-
 ## @param tcpConfigMapNamespace Allows customization of the tcp-services-configmap namespace
 ## Defaults to .Release.Namespace
 ##
 tcpConfigMapNamespace: ''
-
 ## @param udpConfigMapNamespace Allows customization of the udp-services-configmap namespace
 ## Defaults to .Release.Namespace
 ##
 udpConfigMapNamespace: ''
-
 ## @param maxmindLicenseKey License key used to download Geolite2 database
 ##
 maxmindLicenseKey: ''
-
 ## @param dhParam A base64ed Diffie-Hellman parameter
 ## This can be generated with: openssl dhparam 4096 2> /
 ## Ref: https://github.com/krmichel/ingress-nginx/blob/master/docs/examples/customization/ssl-dh-param
 dhParam:
-
 ## @param tcp TCP service key:value pairs
 ## ref: https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/tcp
 ## e.g:
@@ -147,7 +137,6 @@ dhParam:
 ##   8080: "default/example-tcp-svc:9000"
 ##
 tcp: {}
-
 ## @param udp UDP service key:value pairs
 ## ref: https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/udp
 ## e.g:
@@ -155,42 +144,18 @@ tcp: {}
 ##   53: "kube-system/kube-dns:53"
 ##
 udp: {}
-
-## @param kind Install as Deployment or DaemonSet
-##
-kind: Deployment
-
-## Daemonset configuration
-##
-daemonset:
-  ## @param daemonset.useHostPort If `kind` is `DaemonSet`, this will enable `hostPort` for `TCP/80` and `TCP/443`
-  ##
-  useHostPort: false
-
-  ## @param daemonset.hostPorts [object] HTTP and HTTPS ports
-  ##
-  hostPorts:
-    http: 80
-    https: 443
-
-## @param replicaCount Desired number of Controller pods
-##
-replicaCount: 1
-
 ## @param command Override default container command (useful when using custom images)
 ##
 command: []
 ## @param args Override default container args (useful when using custom images)
 ##
 args: []
-
 ## @param extraArgs Additional command line arguments to pass to nginx-ingress-controller
 ## E.g. to specify the default SSL certificate you can use
 ## extraArgs:
 ##   default-ssl-certificate: "<namespace>/<secret_name>"
 ##
 extraArgs: {}
-
 ## @param extraEnvVars Extra environment variables to be set on Nginx Ingress container
 ## E.g:
 ## extraEnvs:
@@ -201,31 +166,39 @@ extraArgs: {}
 ##         name: secret-resource
 ##
 extraEnvVars: []
-
 ## @param extraEnvVarsCM Name of a existing ConfigMap containing extra environment variables
 ##
 extraEnvVarsCM:
-
 ## @param extraEnvVarsSecret Name of a existing Secret containing extra environment variables
 ##
 extraEnvVarsSecret:
 
-## @param containerPorts [object] Controller container ports to open
-##
-containerPorts:
-  http: 80
-  https: 443
-  metrics: 10254
+## @section Nginx Ingress deployment / daemonset parameters
 
+## @param kind Install as Deployment or DaemonSet
+##
+kind: Deployment
+## Daemonset configuration
+##
+daemonset:
+  ## @param daemonset.useHostPort If `kind` is `DaemonSet`, this will enable `hostPort` for `TCP/80` and `TCP/443`
+  ##
+  useHostPort: false
+  ## @param daemonset.hostPorts [object] HTTP and HTTPS ports
+  ##
+  hostPorts:
+    http: 80
+    https: 443
+## @param replicaCount Desired number of Controller pods
+##
+replicaCount: 1
 ## @param updateStrategy Strategy to use to update Pods
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
 ##
 updateStrategy: {}
-
 ## @param revisionHistoryLimit The number of old history to retain to allow rollback
 ##
 revisionHistoryLimit: 10
-
 ## Controller pods' Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param podSecurityContext.enabled Enable Controller pods' Security Context
@@ -234,7 +207,6 @@ revisionHistoryLimit: 10
 podSecurityContext:
   enabled: true
   fsGroup: 1001
-
 ## Controller containers' Security Context (only main container)
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 ## @param containerSecurityContext.enabled Enable Controller containers' Security Context
@@ -250,11 +222,9 @@ containerSecurityContext:
   capabilities:
     drop: ["ALL"]
     add: ["NET_BIND_SERVICE"]
-
 ## @param minReadySeconds How many seconds a pod needs to be ready before killing the next, during update
 ##
 minReadySeconds: 0
-
 ## Controller containers' resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources
 ## We usually recommend not to specify default resources and to leave this as a conscious
@@ -275,7 +245,6 @@ resources:
   ##    cpu: 250m
   ##    memory: 256Mi
   requests: {}
-
 ## Controller containers' liveness probe. Evaluated as a template.
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 ## @param livenessProbe.enabled Enable livenessProbe
@@ -322,60 +291,48 @@ readinessProbe:
   periodSeconds: 10
   successThreshold: 1
   timeoutSeconds: 1
-
 ## @param customLivenessProbe Override default liveness probe
 ##
 customLivenessProbe: {}
-
 ## @param customReadinessProbe Override default readiness probe
 ##
 customReadinessProbe: {}
-
 ## @param lifecycle LifecycleHooks to set additional configuration at startup
 ##
 lifecycle: {}
-
 ## @param podLabels Extra labels for Controller pods
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ##
 podLabels: {}
-
 ## @param podAnnotations Annotations for Controller pods
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 ##
 podAnnotations: {}
-
 ## @param priorityClassName Controller priorityClassName
 ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
 ##
 priorityClassName: ''
-
 ## @param hostNetwork If the Nginx deployment / daemonset should run on the host's network namespace
 ## Required on CNI based K8s installations, since CNI and hostport don't mix yet
 ## Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920 is merged
 ##
 hostNetwork: false
-
 ## @param dnsPolicy By default, while using host network, name resolution uses the host's DNS
 ## Optionally, change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true' if you wish nginx-controller
 ## to keep resolving names inside the Kubernetes network
 ##
 dnsPolicy: ClusterFirst
-
 ## @param terminationGracePeriodSeconds How many seconds to wait before terminating a pod
 ##
 terminationGracePeriodSeconds: 60
-
 ## @param podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
 ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
 ##
 podAffinityPreset: ""
-
 ## @param podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
 ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
 ##
 podAntiAffinityPreset: soft
-
 ## Node affinity preset
 ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
 ##
@@ -395,31 +352,25 @@ nodeAffinityPreset:
   ##   - e2e-az2
   ##
   values: []
-
 ## @param affinity Affinity for pod assignment. Evaluated as a template.
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 ## Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
 ##
 affinity: {}
-
 ## @param nodeSelector Node labels for pod assignment. Evaluated as a template.
 ## ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##
 nodeSelector: {}
-
 ## @param tolerations Tolerations for pod assignment. Evaluated as a template.
 ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
 tolerations: []
-
 ## @param extraVolumes Optionally specify extra list of additional volumes for Controller pods
 ##
 extraVolumes: []
-
 ## @param extraVolumeMounts Optionally specify extra list of additional volumeMounts for Controller container(s)
 ##
 extraVolumeMounts: []
-
 ## @param initContainers Add init containers to the controller pods
 ## Example:
 ## initContainers:
@@ -431,7 +382,6 @@ extraVolumeMounts: []
 ##         containerPort: 1234
 ##
 initContainers: {}
-
 ## @param sidecars Add sidecars to the controller pods.
 ## Example:
 ## sidecars:
@@ -443,77 +393,11 @@ initContainers: {}
 ##         containerPort: 1234
 ##
 sidecars: {}
-
 ## @param customTemplate [object] Override NGINX template
 ##
 customTemplate:
   configMapName: ''
   configMapKey: ''
-
-## Service parameters
-##
-service:
-  ## @param service.type Kubernetes Service type for Controller
-  ##
-  type: LoadBalancer
-
-  ## @param service.ports [object] Service ports
-  ##
-  ports:
-    http: 80
-    https: 443
-
-  ## @param service.targetPorts [object] Map the controller service HTTP/HTTPS port
-  ##
-  targetPorts:
-    http: http
-    https: https
-
-  ## @param service.nodePorts [object] Specify the nodePort value(s) for the LoadBalancer and NodePort service types.
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
-  ##
-  nodePorts:
-    http: ''
-    https: ''
-    tcp: {}
-    udp: {}
-
-  ## @param service.annotations Annotations for controller service
-  ## This can be used to set the LoadBalancer service type to internal only.
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
-  ##
-  annotations: {}
-  ## @param service.labels Labels for controller service
-  ##
-  labels: {}
-
-  ## @param service.clusterIP Controller Internal Cluster Service IP (optional)
-  ##
-  clusterIP:
-
-  ## @param service.externalIPs Controller Service external IP addresses
-  ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
-  ##
-  externalIPs: []
-
-  ## @param service.loadBalancerIP Kubernetes LoadBalancerIP to request for Controller (optional, cloud specific)
-  ## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
-  ##
-  loadBalancerIP:
-  ## @param service.loadBalancerSourceRanges List of IP CIDRs allowed access to load balancer (if supported)
-  ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
-  ##
-  loadBalancerSourceRanges: []
-
-  ## @param service.externalTrafficPolicy Set external traffic policy to: "Local" to preserve source IP on providers supporting it
-  ## Enable client source IP preservation
-  ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
-  ##
-  externalTrafficPolicy: ''
-  ## @param service.healthCheckNodePort Set this to the managed health-check port the kube-proxy will expose. If blank, a random port in the `NodePort` range will be assigned
-  ##
-  healthCheckNodePort: 0
-
 ## @param topologySpreadConstraints Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in
 ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
 ##
@@ -526,64 +410,13 @@ service:
 ##         app.kubernetes.io/instance: ingress-nginx-internal
 ##
 topologySpreadConstraints: []
-
-## Role Based Access
-## Ref: https://kubernetes.io/docs/admin/authorization/rbac/
-##
-rbac:
-  ## @param rbac.create Specifies whether RBAC rules should be created
-  ##
-  create: true
-
-## Pods Service Account
-## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-##
-serviceAccount:
-  ## @param serviceAccount.create Enable the creation of a ServiceAccount for Controller pods
-  ##
-  create: true
-  ## @param serviceAccount.name Name of the created ServiceAccount
-  ## If not set and create is true, a name is generated using the metrics-server.fullname template
-  name:
-
-  ## @param serviceAccount.annotations Annotations for service account.
-  ## Only used if `create` is `true`.
-  ##
-  annotations: {}
-
-## Controller Pod Disruption Budget configuration
-## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
-##
-pdb:
-  ## @param pdb.create Enable/disable a Pod Disruption Budget creation for Controller
-  ##
-  create: false
-  ## @param pdb.minAvailable Minimum number/percentage of Controller pods that should remain scheduled
-  ##
-  minAvailable: 1
-  ## @param pdb.maxUnavailable Maximum number/percentage of Controller pods that may be made unavailable
-  ##
-  maxUnavailable:
-
-## Controller Autoscaling configuration
-## @param autoscaling.enabled Enable autoscaling for Controller
-## @param autoscaling.minReplicas Minimum number of Controller replicas
-## @param autoscaling.maxReplicas Maximum number of Controller replicas
-## @param autoscaling.targetCPU Target CPU utilization percentage
-## @param autoscaling.targetMemory Target Memory utilization percentage
-##
-autoscaling:
-  enabled: false
-  minReplicas: 1
-  maxReplicas: 11
-  targetCPU:
-  targetMemory:
-
 ## @param podSecurityPolicy.enabled If true, create & use Pod Security Policy resources
 ## https://kubernetes.io/docs/concepts/policy/pod-security-policy/
 ##
 podSecurityPolicy:
   enabled: false
+
+## @section Default backend parameters
 
 ## Default 404 backend
 ##
@@ -620,15 +453,13 @@ defaultBackend:
     ##   - myRegistryKeySecretName
     ##
     pullSecrets: []
-
   ## @param defaultBackend.extraArgs Additional command line arguments to pass to Nginx container
   ##
   extraArgs: {}
   ## @param defaultBackend.containerPort HTTP container port number
   ##
   containerPort: 8080
-
-  ## @param defaultBackend.serverBlockConfig NGINX backend default server block configuration
+  ## @param defaultBackend.serverBlockConfig [string] NGINX backend default server block configuration
   ## Should be compliant with: https://kubernetes.github.io/ingress-nginx/user-guide/default-backend/
   ##
   serverBlockConfig: |-
@@ -639,11 +470,9 @@ defaultBackend:
     location / {
       return 404;
     }
-
   ## @param defaultBackend.replicaCount Desired number of default backend pods
   ##
   replicaCount: 1
-
   ## Default backend pods' Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param defaultBackend.podSecurityContext.enabled Enable Default backend pods' Security Context
@@ -652,7 +481,6 @@ defaultBackend:
   podSecurityContext:
     enabled: true
     fsGroup: 1001
-
   ## Default backend containers' Security Context (only main container)
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param defaultBackend.containerSecurityContext.enabled Enable Default backend containers' Security Context
@@ -661,7 +489,6 @@ defaultBackend:
   containerSecurityContext:
     enabled: true
     runAsUser: 1001
-
   ## Default backend containers' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources
   ## We usually recommend not to specify default resources and to leave this as a conscious
@@ -682,7 +509,6 @@ defaultBackend:
     ##    cpu: 250m
     ##    memory: 256Mi
     requests: {}
-
   ## Default backend containers' liveness probe. Evaluated as a template.
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   ## @param defaultBackend.livenessProbe.enabled Enable livenessProbe
@@ -729,32 +555,26 @@ defaultBackend:
     periodSeconds: 5
     successThreshold: 1
     timeoutSeconds: 5
-
   ## @param defaultBackend.podLabels Extra labels for Controller pods
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   ##
   podLabels: {}
-
   ## @param defaultBackend.podAnnotations Annotations for Controller pods
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##
   podAnnotations: {}
-
   ## @param defaultBackend.priorityClassName priorityClassName
   ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
   ##
   priorityClassName: ''
-
   ## @param defaultBackend.podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
   ##
   podAffinityPreset: ""
-
   ## @param defaultBackend.podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
   ##
   podAntiAffinityPreset: soft
-
   ## Node affinity preset
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
   ##
@@ -774,23 +594,19 @@ defaultBackend:
     ##   - e2e-az2
     ##
     values: []
-
   ## @param defaultBackend.affinity Affinity for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ## Note: defaultBackend.podAffinityPreset, defaultBackend.podAntiAffinityPreset, and defaultBackend.nodeAffinityPreset will be ignored when it's set
   ##
   affinity: {}
-
   ## @param defaultBackend.nodeSelector Node labels for pod assignment
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
   nodeSelector: {}
-
   ## @param defaultBackend.tolerations Tolerations for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
   tolerations: []
-
   ## Default backend Service parameters
   ##
   service:
@@ -800,7 +616,6 @@ defaultBackend:
     ## @param defaultBackend.service.port Default backend service port
     ##
     port: 80
-
   ## Default backend Pod Disruption Budget configuration
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   ##
@@ -813,7 +628,120 @@ defaultBackend:
     minAvailable: 1
     ## @param defaultBackend.pdb.maxUnavailable Maximum number/percentage of Default backend pods that may be made unavailable
     ##
-    maxUnavailable: 1
+    maxUnavailable:
+
+## @section Traffic exposure parameters
+
+## Service parameters
+##
+service:
+  ## @param service.type Kubernetes Service type for Controller
+  ##
+  type: LoadBalancer
+  ## @param service.ports [object] Service ports
+  ##
+  ports:
+    http: 80
+    https: 443
+  ## @param service.targetPorts [object] Map the controller service HTTP/HTTPS port
+  ##
+  targetPorts:
+    http: http
+    https: https
+  ## @param service.nodePorts [object] Specify the nodePort value(s) for the LoadBalancer and NodePort service types.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+  ##
+  nodePorts:
+    http: ''
+    https: ''
+    tcp: {}
+    udp: {}
+  ## @param service.annotations Annotations for controller service
+  ## This can be used to set the LoadBalancer service type to internal only.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+  ##
+  annotations: {}
+  ## @param service.labels Labels for controller service
+  ##
+  labels: {}
+  ## @param service.clusterIP Controller Internal Cluster Service IP (optional)
+  ##
+  clusterIP:
+  ## @param service.externalIPs Controller Service external IP addresses
+  ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+  ##
+  externalIPs: []
+  ## @param service.loadBalancerIP Kubernetes LoadBalancerIP to request for Controller (optional, cloud specific)
+  ## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
+  ##
+  loadBalancerIP:
+  ## @param service.loadBalancerSourceRanges List of IP CIDRs allowed access to load balancer (if supported)
+  ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  ##
+  loadBalancerSourceRanges: []
+  ## @param service.externalTrafficPolicy Set external traffic policy to: "Local" to preserve source IP on providers supporting it
+  ## Enable client source IP preservation
+  ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
+  ##
+  externalTrafficPolicy: ''
+  ## @param service.healthCheckNodePort Set this to the managed health-check port the kube-proxy will expose. If blank, a random port in the `NodePort` range will be assigned
+  ##
+  healthCheckNodePort: 0
+
+## @section RBAC parameters
+
+## Pods Service Account
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  ## @param serviceAccount.create Enable the creation of a ServiceAccount for Controller pods
+  ##
+  create: true
+  ## @param serviceAccount.name Name of the created ServiceAccount
+  ## If not set and create is true, a name is generated using the metrics-server.fullname template
+  name:
+  ## @param serviceAccount.annotations Annotations for service account.
+  ## Only used if `create` is `true`.
+  ##
+  annotations: {}
+## Role Based Access
+## Ref: https://kubernetes.io/docs/admin/authorization/rbac/
+##
+rbac:
+  ## @param rbac.create Specifies whether RBAC rules should be created
+  ##
+  create: true
+
+## @section Other parameters
+
+## Controller Pod Disruption Budget configuration
+## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+##
+pdb:
+  ## @param pdb.create Enable/disable a Pod Disruption Budget creation for Controller
+  ##
+  create: false
+  ## @param pdb.minAvailable Minimum number/percentage of Controller pods that should remain scheduled
+  ##
+  minAvailable: 1
+  ## @param pdb.maxUnavailable Maximum number/percentage of Controller pods that may be made unavailable
+  ##
+  maxUnavailable:
+## Controller Autoscaling configuration
+## @param autoscaling.enabled Enable autoscaling for Controller
+## @param autoscaling.minReplicas Minimum number of Controller replicas
+## @param autoscaling.maxReplicas Maximum number of Controller replicas
+## @param autoscaling.targetCPU Target CPU utilization percentage
+## @param autoscaling.targetMemory Target Memory utilization percentage
+##
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 11
+  targetCPU:
+  targetMemory:
+
+## @section Metrics parameters
 
 ## Prometheus exporter parameters
 ##
@@ -821,7 +749,6 @@ metrics:
   ## @param metrics.enabled Enable exposing Controller statistics
   ##
   enabled: false
-
   ## Prometheus exporter service parameters
   ##
   service:
@@ -836,7 +763,6 @@ metrics:
     annotations:
       prometheus.io/scrape: "true"
       prometheus.io/port: "{{ .Values.metrics.service.port }}"
-
   ## Prometheus Operator ServiceMonitor configuration
   ##
   serviceMonitor:

--- a/bitnami/node-exporter/Chart.yaml
+++ b/bitnami/node-exporter/Chart.yaml
@@ -24,4 +24,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-node-exporter
   - https://github.com/prometheus/node_exporter
   - https://prometheus.io/
-version: 2.3.0
+version: 2.3.1

--- a/bitnami/node-exporter/README.md
+++ b/bitnami/node-exporter/README.md
@@ -48,77 +48,91 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Parameters
 
-The following table lists the configurable parameters of the Node Exporter chart and their default values.
+### Global parameters
 
-| Parameter                               | Description                                                                               | Default                                                                   |
-|-----------------------------------------|-------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
-| `global.imageRegistry`                  | Global Docker image registry                                                              | `nil`                                                                     |
-| `global.imagePullSecrets`               | Global Docker registry secret names as an array                                           | `[]` (does not add image pull secrets to deployed pods)                   |
-| `global.storageClass`                   | Global storage class for dynamic provisioning                                             | `nil`                                                                     |
-| `nameOverride`                          | String to partially override `common.names.fullname` template with a string               | `nil`                                                                     |
-| `fullnameOverride`                      | String to fully override `common.names.fullname` template with a string                   | `nil`                                                                     |
-| `commonLabels`                          | Labels to add to all deployed objects                                                     | `{}`                                                                      |
-| `hostAliases`                           | Add deployment host aliases                                                               | `[]`                                                                      |
-| `rbac.create`                           | Whether to create & use RBAC resources or not                                             | `true`                                                                    |
-| `rbac.apiVersion`                       | Version of the RBAC API                                                                   | `v1beta1`                                                                 |
-| `rbac.pspEnabled`                       | PodSecurityPolicy                                                                         | `true`                                                                    |
-| `serviceAccount.create`                 | Specify whether to create a ServiceAccount for Node Exporter                              | `true`                                                                    |
-| `serviceAccount.name`                   | The name of the ServiceAccount to create                                                  | Generated using the `common.names.fullname` template                      |
-| `image.registry`                        | Node Exporter image registry                                                              | `docker.io`                                                               |
-| `image.repository`                      | Node Exporter Image name                                                                  | `bitnami/node-exporter`                                                   |
-| `image.tag`                             | Node Exporter Image tag                                                                   | `{TAG_NAME}`                                                              |
-| `image.pullPolicy`                      | Node Exporter image pull policy                                                           | `IfNotPresent`                                                            |
-| `image.pullSecrets`                     | Specify docker-registry secret names as an array                                          | `[]` (does not add image pull secrets to deployed pods)                   |
-| `extraArgs`                             | Additional command line arguments to pass to node-exporter                                | `{}`                                                                      |
-| `extraVolumes`                          | Additional volumes to the node-exporter pods                                              | `{}`                                                                      |
-| `extraVolumeMounts`                     | Additional volumeMounts to the node-exporter container                                    | `{}`                                                                      |
-| `securityContext.enabled`               | Enable security context                                                                   | `true`                                                                    |
-| `securityContext.runAsUser`             | User ID for the container                                                                 | `1001`                                                                    |
-| `securityContext.fsGroup`               | Group ID for the container filesystem                                                     | `1001`                                                                    |
-| `service.type`                          | Kubernetes service type                                                                   | `ClusterIP`                                                               |
-| `service.port`                          | Node Exporter service port                                                                | `9100`                                                                    |
-| `service.targetPort`                    | Node Exporter container target port                                                       | `9100`                                                                    |
-| `service.clusterIP`                     | Specific cluster IP when service type is cluster IP. Use `None` for headless service      | `nil`                                                                     |
-| `service.nodePort`                      | Kubernetes Service nodePort                                                               | `nil`                                                                     |
-| `service.loadBalancerIP`                | `loadBalancerIP` if service type is `LoadBalancer`                                        | `nil`                                                                     |
-| `service.loadBalancerSourceRanges`      | Address that are allowed when svc is `LoadBalancer`                                       | `[]`                                                                      |
-| `service.addPrometheusScrapeAnnotation` | Add the `prometheus.io/scrape: "true"` annotation to the service                          | `true`                                                                    |
-| `service.annotations`                   | Additional annotations for Node Exporter service                                          | `{}`                                                                      |
-| `service.labels`                        | Additional labels for Node Exporter service                                               | `{}`                                                                      |
-| `updateStrategy`                        | The update strategy to apply to the DaemonSet                                             | `{ "type": "RollingUpdate", "rollingUpdate": { "maxUnavailable": "1" } }` |
-| `hostNetwork`                           | Expose the service to the host network                                                    | `true`                                                                    |
-| `minReadySeconds`                       | `minReadySeconds` to avoid killing pods before we are ready                               | `0`                                                                       |
-| `priorityClassName`                     | Priority class assigned to the Pods                                                       | `nil`                                                                     |
-| `resources`                             | Resource requests/limit                                                                   | `{}`                                                                      |
-| `podLabels`                             | Pod labels                                                                                | `{}`                                                                      |
-| `podAnnotations`                        | Pod annotations                                                                           | `{}`                                                                      |
-| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                                                                      |
-| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                                                    |
-| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                                                                      |
-| `nodeAffinityPreset.key`                | Node label key to match Ignored if `affinity` is set.                                     | `""`                                                                      |
-| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                                                                      |
-| `affinity`                              | Affinity for pod assignment                                                               | `{}` (evaluated as a template)                                            |
-| `nodeSelector`                          | Node labels for pod assignment                                                            | `{}` (evaluated as a template)                                            |
-| `tolerations`                           | Tolerations for pod assignment                                                            | `[]` (evaluated as a template)                                            |
-| `livenessProbe.enabled`                 | Turn on and off liveness probe                                                            | `true`                                                                    |
-| `livenessProbe.initialDelaySeconds`     | Delay before liveness probe is initiated                                                  | `120`                                                                     |
-| `livenessProbe.periodSeconds`           | How often to perform the probe                                                            | `10`                                                                      |
-| `livenessProbe.timeoutSeconds`          | When the probe times out                                                                  | `5`                                                                       |
-| `livenessProbe.failureThreshold`        | Minimum consecutive failures for the probe                                                | `6`                                                                       |
-| `livenessProbe.successThreshold`        | Minimum consecutive successes for the probe                                               | `1`                                                                       |
-| `readinessProbe.enabled`                | Turn on and off readiness probe                                                           | `true`                                                                    |
-| `readinessProbe.initialDelaySeconds`    | Delay before readiness probe is initiated                                                 | `30`                                                                      |
-| `readinessProbe.periodSeconds`          | How often to perform the probe                                                            | `10`                                                                      |
-| `readinessProbe.timeoutSeconds`         | When the probe times out                                                                  | `5`                                                                       |
-| `readinessProbe.failureThreshold`       | Minimum consecutive failures for the probe                                                | `6`                                                                       |
-| `readinessProbe.successThreshold`       | Minimum consecutive successes for the probe                                               | `1`                                                                       |
-| `serviceMonitor.enabled`                | Creates a ServiceMonitor to monitor Node Exporter                                         | `false`                                                                   |
-| `serviceMonitor.namespace`              | Namespace in which Prometheus is running                                                  | `nil`                                                                     |
-| `serviceMonitor.interval`               | Scrape interval (use by default, falling back to Prometheus' default)                     | `nil`                                                                     |
-| `serviceMonitor.jobLabel`               | The name of the label on the target service to use as the job name in prometheus.         | `nil`                                                                     |
-| `serviceMonitor.selector`               | ServiceMonitor selector labels                                                            | `[]`                                                                      |
-| `serviceMonitor.relabelings`            | ServiceMonitor relabelings                                                                | `[]`                                                                      |
-| `serviceMonitor.metricRelabelings`      | ServiceMonitor metricRelabelings                                                          | `[]`                                                                      |
+| Name                      | Description                                     | Value |
+| ------------------------- | ----------------------------------------------- | ----- |
+| `global.imageRegistry`    | Global Docker image registry                    | `nil` |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
+| `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `nil` |
+
+
+### Common parameters
+
+| Name               | Description                                                                                  | Value |
+| ------------------ | -------------------------------------------------------------------------------------------- | ----- |
+| `nameOverride`     | String to partially override common.names.fullname template (will maintain the release name) | `nil` |
+| `fullnameOverride` | String to fully override `common.names.fullname` template with a string                      | `nil` |
+| `commonLabels`     | Add labels to all the deployed resources                                                     | `{}`  |
+
+
+### Node Exporter parameters
+
+| Name                                          | Description                                                                               | Value                   |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------- | ----------------------- |
+| `hostAliases`                                 | Deployment pod host aliases                                                               | `[]`                    |
+| `rbac.create`                                 | Whether to create and use RBAC resources or not                                           | `true`                  |
+| `rbac.apiVersion`                             | Version of the RBAC API                                                                   | `v1beta1`               |
+| `rbac.pspEnabled`                             | Enable Pod Security Policy                                                                | `true`                  |
+| `serviceAccount.create`                       | Specify whether to create a ServiceAccount for Node Exporter                              | `true`                  |
+| `serviceAccount.name`                         | The name of the ServiceAccount to create                                                  | `nil`                   |
+| `image.registry`                              | Node Exporter image registry                                                              | `docker.io`             |
+| `image.repository`                            | Node Exporter image repository                                                            | `bitnami/node-exporter` |
+| `image.tag`                                   | Node Exporter Image tag (immutable tags are recommended)                                  | `1.1.2-debian-10-r90`   |
+| `image.pullPolicy`                            | Node Exporter image pull policy                                                           | `IfNotPresent`          |
+| `image.pullSecrets`                           | Specify docker-registry secret names as an array                                          | `[]`                    |
+| `extraArgs`                                   | Additional command line arguments to pass to node-exporter                                | `{}`                    |
+| `extraVolumes`                                | Additional volumes to the node-exporter pods                                              | `[]`                    |
+| `extraVolumeMounts`                           | Additional volumeMounts to the node-exporter container                                    | `[]`                    |
+| `securityContext.enabled`                     | Enable security context                                                                   | `true`                  |
+| `securityContext.fsGroup`                     | Group ID for the container filesystem                                                     | `1001`                  |
+| `securityContext.runAsUser`                   | User ID for the container                                                                 | `1001`                  |
+| `service.type`                                | Kubernetes service type                                                                   | `ClusterIP`             |
+| `service.targetPort`                          | Node Exporter container target port                                                       | `9100`                  |
+| `service.port`                                | Node Exporter service port                                                                | `9100`                  |
+| `service.clusterIP`                           | Specific cluster IP when service type is cluster IP. Use `None` for headless service      | `nil`                   |
+| `service.nodePort`                            | Specify the nodePort value for the LoadBalancer and NodePort service types                | `nil`                   |
+| `service.loadBalancerIP`                      | `loadBalancerIP` if service type is `LoadBalancer`                                        | `nil`                   |
+| `service.loadBalancerSourceRanges`            | Address that are allowed when service is `LoadBalancer`                                   | `[]`                    |
+| `service.addPrometheusScrapeAnnotation`       | Add the `prometheus.io/scrape: "true"` annotation to the service                          | `true`                  |
+| `service.annotations`                         | Additional annotations for Node Exporter service                                          | `{}`                    |
+| `service.labels`                              | Additional labels for Node Exporter service                                               | `{}`                    |
+| `updateStrategy.type`                         | The update strategy type to apply to the DaemonSet                                        | `RollingUpdate`         |
+| `updateStrategy.rollingUpdate.maxUnavailable` | Maximum number of pods that may be made unavailable                                       | `1`                     |
+| `hostNetwork`                                 | Expose the service to the host network                                                    | `true`                  |
+| `minReadySeconds`                             | `minReadySeconds` to avoid killing pods before we are ready                               | `0`                     |
+| `priorityClassName`                           | Priority class assigned to the Pods                                                       | `""`                    |
+| `resources.limits`                            | The resources limits for the container                                                    | `{}`                    |
+| `resources.requests`                          | The requested resources for the container                                                 | `{}`                    |
+| `podLabels`                                   | Pod labels                                                                                | `{}`                    |
+| `podAnnotations`                              | Pod annotations                                                                           | `{}`                    |
+| `podAffinityPreset`                           | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                    |
+| `podAntiAffinityPreset`                       | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                  |
+| `nodeAffinityPreset.type`                     | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                    |
+| `nodeAffinityPreset.key`                      | Node label key to match Ignored if `affinity` is set.                                     | `""`                    |
+| `nodeAffinityPreset.values`                   | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                    |
+| `affinity`                                    | Affinity for pod assignment. Evaluated as a template.                                     | `{}`                    |
+| `nodeSelector`                                | Node labels for pod assignment. Evaluated as a template.                                  | `{}`                    |
+| `tolerations`                                 | Tolerations for pod assignment. Evaluated as a template.                                  | `[]`                    |
+| `livenessProbe.initialDelaySeconds`           | Initial delay seconds for livenessProbe                                                   | `120`                   |
+| `livenessProbe.periodSeconds`                 | Period seconds for livenessProbe                                                          | `10`                    |
+| `livenessProbe.timeoutSeconds`                | Timeout seconds for livenessProbe                                                         | `5`                     |
+| `livenessProbe.failureThreshold`              | Failure threshold for livenessProbe                                                       | `6`                     |
+| `livenessProbe.successThreshold`              | Success threshold for livenessProbe                                                       | `1`                     |
+| `readinessProbe.initialDelaySeconds`          | Initial delay seconds for readinessProbe                                                  | `30`                    |
+| `readinessProbe.periodSeconds`                | Period seconds for readinessProbe                                                         | `10`                    |
+| `readinessProbe.timeoutSeconds`               | Timeout seconds for readinessProbe                                                        | `5`                     |
+| `readinessProbe.failureThreshold`             | Failure threshold for readinessProbe                                                      | `6`                     |
+| `readinessProbe.successThreshold`             | Success threshold for readinessProbe                                                      | `1`                     |
+| `serviceMonitor.enabled`                      | Creates a ServiceMonitor to monitor Node Exporter                                         | `false`                 |
+| `serviceMonitor.namespace`                    | Namespace in which Prometheus is running                                                  | `nil`                   |
+| `serviceMonitor.jobLabel`                     | The name of the label on the target service to use as the job name in prometheus.         | `nil`                   |
+| `serviceMonitor.interval`                     | Scrape interval (use by default, falling back to Prometheus' default)                     | `nil`                   |
+| `serviceMonitor.scrapeTimeout`                | Timeout after which the scrape is ended                                                   | `nil`                   |
+| `serviceMonitor.selector`                     | ServiceMonitor selector labels                                                            | `{}`                    |
+| `serviceMonitor.relabelings`                  | RelabelConfigs to apply to samples before scraping                                        | `[]`                    |
+| `serviceMonitor.metricRelabelings`            | MetricRelabelConfigs to apply to samples before ingestion                                 | `[]`                    |
+
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example the following command sets the `minReadySeconds` of the Node Exporter Pods to `120` seconds.
 

--- a/bitnami/node-exporter/values.yaml
+++ b/bitnami/node-exporter/values.yaml
@@ -16,23 +16,24 @@ global:
   imagePullSecrets: []
   storageClass:
 
+## @section Common parameters
+
 ## @param nameOverride String to partially override common.names.fullname template (will maintain the release name)
 ##
 nameOverride:
-
 ## @param fullnameOverride String to fully override `common.names.fullname` template with a string
 ##
 fullnameOverride:
-
 ## @param commonLabels Add labels to all the deployed resources
 ##
 commonLabels: {}
+
+## @section Node Exporter parameters
 
 ## @param hostAliases Deployment pod host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
 hostAliases: []
-
 ## Role Based Access
 ## Ref: https://kubernetes.io/docs/admin/authorization/rbac/
 ##
@@ -40,15 +41,12 @@ rbac:
   ## @param rbac.create Whether to create and use RBAC resources or not
   ##
   create: true
-
   ## @param rbac.apiVersion Version of the RBAC API
   ##
   apiVersion: v1beta1
-
   ## @param rbac.pspEnabled Enable Pod Security Policy
   ##
   pspEnabled: true
-
 ## Service account for Node Exporter to use.
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 ##
@@ -59,7 +57,6 @@ serviceAccount:
   ## @param serviceAccount.name The name of the ServiceAccount to create
   ## If not set and create is true, a name is generated using the common.names.fullname template
   name:
-
 ## Bitnami Node Exporter image version
 ## ref: https://hub.docker.com/r/bitnami/node-exporter/tags/
 ## @param image.registry Node Exporter image registry
@@ -67,13 +64,11 @@ serviceAccount:
 ## @param image.tag Node Exporter Image tag (immutable tags are recommended)
 ## @param image.pullPolicy Node Exporter image pull policy
 ## @param image.pullSecrets Specify docker-registry secret names as an array
-
 ##
 image:
   registry: docker.io
   repository: bitnami/node-exporter
   tag: 1.1.2-debian-10-r90
-
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -87,28 +82,24 @@ image:
   ##   - myRegistryKeySecretName
   ##
   pullSecrets: []
-
 ## @param extraArgs Additional command line arguments to pass to node-exporter
 ## e.g:
 ##  collector.filesystem.ignored-mount-points: "^/(dev|proc|sys|var/lib/docker/.+)($|/)"
 ##  collector.filesystem.ignored-fs-types: "^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$"
 ##
 extraArgs: {}
-
 ## @param extraVolumes Additional volumes to the node-exporter pods
 ## e.g:
 ##  - name: copy-portal-skins
 ##    emptyDir: {}
 ##
 extraVolumes: []
-
 ## @param extraVolumeMounts Additional volumeMounts to the node-exporter container
 ## e.g:
 ##  - name: copy-portal-skins
 ##   mountPath: /var/lib/lemonldap-ng/portal/skins
 ##
 extraVolumeMounts: []
-
 ## SecurityContext configuration
 ## @param securityContext.enabled Enable security context
 ## @param securityContext.fsGroup Group ID for the container filesystem
@@ -118,7 +109,6 @@ securityContext:
   enabled: true
   runAsUser: 1001
   fsGroup: 1001
-
 ## Node Exporter Service
 ##
 service:
@@ -134,20 +124,17 @@ service:
   ## @param service.clusterIP Specific cluster IP when service type is cluster IP. Use `None` for headless service
   ##
   clusterIP:
-
   ## @param service.nodePort Specify the nodePort value for the LoadBalancer and NodePort service types
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
   ## e.g:
   ## nodePort: 30080
   ##
   nodePort:
-
   ## @param service.loadBalancerIP `loadBalancerIP` if service type is `LoadBalancer`
   ## Set the LoadBalancer service type to internal only
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
   ##
   loadBalancerIP:
-
   ## @param service.loadBalancerSourceRanges Address that are allowed when service is `LoadBalancer`
   ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
   ##
@@ -155,19 +142,15 @@ service:
   ## - 10.10.10.0/24
   ##
   loadBalancerSourceRanges: []
-
   ## @param service.addPrometheusScrapeAnnotation Add the `prometheus.io/scrape: "true"` annotation to the service
   ##
   addPrometheusScrapeAnnotation: true
-
   ## @param service.annotations Additional annotations for Node Exporter service
   ##
   annotations: {}
-
   ## @param service.labels Additional labels for Node Exporter service
   ##
   labels: {}
-
 ## @param updateStrategy.type The update strategy type to apply to the DaemonSet
 ## @param updateStrategy.rollingUpdate.maxUnavailable Maximum number of pods that may be made unavailable
 ##
@@ -175,18 +158,14 @@ updateStrategy:
   type: RollingUpdate
   rollingUpdate:
     maxUnavailable: 1
-
 ## @param hostNetwork Expose the service to the host network
 hostNetwork: true
-
 ## @param minReadySeconds `minReadySeconds` to avoid killing pods before we are ready
 ##
 minReadySeconds: 0
-
 ## @param priorityClassName Priority class assigned to the Pods
 ##
 priorityClassName: ""
-
 ## Resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ## We usually recommend not to specify default resources and to leave this as a conscious
@@ -207,27 +186,22 @@ resources:
   ##    cpu: 100m
   ##    memory: 128Mi
   requests: {}
-
 ## @param podLabels Pod labels
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ##
 podLabels: {}
-
 ## @param podAnnotations Pod annotations
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 ##
 podAnnotations: {}
-
 ## @param podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
 ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
 ##
 podAffinityPreset: ""
-
 ## @param podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
 ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
 ##
 podAntiAffinityPreset: soft
-
 ## Node affinity preset
 ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
 ##
@@ -247,23 +221,19 @@ nodeAffinityPreset:
   ##   - e2e-az2
   ##
   values: []
-
 ## @param affinity Affinity for pod assignment. Evaluated as a template.
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 ## Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
 ##
 affinity: {}
-
 ## @param nodeSelector Node labels for pod assignment. Evaluated as a template.
 ## ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##
 nodeSelector: {}
-
 ## @param tolerations Tolerations for pod assignment. Evaluated as a template.
 ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
 tolerations: []
-
 ## Configure extra options for liveness probe
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
 ## @param livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
@@ -292,7 +262,6 @@ readinessProbe:
   timeoutSeconds: 5
   failureThreshold: 6
   successThreshold: 1
-
 ## ServiceMonitor configuration
 ##
 serviceMonitor:
@@ -302,25 +271,21 @@ serviceMonitor:
   ## @param serviceMonitor.namespace Namespace in which Prometheus is running
   ##
   namespace:
-
   ## @param serviceMonitor.jobLabel The name of the label on the target service to use as the job name in prometheus.
   ##
   jobLabel:
-
   ## @param serviceMonitor.interval Scrape interval (use by default, falling back to Prometheus' default)
   ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
   ## e.g:
   ## interval: 10s
   ##
   interval:
-
   ## @param serviceMonitor.scrapeTimeout Timeout after which the scrape is ended
   ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
   ## e.g:
   ## scrapeTimeout: 10s
   ##
   scrapeTimeout:
-
   ## @param serviceMonitor.selector ServiceMonitor selector labels
   ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
   ##
@@ -328,12 +293,10 @@ serviceMonitor:
   ##   prometheus: my-prometheus
   ##
   selector: {}
-
   ## @param serviceMonitor.relabelings RelabelConfigs to apply to samples before scraping
   ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
   ##
   relabelings: []
-
   ## @param serviceMonitor.metricRelabelings MetricRelabelConfigs to apply to samples before ingestion
   ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
   ##

--- a/bitnami/node-exporter/values.yaml
+++ b/bitnami/node-exporter/values.yaml
@@ -1,26 +1,34 @@
+## @section Global parameters
 ## Global Docker image parameters
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value
-## Current available global Docker image parameters: imageRegistry and imagePullSecrets
+## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
+
+## @param global.imageRegistry Global Docker image registry
+## @param global.imagePullSecrets Global Docker registry secret names as an array
+## @param global.storageClass Global StorageClass for Persistent Volume(s)
 ##
 global:
-  # imageRegistry: myRegistryName
-  # imagePullSecrets:
-  #   - myRegistryKeySecretName
-  # storageClass: myStorageClass
+  imageRegistry:
+  ## E.g.
+  ## imagePullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
+  storageClass:
 
-## String to partially override common.names.fullname template (will maintain the release name)
+## @param nameOverride String to partially override common.names.fullname template (will maintain the release name)
 ##
-# nameOverride:
+nameOverride:
 
-## String to fully override common.names.fullname template
+## @param fullnameOverride String to fully override `common.names.fullname` template with a string
 ##
-# fullnameOverride:
+fullnameOverride:
 
-## Add labels to all the deployed resources
+## @param commonLabels Add labels to all the deployed resources
 ##
 commonLabels: {}
 
-## Deployment pod host aliases
+## @param hostAliases Deployment pod host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
 hostAliases: []
@@ -29,13 +37,15 @@ hostAliases: []
 ## Ref: https://kubernetes.io/docs/admin/authorization/rbac/
 ##
 rbac:
+  ## @param rbac.create Whether to create and use RBAC resources or not
+  ##
   create: true
 
-  ## RBAC API version
+  ## @param rbac.apiVersion Version of the RBAC API
   ##
   apiVersion: v1beta1
 
-  ## Podsecuritypolicy
+  ## @param rbac.pspEnabled Enable Pod Security Policy
   ##
   pspEnabled: true
 
@@ -43,15 +53,21 @@ rbac:
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 ##
 serviceAccount:
-  ## Specifies whether a ServiceAccount should be created
+  ## @param serviceAccount.create Specify whether to create a ServiceAccount for Node Exporter
   ##
   create: true
-  ## The name of the ServiceAccount to use.
+  ## @param serviceAccount.name The name of the ServiceAccount to create
   ## If not set and create is true, a name is generated using the common.names.fullname template
-  # name:
+  name:
 
 ## Bitnami Node Exporter image version
 ## ref: https://hub.docker.com/r/bitnami/node-exporter/tags/
+## @param image.registry Node Exporter image registry
+## @param image.repository Node Exporter image repository
+## @param image.tag Node Exporter Image tag (immutable tags are recommended)
+## @param image.pullPolicy Node Exporter image pull policy
+## @param image.pullSecrets Specify docker-registry secret names as an array
+
 ##
 image:
   registry: docker.io
@@ -66,29 +82,37 @@ image:
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## Example:
+  ## pullSecrets:
+  ##   - myRegistryKeySecretName
   ##
-  # pullSecrets:
-  #   - myRegistryKeySecretName
+  pullSecrets: []
 
-## Additional command line arguments to pass to node-exporter
+## @param extraArgs Additional command line arguments to pass to node-exporter
+## e.g:
+##  collector.filesystem.ignored-mount-points: "^/(dev|proc|sys|var/lib/docker/.+)($|/)"
+##  collector.filesystem.ignored-fs-types: "^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$"
 ##
 extraArgs: {}
-#  collector.filesystem.ignored-mount-points: "^/(dev|proc|sys|var/lib/docker/.+)($|/)"
-#  collector.filesystem.ignored-fs-types: "^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$"
 
-## Additional volumes to the node-exporter pods
+## @param extraVolumes Additional volumes to the node-exporter pods
+## e.g:
+##  - name: copy-portal-skins
+##    emptyDir: {}
 ##
 extraVolumes: []
-#  - name: copy-portal-skins
-#    emptyDir: {}
 
-## Additional volumeMounts to the node-exporter container
+## @param extraVolumeMounts Additional volumeMounts to the node-exporter container
+## e.g:
+##  - name: copy-portal-skins
+##   mountPath: /var/lib/lemonldap-ng/portal/skins
 ##
 extraVolumeMounts: []
-#  - name: copy-portal-skins
-#   mountPath: /var/lib/lemonldap-ng/portal/skins
 
 ## SecurityContext configuration
+## @param securityContext.enabled Enable security context
+## @param securityContext.fsGroup Group ID for the container filesystem
+## @param securityContext.runAsUser User ID for the container
 ##
 securityContext:
   enabled: true
@@ -98,110 +122,125 @@ securityContext:
 ## Node Exporter Service
 ##
 service:
-  ## Kubernetes service type and port number
+  ## @param service.type Kubernetes service type
   ##
   type: ClusterIP
-  targetPort: 9100
-  port: 9100
-  # clusterIP: None
-
-  ## Specify the nodePort value for the LoadBalancer and NodePort service types.
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+  ## @param service.targetPort Node Exporter container target port
   ##
-  # nodePort: 30080
+  targetPort: 9100
+  ## @param service.port Node Exporter service port
+  ##
+  port: 9100
+  ## @param service.clusterIP Specific cluster IP when service type is cluster IP. Use `None` for headless service
+  ##
+  clusterIP:
 
-  ## Set the LoadBalancer service type to internal only.
+  ## @param service.nodePort Specify the nodePort value for the LoadBalancer and NodePort service types
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+  ## e.g:
+  ## nodePort: 30080
+  ##
+  nodePort:
+
+  ## @param service.loadBalancerIP `loadBalancerIP` if service type is `LoadBalancer`
+  ## Set the LoadBalancer service type to internal only
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
   ##
-  # loadBalancerIP:
+  loadBalancerIP:
 
-  ## Load Balancer sources
+  ## @param service.loadBalancerSourceRanges Address that are allowed when service is `LoadBalancer`
   ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
   ##
-  # loadBalancerSourceRanges:
-  # - 10.10.10.0/24
+  ## loadBalancerSourceRanges:
+  ## - 10.10.10.0/24
+  ##
+  loadBalancerSourceRanges: []
 
-  # Add the `prometheus.io/scrape: "true"` annotation to the service
+  ## @param service.addPrometheusScrapeAnnotation Add the `prometheus.io/scrape: "true"` annotation to the service
+  ##
   addPrometheusScrapeAnnotation: true
 
-  ## Provide any additional service annotations
+  ## @param service.annotations Additional annotations for Node Exporter service
   ##
   annotations: {}
 
-  ## Provide any additional service labels
+  ## @param service.labels Additional labels for Node Exporter service
   ##
   labels: {}
 
-# The update strategy to apply to the DaemonSet
+## @param updateStrategy.type The update strategy type to apply to the DaemonSet
+## @param updateStrategy.rollingUpdate.maxUnavailable Maximum number of pods that may be made unavailable
 ##
 updateStrategy:
   type: RollingUpdate
   rollingUpdate:
     maxUnavailable: 1
 
-# Expose the service to the host network
+## @param hostNetwork Expose the service to the host network
 hostNetwork: true
 
-# minReadySeconds to avoid killing pods before we are ready
+## @param minReadySeconds `minReadySeconds` to avoid killing pods before we are ready
 ##
 minReadySeconds: 0
 
-## Priority class assigned to the Pods
+## @param priorityClassName Priority class assigned to the Pods
 ##
 priorityClassName: ""
 
 ## Resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+## We usually recommend not to specify default resources and to leave this as a conscious
+## choice for the user. This also increases chances charts run on environments with little
+## resources, such as Minikube. If you do want to specify resources, uncomment the following
+## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+## @param resources.limits The resources limits for the container
+## @param resources.requests The requested resources for the container
 ##
 resources:
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ## Example:
+  ## limits:
+  ##    cpu: 100m
+  ##    memory: 128Mi
   limits: {}
-  #   cpu: 100m
-  #   memory: 128Mi
+  ## Examples:
+  ## requests:
+  ##    cpu: 100m
+  ##    memory: 128Mi
   requests: {}
-  #   cpu: 100m
-  #   memory: 128Mi
 
-## Pod labels
+## @param podLabels Pod labels
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ##
 podLabels: {}
 
-## Pod annotations
+## @param podAnnotations Pod annotations
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 ##
 podAnnotations: {}
 
-## Pod affinity preset
+## @param podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
 ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
-## Allowed values: soft, hard
 ##
 podAffinityPreset: ""
 
-## Pod anti-affinity preset
+## @param podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
 ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
-## Allowed values: soft, hard
 ##
 podAntiAffinityPreset: soft
 
 ## Node affinity preset
 ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
-## Allowed values: soft, hard
 ##
 nodeAffinityPreset:
-  ## Node affinity type
-  ## Allowed values: soft, hard
+  ## @param nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
   ##
   type: ""
-  ## Node label key to match
+  ## @param nodeAffinityPreset.key Node label key to match Ignored if `affinity` is set.
   ## E.g.
   ## key: "kubernetes.io/e2e-az-name"
   ##
   key: ""
-  ## Node label values to match
+  ## @param nodeAffinityPreset.values Node label values to match. Ignored if `affinity` is set.
   ## E.g.
   ## values:
   ##   - e2e-az1
@@ -209,24 +248,29 @@ nodeAffinityPreset:
   ##
   values: []
 
-## Affinity for pod assignment. Evaluated as a template.
+## @param affinity Affinity for pod assignment. Evaluated as a template.
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 ## Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
 ##
 affinity: {}
 
-## Node labels for pod assignment. Evaluated as a template.
+## @param nodeSelector Node labels for pod assignment. Evaluated as a template.
 ## ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##
 nodeSelector: {}
 
-## Tolerations for pod assignment. Evaluated as a template.
+## @param tolerations Tolerations for pod assignment. Evaluated as a template.
 ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
 tolerations: []
 
-## Configure extra options for liveness and readiness probes
-## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+## Configure extra options for liveness probe
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+## @param livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+## @param livenessProbe.periodSeconds Period seconds for livenessProbe
+## @param livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+## @param livenessProbe.failureThreshold Failure threshold for livenessProbe
+## @param livenessProbe.successThreshold Success threshold for livenessProbe
 ##
 livenessProbe:
   initialDelaySeconds: 120
@@ -234,7 +278,14 @@ livenessProbe:
   timeoutSeconds: 5
   failureThreshold: 6
   successThreshold: 1
-
+## Configure extra options for readiness probe
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+## @param readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+## @param readinessProbe.periodSeconds Period seconds for readinessProbe
+## @param readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+## @param readinessProbe.failureThreshold Failure threshold for readinessProbe
+## @param readinessProbe.successThreshold Success threshold for readinessProbe
+##
 readinessProbe:
   initialDelaySeconds: 30
   periodSeconds: 10
@@ -245,36 +296,45 @@ readinessProbe:
 ## ServiceMonitor configuration
 ##
 serviceMonitor:
+  ## @param serviceMonitor.enabled Creates a ServiceMonitor to monitor Node Exporter
+  ##
   enabled: false
-  ## Namespace in which Prometheus is running
+  ## @param serviceMonitor.namespace Namespace in which Prometheus is running
   ##
-  # namespace: monitoring
+  namespace:
 
-  ## The name of the label on the target service to use as the job name in prometheus
-  # jobLabel:
+  ## @param serviceMonitor.jobLabel The name of the label on the target service to use as the job name in prometheus.
+  ##
+  jobLabel:
 
-  ## Interval at which metrics should be scraped.
+  ## @param serviceMonitor.interval Scrape interval (use by default, falling back to Prometheus' default)
   ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+  ## e.g:
+  ## interval: 10s
   ##
-  # interval: 10s
+  interval:
 
-  ## Timeout after which the scrape is ended
+  ## @param serviceMonitor.scrapeTimeout Timeout after which the scrape is ended
   ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+  ## e.g:
+  ## scrapeTimeout: 10s
   ##
-  # scrapeTimeout: 10s
+  scrapeTimeout:
 
-  ## ServiceMonitor selector labels
+  ## @param serviceMonitor.selector ServiceMonitor selector labels
   ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
   ##
-  # selector:
-  #   prometheus: my-prometheus
+  ## selector:
+  ##   prometheus: my-prometheus
+  ##
+  selector: {}
 
-  ## RelabelConfigs to apply to samples before scraping
+  ## @param serviceMonitor.relabelings RelabelConfigs to apply to samples before scraping
   ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
   ##
-  # relabelings: []
+  relabelings: []
 
-  ## MetricRelabelConfigs to apply to samples before ingestion
+  ## @param serviceMonitor.metricRelabelings MetricRelabelConfigs to apply to samples before ingestion
   ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
   ##
-  # metricRelabelings: []
+  metricRelabelings: []

--- a/bitnami/node/Chart.yaml
+++ b/bitnami/node/Chart.yaml
@@ -28,4 +28,4 @@ name: node
 sources:
   - https://github.com/bitnami/bitnami-docker-node
   - http://nodejs.org/
-version: 15.2.15
+version: 15.2.16

--- a/bitnami/node/README.md
+++ b/bitnami/node/README.md
@@ -51,141 +51,167 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Parameters
 
-The following table lists the configurable parameters of the Node chart and their default values.
+### Global parameters
 
-| Parameter                 | Description                                     | Default                                                 |
-|---------------------------|-------------------------------------------------|---------------------------------------------------------|
-| `global.imageRegistry`    | Global Docker image registry                    | `nil`                                                   |
-| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
-| `global.storageClass`     | Global storage class for dynamic provisioning   | `nil`                                                   |
+| Name                      | Description                                     | Value |
+| ------------------------- | ----------------------------------------------- | ----- |
+| `global.imageRegistry`    | Global Docker image registry                    | `nil` |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
+| `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `nil` |
+
 
 ### Common parameters
 
-| Parameter           | Description                                                                 | Default |
-|---------------------|-----------------------------------------------------------------------------|---------|
-| `nameOverride`      | String to partially override node.fullname template                         | `nil`   |
-| `fullnameOverride`  | String to fully override node.fullname template                             | `nil`   |
-| `commonLabels`      | Labels to add to all deployed objects                                       | `nil`   |
-| `commonAnnotations` | Annotations to add to all deployed objects                                  | `[]`    |
-| `extraDeploy`       | Array of extra objects to deploy with the release (evaluated as a template) | `nil`   |
-| `kubeVersion`       | Force target Kubernetes version (using Helm capabilities if not set)        | `nil`   |
+| Name                | Description                                                                          | Value |
+| ------------------- | ------------------------------------------------------------------------------------ | ----- |
+| `kubeVersion`       | Force target Kubernetes version (using Helm capabilities if not set)                 | `nil` |
+| `nameOverride`      | String to partially override node.fullname template (will maintain the release name) | `nil` |
+| `fullnameOverride`  | String to fully override node.fullname template                                      | `nil` |
+| `commonLabels`      | Add labels to all the deployed resources                                             | `{}`  |
+| `commonAnnotations` | Add annotations to all the deployed resources                                        | `{}`  |
 
-## Node parameters
 
-| Parameter                               | Description                                                               | Default                                                 |
-|-----------------------------------------|---------------------------------------------------------------------------|---------------------------------------------------------|
-| `image.registry`                        | NodeJS image registry                                                     | `docker.io`                                             |
-| `image.repository`                      | NodeJS image name                                                         | `bitnami/node`                                          |
-| `image.tag`                             | NodeJS image tag                                                          | `{TAG_NAME}`                                            |
-| `image.pullPolicy`                      | NodeJS image pull policy                                                  | `IfNotPresent`                                          |
-| `image.pullSecrets`                     | Specify docker-registry secret names as an array                          | `[]` (does not add image pull secrets to deployed pods) |
-| `command`                               | Override default container command (useful when using custom images)      | `['/bin/bash', '-ec', 'npm start']`                     |
-| `args`                                  | Override default container args (useful when using custom images)         | `[]`                                                    |
-| `hostAliases`                           | Add deployment host aliases                                               | `[]`                                                    |
-| `extraEnvVars`                          | Extra environment variables to be set on Node container                   | `[]`                                                    |
-| `extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars                      | `nil`                                                   |
-| `extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars                         | `nil`                                                   |
-| `mongodb.enabled`                       | Whether to install or not the MongoDB&reg; chart                               | `true`                                                  |
-| `mongodb.auth.enabled`                  | Whether to enable auth or not for the MongoDB&reg; chart                       | `true`                                                  |
-| `mongodb.auth.rootPassword`             | MongoDB&reg; admin password                                                    | `nil`                                                   |
-| `mongodb.auth.username`                 | MongoDB&reg; custom user                                                       | `user`                                                  |
-| `mongodb.auth.database`                 | MongoDB&reg; custom database                                                   | `test_db`                                               |
-| `mongodb.auth.password`                 | MongoDB&reg; custom password                                                   | `secret_password`                                       |
-| `externaldb.enabled`                    | Enables or disables external database (ignored if `mongodb.enabled=true`) | `false`                                                 |
-| `externaldb.secretName`                 | Secret containing existing database credentials                           | `nil`                                                   |
-| `externaldb.type`                       | Type of database that defines the database secret mapping                 | `osba`                                                  |
-| `externaldb.broker.serviceInstanceName` | The existing ServiceInstance to be used                                   | `nil`                                                   |
+### Node parameters
 
-## Node deployment parameters
+| Name                                    | Description                                                                                                          | Value             |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `command`                               | Override default container command (useful when using custom images)                                                 | `[]`              |
+| `args`                                  | Override default container args (useful when using custom images)                                                    | `[]`              |
+| `hostAliases`                           | Deployment pod host aliases                                                                                          | `[]`              |
+| `extraEnvVars`                          | Extra environment variables to be set on Node container                                                              | `[]`              |
+| `extraEnvVarsCM`                        | Name of existing ConfigMap containing extra environment variables                                                    | `nil`             |
+| `extraEnvVarsSecret`                    | Name of existing Secret containing extra environment variables                                                       | `nil`             |
+| `mongodb.enabled`                       | Whether to install or not the MongoDB&reg; chart                                                                     | `true`            |
+| `mongodb.auth.enabled`                  | Whether to enable auth or not for the MongoDB&reg; chart                                                             | `true`            |
+| `mongodb.auth.rootPassword`             | MongoDB&reg; admin password                                                                                          | `""`              |
+| `mongodb.auth.username`                 | MongoDB&reg; custom user                                                                                             | `user`            |
+| `mongodb.auth.database`                 | MongoDB&reg; custom database                                                                                         | `test_db`         |
+| `mongodb.auth.password`                 | MongoDB&reg; custom password                                                                                         | `secret_password` |
+| `externaldb.enabled`                    | Enables or disables external database (ignored if `mongodb.enabled=true`)                                            | `false`           |
+| `externaldb.ssl`                        | Set to true if your external database has ssl enabled                                                                | `false`           |
+| `externaldb.secretName`                 | Secret containing existing database credentials                                                                      | `nil`             |
+| `externaldb.type`                       | Only if using Kubernetes Service Catalog you can specify the kind of broker used. Available options are osba|gce|aws | `osba`            |
+| `externaldb.broker.serviceInstanceName` | If you provide the serviceInstanceName, the chart will create a ServiceBinding for that ServiceInstance              | `nil`             |
 
-| Parameter                            | Description                                                                               | Default                        |
-|--------------------------------------|-------------------------------------------------------------------------------------------|--------------------------------|
-| `replicaCount`                       | Number of Node replicas to deploy                                                         | `1`                            |
-| `priorityClassName`                  | Node priorityClassName                                                                    | `nil`                          |
-| `podAffinityPreset`                  | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                           |
-| `podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                         |
-| `nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                           |
-| `nodeAffinityPreset.key`             | Node label key to match Ignored if `affinity` is set.                                     | `""`                           |
-| `nodeAffinityPreset.values`          | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                           |
-| `affinity`                           | Affinity for pod assignment                                                               | `{}` (evaluated as a template) |
-| `nodeSelector`                       | Node labels for pod assignment                                                            | `{}` (evaluated as a template) |
-| `tolerations`                        | Tolerations for pod assignment                                                            | `[]` (evaluated as a template) |
-| `podLabels`                          | Additional labels for Node pods                                                           | `{}` (evaluated as a template) |
-| `podAnnotations`                     | Annotations for Node pods                                                                 | `{}` (evaluated as a template) |
-| `podSecurityContext.enabled`         | Enable security context for Node pods                                                     | `true`                         |
-| `podSecurityContext.fsGroup`         | Group ID for the volumes of the pod                                                       | `1001`                         |
-| `containerSecurityContext.enabled`   | Node Container securityContext                                                            | `false`                        |
-| `containerSecurityContext.runAsUser` | User ID for the Node container                                                            | `1001`                         |
-| `applicationPort`                    | Port where the application will be running                                                | `3000`                         |
-| `resources.limits`                   | The resources limits for the Node container                                               | `{}`                           |
-| `resources.requests`                 | The requested resources for the Node container                                            | `{}`                           |
-| `livenessProbe`                      | Liveness probe configuration for Node                                                     | Check `values.yaml` file       |
-| `readinessProbe`                     | Readiness probe configuration for Node                                                    | Check `values.yaml` file       |
-| `customLivenessProbe`                | Override default liveness probe                                                           | `nil`                          |
-| `customReadinessProbe`               | Override default readiness probe                                                          | `nil`                          |
-| `extraVolumes`                       | Array to add extra volumes                                                                | `[]` (evaluated as a template) |
-| `extraVolumeMounts`                  | Array to add extra mount                                                                  | `[]` (evaluated as a template) |
-| `initContainers`                     | Add additional init containers to the Node pods                                           | `{}` (evaluated as a template) |
-| `sidecars`                           | Add additional sidecar containers to the Node pods                                        | `{}` (evaluated as a template) |
 
-## Node application parameters
+### Node deployment parameters
 
-| Parameter                      | Description                                      | Default                                      |
-|--------------------------------|--------------------------------------------------|----------------------------------------------|
-| `git.image.registry`           | Git image registry                               | `docker.io`                                  |
-| `git.image.repository`         | Git image name                                   | `bitnami/git`                                |
-| `git.image.tag`                | Git image tag                                    | `{TAG_NAME}`                                 |
-| `git.image.pullPolicy`         | Git image pull policy                            | `IfNotPresent`                               |
-| `git.extraVolumeMounts`        | Add extra volume mounts for the Git container    | `[]`                                         |
-| `getAppFromExternalRepository` | Whether to get app from external git repo or not | `true`                                       |
-| `repository`                   | Repo of the application                          | `https://github.com/bitnami/sample-mean.git` |
-| `revision`                     | Revision to checkout                             | `master`                                     |
+| Name                                    | Description                                                                               | Value                  |
+| --------------------------------------- | ----------------------------------------------------------------------------------------- | ---------------------- |
+| `image.registry`                        | NodeJS image registry                                                                     | `docker.io`            |
+| `image.repository`                      | NodeJS image repository                                                                   | `bitnami/node`         |
+| `image.tag`                             | NodeJS image tag (immutable tags are recommended)                                         | `14.17.3-debian-10-r0` |
+| `image.pullPolicy`                      | NodeJS image pull policy                                                                  | `IfNotPresent`         |
+| `image.pullSecrets`                     | Specify docker-registry secret names as an array                                          | `[]`                   |
+| `replicaCount`                          | Specify the number of replicas for the application                                        | `1`                    |
+| `applicationPort`                       | Specify the port where your application will be running                                   | `3000`                 |
+| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                   |
+| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                 |
+| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                   |
+| `nodeAffinityPreset.key`                | Node label key to match Ignored if `affinity` is set.                                     | `""`                   |
+| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                   |
+| `affinity`                              | Affinity for pod assignment. Evaluated as a template.                                     | `{}`                   |
+| `nodeSelector`                          | Node labels for pod assignment. Evaluated as a template.                                  | `{}`                   |
+| `tolerations`                           | Tolerations for pod assignment. Evaluated as a template.                                  | `{}`                   |
+| `podAnnotations`                        | Additional pod annotations                                                                | `{}`                   |
+| `podLabels`                             | Additional labels for Node pods                                                           | `{}`                   |
+| `extraDeploy`                           | Array of extra objects to deploy with the release (evaluated as a template)               | `[]`                   |
+| `livenessProbe.enabled`                 | Enable livenessProbe                                                                      | `true`                 |
+| `livenessProbe.path`                    | Request path for livenessProbe                                                            | `/`                    |
+| `livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                   | `60`                   |
+| `livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                          | `10`                   |
+| `livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                         | `5`                    |
+| `livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                       | `6`                    |
+| `livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                       | `1`                    |
+| `readinessProbe.enabled`                | Enable readinessProbe                                                                     | `true`                 |
+| `readinessProbe.path`                   | Request path for readinessProbe                                                           | `/`                    |
+| `readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                  | `10`                   |
+| `readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                         | `5`                    |
+| `readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                        | `3`                    |
+| `readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                      | `3`                    |
+| `readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                      | `1`                    |
+| `customLivenessProbe`                   | Override default liveness probe                                                           | `{}`                   |
+| `customReadinessProbe`                  | Override default readiness probe                                                          | `{}`                   |
+| `priorityClassName`                     | Node priorityClassName                                                                    | `nil`                  |
+| `lifecycleHooks`                        | lifecycleHooks for the Node container to automate configuration before or after startup.  | `{}`                   |
+| `sidecars`                              | Add sidecars to the Node pods                                                             | `{}`                   |
+| `initContainers`                        | Add init containers to the Node pods                                                      | `{}`                   |
+| `extraVolumes`                          | Extra volumes to add to the deployment                                                    | `[]`                   |
+| `extraVolumeMounts`                     | Extra volume mounts to add to the container                                               | `[]`                   |
+| `containerSecurityContext.enabled`      | Node Container securityContext                                                            | `true`                 |
+| `containerSecurityContext.runAsUser`    | User ID for the Node container                                                            | `1001`                 |
+| `containerSecurityContext.runAsNonRoot` | Set container's Security Context runAsNonRoot                                             | `true`                 |
+| `podSecurityContext.enabled`            | Enable security context for Node pods                                                     | `true`                 |
+| `podSecurityContext.fsGroup`            | Group ID for the volumes of the pod                                                       | `1001`                 |
+| `resources.limits`                      | The resources limits for the Node container                                               | `{}`                   |
+| `resources.requests`                    | The requested resources for the Node container                                            | `{}`                   |
 
-## Volume permissions parameters
 
-| Parameter                            | Description                                                                 | Default                 |
-|--------------------------------------|-----------------------------------------------------------------------------|-------------------------|
-| `volumePermissions.enabled`          | Enable init container that changes volume permissions in the data directory | `false`                 |
-| `volumePermissions.image.registry`   | Init container volume-permissions image registry                            | `docker.io`             |
-| `volumePermissions.image.repository` | Init container volume-permissions image name                                | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`        | Init container volume-permissions image tag                                 | `"10"`                  |
-| `volumePermissions.image.pullPolicy` | Init container volume-permissions image pull policy                         | `Always`                |
-| `volumePermissions.resources`        | Init container resource requests/limit                                      | `{}`                    |
+### Node application parameters
+
+| Name                           | Description                                         | Value                                        |
+| ------------------------------ | --------------------------------------------------- | -------------------------------------------- |
+| `git.image.registry`           | Git image registry                                  | `docker.io`                                  |
+| `git.image.repository`         | Git image repository                                | `bitnami/git`                                |
+| `git.image.tag`                | Git image tag (immutable tags are recommended)      | `2.32.0-debian-10-r24`                       |
+| `git.image.pullPolicy`         | Git image pull policy                               | `IfNotPresent`                               |
+| `git.image.pullSecrets`        | Specify docker-registry secret names as an array    | `[]`                                         |
+| `git.extraVolumeMounts`        | Add extra volume mounts for the Git container       | `[]`                                         |
+| `getAppFromExternalRepository` | Enable to download app from external git repository | `true`                                       |
+| `repository`                   | Git repository http/https url                       | `https://github.com/bitnami/sample-mean.git` |
+| `revision`                     | Git repository revision to checkout                 | `master`                                     |
+
+
+### Volume permissions parameters
+
+| Name                                   | Description                                                                  | Value                   |
+| -------------------------------------- | ---------------------------------------------------------------------------- | ----------------------- |
+| `volumePermissions.enabled`            | Enable init container that changes volume permissions in the data directory  | `false`                 |
+| `volumePermissions.image.registry`     | Init container volume-permissions image registry                             | `docker.io`             |
+| `volumePermissions.image.repository`   | Init container volume-permissions image repository                           | `bitnami/bitnami-shell` |
+| `volumePermissions.image.tag`          | Init container volume-permissions image tag (immutable tags are recommended) | `10-debian-10-r125`     |
+| `volumePermissions.image.pullPolicy`   | Init container volume-permissions image pull policy                          | `Always`                |
+| `volumePermissions.image.pullSecrets`  | Specify docker-registry secret names as an array                             | `[]`                    |
+| `volumePermissions.resources.limits`   | The resources limits for the container                                       | `{}`                    |
+| `volumePermissions.resources.requests` | The requested resources for the container                                    | `{}`                    |
+
 
 ### Persistence parameters
 
-| Parameter                | Description                  | Default         |
-|--------------------------|------------------------------|-----------------|
-| `persistence.enabled`    | Enable persistence using PVC | `false`         |
-| `persistence.path`       | Path to persisted directory  | `/app/data`     |
-| `persistence.accessMode` | PVC Access Mode              | `ReadWriteOnce` |
-| `persistence.size`       | PVC Storage Request          | `1Gi`           |
+| Name                       | Description                     | Value           |
+| -------------------------- | ------------------------------- | --------------- |
+| `persistence.enabled`      | Enable persistence using PVC    | `false`         |
+| `persistence.path`         | Path to persisted directory     | `/app/data`     |
+| `persistence.storageClass` | Persistent Volume Storage Class | `nil`           |
+| `persistence.accessMode`   | PVC Access Mode                 | `ReadWriteOnce` |
+| `persistence.size`         | PVC Storage Request             | `1Gi`           |
 
-### Exposure parameters
 
-| Parameter                          | Description                                                   | Default                        |
-|------------------------------------|---------------------------------------------------------------|--------------------------------|
-| `service.type`                     | Kubernetes Service type                                       | `ClusterIP`                    |
-| `service.port`                     | Kubernetes Service port                                       | `80`                           |
-| `service.annotations`              | Annotations for the Service                                   | {}                             |
-| `service.loadBalancerIP`           | LoadBalancer IP if Service type is `LoadBalancer`             | `nil`                          |
-| `service.nodePort`                 | NodePort if Service type is `LoadBalancer` or `NodePort`      | `nil`                          |
-| `service.loadBalancerSourceRanges` | Limits which client IP's can access the Network Load Balancer | `0.0.0.0/0`                    |
-| `ingress.enabled`                  | Enable ingress controller resource                            | `false`                        |
-| `ingress.certManager`              | Add annotations for cert-manager                              | `false`                        |
-| `ingress.hostname`                 | Default host for the ingress resource                         | `node.local`                   |
-| `ingress.path`                     | Default path for the ingress resource                         | `/`                            |
-| `ingress.pathType`                 | Ingress path type                                             | `ImplementationSpecific`       |
-| `ingress.tls`                      | Create TLS Secret                                             | `false`                        |
-| `ingress.annotations`              | Ingress annotations                                           | `[]` (evaluated as a template) |
-| `ingress.extraHosts[0].name`       | Additional hostnames to be covered                            | `nil`                          |
-| `ingress.extraHosts[0].path`       | Additional hostnames to be covered                            | `nil`                          |
-| `ingress.extraPaths`               | Additional arbitrary path/backend objects                     | `nil`                          |
-| `ingress.extraTls[0].hosts[0]`     | TLS configuration for additional hostnames to be covered      | `nil`                          |
-| `ingress.extraTls[0].secretName`   | TLS configuration for additional hostnames to be covered      | `nil`                          |
-| `ingress.secrets[0].name`          | TLS Secret Name                                               | `nil`                          |
-| `ingress.secrets[0].certificate`   | TLS Secret Certificate                                        | `nil`                          |
-| `ingress.secrets[0].key`           | TLS Secret Key                                                | `nil`                          |
+### Traffic exposure parameters
+
+| Name                               | Description                                                                                                | Value                    |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `service.type`                     | Kubernetes Service type                                                                                    | `ClusterIP`              |
+| `service.port`                     | Kubernetes Service port                                                                                    | `80`                     |
+| `service.clusterIP`                | Service Cluster IP                                                                                         | `nil`                    |
+| `service.sessionAffinity`          | Control where client requests go, to the same pod or round-robin                                           | `None`                   |
+| `service.nodePort`                 | NodePort if Service type is `LoadBalancer` or `NodePort`                                                   | `nil`                    |
+| `service.loadBalancerIP`           | LoadBalancer IP if Service type is `LoadBalancer`                                                          | `nil`                    |
+| `service.loadBalancerSourceRanges` | In order to limit which client IP's can access the Network Load Balancer, specify loadBalancerSourceRanges | `nil`                    |
+| `service.annotations`              | Annotations for the Service                                                                                | `{}`                     |
+| `ingress.enabled`                  | Set to true to enable ingress record generation                                                            | `false`                  |
+| `ingress.certManager`              | Set this to true in order to add the corresponding annotations for cert-manager                            | `false`                  |
+| `ingress.pathType`                 | Ingress path type                                                                                          | `ImplementationSpecific` |
+| `ingress.apiVersion`               | Override API Version (automatically detected if not set)                                                   | `nil`                    |
+| `ingress.hostname`                 | When the ingress is enabled, a host pointing to this will be created                                       | `node.local`             |
+| `ingress.path`                     | The Path to Node.js. You may need to set this to '/*' in order to use this with ALB ingress controllers.   | `ImplementationSpecific` |
+| `ingress.annotations`              | Ingress annotations                                                                                        | `{}`                     |
+| `ingress.tls`                      | Enable TLS configuration for the hostname defined at ingress.hostname parameter                            | `false`                  |
+| `ingress.extraHosts`               | The list of additional hostnames to be covered with this ingress record.                                   | `[]`                     |
+| `ingress.extraPaths`               | Any additional arbitrary paths that may need to be added to the ingress under the main host.               | `[]`                     |
+| `ingress.extraTls`                 | The tls configuration for additional hostnames to be covered with this ingress record.                     | `[]`                     |
+| `ingress.secrets`                  | If you're providing your own certificates, please use this to add the certificates as secrets              | `[]`                     |
+
 
 The above parameters map to the env variables defined in [bitnami/node](http://github.com/bitnami/bitnami-docker-node). For more information please refer to the [bitnami/node](http://github.com/bitnami/bitnami-docker-node) image documentation.
 

--- a/bitnami/node/values.yaml
+++ b/bitnami/node/values.yaml
@@ -1,15 +1,28 @@
+## @section Global parameters
 ## Global Docker image parameters
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value
-## Current available global Docker image parameters: imageRegistry and imagePullSecrets
+## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
+
+## @param global.imageRegistry Global Docker image registry
+## @param global.imagePullSecrets Global Docker registry secret names as an array
+## @param global.storageClass Global StorageClass for Persistent Volume(s)
 ##
-# global:
-#   imageRegistry: myRegistryName
-#   imagePullSecrets:
-#     - myRegistryKeySecretName
-#   storageClass: myStorageClass
+global:
+  imageRegistry:
+  ## E.g.
+  ## imagePullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
+  storageClass:
 
 ## Bitnami node image version
 ## ref: https://hub.docker.com/r/bitnami/node/tags/
+## @param image.registry NodeJS image registry
+## @param image.repository NodeJS image repository
+## @param image.tag NodeJS image tag (immutable tags are recommended)
+## @param image.pullPolicy NodeJS image pull policy
+## @param image.pullSecrets Specify docker-registry secret names as an array
 ##
 image:
   registry: docker.io
@@ -23,23 +36,25 @@ image:
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## Example:
+  ## pullSecrets:
+  ##   - myRegistryKeySecretName
   ##
-  # pullSecrets:
-  #   - myRegistryKeySecretName
+  pullSecrets: []
 
-## Force target Kubernetes version (using Helm capabilites if not set)
+## @param kubeVersion Force target Kubernetes version (using Helm capabilities if not set)
 ##
 kubeVersion:
 
-## String to partially override node.fullname template (will maintain the release name)
+## @param nameOverride String to partially override node.fullname template (will maintain the release name)
 ##
-# nameOverride:
+nameOverride:
 
-## String to fully override node.fullname template
+## @param fullnameOverride String to fully override node.fullname template
 ##
-# fullnameOverride:
+fullnameOverride:
 
-## Deployment pod host aliases
+## @param hostAliases Deployment pod host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
 hostAliases: []
@@ -48,7 +63,15 @@ hostAliases: []
 ## volumePermissions: Change the owner and group of the persistent volume mountpoint to runAsUser:fsGroup values from the securityContext section.
 ##
 volumePermissions:
+  ## @param volumePermissions.enabled Enable init container that changes volume permissions in the data directory
+  ##
   enabled: false
+  ## @param volumePermissions.image.registry Init container volume-permissions image registry
+  ## @param volumePermissions.image.repository Init container volume-permissions image repository
+  ## @param volumePermissions.image.tag Init container volume-permissions image tag (immutable tags are recommended)
+  ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
+  ## @param volumePermissions.image.pullSecrets Specify docker-registry secret names as an array
+  ##
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
@@ -57,23 +80,31 @@ volumePermissions:
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
     ##
-    # pullSecrets:
-    #   - myRegistryKeySecretName
+    pullSecrets: []
   ## Init container' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ## We usually recommend not to specify default resources and to leave this as a conscious
+  ## choice for the user. This also increases chances charts run on environments with little
+  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ## @param volumePermissions.resources.limits The resources limits for the container
+  ## @param volumePermissions.resources.requests The requested resources for the container
   ##
   resources:
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    ## Example:
+    ## limits:
+    ##    cpu: 100m
+    ##    memory: 128Mi
     limits: {}
-    #   cpu: 100m
-    #   memory: 128Mi
+    ## Examples:
+    ## requests:
+    ##    cpu: 100m
+    ##    memory: 128Mi
     requests: {}
-    #   cpu: 100m
-    #   memory: 128Mi
 
 ## Bitnami Git image version
 ## ref: https://hub.docker.com/r/bitnami/git/tags/
@@ -81,6 +112,11 @@ volumePermissions:
 git:
   ## Bitnami git image version
   ## ref: https://hub.docker.com/r/bitnami/git/tags/
+  ## @param git.image.registry Git image registry
+  ## @param git.image.repository Git image repository
+  ## @param git.image.tag Git image tag (immutable tags are recommended)
+  ## @param git.image.pullPolicy Git image pull policy
+  ## @param git.image.pullSecrets Specify docker-registry secret names as an array
   ##
   image:
     registry: docker.io
@@ -94,11 +130,13 @@ git:
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
     ##
     pullSecrets: []
-    #   - myRegistryKeySecretName
 
-  ## Add extra volume mounts for the GIT container
+  ## @param git.extraVolumeMounts Add extra volume mounts for the Git container
   ## Useful to mount keys to connect through ssh. (normally used with extraVolumes)
   ## E.g:
   ## extraVolumeMounts:
@@ -107,53 +145,49 @@ git:
   ##
   extraVolumeMounts: []
 
-## Enable to download app from external git repository.
+## @param getAppFromExternalRepository Enable to download app from external git repository
 ## Disable it if your docker image already includes your application at /app
 ##
 getAppFromExternalRepository: true
 
-## Git repository http/https
+## @param repository Git repository http/https url
 ##
 repository: https://github.com/bitnami/sample-mean.git
-## Git repository revision to checkout
+## @param revision Git repository revision to checkout
 ##
 revision: master
 
-## Specify the number of replicas for the application
+## @param replicaCount Specify the number of replicas for the application
 ##
 replicaCount: 1
 
-## Specify the port where your application will be running
+## @param applicationPort Specify the port where your application will be running
 ##
 applicationPort: 3000
 
-## Pod affinity preset
+## @param podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
 ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
-## Allowed values: soft, hard
 ##
 podAffinityPreset: ''
 
-## Pod anti-affinity preset
+## @param podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
 ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
-## Allowed values: soft, hard
 ##
 podAntiAffinityPreset: soft
 
 ## Node affinity preset
 ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
-## Allowed values: soft, hard
 ##
 nodeAffinityPreset:
-  ## Node affinity type
-  ## Allowed values: soft, hard
+  ## @param nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
   ##
   type: ''
-  ## Node label key to match
+  ## @param nodeAffinityPreset.key Node label key to match Ignored if `affinity` is set.
   ## E.g.
   ## key: "kubernetes.io/e2e-az-name"
   ##
   key: ''
-  ## Node label values to match
+  ## @param nodeAffinityPreset.values Node label values to match. Ignored if `affinity` is set.
   ## E.g.
   ## values:
   ##   - e2e-az1
@@ -161,45 +195,52 @@ nodeAffinityPreset:
   ##
   values: []
 
-## Affinity for pod assignment. Evaluated as a template.
+## @param affinity Affinity for pod assignment. Evaluated as a template.
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 ##
 affinity: {}
 
-## Node labels for pod assignment. Evaluated as a template.
+## @param nodeSelector Node labels for pod assignment. Evaluated as a template.
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##
 nodeSelector: {}
 
-## Tolerations for pod assignment. Evaluated as a template.
+## @param tolerations Tolerations for pod assignment. Evaluated as a template.
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
 tolerations: {}
 
-## Add labels to all the deployed resources
+## @param commonLabels Add labels to all the deployed resources
 ##
 commonLabels: {}
 
-## Add annotations to all the deployed resources
+## @param commonAnnotations Add annotations to all the deployed resources
 ##
 commonAnnotations: {}
 
-## Additional pod annotations
+## @param podAnnotations Additional pod annotations
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 ##
 podAnnotations: {}
 
-## Additional pod labels
+## @param podLabels Additional labels for Node pods
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ##
 podLabels: {}
 
-## Extra objects to deploy (value evaluated as a template)
+## @param extraDeploy Array of extra objects to deploy with the release (evaluated as a template)
 ##
 extraDeploy: []
 
-## Configure extra options for liveness and readiness probes
+## Configure extra options for liveness probe
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+## @param livenessProbe.enabled Enable livenessProbe
+## @param livenessProbe.path Request path for livenessProbe
+## @param livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+## @param livenessProbe.periodSeconds Period seconds for livenessProbe
+## @param livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+## @param livenessProbe.failureThreshold Failure threshold for livenessProbe
+## @param livenessProbe.successThreshold Success threshold for livenessProbe
 ##
 livenessProbe:
   enabled: true
@@ -209,6 +250,16 @@ livenessProbe:
   timeoutSeconds: 5
   failureThreshold: 6
   successThreshold: 1
+## Configure extra options for readiness probe
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+## @param readinessProbe.enabled Enable readinessProbe
+## @param readinessProbe.path Request path for readinessProbe
+## @param readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+## @param readinessProbe.periodSeconds Period seconds for readinessProbe
+## @param readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+## @param readinessProbe.failureThreshold Failure threshold for readinessProbe
+## @param readinessProbe.successThreshold Success threshold for readinessProbe
+##
 readinessProbe:
   enabled: true
   path: '/'
@@ -218,24 +269,24 @@ readinessProbe:
   failureThreshold: 3
   successThreshold: 1
 
-## Custom Liveness probes for Node
+## @param customLivenessProbe Override default liveness probe
 ##
 customLivenessProbe: {}
 
-## Custom Rediness probes Node
+## @param customReadinessProbe Override default readiness probe
 ##
 customReadinessProbe: {}
 
-## Node pods' priority.
+## @param priorityClassName Node priorityClassName
 ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
 ##
-# priorityClassName: ""
+priorityClassName:
 
-## lifecycleHooks for the Node container to automate configuration before or after startup.
+## @param lifecycleHooks lifecycleHooks for the Node container to automate configuration before or after startup.
 ##
 lifecycleHooks: {}
 
-## Add sidecars to the Node pods.
+## @param sidecars Add sidecars to the Node pods
 ## Example:
 ## sidecars:
 ##   - name: your-image-name
@@ -247,7 +298,7 @@ lifecycleHooks: {}
 ##
 sidecars: {}
 
-## Add init containers to the Node pods.
+## @param initContainers Add init containers to the Node pods
 ## Example:
 ## initContainers:
 ##   - name: your-image-name
@@ -259,114 +310,136 @@ sidecars: {}
 ##
 initContainers: {}
 
-## An array to add extra env vars
+## @param extraEnvVars Extra environment variables to be set on Node container
 ## For example:
+##  - name: BEARER_AUTH
+##    value: true
 ##
 extraEnvVars: []
-#  - name: BEARER_AUTH
-#    value: true
 
-## ConfigMap with extra environment variables
+## @param extraEnvVarsCM Name of existing ConfigMap containing extra environment variables
 ##
 extraEnvVarsCM:
 
-## Secret with extra environment variables
+## @param extraEnvVarsSecret Name of existing Secret containing extra environment variables
 ##
 extraEnvVarsSecret:
 
-## Command and args for running the container (set to default if not set). Use array form
+## @param command Override default container command (useful when using custom images)
 ##
 command: ['/bin/bash', '-ec', 'npm start']
+## @param args Override default container args (useful when using custom images)
+##
 args: []
 
-## Extra volumes to add to the deployment
+## @param extraVolumes Extra volumes to add to the deployment
 ##
 extraVolumes: []
 
-## Extra volume mounts to add to the container
+## @param extraVolumeMounts Extra volume mounts to add to the container
 ##
 extraVolumeMounts: []
 
 ## SecurityContext configuration
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+## @param containerSecurityContext.enabled Node Container securityContext
+## @param containerSecurityContext.runAsUser User ID for the Node container
+## @param containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
 ##
 containerSecurityContext:
   enabled: true
   runAsUser: 1001
   runAsNonRoot: true
 
+## @param podSecurityContext.enabled Enable security context for Node pods
+## @param podSecurityContext.fsGroup Group ID for the volumes of the pod
+##
 podSecurityContext:
   enabled: true
   fsGroup: 1001
 
 ## Node conatiners' resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+## We usually recommend not to specify default resources and to leave this as a conscious
+## choice for the user. This also increases chances charts run on environments with little
+## resources, such as Minikube. If you do want to specify resources, uncomment the following
+## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+## @param resources.limits The resources limits for the Node container
+## @param resources.requests The requested resources for the Node container
 ##
 resources:
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ## Example:
+  ## limits:
+  ##    cpu: 100m
+  ##    memory: 128Mi
   limits: {}
-  #   cpu: 100m
-  #   memory: 128Mi
+  ## Examples:
+  ## requests:
+  ##    cpu: 100m
+  ##    memory: 128Mi
   requests: {}
-  #   cpu: 100m
-  #   memory: 128Mi
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##
 persistence:
+  ## @param persistence.enabled Enable persistence using PVC
+  ##
   enabled: false
+  ## @param persistence.path Path to persisted directory
+  ##
   path: /app/data
-  ## Persistent Volume Storage Class
+  ## @param persistence.storageClass Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning
   ## If undefined (the default) or set to null, no storageClassName spec is
   ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
   ##   GKE, AWS & OpenStack)
   ##
-  # storageClass: "-"
+  storageClass:
+  ## @param persistence.accessMode PVC Access Mode
+  ##
   accessMode: ReadWriteOnce
+  ## @param persistence.size PVC Storage Request
+  ##
   size: 1Gi
 
 ## Service parameters
 ##
 service:
-  ## Service type
+  ## @param service.type Kubernetes Service type
   ##
   type: ClusterIP
-  ## HTTP Port
+  ## @param service.port Kubernetes Service port
   ##
   port: 80
 
-  ## clusterIP: ""
-  ## loadBalancerIP for the Node Service (optional, cloud specific)
-  ## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
+  ## @param service.clusterIP Service Cluster IP
   ##
+  clusterIP:
 
-  ## Control where client requests go, to the same pod or round-robin
+  ## @param service.sessionAffinity Control where client requests go, to the same pod or round-robin
   ## Values: ClientIP or None
   ## ref: https://kubernetes.io/docs/user-guide/services/
   ##
   sessionAffinity: 'None'
 
-  ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+  ## @param service.nodePort NodePort if Service type is `LoadBalancer` or `NodePort`
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
   ##
-  # nodePort:
+  nodePort:
+  ## @param service.loadBalancerIP LoadBalancer IP if Service type is `LoadBalancer`
   ## Set the LoadBalancer service type to internal only.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
   ##
-  # loadBalancerIP:
-  ## Provide any additional annotations which may be required. This can be used to
-  ## set the LoadBalancer service type to internal only.
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
-  ##
-  # loadBalancerSourceRanges:
-  ## In order to limit which client IP's can access the Network Load Balancer, specify loadBalancerSourceRanges.
+  loadBalancerIP:
+  ## @param service.loadBalancerSourceRanges In order to limit which client IP's can access the Network Load Balancer, specify loadBalancerSourceRanges
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#aws-nlb-support
+  ##
+  loadBalancerSourceRanges:
+  ## @param service.annotations Annotations for the Service
+  ## This can be used to set the LoadBalancer service type to internal only.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
   ##
   annotations: {}
 
@@ -375,32 +448,31 @@ service:
 ## ref: http://kubernetes.io/docs/user-guide/ingress/
 ##
 ingress:
-  ## Set to true to enable ingress record generation
+  ## @param ingress.enabled Set to true to enable ingress record generation
   ##
   enabled: false
 
-  ## Set this to true in order to add the corresponding annotations for cert-manager
+  ## @param ingress.certManager Set this to true in order to add the corresponding annotations for cert-manager
   ##
   certManager: false
 
-  ## Ingress Path type
+  ## @param ingress.pathType Ingress path type
   ##
   pathType: ImplementationSpecific
 
-  ## Override API Version (automatically detected if not set)
+  ## @param ingress.apiVersion Override API Version (automatically detected if not set)
   ##
   apiVersion:
 
-  ## When the ingress is enabled, a host pointing to this will be created
+  ## @param ingress.hostname When the ingress is enabled, a host pointing to this will be created
   ##
   hostname: node.local
 
-  ## The Path to Node.js. You may need to set this to '/*' in order to use this
-  ## with ALB ingress controllers.
+  ## @param ingress.path The Path to Node.js. You may need to set this to '/*' in order to use this with ALB ingress controllers.
   ##
   path: /
 
-  ## Ingress annotations done as key:value pairs
+  ## @param ingress.annotations Ingress annotations
   ## For a full list of possible ingress annotations, please see
   ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   ##
@@ -408,20 +480,21 @@ ingress:
   ##
   annotations: {}
 
-  ## Enable TLS configuration for the hostname defined at ingress.hostname parameter
+  ## @param ingress.tls Enable TLS configuration for the hostname defined at ingress.hostname parameter
   ## TLS certificates will be retrieved from a TLS secret with name: {{- printf "%s-tls" .Values.ingress.hostname }}
   ## You can use the ingress.secrets parameter to create this TLS secret or relay on cert-manager to create it
   ##
   tls: false
 
-  ## The list of additional hostnames to be covered with this ingress record.
+  ## @param ingress.extraHosts The list of additional hostnames to be covered with this ingress record.
   ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
   ## extraHosts:
   ## - name: node.local
   ##   path: /
   ##
+  extraHosts: []
 
-  ## Any additional arbitrary paths that may need to be added to the ingress under the main host.
+  ## @param ingress.extraPaths Any additional arbitrary paths that may need to be added to the ingress under the main host.
   ## For example: The ALB ingress controller requires a special rule for handling SSL redirection.
   ## extraPaths:
   ## - path: /*
@@ -429,16 +502,18 @@ ingress:
   ##     serviceName: ssl-redirect
   ##     servicePort: use-annotation
   ##
+  extraPaths: []
 
-  ## The tls configuration for additional hostnames to be covered with this ingress record.
+  ## @param ingress.extraTls The tls configuration for additional hostnames to be covered with this ingress record.
   ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
   ## extraTls:
   ## - hosts:
   ##     - node.local
   ##   secretName: node.local-tls
   ##
+  extraTls: []
 
-  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## @param ingress.secrets If you're providing your own certificates, please use this to add the certificates as secrets
   ## key and certificate should start with -----BEGIN CERTIFICATE----- or
   ## -----BEGIN RSA PRIVATE KEY-----
   ##
@@ -447,19 +522,18 @@ ingress:
   ##
   ## It is also possible to create and manage the certificates outside of this helm chart
   ## Please see README.md for more information
-  ##
-  secrets: []
+  ## e.g:
   ## - name: node.local-tls
   ##   key:
   ##   certificate:
   ##
+  secrets: []
 
-##
 ## MongoDB(R) chart configuration
 ## ref: https://github.com/bitnami/charts/blob/master/bitnami/mongodb/values.yaml
 ##
 mongodb:
-  ## Whether to deploy a MongoDB(R) server to satisfy the applications database requirements.
+  ## @param mongodb.enabled Whether to install or not the MongoDB&reg; chart
   ## To use an external database set this to false and configure the externaldb parameters
   ##
   enabled: true
@@ -467,24 +541,27 @@ mongodb:
   ## MongoDB(R) Authentication parameters
   ##
   auth:
-    ## Enable authentication
+    ## @param mongodb.auth.enabled Whether to enable auth or not for the MongoDB&reg; chart
     ## ref: https://docs.mongodb.com/manual/tutorial/enable-authentication/
     ##
     enabled: true
 
-    ## MongoDB(R) root password
+    ## @param mongodb.auth.rootPassword MongoDB&reg; admin password
     ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#setting-the-root-password-on-first-run
     ##
     rootPassword: ''
 
-    ## MongoDB(R) custom user and database
+    ## @param mongodb.auth.username MongoDB&reg; custom user
     ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#creating-a-user-and-database-on-first-run
     ##
     username: user
+    ## @param mongodb.auth.database MongoDB&reg; custom database
+    ##
     database: test_db
+    ## @param mongodb.auth.password MongoDB&reg; custom password
+    ##
     password: secret_password
 
-##
 ## External Database Configuration
 ##
 ## Provision an external database
@@ -493,20 +570,20 @@ mongodb:
 ##    2) Pass an already existing ServiceInstance name and specify the service catalog broker to automatically create a ServiceBinding for your application.
 ##
 externaldb:
-  ## Enables or disables external database
+  ## @param externaldb.enabled Enables or disables external database (ignored if `mongodb.enabled=true`)
   ##
   enabled: false
-  ## Set to true if your external database has ssl enabled
+  ## @param externaldb.ssl Set to true if your external database has ssl enabled
   ##
   ssl: false
-  ### You can use an existing secret containing your database credentials
-  ### Please refer to the respective section in the README to know the details about this secret.
+  ## @param externaldb.secretName Secret containing existing database credentials
+  ## Please refer to the respective section in the README to know the details about this secret.
   ##
   secretName:
-  ## Only if using Kubernetes Service Catalog you can specify the kind of broker used. Available options are osba|gce|aws
+  ## @param externaldb.type Only if using Kubernetes Service Catalog you can specify the kind of broker used. Available options are osba|gce|aws
   ##
   type: osba
-  ## If you provide the serviceInstanceName, the chart will create a ServiceBinding for that ServiceInstance
+  ## @param externaldb.broker.serviceInstanceName If you provide the serviceInstanceName, the chart will create a ServiceBinding for that ServiceInstance
   ##
   broker:
     serviceInstanceName:

--- a/bitnami/node/values.yaml
+++ b/bitnami/node/values.yaml
@@ -16,6 +16,104 @@ global:
   imagePullSecrets: []
   storageClass:
 
+## @section Common parameters
+
+## @param kubeVersion Force target Kubernetes version (using Helm capabilities if not set)
+##
+kubeVersion:
+## @param nameOverride String to partially override node.fullname template (will maintain the release name)
+##
+nameOverride:
+## @param fullnameOverride String to fully override node.fullname template
+##
+fullnameOverride:
+## @param commonLabels Add labels to all the deployed resources
+##
+commonLabels: {}
+## @param commonAnnotations Add annotations to all the deployed resources
+##
+commonAnnotations: {}
+
+## @section Node parameters
+
+## @param command Override default container command (useful when using custom images)
+##
+command: ['/bin/bash', '-ec', 'npm start']
+## @param args Override default container args (useful when using custom images)
+##
+args: []
+## @param hostAliases Deployment pod host aliases
+## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+##
+hostAliases: []
+## @param extraEnvVars Extra environment variables to be set on Node container
+## For example:
+##  - name: BEARER_AUTH
+##    value: true
+##
+extraEnvVars: []
+## @param extraEnvVarsCM Name of existing ConfigMap containing extra environment variables
+##
+extraEnvVarsCM:
+## @param extraEnvVarsSecret Name of existing Secret containing extra environment variables
+##
+extraEnvVarsSecret:
+## MongoDB(R) chart configuration
+## ref: https://github.com/bitnami/charts/blob/master/bitnami/mongodb/values.yaml
+##
+mongodb:
+  ## @param mongodb.enabled Whether to install or not the MongoDB&reg; chart
+  ## To use an external database set this to false and configure the externaldb parameters
+  ##
+  enabled: true
+  ## MongoDB(R) Authentication parameters
+  ##
+  auth:
+    ## @param mongodb.auth.enabled Whether to enable auth or not for the MongoDB&reg; chart
+    ## ref: https://docs.mongodb.com/manual/tutorial/enable-authentication/
+    ##
+    enabled: true
+    ## @param mongodb.auth.rootPassword MongoDB&reg; admin password
+    ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#setting-the-root-password-on-first-run
+    ##
+    rootPassword: ''
+    ## @param mongodb.auth.username MongoDB&reg; custom user
+    ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#creating-a-user-and-database-on-first-run
+    ##
+    username: user
+    ## @param mongodb.auth.database MongoDB&reg; custom database
+    ##
+    database: test_db
+    ## @param mongodb.auth.password MongoDB&reg; custom password
+    ##
+    password: secret_password
+## External Database Configuration
+## Provision an external database
+## You have two alternatives:
+##    1) Pass an already existing Secret with your database credentials
+##    2) Pass an already existing ServiceInstance name and specify the service catalog broker to automatically create a ServiceBinding for your application.
+##
+externaldb:
+  ## @param externaldb.enabled Enables or disables external database (ignored if `mongodb.enabled=true`)
+  ##
+  enabled: false
+  ## @param externaldb.ssl Set to true if your external database has ssl enabled
+  ##
+  ssl: false
+  ## @param externaldb.secretName Secret containing existing database credentials
+  ## Please refer to the respective section in the README to know the details about this secret.
+  ##
+  secretName:
+  ## @param externaldb.type Only if using Kubernetes Service Catalog you can specify the kind of broker used. Available options are osba|gce|aws
+  ##
+  type: osba
+  ## @param externaldb.broker.serviceInstanceName If you provide the serviceInstanceName, the chart will create a ServiceBinding for that ServiceInstance
+  ##
+  broker:
+    serviceInstanceName:
+
+## @section Node deployment parameters
+
 ## Bitnami node image version
 ## ref: https://hub.docker.com/r/bitnami/node/tags/
 ## @param image.registry NodeJS image registry
@@ -41,23 +139,227 @@ image:
   ##   - myRegistryKeySecretName
   ##
   pullSecrets: []
-
-## @param kubeVersion Force target Kubernetes version (using Helm capabilities if not set)
+## @param replicaCount Specify the number of replicas for the application
 ##
-kubeVersion:
-
-## @param nameOverride String to partially override node.fullname template (will maintain the release name)
+replicaCount: 1
+## @param applicationPort Specify the port where your application will be running
 ##
-nameOverride:
-
-## @param fullnameOverride String to fully override node.fullname template
+applicationPort: 3000
+## @param podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
 ##
-fullnameOverride:
-
-## @param hostAliases Deployment pod host aliases
-## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+podAffinityPreset: ''
+## @param podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
 ##
-hostAliases: []
+podAntiAffinityPreset: soft
+## Node affinity preset
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+##
+nodeAffinityPreset:
+  ## @param nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  ##
+  type: ''
+  ## @param nodeAffinityPreset.key Node label key to match Ignored if `affinity` is set.
+  ## E.g.
+  ## key: "kubernetes.io/e2e-az-name"
+  ##
+  key: ''
+  ## @param nodeAffinityPreset.values Node label values to match. Ignored if `affinity` is set.
+  ## E.g.
+  ## values:
+  ##   - e2e-az1
+  ##   - e2e-az2
+  ##
+  values: []
+## @param affinity Affinity for pod assignment. Evaluated as a template.
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+affinity: {}
+## @param nodeSelector Node labels for pod assignment. Evaluated as a template.
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+## @param tolerations Tolerations for pod assignment. Evaluated as a template.
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: {}
+## @param podAnnotations Additional pod annotations
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+## @param podLabels Additional labels for Node pods
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+##
+podLabels: {}
+## @param extraDeploy Array of extra objects to deploy with the release (evaluated as a template)
+##
+extraDeploy: []
+## Configure extra options for liveness probe
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+## @param livenessProbe.enabled Enable livenessProbe
+## @param livenessProbe.path Request path for livenessProbe
+## @param livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+## @param livenessProbe.periodSeconds Period seconds for livenessProbe
+## @param livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+## @param livenessProbe.failureThreshold Failure threshold for livenessProbe
+## @param livenessProbe.successThreshold Success threshold for livenessProbe
+##
+livenessProbe:
+  enabled: true
+  path: '/'
+  initialDelaySeconds: 60
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+## Configure extra options for readiness probe
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+## @param readinessProbe.enabled Enable readinessProbe
+## @param readinessProbe.path Request path for readinessProbe
+## @param readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+## @param readinessProbe.periodSeconds Period seconds for readinessProbe
+## @param readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+## @param readinessProbe.failureThreshold Failure threshold for readinessProbe
+## @param readinessProbe.successThreshold Success threshold for readinessProbe
+##
+readinessProbe:
+  enabled: true
+  path: '/'
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+  successThreshold: 1
+## @param customLivenessProbe Override default liveness probe
+##
+customLivenessProbe: {}
+## @param customReadinessProbe Override default readiness probe
+##
+customReadinessProbe: {}
+## @param priorityClassName Node priorityClassName
+## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+##
+priorityClassName:
+## @param lifecycleHooks lifecycleHooks for the Node container to automate configuration before or after startup.
+##
+lifecycleHooks: {}
+## @param sidecars Add sidecars to the Node pods
+## Example:
+## sidecars:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+sidecars: {}
+## @param initContainers Add init containers to the Node pods
+## Example:
+## initContainers:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+initContainers: {}
+## @param extraVolumes Extra volumes to add to the deployment
+##
+extraVolumes: []
+## @param extraVolumeMounts Extra volume mounts to add to the container
+##
+extraVolumeMounts: []
+## SecurityContext configuration
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+## @param containerSecurityContext.enabled Node Container securityContext
+## @param containerSecurityContext.runAsUser User ID for the Node container
+## @param containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
+##
+containerSecurityContext:
+  enabled: true
+  runAsUser: 1001
+  runAsNonRoot: true
+## @param podSecurityContext.enabled Enable security context for Node pods
+## @param podSecurityContext.fsGroup Group ID for the volumes of the pod
+##
+podSecurityContext:
+  enabled: true
+  fsGroup: 1001
+## Node conatiners' resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+## We usually recommend not to specify default resources and to leave this as a conscious
+## choice for the user. This also increases chances charts run on environments with little
+## resources, such as Minikube. If you do want to specify resources, uncomment the following
+## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+## @param resources.limits The resources limits for the Node container
+## @param resources.requests The requested resources for the Node container
+##
+resources:
+  ## Example:
+  ## limits:
+  ##    cpu: 100m
+  ##    memory: 128Mi
+  limits: {}
+  ## Examples:
+  ## requests:
+  ##    cpu: 100m
+  ##    memory: 128Mi
+  requests: {}
+
+## @section Node application parameters
+
+## Bitnami Git image version
+## ref: https://hub.docker.com/r/bitnami/git/tags/
+##
+git:
+  ## Bitnami git image version
+  ## ref: https://hub.docker.com/r/bitnami/git/tags/
+  ## @param git.image.registry Git image registry
+  ## @param git.image.repository Git image repository
+  ## @param git.image.tag Git image tag (immutable tags are recommended)
+  ## @param git.image.pullPolicy Git image pull policy
+  ## @param git.image.pullSecrets Specify docker-registry secret names as an array
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/git
+    tag: 2.32.0-debian-10-r24
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+  ## @param git.extraVolumeMounts Add extra volume mounts for the Git container
+  ## Useful to mount keys to connect through ssh. (normally used with extraVolumes)
+  ## E.g:
+  ## extraVolumeMounts:
+  ##   - name: ssh-dir
+  ##     mountPath: /root/.ssh/
+  ##
+  extraVolumeMounts: []
+## @param getAppFromExternalRepository Enable to download app from external git repository
+## Disable it if your docker image already includes your application at /app
+##
+getAppFromExternalRepository: true
+## @param repository Git repository http/https url
+##
+repository: https://github.com/bitnami/sample-mean.git
+## @param revision Git repository revision to checkout
+##
+revision: master
+
+## @section Volume permissions parameters
 
 ## Init containers parameters:
 ## volumePermissions: Change the owner and group of the persistent volume mountpoint to runAsUser:fsGroup values from the securityContext section.
@@ -106,278 +408,7 @@ volumePermissions:
     ##    memory: 128Mi
     requests: {}
 
-## Bitnami Git image version
-## ref: https://hub.docker.com/r/bitnami/git/tags/
-##
-git:
-  ## Bitnami git image version
-  ## ref: https://hub.docker.com/r/bitnami/git/tags/
-  ## @param git.image.registry Git image registry
-  ## @param git.image.repository Git image repository
-  ## @param git.image.tag Git image tag (immutable tags are recommended)
-  ## @param git.image.pullPolicy Git image pull policy
-  ## @param git.image.pullSecrets Specify docker-registry secret names as an array
-  ##
-  image:
-    registry: docker.io
-    repository: bitnami/git
-    tag: 2.32.0-debian-10-r24
-    ## Specify a imagePullPolicy
-    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-    ##
-    pullPolicy: IfNotPresent
-    ## Optionally specify an array of imagePullSecrets.
-    ## Secrets must be manually created in the namespace.
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ## Example:
-    ## pullSecrets:
-    ##   - myRegistryKeySecretName
-    ##
-    pullSecrets: []
-
-  ## @param git.extraVolumeMounts Add extra volume mounts for the Git container
-  ## Useful to mount keys to connect through ssh. (normally used with extraVolumes)
-  ## E.g:
-  ## extraVolumeMounts:
-  ##   - name: ssh-dir
-  ##     mountPath: /root/.ssh/
-  ##
-  extraVolumeMounts: []
-
-## @param getAppFromExternalRepository Enable to download app from external git repository
-## Disable it if your docker image already includes your application at /app
-##
-getAppFromExternalRepository: true
-
-## @param repository Git repository http/https url
-##
-repository: https://github.com/bitnami/sample-mean.git
-## @param revision Git repository revision to checkout
-##
-revision: master
-
-## @param replicaCount Specify the number of replicas for the application
-##
-replicaCount: 1
-
-## @param applicationPort Specify the port where your application will be running
-##
-applicationPort: 3000
-
-## @param podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
-## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
-##
-podAffinityPreset: ''
-
-## @param podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
-## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
-##
-podAntiAffinityPreset: soft
-
-## Node affinity preset
-## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
-##
-nodeAffinityPreset:
-  ## @param nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
-  ##
-  type: ''
-  ## @param nodeAffinityPreset.key Node label key to match Ignored if `affinity` is set.
-  ## E.g.
-  ## key: "kubernetes.io/e2e-az-name"
-  ##
-  key: ''
-  ## @param nodeAffinityPreset.values Node label values to match. Ignored if `affinity` is set.
-  ## E.g.
-  ## values:
-  ##   - e2e-az1
-  ##   - e2e-az2
-  ##
-  values: []
-
-## @param affinity Affinity for pod assignment. Evaluated as a template.
-## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-##
-affinity: {}
-
-## @param nodeSelector Node labels for pod assignment. Evaluated as a template.
-## Ref: https://kubernetes.io/docs/user-guide/node-selection/
-##
-nodeSelector: {}
-
-## @param tolerations Tolerations for pod assignment. Evaluated as a template.
-## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-##
-tolerations: {}
-
-## @param commonLabels Add labels to all the deployed resources
-##
-commonLabels: {}
-
-## @param commonAnnotations Add annotations to all the deployed resources
-##
-commonAnnotations: {}
-
-## @param podAnnotations Additional pod annotations
-## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-##
-podAnnotations: {}
-
-## @param podLabels Additional labels for Node pods
-## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-##
-podLabels: {}
-
-## @param extraDeploy Array of extra objects to deploy with the release (evaluated as a template)
-##
-extraDeploy: []
-
-## Configure extra options for liveness probe
-## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
-## @param livenessProbe.enabled Enable livenessProbe
-## @param livenessProbe.path Request path for livenessProbe
-## @param livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
-## @param livenessProbe.periodSeconds Period seconds for livenessProbe
-## @param livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
-## @param livenessProbe.failureThreshold Failure threshold for livenessProbe
-## @param livenessProbe.successThreshold Success threshold for livenessProbe
-##
-livenessProbe:
-  enabled: true
-  path: '/'
-  initialDelaySeconds: 60
-  periodSeconds: 10
-  timeoutSeconds: 5
-  failureThreshold: 6
-  successThreshold: 1
-## Configure extra options for readiness probe
-## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
-## @param readinessProbe.enabled Enable readinessProbe
-## @param readinessProbe.path Request path for readinessProbe
-## @param readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
-## @param readinessProbe.periodSeconds Period seconds for readinessProbe
-## @param readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
-## @param readinessProbe.failureThreshold Failure threshold for readinessProbe
-## @param readinessProbe.successThreshold Success threshold for readinessProbe
-##
-readinessProbe:
-  enabled: true
-  path: '/'
-  initialDelaySeconds: 10
-  periodSeconds: 5
-  timeoutSeconds: 3
-  failureThreshold: 3
-  successThreshold: 1
-
-## @param customLivenessProbe Override default liveness probe
-##
-customLivenessProbe: {}
-
-## @param customReadinessProbe Override default readiness probe
-##
-customReadinessProbe: {}
-
-## @param priorityClassName Node priorityClassName
-## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
-##
-priorityClassName:
-
-## @param lifecycleHooks lifecycleHooks for the Node container to automate configuration before or after startup.
-##
-lifecycleHooks: {}
-
-## @param sidecars Add sidecars to the Node pods
-## Example:
-## sidecars:
-##   - name: your-image-name
-##     image: your-image
-##     imagePullPolicy: Always
-##     ports:
-##       - name: portname
-##         containerPort: 1234
-##
-sidecars: {}
-
-## @param initContainers Add init containers to the Node pods
-## Example:
-## initContainers:
-##   - name: your-image-name
-##     image: your-image
-##     imagePullPolicy: Always
-##     ports:
-##       - name: portname
-##         containerPort: 1234
-##
-initContainers: {}
-
-## @param extraEnvVars Extra environment variables to be set on Node container
-## For example:
-##  - name: BEARER_AUTH
-##    value: true
-##
-extraEnvVars: []
-
-## @param extraEnvVarsCM Name of existing ConfigMap containing extra environment variables
-##
-extraEnvVarsCM:
-
-## @param extraEnvVarsSecret Name of existing Secret containing extra environment variables
-##
-extraEnvVarsSecret:
-
-## @param command Override default container command (useful when using custom images)
-##
-command: ['/bin/bash', '-ec', 'npm start']
-## @param args Override default container args (useful when using custom images)
-##
-args: []
-
-## @param extraVolumes Extra volumes to add to the deployment
-##
-extraVolumes: []
-
-## @param extraVolumeMounts Extra volume mounts to add to the container
-##
-extraVolumeMounts: []
-
-## SecurityContext configuration
-## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-## @param containerSecurityContext.enabled Node Container securityContext
-## @param containerSecurityContext.runAsUser User ID for the Node container
-## @param containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
-##
-containerSecurityContext:
-  enabled: true
-  runAsUser: 1001
-  runAsNonRoot: true
-
-## @param podSecurityContext.enabled Enable security context for Node pods
-## @param podSecurityContext.fsGroup Group ID for the volumes of the pod
-##
-podSecurityContext:
-  enabled: true
-  fsGroup: 1001
-
-## Node conatiners' resource requests and limits
-## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-## We usually recommend not to specify default resources and to leave this as a conscious
-## choice for the user. This also increases chances charts run on environments with little
-## resources, such as Minikube. If you do want to specify resources, uncomment the following
-## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-## @param resources.limits The resources limits for the Node container
-## @param resources.requests The requested resources for the Node container
-##
-resources:
-  ## Example:
-  ## limits:
-  ##    cpu: 100m
-  ##    memory: 128Mi
-  limits: {}
-  ## Examples:
-  ## requests:
-  ##    cpu: 100m
-  ##    memory: 128Mi
-  requests: {}
+## @section Persistence parameters
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
@@ -404,6 +435,8 @@ persistence:
   ##
   size: 1Gi
 
+## @section Traffic exposure parameters
+
 ## Service parameters
 ##
 service:
@@ -413,17 +446,14 @@ service:
   ## @param service.port Kubernetes Service port
   ##
   port: 80
-
   ## @param service.clusterIP Service Cluster IP
   ##
   clusterIP:
-
   ## @param service.sessionAffinity Control where client requests go, to the same pod or round-robin
   ## Values: ClientIP or None
   ## ref: https://kubernetes.io/docs/user-guide/services/
   ##
   sessionAffinity: 'None'
-
   ## @param service.nodePort NodePort if Service type is `LoadBalancer` or `NodePort`
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
   ##
@@ -442,7 +472,6 @@ service:
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
   ##
   annotations: {}
-
 ## Configure the ingress resource that allows you to access the
 ## Node.js installation. Set up the URL
 ## ref: http://kubernetes.io/docs/user-guide/ingress/
@@ -451,27 +480,21 @@ ingress:
   ## @param ingress.enabled Set to true to enable ingress record generation
   ##
   enabled: false
-
   ## @param ingress.certManager Set this to true in order to add the corresponding annotations for cert-manager
   ##
   certManager: false
-
   ## @param ingress.pathType Ingress path type
   ##
   pathType: ImplementationSpecific
-
   ## @param ingress.apiVersion Override API Version (automatically detected if not set)
   ##
   apiVersion:
-
   ## @param ingress.hostname When the ingress is enabled, a host pointing to this will be created
   ##
   hostname: node.local
-
   ## @param ingress.path The Path to Node.js. You may need to set this to '/*' in order to use this with ALB ingress controllers.
   ##
   path: /
-
   ## @param ingress.annotations Ingress annotations
   ## For a full list of possible ingress annotations, please see
   ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
@@ -479,13 +502,11 @@ ingress:
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
   ##
   annotations: {}
-
   ## @param ingress.tls Enable TLS configuration for the hostname defined at ingress.hostname parameter
   ## TLS certificates will be retrieved from a TLS secret with name: {{- printf "%s-tls" .Values.ingress.hostname }}
   ## You can use the ingress.secrets parameter to create this TLS secret or relay on cert-manager to create it
   ##
   tls: false
-
   ## @param ingress.extraHosts The list of additional hostnames to be covered with this ingress record.
   ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
   ## extraHosts:
@@ -493,7 +514,6 @@ ingress:
   ##   path: /
   ##
   extraHosts: []
-
   ## @param ingress.extraPaths Any additional arbitrary paths that may need to be added to the ingress under the main host.
   ## For example: The ALB ingress controller requires a special rule for handling SSL redirection.
   ## extraPaths:
@@ -503,7 +523,6 @@ ingress:
   ##     servicePort: use-annotation
   ##
   extraPaths: []
-
   ## @param ingress.extraTls The tls configuration for additional hostnames to be covered with this ingress record.
   ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
   ## extraTls:
@@ -512,7 +531,6 @@ ingress:
   ##   secretName: node.local-tls
   ##
   extraTls: []
-
   ## @param ingress.secrets If you're providing your own certificates, please use this to add the certificates as secrets
   ## key and certificate should start with -----BEGIN CERTIFICATE----- or
   ## -----BEGIN RSA PRIVATE KEY-----
@@ -528,62 +546,3 @@ ingress:
   ##   certificate:
   ##
   secrets: []
-
-## MongoDB(R) chart configuration
-## ref: https://github.com/bitnami/charts/blob/master/bitnami/mongodb/values.yaml
-##
-mongodb:
-  ## @param mongodb.enabled Whether to install or not the MongoDB&reg; chart
-  ## To use an external database set this to false and configure the externaldb parameters
-  ##
-  enabled: true
-
-  ## MongoDB(R) Authentication parameters
-  ##
-  auth:
-    ## @param mongodb.auth.enabled Whether to enable auth or not for the MongoDB&reg; chart
-    ## ref: https://docs.mongodb.com/manual/tutorial/enable-authentication/
-    ##
-    enabled: true
-
-    ## @param mongodb.auth.rootPassword MongoDB&reg; admin password
-    ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#setting-the-root-password-on-first-run
-    ##
-    rootPassword: ''
-
-    ## @param mongodb.auth.username MongoDB&reg; custom user
-    ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#creating-a-user-and-database-on-first-run
-    ##
-    username: user
-    ## @param mongodb.auth.database MongoDB&reg; custom database
-    ##
-    database: test_db
-    ## @param mongodb.auth.password MongoDB&reg; custom password
-    ##
-    password: secret_password
-
-## External Database Configuration
-##
-## Provision an external database
-## You have two alternatives:
-##    1) Pass an already existing Secret with your database credentials
-##    2) Pass an already existing ServiceInstance name and specify the service catalog broker to automatically create a ServiceBinding for your application.
-##
-externaldb:
-  ## @param externaldb.enabled Enables or disables external database (ignored if `mongodb.enabled=true`)
-  ##
-  enabled: false
-  ## @param externaldb.ssl Set to true if your external database has ssl enabled
-  ##
-  ssl: false
-  ## @param externaldb.secretName Secret containing existing database credentials
-  ## Please refer to the respective section in the README to know the details about this secret.
-  ##
-  secretName:
-  ## @param externaldb.type Only if using Kubernetes Service Catalog you can specify the kind of broker used. Available options are osba|gce|aws
-  ##
-  type: osba
-  ## @param externaldb.broker.serviceInstanceName If you provide the serviceInstanceName, the chart will create a ServiceBinding for that ServiceInstance
-  ##
-  broker:
-    serviceInstanceName:


### PR DESCRIPTION
**Description of the change**

Add metadata to `values.yaml` in order to be used by [readme-generator](https://github.com/bitnami-labs/readme-generator-for-helm) to automatically generate the "Parameters" section of the `README.md`.

General rules followed:
- If `values.yaml` doesn't have a description for a key in a comment → Use `README.md` description
- If `values.yaml` does have a description for a key in a comment but the `README.md` description provides more info → Use `README.md` description
- Else → Leave the `values.yaml` description

**Benefits**

Less manual work and consistency between `values.yaml` and `README.md`.

**Additional information**

Commented keys are not picked by readme-generator so some had to be uncommented in order to appear in the README, however none of them affect the default installation of the chart, verified comparing the output before and after the changes of
```bash
helm install chart . -f values.yaml --dry-run --debug
```

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])