### PR TITLE
[bitnami/discourse] Avoid to include ports in DISCOURSE_HOST

### DIFF
--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-discourse
   - https://github.com/spinnaker
   - https://www.discourse.org/
-version: 4.2.3
+version: 4.2.4

--- a/bitnami/discourse/templates/configmaps.yaml
+++ b/bitnami/discourse/templates/configmaps.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- end }}
 data:
   {{- $port := .Values.service.port | toString }}
-  DISCOURSE_HOST: "{{ include "discourse.host" . }}{{- if (and (ne $port "80") (ne $port "443")) }}:{{ .Values.service.port }}{{ end }}"
+  DISCOURSE_HOST: "{{ include "discourse.host" . }}"
   DISCOURSE_SKIP_INSTALL: {{ ternary "yes" "no" .Values.discourse.skipInstall | quote }}
   DISCOURSE_SITE_NAME: {{ .Values.discourse.siteName | quote }}
   DISCOURSE_USERNAME: {{ .Values.discourse.username | quote }}

--- a/bitnami/discourse/templates/configmaps.yaml
+++ b/bitnami/discourse/templates/configmaps.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- end }}
 data:
   {{- $port := .Values.service.port | toString }}
-  DISCOURSE_HOST: "{{ include "discourse.host" . }}{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}"
+  DISCOURSE_HOST: "{{ include "discourse.host" . }}{{- if (and (ne $port "80") (ne $port "443")) }}:{{ .Values.service.port }}{{ end }}"
   DISCOURSE_SKIP_INSTALL: {{ ternary "yes" "no" .Values.discourse.skipInstall | quote }}
   DISCOURSE_SITE_NAME: {{ .Values.discourse.siteName | quote }}
   DISCOURSE_USERNAME: {{ .Values.discourse.username | quote }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This patch modifies the way that we are including the port inside the DISCOURSE_HOST in our chart. After an internal investigation, it seems that Discourse doesn't support to modify the default 80 or 443 ports:

https://meta.discourse.org/t/how-to-specify-a-different-port-not-80-during-installation/47859/10

This patch modifies the DISCOURSE_HOST included in our configmap to set up just the host without the port.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #6932

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
