### PR TITLE
[bitnami/redis] Fix: Redis initialDelaySeconds too short

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -25,4 +25,4 @@ name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 14.7.0
+version: 14.7.1

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -122,13 +122,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | `master.extraEnvVarsSecret`                 | Name of existing Secret containing extra env vars for Redis(TM) master nodes                     | `nil`           |
 | `master.containerPort`                      | Container port to open on Redis(TM) master nodes                                                 | `6379`          |
 | `master.livenessProbe.enabled`              | Enable livenessProbe on Redis(TM) master nodes                                                   | `true`          |
-| `master.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                          | `5`             |
+| `master.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                          | `10`            |
 | `master.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                 | `5`             |
 | `master.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                | `5`             |
 | `master.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                              | `5`             |
 | `master.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                              | `1`             |
 | `master.readinessProbe.enabled`             | Enable readinessProbe on Redis(TM) master nodes                                                  | `true`          |
-| `master.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                         | `5`             |
+| `master.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                         | `10`            |
 | `master.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                | `5`             |
 | `master.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                               | `1`             |
 | `master.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                             | `5`             |
@@ -197,13 +197,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | `replica.extraEnvVarsSecret`                 | Name of existing Secret containing extra env vars for Redis(TM) replicas nodes                    | `nil`           |
 | `replica.containerPort`                      | Container port to open on Redis(TM) replicas nodes                                                | `6379`          |
 | `replica.livenessProbe.enabled`              | Enable livenessProbe on Redis(TM) replicas nodes                                                  | `true`          |
-| `replica.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                           | `5`             |
+| `replica.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                           | `10`            |
 | `replica.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                  | `5`             |
 | `replica.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                 | `5`             |
 | `replica.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                               | `5`             |
 | `replica.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                               | `1`             |
 | `replica.readinessProbe.enabled`             | Enable readinessProbe on Redis(TM) replicas nodes                                                 | `true`          |
-| `replica.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                          | `5`             |
+| `replica.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                          | `10`            |
 | `replica.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                 | `5`             |
 | `replica.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                | `1`             |
 | `replica.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                              | `5`             |
@@ -284,13 +284,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | `sentinel.preExecCmds`                        | Additional commands to run prior to starting Redis(TM) Sentinel                                  | `[]`                     |
 | `sentinel.containerPort`                      | Container port to open on Redis(TM) Sentinel nodes                                               | `26379`                  |
 | `sentinel.livenessProbe.enabled`              | Enable livenessProbe on Redis(TM) Sentinel nodes                                                 | `true`                   |
-| `sentinel.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                          | `5`                      |
+| `sentinel.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                          | `10`                     |
 | `sentinel.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                 | `5`                      |
 | `sentinel.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                | `5`                      |
 | `sentinel.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                              | `5`                      |
 | `sentinel.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                              | `1`                      |
 | `sentinel.readinessProbe.enabled`             | Enable readinessProbe on Redis(TM) Sentinel nodes                                                | `true`                   |
-| `sentinel.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                         | `5`                      |
+| `sentinel.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                         | `10`                     |
 | `sentinel.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                | `5`                      |
 | `sentinel.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                               | `1`                      |
 | `sentinel.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                             | `5`                      |

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -122,13 +122,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | `master.extraEnvVarsSecret`                 | Name of existing Secret containing extra env vars for Redis(TM) master nodes                     | `nil`           |
 | `master.containerPort`                      | Container port to open on Redis(TM) master nodes                                                 | `6379`          |
 | `master.livenessProbe.enabled`              | Enable livenessProbe on Redis(TM) master nodes                                                   | `true`          |
-| `master.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                          | `10`            |
+| `master.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                          | `20`            |
 | `master.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                 | `5`             |
 | `master.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                | `5`             |
 | `master.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                              | `5`             |
 | `master.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                              | `1`             |
 | `master.readinessProbe.enabled`             | Enable readinessProbe on Redis(TM) master nodes                                                  | `true`          |
-| `master.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                         | `10`            |
+| `master.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                         | `20`            |
 | `master.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                | `5`             |
 | `master.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                               | `1`             |
 | `master.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                             | `5`             |
@@ -197,13 +197,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | `replica.extraEnvVarsSecret`                 | Name of existing Secret containing extra env vars for Redis(TM) replicas nodes                    | `nil`           |
 | `replica.containerPort`                      | Container port to open on Redis(TM) replicas nodes                                                | `6379`          |
 | `replica.livenessProbe.enabled`              | Enable livenessProbe on Redis(TM) replicas nodes                                                  | `true`          |
-| `replica.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                           | `10`            |
+| `replica.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                           | `20`            |
 | `replica.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                  | `5`             |
 | `replica.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                 | `5`             |
 | `replica.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                               | `5`             |
 | `replica.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                               | `1`             |
 | `replica.readinessProbe.enabled`             | Enable readinessProbe on Redis(TM) replicas nodes                                                 | `true`          |
