### PR TITLE
[bitnami/nginx]: disable automount of SA token

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -25,4 +25,4 @@ name: nginx
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx
   - http://www.nginx.org
-version: 9.3.8
+version: 9.4.0

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -133,6 +133,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `autoscaling.targetMemory`              | Target Memory utilization percentage                                                      | `nil`   |
 | `extraVolumes`                          | Array to add extra volumes                                                                | `[]`    |
 | `extraVolumeMounts`                     | Array to add extra mount                                                                  | `[]`    |
+| `serviceAccount.autoMount`              | Auto-mount the service account token in the pod                                           | `false` |
 | `serviceAccount.create`                 | Enable creation of ServiceAccount for nginx pod                                           | `false` |
 | `serviceAccount.name`                   | The name of the ServiceAccount to use.                                                    | `nil`   |
 | `serviceAccount.annotations`            | Annotations for service account. Evaluated as a template.                                 | `{}`    |

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       {{- end }}
     spec:
       {{- include "nginx.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.autoMount }}
       serviceAccountName: {{ template "nginx.serviceAccountName" . }}
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -274,6 +274,9 @@ serviceAccount:
   ## Only used if `create` is `true`.
   ##
   annotations: {}
+  ## @param serviceAccount.autoMount Auto-mount the service account token in the pod
+  ##
+  autoMount: false
 ## @param sidecars Sidecar parameters
 ## e.g:
 ## sidecars:


### PR DESCRIPTION
**Description of the change**
It disables the automounting of the service account token in the pod. Nginx does not need this. This commit disables it by default, but leaves it configurable if anyone needs to use it.

**Benefits**
By disabling the automount, potential attackers cannot access the Kubernetes API on behalf/through the pod.

**Possible drawbacks**
In the unlikely event that anyone is using some sidecar to access the Kubernetes API, relying on the mounted SA token, it will break with this commit.

**Applicable issues**
If raising an issue is required or helpful, please tell me and I'd be glad to do so.

**Additional information**

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])