### PR TITLE
[bitnami/elasticsearch] Curator sidecars are placed at the wrong level

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/bitnami-docker-elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 15.9.1
+version: 15.9.2

--- a/bitnami/elasticsearch/templates/cronjob.yaml
+++ b/bitnami/elasticsearch/templates/cronjob.yaml
@@ -117,7 +117,7 @@ spec:
               {{- if .Values.curator.resources }}
               resources: {{- toYaml .Values.curator.resources | nindent 16 }}
               {{- end }}
-        {{- if .Values.curator.sidecars }}
-        {{- include "common.tplvalues.render" ( dict "value" .Values.curator.sidecars "context" $) | nindent 8 }}
-        {{- end }}
+              {{- if .Values.curator.sidecars }}
+              {{- include "common.tplvalues.render" ( dict "value" .Values.curator.sidecars "context" $) | nindent 14 }}
+              {{- end }}
 {{- end }}

--- a/bitnami/elasticsearch/templates/cronjob.yaml
+++ b/bitnami/elasticsearch/templates/cronjob.yaml
@@ -116,8 +116,8 @@ spec:
                 {{- end }}
               {{- if .Values.curator.resources }}
               resources: {{- toYaml .Values.curator.resources | nindent 16 }}
-              {{- end }}
-              {{- if .Values.curator.sidecars }}
-              {{- include "common.tplvalues.render" ( dict "value" .Values.curator.sidecars "context" $) | nindent 14 }}
-              {{- end }}
+            {{- end }}
+            {{- if .Values.curator.sidecars }}
+            {{- include "common.tplvalues.render" ( dict "value" .Values.curator.sidecars "context" $) | nindent 12 }}
+            {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Currently the sidecars are placed on the wrong level (or under the wrong yaml property). 

**Benefits**
The sidecars specification is placed under the right section ("Containers:") and not under ("Spec:")

**Possible drawbacks**
None known, since I fear it has never worked. 

**Applicable issues**
https://github.com/bitnami/charts/issues/6956

**Additional information**


**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