-| `replica.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                          | `10`            |
+| `replica.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                          | `20`            |
 | `replica.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                 | `5`             |
 | `replica.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                | `1`             |
 | `replica.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                              | `5`             |
@@ -284,13 +284,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | `sentinel.preExecCmds`                        | Additional commands to run prior to starting Redis(TM) Sentinel                                  | `[]`                     |
 | `sentinel.containerPort`                      | Container port to open on Redis(TM) Sentinel nodes                                               | `26379`                  |
 | `sentinel.livenessProbe.enabled`              | Enable livenessProbe on Redis(TM) Sentinel nodes                                                 | `true`                   |
-| `sentinel.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                          | `10`                     |
+| `sentinel.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                          | `20`                     |
 | `sentinel.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                 | `5`                      |
 | `sentinel.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                | `5`                      |
 | `sentinel.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                              | `5`                      |
 | `sentinel.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                              | `1`                      |
 | `sentinel.readinessProbe.enabled`             | Enable readinessProbe on Redis(TM) Sentinel nodes                                                | `true`                   |
-| `sentinel.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                         | `10`                     |
+| `sentinel.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                         | `20`                     |
 | `sentinel.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                | `5`                      |
 | `sentinel.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                               | `1`                      |
 | `sentinel.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                             | `5`                      |

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -195,7 +195,7 @@ master:
   ##
   livenessProbe:
     enabled: true
-    initialDelaySeconds: 5
+    initialDelaySeconds: 10
     periodSeconds: 5
     timeoutSeconds: 5
     successThreshold: 1
@@ -209,7 +209,7 @@ master:
   ##
   readinessProbe:
     enabled: true
-    initialDelaySeconds: 5
+    initialDelaySeconds: 10
     periodSeconds: 5
     timeoutSeconds: 1
     successThreshold: 1
@@ -496,7 +496,7 @@ replica:
   ##
   livenessProbe:
     enabled: true
-    initialDelaySeconds: 5
+    initialDelaySeconds: 10
     periodSeconds: 5
     timeoutSeconds: 5
     successThreshold: 1
@@ -510,7 +510,7 @@ replica:
   ##
   readinessProbe:
     enabled: true
-    initialDelaySeconds: 5
+    initialDelaySeconds: 10
     periodSeconds: 5
     timeoutSeconds: 1
     successThreshold: 1
@@ -845,7 +845,7 @@ sentinel:
   ##
   livenessProbe:
     enabled: true
-    initialDelaySeconds: 5
+    initialDelaySeconds: 10
     periodSeconds: 5
     timeoutSeconds: 5
     successThreshold: 1
@@ -859,7 +859,7 @@ sentinel:
   ##
   readinessProbe:
     enabled: true
-    initialDelaySeconds: 5
+    initialDelaySeconds: 10
     periodSeconds: 5
     timeoutSeconds: 1
     successThreshold: 1

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -195,7 +195,7 @@ master:
   ##
   livenessProbe:
     enabled: true
-    initialDelaySeconds: 10
+    initialDelaySeconds: 20
     periodSeconds: 5
     timeoutSeconds: 5
     successThreshold: 1
@@ -209,7 +209,7 @@ master:
   ##
   readinessProbe:
     enabled: true
-    initialDelaySeconds: 10
+    initialDelaySeconds: 20
     periodSeconds: 5
     timeoutSeconds: 1
     successThreshold: 1
@@ -496,7 +496,7 @@ replica:
   ##
   livenessProbe:
     enabled: true
-    initialDelaySeconds: 10
+    initialDelaySeconds: 20
     periodSeconds: 5
     timeoutSeconds: 5
     successThreshold: 1
@@ -510,7 +510,7 @@ replica:
   ##
   readinessProbe:
     enabled: true
-    initialDelaySeconds: 10
+    initialDelaySeconds: 20
     periodSeconds: 5
     timeoutSeconds: 1
     successThreshold: 1
@@ -845,7 +845,7 @@ sentinel:
   ##
   livenessProbe:
     enabled: true
-    initialDelaySeconds: 10
+    initialDelaySeconds: 20
     periodSeconds: 5
     timeoutSeconds: 5
     successThreshold: 1
@@ -859,7 +859,7 @@ sentinel:
   ##
   readinessProbe:
     enabled: true
-    initialDelaySeconds: 10
+    initialDelaySeconds: 20
     periodSeconds: 5
     timeoutSeconds: 1
     successThreshold: 1


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Change default initialDelaySeconds from 5 to 20 for all probes. Although the logs end in a few seconds, Redis does take a while to init after that.

**Benefits**

1. Resolve Redis pods from getting killed on decent spec computers including i5 and i7 due to liveness probe unhealthy.
2. Resolve them from getting killed on Github actions using default values. Take a look at `Lint and Test Charts / test` log for commit aed05d3 (attached in additional info).
3. Mitigate chain reaction causing a cascading failure. If running on replica mode, Redis-1 will spin up since Redis-0 is ready, but Redis-0 is being killed due to the liveness probe unhealthy. Redis-1 will be killed as well and so on.

**Possible drawbacks**

Nil

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

If you look at the `Lint and Test Charts / test` logs here (even at 10s), it's dangerously close to being killed (4/5) liveness probe failed.
```
Could not connect to Redis at localhost:6379: Connection refused
  Warning  Unhealthy  17s (x2 over 22s)  kubelet  Liveness probe failed: 
Could not connect to Redis at localhost:6379: Connection refused
  Warning  Unhealthy  7s (x4 over 22s)  kubelet  Liveness probe failed: 
Could not connect to Redis at localhost:26379: Connection refused
  Warning  Unhealthy  7s (x4 over 22s)  kubelet  Readiness probe failed: 
Could not connect to Redis at localhost:26379: Connection refused
```

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
