### PR TITLE
[bitnami/*] Adapt values.yaml of common library, Tomcat, Wavefront and ZooKeeper charts

### DIFF
--- a/.github/workflows/generate-chart-readme.yml
+++ b/.github/workflows/generate-chart-readme.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - 'bitnami/airflow/values.yaml'
+      - 'bitnami/common/values.yaml'
       - 'bitnami/dokuwiki/values.yaml'
       - 'bitnami/drupal/values.yaml'
       - 'bitnami/ejbca/values.yaml'
@@ -49,6 +50,14 @@ on:
       - 'bitnami/spark/values.yaml'
       - 'bitnami/spring-cloud-dataflow/values.yaml'
       - 'bitnami/suitecrm/values.yaml'
+      - 'bitnami/tomcat/values.yaml'
+      - 'bitnami/wavefront/values.yaml'
+      - 'bitnami/wavefront-adapter-for-istio/values.yaml'
+      - 'bitnami/wavefront-hpa-adapter/values.yaml'
+      - 'bitnami/wavefront-prometheus-storage-adapter/values.yaml'
+      - 'bitnami/wildfly/values.yaml'
+      - 'bitnami/wordpress/values.yaml'
+      - 'bitnami/zookeeper/values.yaml'
 
 jobs:
   generate-chart-readme:

--- a/bitnami/common/values.yaml
+++ b/bitnami/common/values.yaml
@@ -1,3 +1,5 @@
 ## bitnami/common
 ## It is required by CI/CD tools and processes.
+## @skip exampleValue
+##
 exampleValue: common-chart

--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -26,4 +26,4 @@ name: tomcat
 sources:
   - https://github.com/bitnami/bitnami-docker-tomcat
   - http://tomcat.apache.org
-version: 9.2.16
+version: 9.2.17

--- a/bitnami/tomcat/README.md
+++ b/bitnami/tomcat/README.md
@@ -47,125 +47,142 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Parameters
 
-The following tables lists the configurable parameters of the Tomcat chart and their default values per section/component:
-
 ### Global parameters
 
-| Parameter                 | Description                                     | Default                                                 |
-|---------------------------|-------------------------------------------------|---------------------------------------------------------|
-| `global.imageRegistry`    | Global Docker image registry                    | `nil`                                                   |
-| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
-| `global.storageClass`     | Global storage class for dynamic provisioning   | `nil`                                                   |
+| Name                      | Description                                     | Value |
+| ------------------------- | ----------------------------------------------- | ----- |
+| `global.imageRegistry`    | Global Docker image registry                    | `nil` |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
+| `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `nil` |
+
 
 ### Common parameters
 
-| Parameter           | Description                                                          | Default                        |
-|---------------------|----------------------------------------------------------------------|--------------------------------|
-| `nameOverride`      | String to partially override common.names.fullname                   | `nil`                          |
-| `fullnameOverride`  | String to fully override common.names.fullname                       | `nil`                          |
-| `commonLabels`      | Labels to add to all deployed objects                                | `{}`                           |
-| `commonAnnotations` | Annotations to add to all deployed objects                           | `{}`                           |
-| `clusterDomain`     | Default Kubernetes cluster domain                                    | `cluster.local`                |
-| `extraDeploy`       | Array of extra objects to deploy with the release                    | `[]` (evaluated as a template) |
-| `kubeVersion`       | Force target Kubernetes version (using Helm capabilities if not set) | `nil`                          |
+| Name                | Description                                                                                  | Value           |
+| ------------------- | -------------------------------------------------------------------------------------------- | --------------- |
+| `kubeVersion`       | Force target Kubernetes version (using Helm capabilities if not set)                         | `nil`           |
+| `nameOverride`      | String to partially override common.names.fullname template (will maintain the release name) | `nil`           |
+| `fullnameOverride`  | String to fully override common.names.fullname template                                      | `nil`           |
+| `commonLabels`      | Add labels to all the deployed resources                                                     | `{}`            |
+| `commonAnnotations` | Add annotations to all the deployed resources                                                | `{}`            |
+| `clusterDomain`     | Kubernetes Cluster Domain                                                                    | `cluster.local` |
+| `extraDeploy`       | Array of extra objects to deploy with the release                                            | `[]`            |
+
 
 ### Tomcat parameters
 
-| Parameter                     | Description                                                          | Default                                                 |
-|-------------------------------|----------------------------------------------------------------------|---------------------------------------------------------|
-| `image.registry`              | Tomcat image registry                                                | `docker.io`                                             |
-| `image.repository`            | Tomcat image name                                                    | `bitnami/tomcat`                                        |
-| `image.tag`                   | Tomcat image tag                                                     | `{TAG_NAME}`                                            |
-| `image.pullPolicy`            | Tomcat image pull policy                                             | `IfNotPresent`                                          |
-| `image.pullSecrets`           | Specify docker-registry secret names as an array                     | `[]` (does not add image pull secrets to deployed pods) |
-| `image.debug`                 | Specify if debug logs should be enabled                              | `false`                                                 |
-| `hostAliases`                 | Add deployment host aliases                                          | `[]`                                                    |
-| `tomcatUsername`              | Tomcat admin user                                                    | `user`                                                  |
-| `tomcatPassword`              | Tomcat admin password                                                | _random 10 character alphanumeric string_               |
-| `tomcatAllowRemoteManagement` | Enable remote access to management interface                         | `0` (disabled)                                          |
-| `command`                     | Override default container command (useful when using custom images) | `nil`                                                   |
-| `args`                        | Override default container args (useful when using custom images)    | `nil`                                                   |
-| `extraEnvVars`                | Extra environment variables to be set on Tomcat container            | `{}`                                                    |
-| `extraEnvVarsCM`              | Name of existing ConfigMap containing extra env vars                 | `nil`                                                   |
-| `extraEnvVarsSecret`          | Name of existing Secret containing extra env vars                    | `nil`                                                   |
+| Name                          | Description                                                          | Value                 |
+| ----------------------------- | -------------------------------------------------------------------- | --------------------- |
+| `image.registry`              | Tomcat image registry                                                | `docker.io`           |
+| `image.repository`            | Tomcat image repository                                              | `bitnami/tomcat`      |
+| `image.tag`                   | Tomcat image tag (immutable tags are recommended)                    | `10.0.8-debian-10-r1` |
+| `image.pullPolicy`            | Tomcat image pull policy                                             | `IfNotPresent`        |
+| `image.pullSecrets`           | Specify docker-registry secret names as an array                     | `[]`                  |
+| `image.debug`                 | Specify if debug logs should be enabled                              | `false`               |
+| `hostAliases`                 | Deployment pod host aliases                                          | `[]`                  |
+| `tomcatUsername`              | Tomcat admin user                                                    | `user`                |
+| `tomcatPassword`              | Tomcat admin password                                                | `nil`                 |
+| `tomcatAllowRemoteManagement` | Enable remote access to management interface                         | `0`                   |
+| `command`                     | Override default container command (useful when using custom images) | `[]`                  |
+| `args`                        | Override default container args (useful when using custom images)    | `[]`                  |
+| `extraEnvVars`                | Extra environment variables to be set on Tomcat container            | `[]`                  |
+| `extraEnvVarsCM`              | Name of existing ConfigMap containing extra environment variables    | `nil`                 |
+| `extraEnvVarsSecret`          | Name of existing Secret containing extra environment variables       | `nil`                 |
+
 
 ### Tomcat deployment parameters
 
-| Parameter                   | Description                                                                               | Default                                     |
-|-----------------------------|-------------------------------------------------------------------------------------------|---------------------------------------------|
-| `deployment.type`           | Use Deployment or StatefulSet                                                              | `deployment`                                      |
-| `replicaCount`              | Specify number of Tomcat replicas                                                         | `1`                                         |
-| `containerPort`             | HTTP port to expose at container level                                                    | `8080`                                      |
-| `containerExtraPorts`       | Extra ports to expose at container level                                               | `{}`                                      |
-| `podSecurityContext`        | Tomcat pods' Security Context                                                             | Check `values.yaml` file                    |
-| `containerSecurityContext`  | Tomcat containers' Security Context                                                       | Check `values.yaml` file                    |
-| `resources.limits`          | The resources limits for the Tomcat container                                             | `{}`                                        |
-| `resources.requests`        | The requested resources for the Tomcat container                                          | `{"memory": "512Mi", "cpu": "300m"}`        |
-| `livenessProbe`             | Liveness probe configuration for Tomcat                                                   | Check `values.yaml` file                    |
-| `readinessProbe`            | Readiness probe configuration for Tomcat                                                  | Check `values.yaml` file                    |
-| `customLivenessProbe`       | Override default liveness probe                                                           | `nil`                                       |
-| `customReadinessProbe`      | Override default readiness probe                                                          | `nil`                                       |
-| `updateStrategy`            | Strategy to use to update Pods                                                            | Check `values.yaml` file                    |
-| `podAffinityPreset`         | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                                        |
-| `podAntiAffinityPreset`     | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                      |
-| `nodeAffinityPreset.type`   | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                                        |
-| `nodeAffinityPreset.key`    | Node label key to match. Ignored if `affinity` is set.                                    | `""`                                        |
-| `nodeAffinityPreset.values` | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                                        |
-| `affinity`                  | Affinity for pod assignment                                                               | `{}` (evaluated as a template)              |
-| `nodeSelector`              | Node labels for pod assignment                                                            | `{}` (evaluated as a template)              |
-| `tolerations`               | Tolerations for pod assignment                                                            | `[]` (evaluated as a template)              |
-| `podLabels`                 | Extra labels for Tomcat pods                                                              | `{}` (evaluated as a template)              |
-| `podAnnotations`            | Annotations for Tomcat pods                                                               | `{}` (evaluated as a template)              |
-| `extraVolumeMounts`         | Optionally specify extra list of additional volumeMounts for Tomcat container(s)          | `[]`                                        |
-| `extraVolumes`              | Optionally specify extra list of additional volumes for Tomcat pods in Deployment                      | `[]`                                        |
-| `extraVolumeClaimTemplates` | Optionally specify extra list of additional volume claim templates for Tomcat pods in StatefulSet      | `[]`                                        |
-| `initContainers`            | Add additional init containers to the Tomcat pods                                         | `{}` (evaluated as a template)              |
-| `sidecars`                  | Add additional sidecar containers to the Tomcat pods                                      | `{}` (evaluated as a template)              |
-| `persistence.enabled`       | Enable persistence                                                              | `true`                                      |
-| `persistence.storageClass`  | PVC Storage Class for Tomcat volume                                                       | `nil` (uses alpha storage class annotation) |
-| `persistence.existingClaim` | An Existing PVC name for Tomcat volume                                                    | `nil` (uses alpha storage class annotation) |
-| `persistence.accessModes`   | PVC Access Modes for Tomcat volume                                                         | `ReadWriteOnce`                             |
-| `persistence.size`          | PVC Storage Request for Tomcat volume                                                     | `8Gi`                                       |
-| `persistence.selectorLabels`| Selector labels to use in volume claim template for Tomcat volume (Applicable when deployment.type is statefulset)                       | `nil` |
+| Name                                 | Description                                                                                       | Value           |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------- | --------------- |
+| `replicaCount`                       | Specify number of Tomcat replicas                                                                 | `1`             |
+| `deployment.type`                    | Use Deployment or StatefulSet                                                                     | `deployment`    |
+| `updateStrategy.type`                | StrategyType                                                                                      | `RollingUpdate` |
+| `containerPort`                      | HTTP port to expose at container level                                                            | `8080`          |
+| `containerExtraPorts`                | Extra ports to expose at container level                                                          | `{}`            |
+| `podSecurityContext.enabled`         | Enable Tomcat pods' Security Context                                                              | `true`          |
+| `podSecurityContext.fsGroup`         | Set Tomcat pod's Security Context fsGroup                                                         | `1001`          |
+| `containerSecurityContext.enabled`   | Enable Tomcat containers' SecurityContext                                                         | `true`          |
+| `containerSecurityContext.runAsUser` | User ID for the Tomcat container                                                                  | `1001`          |
+| `resources.limits`                   | The resources limits for the Tomcat container                                                     | `{}`            |
+| `resources.requests`                 | The requested resources for the Tomcat container                                                  | `{}`            |
+| `livenessProbe.enabled`              | Enable livenessProbe                                                                              | `true`          |
+| `livenessProbe.httpGet.path`         | Request path for livenessProbe                                                                    | `/`             |
+| `livenessProbe.httpGet.port`         | Port for livenessProbe                                                                            | `http`          |
+| `livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                           | `120`           |
+| `livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                  | `10`            |
+| `livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                 | `5`             |
+| `livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                               | `6`             |
+| `livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                               | `1`             |
+| `readinessProbe.enabled`             | Enable readinessProbe                                                                             | `true`          |
+| `readinessProbe.httpGet.path`        | Request path for readinessProbe                                                                   | `/`             |
+| `readinessProbe.httpGet.port`        | Port for readinessProbe                                                                           | `http`          |
+| `readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                          | `30`            |
+| `readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                 | `5`             |
+| `readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                | `3`             |
+| `readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                              | `3`             |
+| `readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                              | `1`             |
+| `customLivenessProbe`                | Override default liveness probe                                                                   | `{}`            |
+| `customReadinessProbe`               | Override default readiness probe                                                                  | `{}`            |
+| `podLabels`                          | Extra labels for Tomcat pods                                                                      | `{}`            |
+| `podAnnotations`                     | Annotations for Tomcat pods                                                                       | `{}`            |
+| `podAffinityPreset`                  | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`               | `""`            |
+| `podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`          | `soft`          |
+| `nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`         | `""`            |
+| `nodeAffinityPreset.key`             | Node label key to match. Ignored if `affinity` is set.                                            | `""`            |
+| `nodeAffinityPreset.values`          | Node label values to match. Ignored if `affinity` is set.                                         | `[]`            |
+| `affinity`                           | Affinity for pod assignment. Evaluated as a template.                                             | `{}`            |
+| `nodeSelector`                       | Node labels for pod assignment. Evaluated as a template.                                          | `{}`            |
+| `tolerations`                        | Tolerations for pod assignment. Evaluated as a template.                                          | `[]`            |
+| `extraVolumes`                       | Optionally specify extra list of additional volumes for Tomcat pods in Deployment                 | `[]`            |
+| `extraVolumeClaimTemplates`          | Optionally specify extra list of additional volume claim templates for Tomcat pods in StatefulSet | `[]`            |
+| `extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for Tomcat container(s)                  | `[]`            |
+| `initContainers`                     | Add init containers to the Tomcat pods.                                                           | `{}`            |
+| `sidecars`                           | Add sidecars to the Tomcat pods.                                                                  | `{}`            |
+| `persistence.enabled`                | Enable persistence                                                                                | `true`          |
+| `persistence.storageClass`           | PVC Storage Class for Tomcat volume                                                               | `nil`           |
+| `persistence.annotations`            | Persistent Volume Claim annotations                                                               | `nil`           |
+| `persistence.accessModes`            | PVC Access Modes for Tomcat volume                                                                | `[]`            |
+| `persistence.size`                   | PVC Storage Request for Tomcat volume                                                             | `8Gi`           |
+| `persistence.existingClaim`          | An Existing PVC name for Tomcat volume                                                            | `nil`           |
+| `persistence.selectorLabels`         | Selector labels to use in volume claim template in statefulset                                    | `nil`           |
 
-### Exposure parameters
 
-| Parameter                        | Description                                                                       | Default                        |
-|----------------------------------|-----------------------------------------------------------------------------------|--------------------------------|
-| `service.type`                   | Kubernetes Service type                                                           | `LoadBalancer`                 |
-| `service.port`                   | Service HTTP port                                                                 | `80`                           |
-| `service.nodePort`               | Kubernetes http node port                                                         | `""`                           |
-| `service.loadBalancerIP`         | Kubernetes LoadBalancerIP to request                                              | `nil`                          |
-| `service.externalTrafficPolicy`  | Enable client source IP preservation                                              | `Cluster`                      |
-| `service.annotations`            | Annotations for Tomcat service                                                    | `{}` (evaluated as a template) |
-| `ingress.enabled`                | Enable ingress controller resource                                                | `false`                        |
-| `ingress.apiVersion`             | Force Ingress API version (automatically detected if not set)                     | ``                             |
-| `ingress.path`                   | Ingress path                                                                      | `/`                            |
-| `ingress.pathType`               | Ingress path type                                                                 | `ImplementationSpecific`       |
-| `ingress.certManager`            | Add annotations for cert-manager                                                  | `false`                        |
-| `ingress.hostname`               | Default host for the ingress resource                                             | `tomcat.local`                 |
-| `ingress.tls`                    | Enable TLS configuration for the hostname defined at `ingress.hostname` parameter | `false`                        |
-| `ingress.annotations`            | Ingress annotations                                                               | `{}` (evaluated as a template) |
-| `ingress.extraHosts[0].name`     | Additional hostnames to be covered                                                | `nil`                          |
-| `ingress.extraHosts[0].path`     | Additional hostnames to be covered                                                | `nil`                          |
-| `ingress.extraTls[0].hosts[0]`   | TLS configuration for additional hostnames to be covered                          | `nil`                          |
-| `ingress.extraTls[0].secretName` | TLS configuration for additional hostnames to be covered                          | `nil`                          |
-| `ingress.secrets[0].name`        | TLS Secret Name                                                                   | `nil`                          |
-| `ingress.secrets[0].certificate` | TLS Secret Certificate                                                            | `nil`                          |
-| `ingress.secrets[0].key`         | TLS Secret Key                                                                    | `nil`                          |
+### Traffic Exposure parameters
+
+| Name                            | Description                                                                                   | Value                    |
+| ------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------ |
+| `service.type`                  | Kubernetes Service type                                                                       | `LoadBalancer`           |
+| `service.port`                  | Service HTTP port                                                                             | `80`                     |
+| `service.nodePort`              | Kubernetes http node port                                                                     | `""`                     |
+| `service.loadBalancerIP`        | Port Use serviceLoadBalancerIP to request a specific static IP, otherwise leave blank         | `nil`                    |
+| `service.externalTrafficPolicy` | Enable client source IP preservation                                                          | `Cluster`                |
+| `service.annotations`           | Annotations for Tomcat service                                                                | `{}`                     |
+| `ingress.enabled`               | Enable ingress controller resource                                                            | `false`                  |
+| `ingress.certManager`           | Set this to true in order to add the corresponding annotations for cert-manager               | `false`                  |
+| `ingress.hostname`              | Default host for the ingress resource                                                         | `tomcat.local`           |
+| `ingress.annotations`           | Ingress annotations                                                                           | `{}`                     |
+| `ingress.tls`                   | Enable TLS configuration for the hostname defined at `ingress.hostname` parameter             | `false`                  |
+| `ingress.extraHosts`            | The list of additional hostnames to be covered with this ingress record.                      | `[]`                     |
+| `ingress.extraTls`              | The tls configuration for additional hostnames to be covered with this ingress record.        | `[]`                     |
+| `ingress.secrets`               | If you're providing your own certificates, please use this to add the certificates as secrets | `[]`                     |
+| `ingress.apiVersion`            | Force Ingress API version (automatically detected if not set)                                 | `nil`                    |
+| `ingress.path`                  | Ingress path                                                                                  | `/`                      |
+| `ingress.pathType`              | Ingress path type                                                                             | `ImplementationSpecific` |
+
 
 ### Volume Permissions parameters
 
-| Parameter                              | Description                                                                 | Default                                                 |
-|----------------------------------------|-----------------------------------------------------------------------------|---------------------------------------------------------|
-| `volumePermissions.enabled`            | Enable init container that changes volume permissions in the data directory | `false`                                                 |
-| `volumePermissions.image.registry`     | Init container volume-permissions image registry                            | `docker.io`                                             |
-| `volumePermissions.image.repository`   | Init container volume-permissions image name                                | `bitnami/bitnami-shell`                                 |
-| `volumePermissions.image.tag`          | Init container volume-permissions image tag                                 | `"10"`                                                  |
-| `volumePermissions.image.pullPolicy`   | Init container volume-permissions image pull policy                         | `Always`                                                |
-| `volumePermissions.image.pullSecrets`  | Specify docker-registry secret names as an array                            | `[]` (does not add image pull secrets to deployed pods) |
-| `volumePermissions.resources.limits`   | Init container volume-permissions resource  limits                          | `{}`                                                    |
-| `volumePermissions.resources.requests` | Init container volume-permissions resource  requests                        | `{}`                                                    |
+| Name                                   | Description                                                                 | Value                   |
+| -------------------------------------- | --------------------------------------------------------------------------- | ----------------------- |
+| `volumePermissions.enabled`            | Enable init container that changes volume permissions in the data directory | `false`                 |
+| `volumePermissions.image.registry`     | Init container volume-permissions image registry                            | `docker.io`             |
+| `volumePermissions.image.repository`   | Init container volume-permissions image repository                          | `bitnami/bitnami-shell` |
+| `volumePermissions.image.tag`          | Init container volume-permissions image tag                                 | `10-debian-10-r126`     |
+| `volumePermissions.image.pullPolicy`   | Init container volume-permissions image pull policy                         | `Always`                |
+| `volumePermissions.image.pullSecrets`  | Specify docker-registry secret names as an array                            | `[]`                    |
+| `volumePermissions.resources.limits`   | Init container volume-permissions resource  limits                          | `{}`                    |
+| `volumePermissions.resources.requests` | Init container volume-permissions resource  requests                        | `{}`                    |
+
 
 The above parameters map to the env variables defined in [bitnami/tomcat](http://github.com/bitnami/bitnami-docker-tomcat). For more information please refer to the [bitnami/tomcat](http://github.com/bitnami/bitnami-docker-tomcat) image documentation.
 

--- a/bitnami/tomcat/values.yaml
+++ b/bitnami/tomcat/values.yaml
@@ -468,9 +468,9 @@ volumePermissions:
     ## limits:
     ##    cpu: 100m
     ##    memory: 128Mi
-    limits: { }
+    limits: {}
     ## Examples:
     ## requests:
     ##    cpu: 100m
     ##    memory: 128Mi
-    requests: { }
+    requests: {}

--- a/bitnami/tomcat/values.yaml
+++ b/bitnami/tomcat/values.yaml
@@ -16,9 +16,31 @@ global:
   imagePullSecrets: []
   storageClass:
 
+## @section Common parameters
+
 ## @param kubeVersion Force target Kubernetes version (using Helm capabilities if not set)
 ##
 kubeVersion:
+## @param nameOverride String to partially override common.names.fullname template (will maintain the release name)
+##
+nameOverride:
+## @param fullnameOverride String to fully override common.names.fullname template
+##
+fullnameOverride:
+## @param commonLabels Add labels to all the deployed resources
+##
+commonLabels: {}
+## @param commonAnnotations Add annotations to all the deployed resources
+##
+commonAnnotations: {}
+## @param clusterDomain Kubernetes Cluster Domain
+##
+clusterDomain: cluster.local
+## @param extraDeploy Array of extra objects to deploy with the release
+##
+extraDeploy: []
+
+## @section Tomcat parameters
 
 ## Bitnami Tomcat image version
 ## ref: https://hub.docker.com/r/bitnami/tomcat/tags/
@@ -49,58 +71,28 @@ image:
   ## Set to true if you would like to see extra information on logs
   ##
   debug: false
-
-## @param nameOverride String to partially override common.names.fullname template (will maintain the release name)
-##
-nameOverride:
-
-## @param fullnameOverride String to fully override common.names.fullname template
-##
-fullnameOverride:
-
-## @param commonLabels Add labels to all the deployed resources
-##
-commonLabels: {}
-
-## @param commonAnnotations Add annotations to all the deployed resources
-##
-commonAnnotations: {}
-
-## @param clusterDomain Kubernetes Cluster Domain
-##
-clusterDomain: cluster.local
-
-## @param extraDeploy Array of extra objects to deploy with the release
-##
-extraDeploy: []
-
 ## @param hostAliases Deployment pod host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
 hostAliases: []
-
 ## @param tomcatUsername Tomcat admin user
 ## ref: https://github.com/bitnami/bitnami-docker-tomcat#creating-a-custom-user
 ##
 tomcatUsername: user
-
 ## @param tomcatPassword Tomcat admin password
 ## ref: https://github.com/bitnami/bitnami-docker-tomcat#creating-a-custom-user
 ##
 tomcatPassword:
-
 ## @param tomcatAllowRemoteManagement Enable remote access to management interface
 ## ref: https://github.com/bitnami/charts/tree/master/bitnami/tomcat#configuration
 ##
 tomcatAllowRemoteManagement: 0
-
 ## @param command Override default container command (useful when using custom images)
 ##
-command:
+command: []
 ## @param args Override default container args (useful when using custom images)
 ##
-args:
-
+args: []
 ## @param extraEnvVars Extra environment variables to be set on Tomcat container
 ## Example:
 ## extraEnvVars:
@@ -108,26 +100,24 @@ args:
 ##     value: "bar"
 ##
 extraEnvVars: []
-
 ## @param extraEnvVarsCM Name of existing ConfigMap containing extra environment variables
 ##
 extraEnvVarsCM:
-
 ## @param extraEnvVarsSecret Name of existing Secret containing extra environment variables
 ##
 extraEnvVarsSecret:
 
+## @section Tomcat deployment parameters
+
 ## @param replicaCount Specify number of Tomcat replicas
 ##
 replicaCount: 1
-
 ## Deployment
 ##
 deployment:
   ## @param deployment.type Use Deployment or StatefulSet
   ##
   type: deployment
-
 ## Strategy to use to update Pods
 ##
 updateStrategy:
@@ -135,11 +125,9 @@ updateStrategy:
   ## Can be set to RollingUpdate or OnDelete
   ##
   type: RollingUpdate
-
 ## @param containerPort HTTP port to expose at container level
 ##
 containerPort: 8080
-
 ## @param containerExtraPorts Extra ports to expose at container level
 ##
 ## Example:
@@ -148,7 +136,6 @@ containerPort: 8080
 ##    containerPort: 8081
 ##
 containerExtraPorts: {}
-
 ## Tomcat pods' Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 ## @param podSecurityContext.enabled Enable Tomcat pods' Security Context
@@ -157,7 +144,6 @@ containerExtraPorts: {}
 podSecurityContext:
   enabled: true
   fsGroup: 1001
-
 ## Tomcat containers' SecurityContext
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param containerSecurityContext.enabled Enable Tomcat containers' SecurityContext
@@ -166,7 +152,6 @@ podSecurityContext:
 containerSecurityContext:
   enabled: true
   runAsUser: 1001
-
 ## Tomcat containers' resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ## We usually recommend not to specify default resources and to leave this as a conscious
@@ -185,7 +170,6 @@ resources:
   requests:
     cpu: 300m
     memory: 512Mi
-
 ## Configure extra options for liveness probe
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
 ## @param livenessProbe.enabled Enable livenessProbe
@@ -228,35 +212,28 @@ readinessProbe:
   failureThreshold: 3
   timeoutSeconds: 3
   successThreshold: 1
-
 ## @param customLivenessProbe Override default liveness probe
 ##
 customLivenessProbe: {}
-
 ## @param customReadinessProbe Override default readiness probe
 ##
 customReadinessProbe: {}
-
 ## @param podLabels Extra labels for Tomcat pods
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ##
 podLabels: {}
-
 ## @param podAnnotations Annotations for Tomcat pods
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 ##
 podAnnotations: {}
-
 ## @param podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
 ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
 ##
 podAffinityPreset: ""
-
 ## @param podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
 ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
 ##
 podAntiAffinityPreset: soft
-
 ## Node affinity preset
 ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
 ##
@@ -276,35 +253,28 @@ nodeAffinityPreset:
   ##   - e2e-az2
   ##
   values: []
-
 ## @param affinity Affinity for pod assignment. Evaluated as a template.
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 ## Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
 ##
 affinity: {}
-
 ## @param nodeSelector Node labels for pod assignment. Evaluated as a template.
 ## ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##
 nodeSelector: {}
-
 ## @param tolerations Tolerations for pod assignment. Evaluated as a template.
 ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
 tolerations: []
-
 ## @param extraVolumes Optionally specify extra list of additional volumes for Tomcat pods in Deployment
 ##
 extraVolumes: []
-
 ## @param extraVolumeClaimTemplates Optionally specify extra list of additional volume claim templates for Tomcat pods in StatefulSet
 ##
 extraVolumeClaimTemplates: []
-
 ## @param extraVolumeMounts Optionally specify extra list of additional volumeMounts for Tomcat container(s)
 ##
 extraVolumeMounts: []
-
 ## @param initContainers Add init containers to the Tomcat pods.
 ## Example:
 ## initContainers:
@@ -316,7 +286,6 @@ extraVolumeMounts: []
 ##         containerPort: 1234
 ##
 initContainers: {}
-
 ## @param sidecars Add sidecars to the Tomcat pods.
 ## Example:
 ## sidecars:
@@ -328,7 +297,6 @@ initContainers: {}
 ##         containerPort: 1234
 ##
 sidecars: {}
-
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##
@@ -362,6 +330,8 @@ persistence:
   ##
   selectorLabels:
 
+## @section Traffic Exposure parameters
+
 ## Service parameters
 ##
 service:
@@ -388,22 +358,18 @@ service:
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
   ##
   annotations: {}
-
 ## Ingress configuratiom
 ##
 ingress:
   ## @param ingress.enabled Enable ingress controller resource
   ##
   enabled: false
-
   ## @param ingress.certManager Set this to true in order to add the corresponding annotations for cert-manager
   ##
   certManager: false
-
   ## @param ingress.hostname Default host for the ingress resource
   ##
   hostname: tomcat.local
-
   ## @param ingress.annotations Ingress annotations
   ## For a full list of possible ingress annotations, please see
   ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
@@ -411,14 +377,12 @@ ingress:
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
   ##
   annotations: {}
-
   ## @param ingress.tls Enable TLS configuration for the hostname defined at `ingress.hostname` parameter
   ## TLS certificates will be retrieved from a TLS secret with name: {{- printf "%s-tls" .Values.ingress.hostname }}
   ## You can use the ingress.secrets parameter to create this TLS secret, relay on cert-manager to create it, or
   ## let the chart create self-signed certificates for you
   ##
   tls: false
-
   ## @param ingress.extraHosts The list of additional hostnames to be covered with this ingress record.
   ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
   ## Example:
@@ -427,7 +391,6 @@ ingress:
   ##     path: /
   ##
   extraHosts: []
-
   ## @param ingress.extraTls The tls configuration for additional hostnames to be covered with this ingress record.
   ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
   ## Example:
@@ -437,7 +400,6 @@ ingress:
   ##   secretName: tomcat.local-tls
   ##
   extraTls: []
-
   ## @param ingress.secrets If you're providing your own certificates, please use this to add the certificates as secrets
   ## key and certificate should start with -----BEGIN CERTIFICATE----- or -----BEGIN RSA PRIVATE KEY-----
   ## name should line up with a secretName set further up
@@ -454,18 +416,17 @@ ingress:
   ##     certificate: ""
   ##
   secrets: []
-
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
   apiVersion:
-
   ## @param ingress.path Ingress path
   ##
   path: /
-
   ## @param ingress.pathType Ingress path type
   ##
   pathType: ImplementationSpecific
+
+## @section Volume Permissions parameters
 
 ## Init containers parameters:
 ## volumePermissions: Change the owner and group of the persistent volume mountpoint to runAsUser:fsGroup values from the securityContext section.
@@ -493,7 +454,6 @@ volumePermissions:
     ##   - myRegistryKeySecretName
     ##
     pullSecrets: []
-
   ## Init container' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ## We usually recommend not to specify default resources and to leave this as a conscious

--- a/bitnami/tomcat/values.yaml
+++ b/bitnami/tomcat/values.yaml
@@ -1,19 +1,33 @@
+## @section Global parameters
 ## Global Docker image parameters
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value
-## Current available global Docker image parameters: imageRegistry and imagePullSecrets
-##
-# global:
-#   imageRegistry: myRegistryName
-#   imagePullSecrets:
-#     - myRegistryKeySecretName
-#   storageClass: myStorageClass
+## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
 
-## Force target Kubernetes version (using Helm capabilites if not set)
+## @param global.imageRegistry Global Docker image registry
+## @param global.imagePullSecrets Global Docker registry secret names as an array
+## @param global.storageClass Global StorageClass for Persistent Volume(s)
+##
+global:
+  imageRegistry:
+  ## E.g.
+  ## imagePullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
+  storageClass:
+
+## @param kubeVersion Force target Kubernetes version (using Helm capabilities if not set)
 ##
 kubeVersion:
 
 ## Bitnami Tomcat image version
 ## ref: https://hub.docker.com/r/bitnami/tomcat/tags/
+## @param image.registry Tomcat image registry
+## @param image.repository Tomcat image repository
+## @param image.tag Tomcat image tag (immutable tags are recommended)
+## @param image.pullPolicy Tomcat image pull policy
+## @param image.pullSecrets Specify docker-registry secret names as an array
+## @param image.debug Specify if debug logs should be enabled
 ##
 image:
   registry: docker.io
@@ -36,56 +50,58 @@ image:
   ##
   debug: false
 
-## String to partially override common.names.fullname template (will maintain the release name)
+## @param nameOverride String to partially override common.names.fullname template (will maintain the release name)
 ##
-# nameOverride:
+nameOverride:
 
-## String to fully override common.names.fullname template
+## @param fullnameOverride String to fully override common.names.fullname template
 ##
-# fullnameOverride:
+fullnameOverride:
 
-## Add labels to all the deployed resources
+## @param commonLabels Add labels to all the deployed resources
 ##
 commonLabels: {}
 
-## Add annotations to all the deployed resources
+## @param commonAnnotations Add annotations to all the deployed resources
 ##
 commonAnnotations: {}
 
-## Kubernetes Cluster Domain
+## @param clusterDomain Kubernetes Cluster Domain
 ##
 clusterDomain: cluster.local
 
-## Extra objects to deploy (value evaluated as a template)
+## @param extraDeploy Array of extra objects to deploy with the release
 ##
 extraDeploy: []
 
-## Deployment pod host aliases
+## @param hostAliases Deployment pod host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
 hostAliases: []
 
-## Admin user
+## @param tomcatUsername Tomcat admin user
 ## ref: https://github.com/bitnami/bitnami-docker-tomcat#creating-a-custom-user
 ##
 tomcatUsername: user
 
-## Admin password
+## @param tomcatPassword Tomcat admin password
 ## ref: https://github.com/bitnami/bitnami-docker-tomcat#creating-a-custom-user
 ##
-# tomcatPassword:
+tomcatPassword:
 
-## Expose management services
+## @param tomcatAllowRemoteManagement Enable remote access to management interface
 ## ref: https://github.com/bitnami/charts/tree/master/bitnami/tomcat#configuration
 ##
 tomcatAllowRemoteManagement: 0
 
-## Command and args for running the container (set to default if not set). Use array form
+## @param command Override default container command (useful when using custom images)
 ##
-command: []
-args: []
+command:
+## @param args Override default container args (useful when using custom images)
+##
+args:
 
-## Additional environment variables to set
+## @param extraEnvVars Extra environment variables to be set on Tomcat container
 ## Example:
 ## extraEnvVars:
 ##   - name: FOO
@@ -93,38 +109,38 @@ args: []
 ##
 extraEnvVars: []
 
-## ConfigMap with extra environment variables
+## @param extraEnvVarsCM Name of existing ConfigMap containing extra environment variables
 ##
 extraEnvVarsCM:
 
-## Secret with extra environment variables
+## @param extraEnvVarsSecret Name of existing Secret containing extra environment variables
 ##
 extraEnvVarsSecret:
 
-## Number of Tomcat replicas
+## @param replicaCount Specify number of Tomcat replicas
 ##
 replicaCount: 1
 
 ## Deployment
 ##
 deployment:
-  ## Deployment type: deployment or statefulset
+  ## @param deployment.type Use Deployment or StatefulSet
   ##
   type: deployment
 
 ## Strategy to use to update Pods
 ##
 updateStrategy:
-  ## StrategyType
+  ## @param updateStrategy.type StrategyType
   ## Can be set to RollingUpdate or OnDelete
   ##
   type: RollingUpdate
 
-## Tomcat container port to open
+## @param containerPort HTTP port to expose at container level
 ##
 containerPort: 8080
 
-## Tomcat container extra ports to open
+## @param containerExtraPorts Extra ports to expose at container level
 ##
 ## Example:
 ## containerExtraPorts:
@@ -135,6 +151,8 @@ containerExtraPorts: {}
 
 ## Tomcat pods' Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+## @param podSecurityContext.enabled Enable Tomcat pods' Security Context
+## @param podSecurityContext.fsGroup Set Tomcat pod's Security Context fsGroup
 ##
 podSecurityContext:
   enabled: true
@@ -142,6 +160,8 @@ podSecurityContext:
 
 ## Tomcat containers' SecurityContext
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+## @param containerSecurityContext.enabled Enable Tomcat containers' SecurityContext
+## @param containerSecurityContext.runAsUser User ID for the Tomcat container
 ##
 containerSecurityContext:
   enabled: true
@@ -149,21 +169,33 @@ containerSecurityContext:
 
 ## Tomcat containers' resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+## We usually recommend not to specify default resources and to leave this as a conscious
+## choice for the user. This also increases chances charts run on environments with little
+## resources, such as Minikube. If you do want to specify resources, uncomment the following
+## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+## @param resources.limits The resources limits for the Tomcat container
+## @param resources.requests [object] The requested resources for the Tomcat container
 ##
 resources:
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ## Example:
+  ## limits:
+  ##    cpu: 500m
+  ##    memory: 1Gi
   limits: {}
-  #   cpu: 500m
-  #   memory: 1Gi
   requests:
     cpu: 300m
     memory: 512Mi
 
-## Liveness and Readiness probes
-## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+## Configure extra options for liveness probe
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+## @param livenessProbe.enabled Enable livenessProbe
+## @param livenessProbe.httpGet.path Request path for livenessProbe
+## @param livenessProbe.httpGet.port Port for livenessProbe
+## @param livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+## @param livenessProbe.periodSeconds Period seconds for livenessProbe
+## @param livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+## @param livenessProbe.failureThreshold Failure threshold for livenessProbe
+## @param livenessProbe.successThreshold Success threshold for livenessProbe
 ##
 livenessProbe:
   enabled: true
@@ -175,6 +207,17 @@ livenessProbe:
   failureThreshold: 6
   timeoutSeconds: 5
   successThreshold: 1
+## Configure extra options for readiness probe
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+## @param readinessProbe.enabled Enable readinessProbe
+## @param readinessProbe.httpGet.path Request path for readinessProbe
+## @param readinessProbe.httpGet.port Port for readinessProbe
+## @param readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+## @param readinessProbe.periodSeconds Period seconds for readinessProbe
+## @param readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+## @param readinessProbe.failureThreshold Failure threshold for readinessProbe
+## @param readinessProbe.successThreshold Success threshold for readinessProbe
+##
 readinessProbe:
   enabled: true
   httpGet:
@@ -186,51 +229,47 @@ readinessProbe:
   timeoutSeconds: 3
   successThreshold: 1
 
-## Custom Liveness probes for Tomcat
+## @param customLivenessProbe Override default liveness probe
 ##
 customLivenessProbe: {}
 
-## Custom Rediness probes Tomcat
+## @param customReadinessProbe Override default readiness probe
 ##
 customReadinessProbe: {}
 
-## Additional pod labels
+## @param podLabels Extra labels for Tomcat pods
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ##
 podLabels: {}
 
-## Additional pod annotations
+## @param podAnnotations Annotations for Tomcat pods
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 ##
 podAnnotations: {}
 
-## Pod affinity preset
+## @param podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
 ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
-## Allowed values: soft, hard
 ##
 podAffinityPreset: ""
 
-## Pod anti-affinity preset
+## @param podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
 ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
-## Allowed values: soft, hard
 ##
 podAntiAffinityPreset: soft
 
 ## Node affinity preset
 ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
-## Allowed values: soft, hard
 ##
 nodeAffinityPreset:
-  ## Node affinity type
-  ## Allowed values: soft, hard
+  ## @param nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
   ##
   type: ""
-  ## Node label key to match
+  ## @param nodeAffinityPreset.key Node label key to match. Ignored if `affinity` is set.
   ## E.g.
   ## key: "kubernetes.io/e2e-az-name"
   ##
   key: ""
-  ## Node label values to match
+  ## @param nodeAffinityPreset.values Node label values to match. Ignored if `affinity` is set.
   ## E.g.
   ## values:
   ##   - e2e-az1
@@ -238,35 +277,35 @@ nodeAffinityPreset:
   ##
   values: []
 
-## Affinity for pod assignment. Evaluated as a template.
+## @param affinity Affinity for pod assignment. Evaluated as a template.
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 ## Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
 ##
 affinity: {}
 
-## Node labels for pod assignment. Evaluated as a template.
+## @param nodeSelector Node labels for pod assignment. Evaluated as a template.
 ## ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##
 nodeSelector: {}
 
-## Tolerations for pod assignment. Evaluated as a template.
+## @param tolerations Tolerations for pod assignment. Evaluated as a template.
 ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
 tolerations: []
 
-## Extra volumes to add to the deployment
+## @param extraVolumes Optionally specify extra list of additional volumes for Tomcat pods in Deployment
 ##
 extraVolumes: []
 
-## Extra volume claim templates to add to the statefulset
+## @param extraVolumeClaimTemplates Optionally specify extra list of additional volume claim templates for Tomcat pods in StatefulSet
 ##
 extraVolumeClaimTemplates: []
 
-## Extra volume mounts to add to the container
+## @param extraVolumeMounts Optionally specify extra list of additional volumeMounts for Tomcat container(s)
 ##
 extraVolumeMounts: []
 
-## Add init containers to the Tomcat pods.
+## @param initContainers Add init containers to the Tomcat pods.
 ## Example:
 ## initContainers:
 ##   - name: your-image-name
@@ -278,7 +317,7 @@ extraVolumeMounts: []
 ##
 initContainers: {}
 
-## Add sidecars to the Tomcat pods.
+## @param sidecars Add sidecars to the Tomcat pods.
 ## Example:
 ## sidecars:
 ##   - name: your-image-name
@@ -294,31 +333,31 @@ sidecars: {}
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##
 persistence:
-  ## If true, use a Persistent Volume Claim, If false, use emptyDir
+  ## @param persistence.enabled Enable persistence
   ##
   enabled: true
-  ## Persistent Volume Storage Class
+  ## @param persistence.storageClass PVC Storage Class for Tomcat volume
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning
   ## If undefined (the default) or set to null, no storageClassName spec is
   ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
   ##   GKE, AWS & OpenStack)
   ##
-  # storageClass: "-"
-  ## Persistent Volume Claim annotations
+  storageClass:
+  ## @param persistence.annotations Persistent Volume Claim annotations
   ##
   annotations:
-  ## Persistent Volume Access Mode
+  ## @param persistence.accessModes PVC Access Modes for Tomcat volume
   ##
   accessModes:
     - ReadWriteOnce
-  ## Persistent Volume size
+  ## @param persistence.size PVC Storage Request for Tomcat volume
   ##
   size: 8Gi
-  ## Name of an existing PVC
+  ## @param persistence.existingClaim An Existing PVC name for Tomcat volume
   ##
   existingClaim:
-  ## Selector labels to use in volume claim template in statefulset
+  ## @param persistence.selectorLabels Selector labels to use in volume claim template in statefulset
   ## Applicable when deployment.type is statefulset
   ##
   selectorLabels:
@@ -326,26 +365,25 @@ persistence:
 ## Service parameters
 ##
 service:
-  ## Kubernetes svc type
+  ## @param service.type Kubernetes Service type
   ## For minikube, set this to NodePort, elsewhere use LoadBalancer
   ##
   type: LoadBalancer
-  ## HTTP Port
+  ## @param service.port Service HTTP port
   ##
   port: 80
-  ## Specify the nodePort(s) value(s) for the LoadBalancer and NodePort service types.
+  ## @param service.nodePort Kubernetes http node port
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
   ##
   nodePort: ""
-  ## Use serviceLoadBalancerIP to request a specific static IP,
-  ## otherwise leave blank
+  ## @param service.loadBalancerIP Port Use serviceLoadBalancerIP to request a specific static IP, otherwise leave blank
   ##
-  # loadBalancerIP:
-  ## Enable client source IP preservation
+  loadBalancerIP:
+  ## @param service.externalTrafficPolicy Enable client source IP preservation
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   ##
   externalTrafficPolicy: Cluster
-  ## Provide any additional annotations which may be required. This can be used to
+  ## @param service.annotations Annotations for Tomcat service
   ## set the LoadBalancer service type to internal only.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
   ##
@@ -354,19 +392,19 @@ service:
 ## Ingress configuratiom
 ##
 ingress:
-  ## Set to true to enable ingress record generation
+  ## @param ingress.enabled Enable ingress controller resource
   ##
   enabled: false
 
-  ## Set this to true in order to add the corresponding annotations for cert-manager
+  ## @param ingress.certManager Set this to true in order to add the corresponding annotations for cert-manager
   ##
   certManager: false
 
-  ## When the ingress is enabled, a host pointing to this will be created
+  ## @param ingress.hostname Default host for the ingress resource
   ##
   hostname: tomcat.local
 
-  ## Ingress annotations done as key:value pairs
+  ## @param ingress.annotations Ingress annotations
   ## For a full list of possible ingress annotations, please see
   ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   ##
@@ -374,14 +412,14 @@ ingress:
   ##
   annotations: {}
 
-  ## Enable TLS configuration for the hostname defined at ingress.hostname parameter
+  ## @param ingress.tls Enable TLS configuration for the hostname defined at `ingress.hostname` parameter
   ## TLS certificates will be retrieved from a TLS secret with name: {{- printf "%s-tls" .Values.ingress.hostname }}
   ## You can use the ingress.secrets parameter to create this TLS secret, relay on cert-manager to create it, or
   ## let the chart create self-signed certificates for you
   ##
   tls: false
 
-  ## The list of additional hostnames to be covered with this ingress record.
+  ## @param ingress.extraHosts The list of additional hostnames to be covered with this ingress record.
   ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
   ## Example:
   ## extraHosts:
@@ -390,7 +428,7 @@ ingress:
   ##
   extraHosts: []
 
-  ## The tls configuration for additional hostnames to be covered with this ingress record.
+  ## @param ingress.extraTls The tls configuration for additional hostnames to be covered with this ingress record.
   ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
   ## Example:
   ## extraTls:
@@ -400,7 +438,7 @@ ingress:
   ##
   extraTls: []
 
-  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## @param ingress.secrets If you're providing your own certificates, please use this to add the certificates as secrets
   ## key and certificate should start with -----BEGIN CERTIFICATE----- or -----BEGIN RSA PRIVATE KEY-----
   ## name should line up with a secretName set further up
   ##
@@ -417,15 +455,15 @@ ingress:
   ##
   secrets: []
 
-  ## Override API Version (automatically detected if not set)
+  ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
   apiVersion:
 
-  ## Ingress Path
+  ## @param ingress.path Ingress path
   ##
   path: /
 
-  ## Ingress Path type
+  ## @param ingress.pathType Ingress path type
   ##
   pathType: ImplementationSpecific
 
@@ -433,7 +471,15 @@ ingress:
 ## volumePermissions: Change the owner and group of the persistent volume mountpoint to runAsUser:fsGroup values from the securityContext section.
 ##
 volumePermissions:
+  ## @param volumePermissions.enabled Enable init container that changes volume permissions in the data directory
+  ##
   enabled: false
+  ## @param volumePermissions.image.registry Init container volume-permissions image registry
+  ## @param volumePermissions.image.repository Init container volume-permissions image repository
+  ## @param volumePermissions.image.tag Init container volume-permissions image tag
+  ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
+  ## @param volumePermissions.image.pullSecrets Specify docker-registry secret names as an array
+  ##
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
@@ -450,15 +496,21 @@ volumePermissions:
 
   ## Init container' resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ## We usually recommend not to specify default resources and to leave this as a conscious
+  ## choice for the user. This also increases chances charts run on environments with little
+  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ## @param volumePermissions.resources.limits Init container volume-permissions resource  limits
+  ## @param volumePermissions.resources.requests Init container volume-permissions resource  requests
   ##
   resources:
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    limits: {}
-    #   cpu: 100m
-    #   memory: 128Mi
-    requests: {}
-    #   cpu: 100m
-    #   memory: 128Mi
+    ## Example:
+    ## limits:
+    ##    cpu: 100m
+    ##    memory: 128Mi
+    limits: { }
+    ## Examples:
+    ## requests:
+    ##    cpu: 100m
+    ##    memory: 128Mi
+    requests: { }

--- a/bitnami/wavefront/Chart.yaml
+++ b/bitnami/wavefront/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-wavefront-proxy
   - https://github.com/wavefrontHQ/wavefront-collector-for-kubernetes
   - https://github.com/wavefrontHQ/wavefront-proxy
-version: 3.1.5
+version: 3.1.6

--- a/bitnami/wavefront/README.md
+++ b/bitnami/wavefront/README.md
@@ -56,159 +56,186 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Parameters
 
-The following table lists the configurable parameters of the Wavefront chart and their default values.
-
 ### Global parameters
 
-| Parameter                 | Description                                     | Default                                                 |
-|---------------------------|-------------------------------------------------|---------------------------------------------------------|
-| `global.imageRegistry`    | Global Docker image registry                    | `nil`                                                   |
-| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
-| `global.storageClass`     | Global storage class for dynamic provisioning   | `nil`                                                   |
+| Name                      | Description                                     | Value |
+| ------------------------- | ----------------------------------------------- | ----- |
+| `global.imageRegistry`    | Global Docker image registry                    | `nil` |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
+| `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `nil` |
+
 
 ### Common parameters
 
-| Parameter                  | Description                                                                 | Default                              |
-|----------------------------|-----------------------------------------------------------------------------|--------------------------------------|
-| `clusterName`              | Unique name for the Kubernetes cluster (required)                           | `KUBERNETES_CLUSTER_NAME`            |
-| `wavefront.url`            | Wavefront URL for your cluster (required)                                   | `https://YOUR_CLUSTER.wavefront.com` |
-| `wavefront.token`          | Wavefront API Token (required)                                              | `YOUR_API_TOKEN`                     |
-| `wavefront.existingSecret` | Name of an existing secret containing the token                             | `nil`                                |
-| `commonLabels`             | Labels to add to all deployed objects                                       | `{}`                                 |
-| `commonAnnotations`        | Annotations to add to all deployed objects                                  | `{}`                                 |
-| `extraDeploy`              | Array of extra objects to deploy with the release                           | `[]` (evaluated as a template)       |
-| `rbac.create`              | Create RBAC resources                                                       | `true`                               |
-| `serviceAccount.create`    | Create Wavefront service account                                            | `true`                               |
-| `serviceAccount.name`      | Name of Wavefront service account                                           | `nil`                                |
-| `podSecurityPolicy.create` | Create a PodSecurityPolicy resources                                        | `false`                              |
-| `projectPacific.enabled`   | Enable and create role binding for Tanzu kubernetes cluster                 | `false`                              |
-| `tkgi.enabled`             | Enable and create role binding for Tanzu Kubernetes Grid Integrated Edition | `false`                              |
+| Name                | Description                                             | Value |
+| ------------------- | ------------------------------------------------------- | ----- |
+| `commonLabels`      | Add labels to all the deployed resources                | `{}`  |
+| `commonAnnotations` | Add annotations to all the deployed resources           | `{}`  |
+| `extraDeploy`       | Extra objects to deploy (value evaluated as a template) | `[]`  |
+
+
+### Wavefront Common parameters
+
+| Name                       | Description                                                                                                                          | Value                                |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------ |
+| `clusterName`              | This is a unique name for the cluster (required)                                                                                     | `KUBERNETES_CLUSTER_NAME`            |
+| `wavefront.url`            | Wavefront URL for your cluster (required)                                                                                            | `https://YOUR_CLUSTER.wavefront.com` |
+| `wavefront.token`          | Wavefront API Token (required)                                                                                                       | `YOUR_API_TOKEN`                     |
+| `wavefront.existingSecret` | Name of an existing secret containing the token                                                                                      | `nil`                                |
+| `podSecurityPolicy.create` | Specifies whether PodSecurityPolicy resources should be created                                                                      | `false`                              |
+| `rbac.create`              | Specifies whether RBAC resources should be created                                                                                   | `true`                               |
+| `serviceAccount.create`    | Create Wavefront service account                                                                                                     | `true`                               |
+| `serviceAccount.name`      | Name of Wavefront service account                                                                                                    | `nil`                                |
+| `projectPacific.enabled`   | Enable and create role binding for Tanzu Kubernetes cluster                                                                          | `false`                              |
+| `tkgi.enabled`             | Properties for TKGI environments. If enabled, a role binding to handle pod security policy will be installed within the TKGI cluster | `false`                              |
+
 
 ### Collector parameters
 
-| Parameter                                  | Description                                                                                                             | Default                                   |
-|--------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|-------------------------------------------|
-| `collector.enabled`                        | Setup and enable the Wavefront collector to gather metrics                                                              | `true`                                    |
-| `collector.image.registry`                 | Wavefront collector Image registry                                                                                      | `docker.io`                               |
-| `collector.image.repository`               | Wavefront collector Image name                                                                                          | `bitnami/wavefront-kubernetes-collector`  |
-| `collector.image.tag`                      | Wavefront collector Image tag                                                                                           | `{TAG_NAME}`                              |
-| `collector.image.pullPolicy`               | Image pull policy                                                                                                       | `IfNotPresent`                            |
-| `collector.image.pullSecrets`              | Specify docker-registry secret names as an array                                                                        | `nil`                                     |
-| `collector.useDaemonset`                   | Use Wavefront collector in Daemonset mode                                                                               | `true`                                    |
-| `collector.usePKSPrefix`                   | (TKGi only) Prefix metrics with 'pks.kubernetes.'                                                                       | `false`                                   |
-| `collector.hostAliases`                    | Add deployment host aliases                                                                                             | `[]`                                      |
-| `collector.maxProx`                        | Max number of CPU cores that can be used (< 1 for default)                                                              | `0`                                       |
-| `collector.logLevel`                       | Min logging level (info, debug, trace)                                                                                  | `info`                                    |
-| `collector.interval`                       | Default metrics collection interval                                                                                     | `60s`                                     |
-| `collector.flushInterval`                  | How often to force a metrics flush                                                                                      | `10s`                                     |
-| `collector.sinkDelay`                      | Timeout for exporting data                                                                                              | `10s`                                     |
-| `collector.useReadOnlyPort`                | Use un-authenticated port for kubelet                                                                                   | `false`                                   |
-| `collector.useProxy`                       | Use a Wavefront Proxy to send metrics through                                                                           | `true`                                    |
-| `collector.proxyAddress`                   | Non-default Wavefront Proxy address to use, should only be set when `proxy.enabled` is false                            | `nil`                                     |
-| `collector.apiServerMetrics`               | Collect metrics about Kubernetes API server                                                                             | `false`                                   |
-| `collector.kubernetesState`                | Collect metrics about Kubernetes resource states                                                                        | `true`                                    |
-| `collector.filters`                        | Filters to apply towards all collected metrics                                                                          | See values.yaml                           |
-| `collector.tags`                           | Map of tags (key/value) to add to all metrics collected                                                                 | `nil`                                     |
-| `collector.events.enabled`                 | Events can also be collected and sent to Wavefront                                                                      | `false`                                   |
-| `collector.discovery.enabled`              | Rules based and Prometheus endpoints auto-discovery                                                                     | `true`                                    |
-| `collector.discovery.annotationPrefix`     | Replaces `prometheus.io` as prefix for annotations of auto-discovered Prometheus endpoints                              | `prometheus.io`                           |
-| `collector.discovery.enableRuntimeConfigs` | Enable runtime discovery rules                                                                                          | `true`                                    |
-| `collector.discovery.config`               | Configuration for rules based auto-discovery                                                                            | `nil`                                     |
-| `collector.existingConfigmap`              | Name of existing ConfigMap with collector configuration                                                                 | `nil`                                     |
-| `collector.command`                        | Override default container command (useful when using custom images)                                                    | `nil`                                     |
-| `collector.args`                           | Override default container args (useful when using custom images)                                                       | `nil`                                     |
-| `collector.resources.limits`               | The resources limits for the collector container                                                                        | `{}`                                      |
-| `collector.resources.requests`             | The requested resources for the collector container                                                                     | `{}`                                      |
-| `collector.containerSecurityContext`       | Container security podSecurityContext                                                                                   | `{ runAsUser: 1001, runAsNonRoot: true }` |
-| `collector.podSecurityContext`             | Pod security                                                                                                            | `{ fsGroup: 1001 }`                       |
-| `collector.podAffinityPreset`              | Wavefront collector pod affinity preset. Ignored if `collector.affinity` is set. Allowed values: `soft` or `hard`       | `""`                                      |
-| `collector.podAntiAffinityPreset`          | Wavefront collector pod anti-affinity preset. Ignored if `collector.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                    |
-| `collector.nodeAffinityPreset.type`        | Wavefront collector node affinity preset type. Ignored if `collector.affinity` is set. Allowed values: `soft` or `hard` | `""`                                      |
-| `collector.nodeAffinityPreset.key`         | Wavefront collector node label key to match Ignored if `collector.affinity` is set.                                     | `""`                                      |
-| `collector.nodeAffinityPreset.values`      | Wavefront collector node label values to match. Ignored if `collector.affinity` is set.                                 | `[]`                                      |
-| `collector.affinity`                       | Wavefront collector affinity for pod assignment                                                                         | `{}` (evaluated as a template)            |
-| `collector.nodeSelector`                   | Wavefront collector node labels for pod assignment                                                                      | `{}` (evaluated as a template)            |
-| `collector.tolerations`                    | Wavefront collector tolerations for pod assignment                                                                      | `[]` (evaluated as a template)            |
-| `collector.podLabels`                      | Add additional labels to the pod (evaluated as a template)                                                              | `nil`                                     |
-| `collector.podAnnotations`                 | Annotations for Wavefront collector pods                                                                                | `{}`                                      |
-| `collector.priorityClassName`              | Collector priorityClassName                                                                                             | `nil`                                     |
-| `collector.lifecycleHooks`                 | LifecycleHooks to set additional configuration at startup.                                                              | `{}` (evaluated as a template)            |
-| `collector.customLivenessProbe`            | Override default liveness probe                                                                                         | `nil`                                     |
-| `collector.customReadinessProbe`           | Override default readiness probe                                                                                        | `nil`                                     |
-| `collector.updateStrategy`                 | Deployment update strategy                                                                                              | `nil`                                     |
-| `collector.extraEnvVars`                   | Extra environment variables to be set on collector container                                                            | `{}`                                      |
-| `collector.extraEnvVarsCM`                 | Name of existing ConfigMap containing extra env vars                                                                    | `nil`                                     |
-| `collector.extraEnvVarsSecret`             | Name of existing Secret containing extra env vars                                                                       | `nil`                                     |
-| `collector.extraVolumeMounts`              | Optionally specify extra list of additional volumeMounts for collector container                                        | `[]`                                      |
-| `collector.extraVolumes`                   | Optionally specify extra list of additional volumes for collector container                                             | `[]`                                      |
-| `collector.initContainers`                 | Add additional init containers to the collector pods                                                                    | `{}` (evaluated as a template)            |
-| `collector.sidecars`                       | Add additional sidecar containers to the collector pods                                                                 | `{}` (evaluated as a template)            |
+| Name                                              | Description                                                                                                             | Value                                    |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| `collector.enabled`                               | Setup and enable the Wavefront collector to gather metrics                                                              | `true`                                   |
+| `collector.image.registry`                        | Wavefront collector Image registry                                                                                      | `docker.io`                              |
+| `collector.image.repository`                      | Wavefront collector Image repository                                                                                    | `bitnami/wavefront-kubernetes-collector` |
+| `collector.image.tag`                             | Wavefront collector Image tag (immutable tags are recommended)                                                          | `1.5.0-scratch-r0`                       |
+| `collector.image.pullPolicy`                      | Image pull policy                                                                                                       | `IfNotPresent`                           |
+| `collector.image.pullSecrets`                     | Specify docker-registry secret names as an array                                                                        | `[]`                                     |
+| `collector.hostAliases`                           | Deployment pod host aliases                                                                                             | `[]`                                     |
+| `collector.useDaemonset`                          | Use Wavefront collector in Daemonset mode                                                                               | `true`                                   |
+| `collector.usePKSPrefix`                          | If installing into a TKGi/PKS environment, set this to true. Prefixes metrics with 'pks.kubernetes.'                    | `nil`                                    |
+| `collector.maxProcs`                              | Maximum number of CPUs that can be used simultaneously                                                                  | `nil`                                    |
+| `collector.logLevel`                              | Log level. Allowed values: `info`, `debug` or `trace`                                                                   | `nil`                                    |
+| `collector.interval`                              | Default metrics collection interval                                                                                     | `nil`                                    |
+| `collector.flushInterval`                         | How often to force a metrics flush                                                                                      | `nil`                                    |
+| `collector.sinkDelay`                             | Timeout for exporting data                                                                                              | `nil`                                    |
+| `collector.useReadOnlyPort`                       | Use un-authenticated port for kubelet                                                                                   | `nil`                                    |
+| `collector.useProxy`                              | Use a Wavefront Proxy to send metrics through                                                                           | `true`                                   |
+| `collector.proxyAddress`                          | Can be used to specify a specific address for the Wavefront Proxy                                                       | `nil`                                    |
+| `collector.kubernetesState`                       | Collect metrics about Kubernetes resource states                                                                        | `true`                                   |
+| `collector.apiServerMetrics`                      | Collect metrics about Kubernetes API server                                                                             | `nil`                                    |
+| `collector.tags`                                  | Map of tags to apply to all metrics collected by the collector                                                          | `{}`                                     |
+| `collector.hostOSMetrics`                         | If set to true, host OS metrics will be collected                                                                       | `false`                                  |
+| `collector.filters.metricDenyList`                | Optimized metrics collection to omit peripheral metrics.                                                                | `[]`                                     |
+| `collector.filters.tagExclude`                    | Filter out generated labels                                                                                             | `[]`                                     |
+| `collector.events.enabled`                        | Events can also be collected and sent to Wavefront                                                                      | `false`                                  |
+| `collector.discovery.enabled`                     | Rules based and Prometheus endpoints auto-discovery                                                                     | `true`                                   |
+| `collector.discovery.annotationPrefix`            | When specified, this replaces `prometheus.io` as the prefix for annotations used to auto-discover Prometheus endpoints  | `""`                                     |
+| `collector.discovery.enableRuntimeConfigs`        | Whether to enable runtime discovery configurations                                                                      | `true`                                   |
+| `collector.discovery.config`                      | Configuration for rules based auto-discovery                                                                            | `[]`                                     |
+| `collector.existingConfigmap`                     | Name of existing ConfigMap with collector configuration                                                                 | `nil`                                    |
+| `collector.command`                               | Override default container command (useful when using custom images)                                                    | `[]`                                     |
+| `collector.args`                                  | Override default container args (useful when using custom images)                                                       | `[]`                                     |
+| `collector.resources.limits`                      | The resources limits for the collector container                                                                        | `{}`                                     |
+| `collector.resources.requests`                    | The requested resources for the collector container                                                                     | `{}`                                     |
+| `collector.containerSecurityContext.enabled`      | Enable Container Security Context configuration                                                                         | `true`                                   |
+| `collector.containerSecurityContext.runAsUser`    | Set Container's Security Context runAsUser                                                                              | `1001`                                   |
+| `collector.containerSecurityContext.runAsNonRoot` | Set Container's Security Context runAsNonRoot                                                                           | `true`                                   |
+| `collector.podSecurityContext.enabled`            | Enable Pod Security Context configuration                                                                               | `true`                                   |
+| `collector.podSecurityContext.fsGroup`            | Group ID for the volumes of the pod                                                                                     | `1001`                                   |
+| `collector.podAffinityPreset`                     | Wavefront collector pod affinity preset. Ignored if `collector.affinity` is set. Allowed values: `soft` or `hard`       | `""`                                     |
+| `collector.podAntiAffinityPreset`                 | Wavefront collector pod anti-affinity preset. Ignored if `collector.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                   |
+| `collector.nodeAffinityPreset.type`               | Wavefront collector node affinity preset type. Ignored if `collector.affinity` is set. Allowed values: `soft` or `hard` | `""`                                     |
+| `collector.nodeAffinityPreset.key`                | Wavefront collector node label key to match Ignored if `collector.affinity` is set.                                     | `""`                                     |
+| `collector.nodeAffinityPreset.values`             | Wavefront collector node label values to match. Ignored if `collector.affinity` is set.                                 | `[]`                                     |
+| `collector.affinity`                              | Wavefront collector affinity for pod assignment                                                                         | `{}`                                     |
+| `collector.nodeSelector`                          | Wavefront collector node labels for pod assignment                                                                      | `{}`                                     |
+| `collector.tolerations`                           | Wavefront collector tolerations for pod assignment                                                                      | `[]`                                     |
+| `collector.podLabels`                             | Wavefront collector pod extra labels                                                                                    | `{}`                                     |
+| `collector.podAnnotations`                        | Annotations for Wavefront collector pods                                                                                | `{}`                                     |
+| `collector.priorityClassName`                     | Wavefront Collector pods' priority                                                                                      | `""`                                     |
+| `collector.lifecycleHooks`                        | Lifecycle hooks for the Wavefront Collector container to automate configuration before or after startup                 | `{}`                                     |
+| `collector.customLivenessProbe`                   | Override default liveness probe                                                                                         | `{}`                                     |
+| `collector.customReadinessProbe`                  | Override default readiness probe                                                                                        | `{}`                                     |
+| `collector.updateStrategy.type`                   | Update strategy - only really applicable for deployments with RWO PVs attached                                          | `RollingUpdate`                          |
+| `collector.extraEnvVars`                          | Extra environment variables to be set on collector container                                                            | `[]`                                     |
+| `collector.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra environment variables                                                       | `nil`                                    |
+| `collector.extraEnvVarsSecret`                    | Name of existing Secret containing extra environment variables                                                          | `nil`                                    |
+| `collector.extraVolumes`                          | Optionally specify extra list of additional volumes for collector container                                             | `[]`                                     |
+| `collector.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for collector container                                        | `[]`                                     |
+| `collector.initContainers`                        | Add init containers to the Wavefront proxy pods                                                                         | `{}`                                     |
+| `collector.sidecars`                              | Add sidecars to the Wavefront proxy pods                                                                                | `{}`                                     |
+
 
 ### Proxy parameters
 
-| Parameter                           | Description                                                                                                            | Default                                   |
-|-------------------------------------|------------------------------------------------------------------------------------------------------------------------|-------------------------------------------|
-| `proxy.enabled`                     | Setup and enable Wavefront proxy to send metrics through                                                               | `true`                                    |
-| `proxy.image.registry`              | Wavefront proxy Image registry                                                                                         | `docker.io`                               |
-| `proxy.image.repository`            | Wavefront proxy Image name                                                                                             | `bitnami/wavefront-proxy`                 |
-| `proxy.image.tag`                   | Wavefront proxy Image tag                                                                                              | `{TAG_NAME}`                              |
-| `proxy.image.pullPolicy`            | Image pull policy                                                                                                      | `IfNotPresent`                            |
-| `proxy.image.pullSecrets`           | Specify docker-registry secret names as an array                                                                       | `nil`                                     |
-| `proxy.replicas`                    | Replicas to deploy for Wavefront proxy (usually 1)                                                                     | `1`                                       |
-| `proxy.resources.limits`            | The resources limits for the proxy container                                                                           | `{}`                                      |
-| `proxy.resources.requests`          | The requested resources for the proxy container                                                                        | `{}`                                      |
-| `proxy.containerSecurityContext`    | Container security podSecurityContext                                                                                  | `{ runAsUser: 1001, runAsNonRoot: true }` |
-| `proxy.podSecurityContext`          | Pod security                                                                                                           | `{ fsGroup: 1001 }`                       |
-| `proxy.podAffinityPreset`           | Wavefront proxy pod affinity preset. Ignored if `proxy.affinity` is set. Allowed values: `soft` or `hard`              | `""`                                      |
-| `proxy.podAntiAffinityPreset`       | Wavefront proxy pod anti-affinity preset. Ignored if `proxy.affinity` is set. Allowed values: `soft` or `hard`         | `soft`                                    |
-| `proxy.nodeAffinityPreset.type`     | Wavefront proxy node affinity preset type. Ignored if `proxy.affinity` is set. Allowed values: `soft` or `hard`        | `""`                                      |
-| `proxy.nodeAffinityPreset.key`      | Wavefront proxy node label key to match Ignored if `proxy.affinity` is set.                                            | `""`                                      |
-| `proxy.nodeAffinityPreset.values`   | Wavefront proxy node label values to match. Ignored if `proxy.affinity` is set.                                        | `[]`                                      |
-| `proxy.affinity`                    | Wavefront proxy affinity for pod assignment                                                                            | `{}` (evaluated as a template)            |
-| `proxy.nodeSelector`                | Wavefront proxy node labels for pod assignment                                                                         | `{}` (evaluated as a template)            |
-| `proxy.tolerations`                 | Wavefront proxy tolerations for pod assignment                                                                         | `[]` (evaluated as a template)            |
-| `proxy.hostAliases`                 | Add deployment host aliases                                                                                            | `[]`                                      |
-| `proxy.podLabels`                   | Add additional labels to the pod (evaluated as a template)                                                             | `nil`                                     |
-| `proxy.podAnnotations`              | Annotations for Wavefront proxy pods                                                                                   | `{}`                                      |
-| `proxy.priorityClassName`           | Proxy priorityClassName                                                                                                | `nil`                                     |
-| `proxy.lifecycleHooks`              | LifecycleHooks to set additional configuration at startup.                                                             | `{}` (evaluated as a template)            |
-| `proxy.livenessProbe`               | Liveness probe configuration for Wavefront proxy                                                                       | Check `values.yaml` file                  |
-| `proxy.readinessProbe`              | Readiness probe configuration for Wavefront proxy                                                                      | Check `values.yaml` file                  |
-| `proxy.customLivenessProbe`         | Override default liveness probe                                                                                        | `nil`                                     |
-| `proxy.customReadinessProbe`        | Override default readiness probe                                                                                       | `nil`                                     |
-| `proxy.updateStrategy`              | Deployment update strategy                                                                                             | `nil`                                     |
-| `proxy.extraEnvVars`                | Extra environment variables to be set on proxy container                                                               | `{}`                                      |
-| `proxy.extraEnvVarsCM`              | Name of existing ConfigMap containing extra env vars                                                                   | `nil`                                     |
-| `proxy.extraEnvVarsSecret`          | Name of existing Secret containing extra env vars                                                                      | `nil`                                     |
-| `proxy.extraVolumeMounts`           | Optionally specify extra list of additional volumeMounts for proxy container                                           | `[]`                                      |
-| `proxy.extraVolumes`                | Optionally specify extra list of additional volumes for proxy container                                                | `[]`                                      |
-| `proxy.initContainers`              | Add additional init containers to the proxy pods                                                                       | `{}` (evaluated as a template)            |
-| `proxy.sidecars`                    | Add additional sidecar containers to the proxy pods                                                                    | `{}` (evaluated as a template)            |
-| `proxy.port`                        | Primary port for Wavefront data format metrics                                                                         | `2878`                                    |
-| `proxy.tracePort`                   | Port for distributed tracing data (usually 30000)                                                                      | `nil`                                     |
-| `proxy.jaegerPort`                  | Port for Jaeger format distributed tracing data (usually 30001)                                                        | `nil`                                     |
-| `proxy.traceJaegerHttpListenerPort` | Port for Jaeger Thrift format data (usually 30080)                                                                     | `nil`                                     |
-| `proxy.traceJaegerGrpcListenerPort` | Port for Jaeger GRPC format data (usually 14250)                                                                       | `nil`                                     |
-| `proxy.zipkinPort`                  | Port for Zipkin format distributed tracing data (usually 9411)                                                         | `nil`                                     |
-| `proxy.traceSamplingRate`           | Distributed tracing data sampling rate (0 to 1)                                                                        | `nil`                                     |
-| `proxy.traceSamplingDuration`       | When set to greater than 0, spans that exceed this duration will force trace to be sampled (ms)                        | `nil`                                     |
-| `proxy.traceJaegerApplicationName`  | Custom application name for traces received on Jaeger's traceJaegerListenerPorts or traceJaegerHttpListenerPorts.      | `nil`                                     |
-| `proxy.traceZipkinApplicationName`  | Custom application name for traces received on Zipkin's traceZipkinListenerPorts.                                      | `nil`                                     |
-| `proxy.histogramPort`               | Port for histogram distribution format data (usually 40000)                                                            | `nil`                                     |
-| `proxy.histogramMinutePort`         | Port to accumulate 1-minute based histograms on Wavefront data format (usually 40001)                                  | `nil`                                     |
-| `proxy.histogramHourPort`           | Port to accumulate 1-hour based histograms on Wavefront data format (usually 40002)                                    | `nil`                                     |
-| `proxy.histogramDayPort`            | Port to accumulate 1-day based histograms on Wavefront data format (usually 40003)                                     | `nil`                                     |
-| `proxy.deltaCounterPort`            | Port to accumulate 1-minute delta counters on Wavefront data format (usually 50000)                                    | `nil`                                     |
-| `proxy.args`                        | Additional Wavefront proxy properties to be passed as command line arguments in the `--<property_name> <value>` format | `nil`                                     |
-| `proxy.heap`                        | Wavefront proxy Java heap maximum usage (java -Xmx command line option)                                                | `nil`                                     |
-| `proxy.existingConfigmap`           | Name of existing ConfigMap with Proxy preprocessor configuration                                                       | `nil`                                     |
-| `proxy.preprocessor.rules.yaml`     | YAML configuration for Wavefront proxy preprocessor rules                                                              | `nil`                                     |
+| Name                                          | Description                                                                                                                             | Value                     |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| `proxy.enabled`                               | Setup and enable Wavefront proxy to send metrics through                                                                                | `true`                    |
+| `proxy.image.registry`                        | Wavefront proxy image registry                                                                                                          | `docker.io`               |
+| `proxy.image.repository`                      | Wavefront proxy image repository                                                                                                        | `bitnami/wavefront-proxy` |
+| `proxy.image.tag`                             | Wavefront proxy image tag (immutable tags are recommended)                                                                              | `9.7.0-debian-10-r73`     |
+| `proxy.image.pullPolicy`                      | Wavefront proxy image pull policy                                                                                                       | `IfNotPresent`            |
+| `proxy.image.pullSecrets`                     | Specify docker-registry secret names as an array                                                                                        | `[]`                      |
+| `proxy.hostAliases`                           | Deployment pod host aliases                                                                                                             | `[]`                      |
+| `proxy.resources.limits`                      | The resources limits for the proxy container                                                                                            | `{}`                      |
+| `proxy.resources.requests`                    | The requested resources for the proxy container                                                                                         | `{}`                      |
+| `proxy.containerSecurityContext.enabled`      | Enable Container Security Context configuration                                                                                         | `true`                    |
+| `proxy.containerSecurityContext.runAsUser`    | Set Container's Security Context runAsUser                                                                                              | `1001`                    |
+| `proxy.containerSecurityContext.runAsNonRoot` | Set Container's Security Context runAsNonRoot                                                                                           | `true`                    |
+| `proxy.podSecurityContext.enabled`            | Enable Pod Security Context configuration                                                                                               | `true`                    |
+| `proxy.podSecurityContext.fsGroup`            | Group ID for the volumes of the pod                                                                                                     | `1001`                    |
+| `proxy.podAffinityPreset`                     | Wavefront proxy pod affinity preset. Ignored if `proxy.affinity` is set. Allowed values: `soft` or `hard`                               | `""`                      |
+| `proxy.podAntiAffinityPreset`                 | Wavefront proxy pod anti-affinity preset. Ignored if `proxy.affinity` is set. Allowed values: `soft` or `hard`                          | `soft`                    |
+| `proxy.nodeAffinityPreset.type`               | Wavefront proxy node affinity preset type. Ignored if `proxy.affinity` is set. Allowed values: `soft` or `hard`                         | `""`                      |
+| `proxy.nodeAffinityPreset.key`                | Wavefront proxy node label key to match Ignored if `proxy.affinity` is set.                                                             | `""`                      |
+| `proxy.nodeAffinityPreset.values`             | Wavefront proxy node label values to match. Ignored if `proxy.affinity` is set.                                                         | `[]`                      |
+| `proxy.affinity`                              | Wavefront proxy affinity for pod assignment                                                                                             | `{}`                      |
+| `proxy.nodeSelector`                          | Wavefront proxy node labels for pod assignment                                                                                          | `{}`                      |
+| `proxy.tolerations`                           | Wavefront proxy tolerations for pod assignment                                                                                          | `[]`                      |
+| `proxy.podLabels`                             | Wavefront proxy pod extra labels                                                                                                        | `{}`                      |
+| `proxy.podAnnotations`                        | Annotations for Wavefront proxy pods                                                                                                    | `{}`                      |
+| `proxy.priorityClassName`                     | Wavefront proxy pods' priority class name                                                                                               | `""`                      |
+| `proxy.lifecycleHooks`                        | Lifecycle hooks for the Wavefront proxy container to automate configuration before or after startup                                     | `{}`                      |
+| `proxy.livenessProbe.enabled`                 | Enable livenessProbe                                                                                                                    | `true`                    |
+| `proxy.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                                                 | `10`                      |
+| `proxy.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                                        | `20`                      |
+| `proxy.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                                                       | `1`                       |
+| `proxy.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                                                     | `6`                       |
+| `proxy.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                                                     | `1`                       |
+| `proxy.readinessProbe.enabled`                | Enable readinessProbe                                                                                                                   | `true`                    |
+| `proxy.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                                                | `10`                      |
+| `proxy.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                                                       | `20`                      |
+| `proxy.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                                                      | `1`                       |
+| `proxy.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                                                    | `6`                       |
+| `proxy.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                                                    | `1`                       |
+| `proxy.customLivenessProbe`                   | Override default liveness probe                                                                                                         | `{}`                      |
+| `proxy.customReadinessProbe`                  | Override default readiness probe                                                                                                        | `{}`                      |
+| `proxy.updateStrategy.type`                   | Update strategy - only really applicable for deployments with RWO PVs attached                                                          | `RollingUpdate`           |
+| `proxy.extraEnvVars`                          | Extra environment variables to be set on proxy container                                                                                | `[]`                      |
+| `proxy.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra environment variables                                                                       | `nil`                     |
+| `proxy.extraEnvVarsSecret`                    | Name of existing Secret containing extra environment variables                                                                          | `nil`                     |
+| `proxy.extraVolumes`                          | Optionally specify extra list of additional volumes for proxy container                                                                 | `[]`                      |
+| `proxy.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for proxy container                                                            | `[]`                      |
+| `proxy.initContainers`                        | Add init containers to the Wavefront proxy pods                                                                                         | `{}`                      |
+| `proxy.sidecars`                              | Add sidecars to the Wavefront proxy pods                                                                                                | `{}`                      |
+| `proxy.replicas`                              | Replicas to deploy for Wavefront proxy (usually 1)                                                                                      | `1`                       |
+| `proxy.port`                                  | The port number the proxy will listen on for metrics in Wavefront data format                                                           | `2878`                    |
+| `proxy.tracePort`                             | The port number the proxy will listen on for tracing spans in Wavefront trace data format (usually 30000)                               | `nil`                     |
+| `proxy.jaegerPort`                            | The port number the proxy will listen on for tracing spans in Jaeger data format (usually 30001)                                        | `nil`                     |
+| `proxy.traceJaegerHttpListenerPort`           | TCP ports to receive Jaeger Thrift formatted data via HTTP. The data is then sent to Wavefront in Wavefront span format (usually 30080) | `nil`                     |
+| `proxy.traceJaegerGrpcListenerPort`           | TCP ports to receive Jaeger GRPC formatted data via HTTP (usually 14250)                                                                | `nil`                     |
+| `proxy.zipkinPort`                            | The port number the proxy will listen on for tracing spans in Zipkin data format (usually 9411)                                         | `nil`                     |
+| `proxy.traceSamplingRate`                     | Sampling rate to apply to tracing spans sent to the proxy                                                                               | `nil`                     |
+| `proxy.traceSamplingDuration`                 | When set to greater than 0, spans that exceed this duration will force trace to be sampled (ms)                                         | `nil`                     |
+| `proxy.traceJaegerApplicationName`            | Custom application name for traces received on Jaeger's traceJaegerListenerPorts or traceJaegerHttpListenerPorts.                       | `nil`                     |
+| `proxy.traceZipkinApplicationName`            | Custom application name for traces received on Zipkin's traceZipkinListenerPorts.                                                       | `nil`                     |
+| `proxy.histogramPort`                         | Port for histogram distribution format data (usually 40000)                                                                             | `nil`                     |
+| `proxy.histogramMinutePort`                   | Port to accumulate 1-minute based histograms on Wavefront data format (usually 40001)                                                   | `nil`                     |
+| `proxy.histogramHourPort`                     | Port to accumulate 1-hour based histograms on Wavefront data format (usually 40002)                                                     | `nil`                     |
+| `proxy.histogramDayPort`                      | Port to accumulate 1-day based histograms on Wavefront data format (usually 40003)                                                      | `nil`                     |
+| `proxy.deltaCounterPort`                      | Port to accumulate 1-minute delta counters on Wavefront data format (usually 50000)                                                     | `nil`                     |
+| `proxy.args`                                  | Any configuration property can be passed to the proxy via command line args in the format: `--<property_name> <value>`                  | `nil`                     |
+| `proxy.heap`                                  | Wavefront proxy Java heap maximum usage (java -Xmx command line option)                                                                 | `nil`                     |
+| `proxy.existingConfigmap`                     | Name of existing ConfigMap with Proxy preprocessor configuration                                                                        | `nil`                     |
+| `proxy.preprocessor`                          | Preprocessor rules is a powerful way to apply filtering or to enhance metrics as they flow                                              | `{}`                      |
+
 
 ### Kube State Metrics parameters
 
-| Parameter                    | Description                                        | Default |
-|------------------------------|----------------------------------------------------|---------|
-| `kube-state-metrics.enabled` | Setup and enable Kube State Metrics for collection | `false` |
+| Name                         | Description                                                                                                                      | Value   |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `kube-state-metrics.enabled` | If enabled the kube-state-metrics chart will be installed as a subchart and the collector will be configured to capture metrics. | `false` |
+
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/wavefront/values.yaml
+++ b/bitnami/wavefront/values.yaml
@@ -16,11 +16,24 @@ global:
   imagePullSecrets: []
   storageClass:
 
+## @section Common parameters
+
+## @param commonLabels Add labels to all the deployed resources
+##
+commonLabels: {}
+## @param commonAnnotations Add annotations to all the deployed resources
+##
+commonAnnotations: {}
+## @param extraDeploy Extra objects to deploy (value evaluated as a template)
+##
+extraDeploy: []
+
+## @section Wavefront Common parameters
+
 ## @param clusterName This is a unique name for the cluster (required)
 ## All metrics will receive a `cluster` tag with this value
 ##
 clusterName: KUBERNETES_CLUSTER_NAME
-
 ## @param wavefront.url Wavefront URL for your cluster (required)
 ## @param wavefront.token Wavefront API Token (required)
 ## @param wavefront.existingSecret Name of an existing secret containing the token
@@ -29,18 +42,33 @@ wavefront:
   url: https://YOUR_CLUSTER.wavefront.com
   token: YOUR_API_TOKEN
   existingSecret:
-
-## @param commonLabels Add labels to all the deployed resources
+## @param podSecurityPolicy.create Specifies whether PodSecurityPolicy resources should be created
 ##
-commonLabels: {}
-
-## @param commonAnnotations Add annotations to all the deployed resources
+podSecurityPolicy:
+  create: false
+## @param rbac.create Specifies whether RBAC resources should be created
 ##
-commonAnnotations: {}
-
-## @param extraDeploy Extra objects to deploy (value evaluated as a template)
+rbac:
+  create: true
+serviceAccount:
+  ## @param serviceAccount.create Create Wavefront service account
+  ##
+  create: true
+  ## @param serviceAccount.name Name of Wavefront service account
+  ## If not set and create is true, a name is generated using the fullname template
+  ##
+  name:
+## @param projectPacific.enabled Enable and create role binding for Tanzu Kubernetes cluster
+## If enabled, a role binding to handle pod security policy will be installed within the Kubernetes cluster
 ##
-extraDeploy: []
+projectPacific:
+  enabled: false
+## @param tkgi.enabled Properties for TKGI environments. If enabled, a role binding to handle pod security policy will be installed within the TKGI cluster
+##
+tkgi:
+  enabled: false
+
+## @section Collector parameters
 
 ## Wavefront Collector is responsible to get all Kubernetes metrics from your cluster.
 ## It will capture Kubernetes resources metrics available from the kubelets,
@@ -73,64 +101,53 @@ collector:
     ##   - myRegistryKeySecretName
     ##
     pullSecrets: []
-
   ## @param collector.hostAliases Deployment pod host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
   hostAliases: []
-
   ## @param collector.useDaemonset Use Wavefront collector in Daemonset mode
   ## If set to false, Deployment will be used for the collector.
   ## Setting this to true is strongly recommended
   ##
   useDaemonset: true
-
   ## @param collector.usePKSPrefix If installing into a TKGi/PKS environment, set this to true. Prefixes metrics with 'pks.kubernetes.'
   ## e.g:
   ## usePKSPrefix: false
   ##
   usePKSPrefix:
-
   ## @param collector.maxProcs Maximum number of CPUs that can be used simultaneously
   ## e.g:
   ## maxProcs: 0
   ##
   maxProcs:
-
   ## @param collector.logLevel Log level. Allowed values: `info`, `debug` or `trace`
   ##
   logLevel:
-
   ## @param collector.interval Default metrics collection interval
   ## e.g:
   ## interval: 60s
   ##
   interval:
-
   ## @param collector.flushInterval How often to force a metrics flush
   ## e.g:
   ## flushInterval: 10s
   ##
   flushInterval:
-
   ## @param collector.sinkDelay Timeout for exporting data
   ## e.g:
   ## sinkDelay: 20s
   ##
   sinkDelay:
-
   ## @param collector.useReadOnlyPort Use un-authenticated port for kubelet
   ## If set to true, will use the unauthenticated real only port for the kubelet
   ## If set to false, will use the encrypted full access port for the kubelet (default false)
   ##
   useReadOnlyPort:
-
   ## @param collector.useProxy Use a Wavefront Proxy to send metrics through
   ## When true you must either specify a value for `collector.proxyAddress` or set `proxy.enabled` to true
   ## If set to false, metrics will be sent to Wavefront via the Direct Ingestion API
   ##
   useProxy: true
-
   ## @param collector.proxyAddress Can be used to specify a specific address for the Wavefront Proxy
   ## The proxy can be anywhere network reachable including outside of the cluster
   ## Required if `collector.useProxy` is true and `proxy.enabled` is false
@@ -138,16 +155,13 @@ collector:
   ## proxyAddress: wavefront-proxy:2878
   ##
   proxyAddress:
-
   ## @param collector.kubernetesState Collect metrics about Kubernetes resource states
   ## These metrics are more efficient than kube-state-metrics
   ##
   kubernetesState: true
-
   ## @param collector.apiServerMetrics Collect metrics about Kubernetes API server
   ##
   apiServerMetrics:
-
   ## @param collector.tags Map of tags to apply to all metrics collected by the collector
   ## Sample tags to include (env, region)
   ## tags:
@@ -155,11 +169,9 @@ collector:
   ##   region: us-west-2
   ##
   tags: {}
-
   ## @param collector.hostOSMetrics If set to true, host OS metrics will be collected
   ##
   hostOSMetrics: false
-
   ## Filters to apply towards all metrics collected by the collector
   ## @param collector.filters.metricDenyList [array] Optimized metrics collection to omit peripheral metrics.
   ## @param collector.filters.tagExclude [array] Filter out generated labels
@@ -196,7 +208,6 @@ collector:
       - 'label?controller?revision*'
       - 'label?pod?template*'
       - 'annotation_kubectl_kubernetes_io_last_applied_configuration'
-
   ## Events can also be collected and sent to Wavefront.
   ## Requires Wavefront Proxy 6.0 or greater.
   ## Events should be filtered before being enabled, see event filtering documentation for details
@@ -206,7 +217,6 @@ collector:
     ## @param collector.events.enabled Events can also be collected and sent to Wavefront
     ##
     enabled: false
-
   ## Rules based discovery configuration
   ## Ref: https://github.com/wavefrontHQ/wavefront-kubernetes-collector/blob/master/docs/discovery.md
   ##
@@ -214,18 +224,15 @@ collector:
     ## @param collector.discovery.enabled Rules based and Prometheus endpoints auto-discovery
     ##
     enabled: true
-
     ## @param collector.discovery.annotationPrefix When specified, this replaces `prometheus.io` as the prefix for annotations used to auto-discover Prometheus endpoints
     ## e.g:
     ##  annotationPrefix: "wavefront.com"
     ##
     annotationPrefix: ""
-
     ## @param collector.discovery.enableRuntimeConfigs Whether to enable runtime discovery configurations
     ## Ref: https://github.com/wavefrontHQ/wavefront-collector-for-kubernetes/blob/master/docs/discovery.md#runtime-configurations
     ##
     enableRuntimeConfigs: true
-
     ## @param collector.discovery.config Configuration for rules based auto-discovery
     ## e.g:
     ##   config:
@@ -269,18 +276,15 @@ collector:
     ##       password = "PASSWORD"
     ##
     config: []
-
   ## @param collector.existingConfigmap Name of existing ConfigMap with collector configuration
   ##
   existingConfigmap:
-
   ## @param collector.command Override default container command (useful when using custom images)
   ##
   command: []
   ## @param collector.args Override default container args (useful when using custom images)
   ##
   args: []
-
   ## Wavefront Collector resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ## We usually recommend not to specify default resources and to leave this as a conscious
@@ -301,7 +305,6 @@ collector:
     ##    cpu: 200m
     ##    memory: 10Mi
     requests: { }
-
   ## Container Security Context configuration
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ## @param collector.containerSecurityContext.enabled Enable Container Security Context configuration
@@ -312,7 +315,6 @@ collector:
     enabled: true
     runAsUser: 1001
     runAsNonRoot: true
-
   ## Pod Security Context configuration
   ## @param collector.podSecurityContext.enabled Enable Pod Security Context configuration
   ## @param collector.podSecurityContext.fsGroup Group ID for the volumes of the pod
@@ -320,17 +322,14 @@ collector:
   podSecurityContext:
     enabled: true
     fsGroup: 1001
-
   ## @param collector.podAffinityPreset Wavefront collector pod affinity preset. Ignored if `collector.affinity` is set. Allowed values: `soft` or `hard`
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
   ##
   podAffinityPreset: ""
-
   ## @param collector.podAntiAffinityPreset Wavefront collector pod anti-affinity preset. Ignored if `collector.affinity` is set. Allowed values: `soft` or `hard`
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
   ##
   podAntiAffinityPreset: soft
-
   ## Wavefront Collector Node affinity preset
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
   ##
@@ -350,50 +349,40 @@ collector:
     ##   - e2e-az2
     ##
     values: []
-
   ## @param collector.affinity Wavefront collector affinity for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ## Note: collector.podAffinityPreset, collector.podAntiAffinityPreset, and collector.nodeAffinityPreset will be ignored when it's set
   ##
   affinity: {}
-
   ## @param collector.nodeSelector Wavefront collector node labels for pod assignment
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
   nodeSelector: {}
-
   ## @param collector.tolerations Wavefront collector tolerations for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
   tolerations: []
-
   ## @param collector.podLabels Wavefront collector pod extra labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   ##
   podLabels: {}
-
   ## @param collector.podAnnotations Annotations for Wavefront collector pods
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##
   podAnnotations: {}
-
   ## @param collector.priorityClassName Wavefront Collector pods' priority
   ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   ##
   priorityClassName: ""
-
   ## @param collector.lifecycleHooks Lifecycle hooks for the Wavefront Collector container to automate configuration before or after startup
   ##
   lifecycleHooks: {}
-
   ## @param collector.customLivenessProbe Override default liveness probe
   ##
   customLivenessProbe: {}
-
   ## @param collector.customReadinessProbe Override default readiness probe
   ##
   customReadinessProbe: {}
-
   ## @param collector.updateStrategy.type Update strategy - only really applicable for deployments with RWO PVs attached
   ## If replicas = 1, an update can get "stuck", as the previous pod remains attached to the
   ## PV, and the "incoming" pod can never start. Changing the strategy to "Recreate" will
@@ -401,30 +390,24 @@ collector:
   ##
   updateStrategy:
     type: RollingUpdate
-
   ## @param collector.extraEnvVars Extra environment variables to be set on collector container
   ## For example:
   ##  - name: BEARER_AUTH
   ##    value: true
   ##
   extraEnvVars: []
-
   ## @param collector.extraEnvVarsCM Name of existing ConfigMap containing extra environment variables
   ##
   extraEnvVarsCM:
-
   ## @param collector.extraEnvVarsSecret Name of existing Secret containing extra environment variables
   ##
   extraEnvVarsSecret:
-
   ## @param collector.extraVolumes Optionally specify extra list of additional volumes for collector container
   ##
   extraVolumes: []
-
   ## @param collector.extraVolumeMounts Optionally specify extra list of additional volumeMounts for collector container
   ##
   extraVolumeMounts: []
-
   ## @param collector.initContainers Add init containers to the Wavefront proxy pods
   ## Example:
   ## initContainers:
@@ -436,7 +419,6 @@ collector:
   ##         containerPort: 1234
   ##
   initContainers: {}
-
   ## @param collector.sidecars Add sidecars to the Wavefront proxy pods
   ## Example:
   ## sidecars:
@@ -448,6 +430,8 @@ collector:
   ##         containerPort: 1234
   ##
   sidecars: {}
+
+## @section Proxy parameters
 
 ## Wavefront Proxy is a metrics forwarder that is used to relay metrics to the Wavefront SaaS service.
 ## It can receive metrics from the Wavefront Collector as well as other metrics collection services
@@ -483,12 +467,10 @@ proxy:
     ##   - myRegistryKeySecretName
     ##
     pullSecrets: []
-
   ## @param proxy.hostAliases Deployment pod host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
   hostAliases: []
-
   ## Wavefront Proxy resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ## We usually recommend not to specify default resources and to leave this as a conscious
@@ -509,7 +491,6 @@ proxy:
     ##    cpu: 100m
     ##    memory: 1Gi
     requests: {}
-
   ## Container Security Context configuration
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ## @param proxy.containerSecurityContext.enabled Enable Container Security Context configuration
@@ -520,7 +501,6 @@ proxy:
     enabled: true
     runAsUser: 1001
     runAsNonRoot: true
-
   ## Pod Security Context configuration
   ## @param proxy.podSecurityContext.enabled Enable Pod Security Context configuration
   ## @param proxy.podSecurityContext.fsGroup Group ID for the volumes of the pod
@@ -528,17 +508,14 @@ proxy:
   podSecurityContext:
     enabled: true
     fsGroup: 1001
-
   ## @param proxy.podAffinityPreset Wavefront proxy pod affinity preset. Ignored if `proxy.affinity` is set. Allowed values: `soft` or `hard`
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
   ##
   podAffinityPreset: ""
-
   ## @param proxy.podAntiAffinityPreset Wavefront proxy pod anti-affinity preset. Ignored if `proxy.affinity` is set. Allowed values: `soft` or `hard`
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
   ##
   podAntiAffinityPreset: soft
-
   ## Wavefront Proxy Node affinity preset
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
   ##
@@ -558,42 +535,34 @@ proxy:
     ##   - e2e-az2
     ##
     values: []
-
   ## @param proxy.affinity Wavefront proxy affinity for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ## Note: proxy.podAffinityPreset, proxy.podAntiAffinityPreset, and proxy.nodeAffinityPreset will be ignored when it's set
   ##
   affinity: {}
-
   ## @param proxy.nodeSelector Wavefront proxy node labels for pod assignment
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
   nodeSelector: {}
-
   ## @param proxy.tolerations Wavefront proxy tolerations for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
   tolerations: []
-
   ## @param proxy.podLabels Wavefront proxy pod extra labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   ##
   podLabels: {}
-
   ## @param proxy.podAnnotations Annotations for Wavefront proxy pods
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##
   podAnnotations: {}
-
   ## @param proxy.priorityClassName Wavefront proxy pods' priority class name
   ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   ##
   priorityClassName: ""
-
   ## @param proxy.lifecycleHooks Lifecycle hooks for the Wavefront proxy container to automate configuration before or after startup
   ##
   lifecycleHooks: {}
-
   ## Wavefront Proxy liveness probe. Evaluated as a template.
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   ## @param proxy.livenessProbe.enabled Enable livenessProbe
@@ -626,15 +595,12 @@ proxy:
     periodSeconds: 20
     failureThreshold: 6
     successThreshold: 1
-
   ## @param proxy.customLivenessProbe Override default liveness probe
   ##
   customLivenessProbe: {}
-
   ## @param proxy.customReadinessProbe Override default readiness probe
   ##
   customReadinessProbe: {}
-
   ## @param proxy.updateStrategy.type Update strategy - only really applicable for deployments with RWO PVs attached
   ## If replicas = 1, an update can get "stuck", as the previous pod remains attached to the
   ## PV, and the "incoming" pod can never start. Changing the strategy to "Recreate" will
@@ -642,30 +608,24 @@ proxy:
   ##
   updateStrategy:
     type: RollingUpdate
-
   ## @param proxy.extraEnvVars Extra environment variables to be set on proxy container
   ## For example:
   ##  - name: BEARER_AUTH
   ##    value: true
   ##
   extraEnvVars: []
-
   ## @param proxy.extraEnvVarsCM Name of existing ConfigMap containing extra environment variables
   ##
   extraEnvVarsCM:
-
   ## @param proxy.extraEnvVarsSecret Name of existing Secret containing extra environment variables
   ##
   extraEnvVarsSecret:
-
   ## @param proxy.extraVolumes Optionally specify extra list of additional volumes for proxy container
   ##
   extraVolumes: []
-
   ## @param proxy.extraVolumeMounts Optionally specify extra list of additional volumeMounts for proxy container
   ##
   extraVolumeMounts: []
-
   ## @param proxy.initContainers Add init containers to the Wavefront proxy pods
   ## Example:
   ## initContainers:
@@ -677,7 +637,6 @@ proxy:
   ##         containerPort: 1234
   ##
   initContainers: {}
-
   ## @param proxy.sidecars Add sidecars to the Wavefront proxy pods
   ## Example:
   ## sidecars:
@@ -689,45 +648,37 @@ proxy:
   ##         containerPort: 1234
   ##
   sidecars: {}
-
   ## @param proxy.replicas Replicas to deploy for Wavefront proxy (usually 1)
   ##
   replicas: 1
-
   ## @param proxy.port The port number the proxy will listen on for metrics in Wavefront data format
   ##
   port: 2878
-
   ## @param proxy.tracePort The port number the proxy will listen on for tracing spans in Wavefront trace data format (usually 30000)
   ## e.g:
   ## tracePort: 30000
   ##
   tracePort:
-
   ## @param proxy.jaegerPort The port number the proxy will listen on for tracing spans in Jaeger data format (usually 30001)
   ## e.g:
   ## jaegerPort: 30001
   ##
   jaegerPort:
-
   ## @param proxy.traceJaegerHttpListenerPort TCP ports to receive Jaeger Thrift formatted data via HTTP. The data is then sent to Wavefront in Wavefront span format (usually 30080)
   ## e.g:
   ## traceJaegerHttpListenerPort: 30080
   ##
   traceJaegerHttpListenerPort:
-
   ## @param proxy.traceJaegerGrpcListenerPort TCP ports to receive Jaeger GRPC formatted data via HTTP (usually 14250)
   ## e.g:
   ## traceJaegerGrpcListenerPort: 14250
   ##
   traceJaegerGrpcListenerPort:
-
   ## @param proxy.zipkinPort The port number the proxy will listen on for tracing spans in Zipkin data format (usually 9411)
   ## e.g:
   ## zipkinPort: 9411
   ##
   zipkinPort:
-
   ## @param proxy.traceSamplingRate Sampling rate to apply to tracing spans sent to the proxy
   ## This rate is applied to all data formats the proxy is listening on.
   ## Value should be between 0.0 and 1.0
@@ -735,73 +686,61 @@ proxy:
   ## traceSamplingRate: 0.25
   ##
   traceSamplingRate:
-
   ## @param proxy.traceSamplingDuration When set to greater than 0, spans that exceed this duration will force trace to be sampled (ms)
   ## spans that are greater than or equal to this value will be sampled.
   ## e.g:
   ## traceSamplingDuration: 500
   ##
   traceSamplingDuration:
-
   ## @param proxy.traceJaegerApplicationName Custom application name for traces received on Jaeger's traceJaegerListenerPorts or traceJaegerHttpListenerPorts.
   ## e.g:
   ## traceJaegerApplicationName: MyJaegerDemo
   ##
   traceJaegerApplicationName:
-
   ## @param proxy.traceZipkinApplicationName Custom application name for traces received on Zipkin's traceZipkinListenerPorts.
   ## e.g:
   ## traceZipkinApplicationName: MyZipkinDemo
   ##
   traceZipkinApplicationName:
-
   ## @param proxy.histogramPort Port for histogram distribution format data (usually 40000)
   ## e.g:
   ## histogramPort: 40000
   ##
   histogramPort:
-
   ## @param proxy.histogramMinutePort Port to accumulate 1-minute based histograms on Wavefront data format (usually 40001)
   ## e.g:
   ## histogramMinutePort: 40001
   ##
   histogramMinutePort:
-
   ## @param proxy.histogramHourPort Port to accumulate 1-hour based histograms on Wavefront data format (usually 40002)
   ## e.g:
   ## histogramHourPort: 40002
   ##
   histogramHourPort:
-
   ## @param proxy.histogramDayPort Port to accumulate 1-day based histograms on Wavefront data format (usually 40003)
   ## e.g:
   ## histogramDayPort: 40003
   ##
   histogramDayPort:
-
   ## @param proxy.deltaCounterPort Port to accumulate 1-minute delta counters on Wavefront data format (usually 50000)
   ## e.g:
   ## deltaCounterPort: 50000
   ##
   deltaCounterPort:
-
   ## @param proxy.args Any configuration property can be passed to the proxy via command line args in the format: `--<property_name> <value>`
   ## Multiple properties can be specified separated by whitespace
   ## Ref: https://docs.wavefront.com/proxies_configuring.html
   ##
   args:
-
   ## @param proxy.heap Wavefront proxy Java heap maximum usage (java -Xmx command line option)
   ## By default Java will consume up to 4G of heap memory
   ## e.g:
   ## heap: 1024m
   ##
   heap:
-
   ## @param proxy.existingConfigmap Name of existing ConfigMap with Proxy preprocessor configuration
   ##
   existingConfigmap:
-
   ## @param proxy.preprocessor Preprocessor rules is a powerful way to apply filtering or to enhance metrics as they flow
   ## through the proxy. You can configure the rules here. By default a rule to drop Kubernetes
   ## generated labels is applied to remove unnecessary and often noisy tags.
@@ -825,38 +764,10 @@ proxy:
   ##
   preprocessor: {}
 
-## @param podSecurityPolicy.create Specifies whether PodSecurityPolicy resources should be created
-##
-podSecurityPolicy:
-  create: false
-
-## @param rbac.create Specifies whether RBAC resources should be created
-##
-rbac:
-  create: true
-
-serviceAccount:
-  ## @param serviceAccount.create Create Wavefront service account
-  ##
-  create: true
-  ## @param serviceAccount.name Name of Wavefront service account
-  ## If not set and create is true, a name is generated using the fullname template
-  ##
-  name:
+## @section Kube State Metrics parameters
 
 ## kube-state-metrics are used to get metrics about the state of the Kubernetes scheduler
 ## @param kube-state-metrics.enabled If enabled the kube-state-metrics chart will be installed as a subchart and the collector will be configured to capture metrics.
 ##
 kube-state-metrics:
-  enabled: false
-
-## @param projectPacific.enabled Enable and create role binding for Tanzu Kubernetes cluster
-## If enabled, a role binding to handle pod security policy will be installed within the Kubernetes cluster
-##
-projectPacific:
-  enabled: false
-
-## @param tkgi.enabled Properties for TKGI environments. If enabled, a role binding to handle pod security policy will be installed within the TKGI cluster
-##
-tkgi:
   enabled: false

--- a/bitnami/wavefront/values.yaml
+++ b/bitnami/wavefront/values.yaml
@@ -299,12 +299,12 @@ collector:
     ## limits:
     ##    cpu: 200m
     ##    memory: 256Mi
-    limits: { }
+    limits: {}
     ## Examples:
     ## requests:
     ##    cpu: 200m
     ##    memory: 10Mi
-    requests: { }
+    requests: {}
   ## Container Security Context configuration
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ## @param collector.containerSecurityContext.enabled Enable Container Security Context configuration

--- a/bitnami/wavefront/values.yaml
+++ b/bitnami/wavefront/values.yaml
@@ -1,36 +1,44 @@
+## @section Global parameters
 ## Global Docker image parameters
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value
-## Current available global Docker image parameters: imageRegistry and imagePullSecrets
-##
-# global:
-#   imageRegistry: myRegistryName
-#   imagePullSecrets:
-#     - myRegistryKeySecretName
-#   storageClass: myStorageClass
+## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
 
-## This is a unique name for the cluster (required)
+## @param global.imageRegistry Global Docker image registry
+## @param global.imagePullSecrets Global Docker registry secret names as an array
+## @param global.storageClass Global StorageClass for Persistent Volume(s)
+##
+global:
+  imageRegistry:
+  ## E.g.
+  ## imagePullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
+  storageClass:
+
+## @param clusterName This is a unique name for the cluster (required)
 ## All metrics will receive a `cluster` tag with this value
 ##
 clusterName: KUBERNETES_CLUSTER_NAME
 
-## Wavefront URL (cluster) and API Token (required)
+## @param wavefront.url Wavefront URL for your cluster (required)
+## @param wavefront.token Wavefront API Token (required)
+## @param wavefront.existingSecret Name of an existing secret containing the token
 ##
 wavefront:
   url: https://YOUR_CLUSTER.wavefront.com
   token: YOUR_API_TOKEN
-  ## Name of an existing secret containing the token
-  ##
   existingSecret:
 
-## Add labels to all the deployed resources
+## @param commonLabels Add labels to all the deployed resources
 ##
 commonLabels: {}
 
-## Add annotations to all the deployed resources
+## @param commonAnnotations Add annotations to all the deployed resources
 ##
 commonAnnotations: {}
 
-## Extra objects to deploy (value evaluated as a template)
+## @param extraDeploy Extra objects to deploy (value evaluated as a template)
 ##
 extraDeploy: []
 
@@ -39,7 +47,15 @@ extraDeploy: []
 ## as well as auto-discovery capabilities.
 ##
 collector:
+  ## @param collector.enabled Setup and enable the Wavefront collector to gather metrics
+  ##
   enabled: true
+  ## @param collector.image.registry Wavefront collector Image registry
+  ## @param collector.image.repository Wavefront collector Image repository
+  ## @param collector.image.tag Wavefront collector Image tag (immutable tags are recommended)
+  ## @param collector.image.pullPolicy Image pull policy
+  ## @param collector.image.pullSecrets Specify docker-registry secret names as an array
+  ##
   image:
     registry: docker.io
     repository: bitnami/wavefront-kubernetes-collector
@@ -52,86 +68,115 @@ collector:
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
     ##
-    # pullSecrets:
-    #   - myRegistryKeySecretName
+    pullSecrets: []
 
-  ## Deployment pod host aliases
+  ## @param collector.hostAliases Deployment pod host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
   hostAliases: []
 
-  ## If set to true, DaemonSet will be used for the collector.
+  ## @param collector.useDaemonset Use Wavefront collector in Daemonset mode
   ## If set to false, Deployment will be used for the collector.
   ## Setting this to true is strongly recommended
   ##
   useDaemonset: true
 
-  ## If installing into a TKGi/PKS environment, set this to true
+  ## @param collector.usePKSPrefix If installing into a TKGi/PKS environment, set this to true. Prefixes metrics with 'pks.kubernetes.'
+  ## e.g:
+  ## usePKSPrefix: false
   ##
-  # usePKSPrefix: false
+  usePKSPrefix:
 
-  ## max number of CPUs that can be used simultaneously. Less than 1 for default (number of cores)
+  ## @param collector.maxProcs Maximum number of CPUs that can be used simultaneously
+  ## e.g:
+  ## maxProcs: 0
   ##
-  # maxProcs: 0
+  maxProcs:
 
-  ## log level one of: info, debug, or trace. (default info)
+  ## @param collector.logLevel Log level. Allowed values: `info`, `debug` or `trace`
   ##
-  # logLevel: info
+  logLevel:
 
-  ## The resolution at which the collector will retain metrics. (default 60s)
+  ## @param collector.interval Default metrics collection interval
+  ## e.g:
+  ## interval: 60s
   ##
-  # interval: 60s
+  interval:
 
-  ## How often collected data is flushed (default 10s)
+  ## @param collector.flushInterval How often to force a metrics flush
+  ## e.g:
+  ## flushInterval: 10s
   ##
-  # flushInterval: 10s
+  flushInterval:
 
-  ## Timeout for exporting data (default 20s)
+  ## @param collector.sinkDelay Timeout for exporting data
+  ## e.g:
+  ## sinkDelay: 20s
   ##
-  # sinkDelay: 20s
+  sinkDelay:
 
+  ## @param collector.useReadOnlyPort Use un-authenticated port for kubelet
   ## If set to true, will use the unauthenticated real only port for the kubelet
   ## If set to false, will use the encrypted full access port for the kubelet (default false)
   ##
-  # useReadOnlyPort: false
+  useReadOnlyPort:
 
-  ## If set to true, metrics will be sent to Wavefront via a Wavefront Proxy.
+  ## @param collector.useProxy Use a Wavefront Proxy to send metrics through
   ## When true you must either specify a value for `collector.proxyAddress` or set `proxy.enabled` to true
   ## If set to false, metrics will be sent to Wavefront via the Direct Ingestion API
   ##
   useProxy: true
 
-  ## Can be used to specify a specific address for the Wavefront Proxy
+  ## @param collector.proxyAddress Can be used to specify a specific address for the Wavefront Proxy
   ## The proxy can be anywhere network reachable including outside of the cluster
   ## Required if `collector.useProxy` is true and `proxy.enabled` is false
+  ## e.g:
+  ## proxyAddress: wavefront-proxy:2878
   ##
-  # proxyAddress: wavefront-proxy:2878
+  proxyAddress:
 
-  ## If set to true, metrics about Kubernetes State will be generated by the collector
+  ## @param collector.kubernetesState Collect metrics about Kubernetes resource states
   ## These metrics are more efficient than kube-state-metrics
   ##
   kubernetesState: true
 
-  ## If set to true Kubernetes API Server will also be scraped for metrics (default false)
+  ## @param collector.apiServerMetrics Collect metrics about Kubernetes API server
   ##
-  # apiServerMetrics: false
+  apiServerMetrics:
 
-  ## Map of tags to apply to all metrics collected by the collector (default empty)
-  ## sample tags to include (env, region)
+  ## @param collector.tags Map of tags to apply to all metrics collected by the collector
+  ## Sample tags to include (env, region)
+  ## tags:
+  ##   env: production
+  ##   region: us-west-2
   ##
-  # tags:
-  #   env: production
-  #   region: us-west-2
+  tags: {}
 
-  ## If set to true, host OS metrics will be collected
+  ## @param collector.hostOSMetrics If set to true, host OS metrics will be collected
   ##
   hostOSMetrics: false
 
   ## Filters to apply towards all metrics collected by the collector
+  ## @param collector.filters.metricDenyList [array] Optimized metrics collection to omit peripheral metrics.
+  ## @param collector.filters.tagExclude [array] Filter out generated labels
+  ## e.g:
+  ##   filters:
+  ##     tagWhilelistSets:
+  ##     - kind:
+  ##       - "Deployment"
+  ##     - reason:
+  ##       - "ScalingReplicaSet"
+  ##       - "ReplicaSetCreateError"
+  ##     - kind:
+  ##       - "HorizontalPodAutoscaler"
+  ##       reason:
+  ##       - "Failed*"
   ##
   filters:
-    # Optimized metrics collection to omit peripheral metrics.
     metricDenyList:
       - 'kubernetes.sys_container.*'
       - 'kubernetes.collector.runtime.*'
@@ -147,8 +192,6 @@ collector:
       - 'kubernetes.*.filesystem.inodes_free'
       - 'kubernetes.*.ephemeral_storage.request'
       - 'kubernetes.*.ephemeral_storage.limit'
-
-    # Filter out generated labels
     tagExclude:
       - 'label?controller?revision*'
       - 'label?pod?template*'
@@ -160,139 +203,147 @@ collector:
   ## Ref: https://github.com/wavefrontHQ/wavefront-collector-for-kubernetes/blob/master/docs/filtering.md
   ##
   events:
+    ## @param collector.events.enabled Events can also be collected and sent to Wavefront
+    ##
     enabled: false
-  #   filters:
-  #     tagWhilelistSets:
-  #     - kind:
-  #       - "Deployment"
-  #     - reason:
-  #       - "ScalingReplicaSet"
-  #       - "ReplicaSetCreateError"
-  #     - kind:
-  #       - "HorizontalPodAutoscaler"
-  #       reason:
-  #       - "Failed*"
 
   ## Rules based discovery configuration
   ## Ref: https://github.com/wavefrontHQ/wavefront-kubernetes-collector/blob/master/docs/discovery.md
   ##
   discovery:
+    ## @param collector.discovery.enabled Rules based and Prometheus endpoints auto-discovery
+    ##
     enabled: true
 
-    ## When specified, this replaces `prometheus.io` as the prefix for annotations used to
-    ## auto-discover Prometheus endpoints
-    #  annotationPrefix: "wavefront.com"
+    ## @param collector.discovery.annotationPrefix When specified, this replaces `prometheus.io` as the prefix for annotations used to auto-discover Prometheus endpoints
+    ## e.g:
+    ##  annotationPrefix: "wavefront.com"
+    ##
+    annotationPrefix: ""
 
-  ## Whether to enable runtime discovery configurations
-  ## Ref: https://github.com/wavefrontHQ/wavefront-collector-for-kubernetes/blob/master/docs/discovery.md#runtime-configurations
-  ##
+    ## @param collector.discovery.enableRuntimeConfigs Whether to enable runtime discovery configurations
+    ## Ref: https://github.com/wavefrontHQ/wavefront-collector-for-kubernetes/blob/master/docs/discovery.md#runtime-configurations
+    ##
     enableRuntimeConfigs: true
 
-  ## Can be used to add additional discovery rules
-  ##
-  #   config:
-  # # auto-discover a sample prometheus application
-  #   - name: prom-example
-  #     type: prometheus
-  #     selectors:
-  #       labels:
-  #         k8s-app:
-  #         - prom-example
-  #     port: 8080
-  #     path: /metrics
-  #     prefix: kube.prom-example.
-  #     tags:
-  #       alt_name: sample-app
-  # # auto-discover mongodb pods (replace USER:PASSWORD)
-  #   - name: mongodb
-  #     type: telegraf/mongodb
-  #     selectors:
-  #       images:
-  #       - '*mongo:*'
-  #     port: 27017
-  #     conf: |
-  #       servers = ["mongodb://USER:PASSWORD@${host}:${port}"]
-  #       gather_perdb_stats = true
-  #     filters:
-  #       metricBlacklist:
-  #       - 'mongodb.member.status'
-  #       - 'mongodb.state'
-  #       - 'mongodb.db.stats.type'
-  # # auto-discover rabbitmq pods (replace USER and PASSWORD)
-  #   - name: rabbitmq
-  #     type: telegraf/rabbitmq
-  #     selectors:
-  #       images:
-  #       - '*rabbitmq:*'
-  #     port: 15672
-  #     conf: |
-  #       url = "http://${host}:${port}"
-  #       username = "USER"
-  #       password = "PASSWORD"
+    ## @param collector.discovery.config Configuration for rules based auto-discovery
+    ## e.g:
+    ##   config:
+    ## # auto-discover a sample prometheus application
+    ##   - name: prom-example
+    ##     type: prometheus
+    ##     selectors:
+    ##       labels:
+    ##         k8s-app:
+    ##         - prom-example
+    ##     port: 8080
+    ##     path: /metrics
+    ##     prefix: kube.prom-example.
+    ##     tags:
+    ##       alt_name: sample-app
+    ## # auto-discover mongodb pods (replace USER:PASSWORD)
+    ##   - name: mongodb
+    ##     type: telegraf/mongodb
+    ##     selectors:
+    ##       images:
+    ##       - '*mongo:*'
+    ##     port: 27017
+    ##     conf: |
+    ##       servers = ["mongodb://USER:PASSWORD@${host}:${port}"]
+    ##       gather_perdb_stats = true
+    ##     filters:
+    ##       metricBlacklist:
+    ##       - 'mongodb.member.status'
+    ##       - 'mongodb.state'
+    ##       - 'mongodb.db.stats.type'
+    ## # auto-discover rabbitmq pods (replace USER and PASSWORD)
+    ##   - name: rabbitmq
+    ##     type: telegraf/rabbitmq
+    ##     selectors:
+    ##       images:
+    ##       - '*rabbitmq:*'
+    ##     port: 15672
+    ##     conf: |
+    ##       url = "http://${host}:${port}"
+    ##       username = "USER"
+    ##       password = "PASSWORD"
+    ##
+    config: []
 
-  ## ConfigMap with Collector Configuration
+  ## @param collector.existingConfigmap Name of existing ConfigMap with collector configuration
   ##
-  # existingConfigmap:
+  existingConfigmap:
 
-  ## Command and args for running the container (set to default if not set). Use array form
+  ## @param collector.command Override default container command (useful when using custom images)
   ##
   command: []
+  ## @param collector.args Override default container args (useful when using custom images)
+  ##
   args: []
 
   ## Wavefront Collector resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ## We usually recommend not to specify default resources and to leave this as a conscious
+  ## choice for the user. This also increases chances charts run on environments with little
+  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ## @param collector.resources.limits The resources limits for the collector container
+  ## @param collector.resources.requests The requested resources for the collector container
   ##
   resources:
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    limits: {}
-    #   cpu: 200m
-    #   memory: 256Mi
-    requests: {}
-    #   cpu: 200m
-    #   memory: 10Mi
+    ## Example:
+    ## limits:
+    ##    cpu: 200m
+    ##    memory: 256Mi
+    limits: { }
+    ## Examples:
+    ## requests:
+    ##    cpu: 200m
+    ##    memory: 10Mi
+    requests: { }
 
-  ## SecurityContext configuration
+  ## Container Security Context configuration
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ## @param collector.containerSecurityContext.enabled Enable Container Security Context configuration
+  ## @param collector.containerSecurityContext.runAsUser Set Container's Security Context runAsUser
+  ## @param collector.containerSecurityContext.runAsNonRoot Set Container's Security Context runAsNonRoot
   ##
   containerSecurityContext:
     enabled: true
     runAsUser: 1001
     runAsNonRoot: true
 
+  ## Pod Security Context configuration
+  ## @param collector.podSecurityContext.enabled Enable Pod Security Context configuration
+  ## @param collector.podSecurityContext.fsGroup Group ID for the volumes of the pod
+  ##
   podSecurityContext:
     enabled: true
     fsGroup: 1001
 
-  ## Wavefront Collector Pod affinity preset
+  ## @param collector.podAffinityPreset Wavefront collector pod affinity preset. Ignored if `collector.affinity` is set. Allowed values: `soft` or `hard`
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
-  ## Allowed values: soft, hard
   ##
   podAffinityPreset: ""
 
-  ## Wavefront Collector Pod anti-affinity preset
+  ## @param collector.podAntiAffinityPreset Wavefront collector pod anti-affinity preset. Ignored if `collector.affinity` is set. Allowed values: `soft` or `hard`
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
-  ## Allowed values: soft, hard
   ##
   podAntiAffinityPreset: soft
 
   ## Wavefront Collector Node affinity preset
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
-  ## Allowed values: soft, hard
   ##
   nodeAffinityPreset:
-    ## Node affinity type
-    ## Allowed values: soft, hard
+    ## @param collector.nodeAffinityPreset.type Wavefront collector node affinity preset type. Ignored if `collector.affinity` is set. Allowed values: `soft` or `hard`
     ##
     type: ""
-    ## Node label key to match
+    ## @param collector.nodeAffinityPreset.key Wavefront collector node label key to match Ignored if `collector.affinity` is set.
     ## E.g.
     ## key: "kubernetes.io/e2e-az-name"
     ##
     key: ""
-    ## Node label values to match
+    ## @param collector.nodeAffinityPreset.values Wavefront collector node label values to match. Ignored if `collector.affinity` is set.
     ## E.g.
     ## values:
     ##   - e2e-az1
@@ -300,50 +351,50 @@ collector:
     ##
     values: []
 
-  ## Wavefront Collector Affinity for pod assignment
+  ## @param collector.affinity Wavefront collector affinity for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ## Note: collector.podAffinityPreset, collector.podAntiAffinityPreset, and collector.nodeAffinityPreset will be ignored when it's set
   ##
   affinity: {}
 
-  ## Wavefront Collector Node labels for pod assignment
+  ## @param collector.nodeSelector Wavefront collector node labels for pod assignment
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
   nodeSelector: {}
 
-  ## Wavefront Collector Tolerations for pod assignment
+  ## @param collector.tolerations Wavefront collector tolerations for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
   tolerations: []
 
-  ## Pod extra labels
+  ## @param collector.podLabels Wavefront collector pod extra labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   ##
   podLabels: {}
 
-  ## Annotations for server pods.
+  ## @param collector.podAnnotations Annotations for Wavefront collector pods
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##
   podAnnotations: {}
 
-  ## Wavefront Collector pods' priority.
+  ## @param collector.priorityClassName Wavefront Collector pods' priority
   ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   ##
-  # priorityClassName: ""
+  priorityClassName: ""
 
-  ## lifecycleHooks for the Wavefront Collector container to automate configuration before or after startup.
+  ## @param collector.lifecycleHooks Lifecycle hooks for the Wavefront Collector container to automate configuration before or after startup
   ##
   lifecycleHooks: {}
 
-  ## Custom Liveness probes for Wavefront Collector
+  ## @param collector.customLivenessProbe Override default liveness probe
   ##
   customLivenessProbe: {}
 
-  ## Custom Rediness probes Wavefront Collector
+  ## @param collector.customReadinessProbe Override default readiness probe
   ##
   customReadinessProbe: {}
 
-  ## Update strategy - only really applicable for deployments with RWO PVs attached
+  ## @param collector.updateStrategy.type Update strategy - only really applicable for deployments with RWO PVs attached
   ## If replicas = 1, an update can get "stuck", as the previous pod remains attached to the
   ## PV, and the "incoming" pod can never start. Changing the strategy to "Recreate" will
   ## terminate the single previous pod, so that the new, incoming pod can attach to the PV
@@ -351,30 +402,30 @@ collector:
   updateStrategy:
     type: RollingUpdate
 
-  ## An array to add extra env vars
+  ## @param collector.extraEnvVars Extra environment variables to be set on collector container
   ## For example:
+  ##  - name: BEARER_AUTH
+  ##    value: true
   ##
   extraEnvVars: []
-  #  - name: BEARER_AUTH
-  #    value: true
 
-  ## ConfigMap with extra environment variables
+  ## @param collector.extraEnvVarsCM Name of existing ConfigMap containing extra environment variables
   ##
   extraEnvVarsCM:
 
-  ## Secret with extra environment variables
+  ## @param collector.extraEnvVarsSecret Name of existing Secret containing extra environment variables
   ##
   extraEnvVarsSecret:
 
-  ## Extra volumes to add to the deployment
+  ## @param collector.extraVolumes Optionally specify extra list of additional volumes for collector container
   ##
   extraVolumes: []
 
-  ## Extra volume mounts to add to the container
+  ## @param collector.extraVolumeMounts Optionally specify extra list of additional volumeMounts for collector container
   ##
   extraVolumeMounts: []
 
-  ## Add init containers to the Wavefront proxy pods.
+  ## @param collector.initContainers Add init containers to the Wavefront proxy pods
   ## Example:
   ## initContainers:
   ##   - name: your-image-name
@@ -386,7 +437,7 @@ collector:
   ##
   initContainers: {}
 
-  ## Add sidecars to the Wavefront proxy pods.
+  ## @param collector.sidecars Add sidecars to the Wavefront proxy pods
   ## Example:
   ## sidecars:
   ##   - name: your-image-name
@@ -406,7 +457,15 @@ collector:
 ## Ref: https://docs.wavefront.com/proxies.html
 ##
 proxy:
+  ## @param proxy.enabled Setup and enable Wavefront proxy to send metrics through
+  ##
   enabled: true
+  ## @param proxy.image.registry Wavefront proxy image registry
+  ## @param proxy.image.repository Wavefront proxy image repository
+  ## @param proxy.image.tag Wavefront proxy image tag (immutable tags are recommended)
+  ## @param proxy.image.pullPolicy Wavefront proxy image pull policy
+  ## @param proxy.image.pullSecrets Specify docker-registry secret names as an array
+  ##
   image:
     registry: docker.io
     repository: bitnami/wavefront-proxy
@@ -419,69 +478,80 @@ proxy:
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
     ##
-    # pullSecrets:
-    #   - myRegistryKeySecretName
+    pullSecrets: []
 
-  ## Deployment pod host aliases
+  ## @param proxy.hostAliases Deployment pod host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
   hostAliases: []
 
   ## Wavefront Proxy resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ## We usually recommend not to specify default resources and to leave this as a conscious
+  ## choice for the user. This also increases chances charts run on environments with little
+  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ## @param proxy.resources.limits The resources limits for the proxy container
+  ## @param proxy.resources.requests The requested resources for the proxy container
   ##
   resources:
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    ## Example:
+    ## limits:
+    ##    cpu: 100m
+    ##    memory: 4Gi
     limits: {}
-    #   cpu: 100m
-    #   memory: 4Gi
+    ## Examples:
+    ## requests:
+    ##    cpu: 100m
+    ##    memory: 1Gi
     requests: {}
-    #   cpu: 100m
-    #   memory: 1Gi
 
-  ## SecurityContext configuration
+  ## Container Security Context configuration
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ## @param proxy.containerSecurityContext.enabled Enable Container Security Context configuration
+  ## @param proxy.containerSecurityContext.runAsUser Set Container's Security Context runAsUser
+  ## @param proxy.containerSecurityContext.runAsNonRoot Set Container's Security Context runAsNonRoot
   ##
   containerSecurityContext:
     enabled: true
     runAsUser: 1001
     runAsNonRoot: true
 
+  ## Pod Security Context configuration
+  ## @param proxy.podSecurityContext.enabled Enable Pod Security Context configuration
+  ## @param proxy.podSecurityContext.fsGroup Group ID for the volumes of the pod
+  ##
   podSecurityContext:
     enabled: true
     fsGroup: 1001
 
-  ## Wavefront Proxy Pod affinity preset
+  ## @param proxy.podAffinityPreset Wavefront proxy pod affinity preset. Ignored if `proxy.affinity` is set. Allowed values: `soft` or `hard`
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
-  ## Allowed values: soft, hard
   ##
   podAffinityPreset: ""
 
-  ## Wavefront Proxy Pod anti-affinity preset
+  ## @param proxy.podAntiAffinityPreset Wavefront proxy pod anti-affinity preset. Ignored if `proxy.affinity` is set. Allowed values: `soft` or `hard`
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
-  ## Allowed values: soft, hard
   ##
   podAntiAffinityPreset: soft
 
   ## Wavefront Proxy Node affinity preset
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
-  ## Allowed values: soft, hard
   ##
   nodeAffinityPreset:
-    ## Node affinity type
-    ## Allowed values: soft, hard
+    ## @param proxy.nodeAffinityPreset.type Wavefront proxy node affinity preset type. Ignored if `proxy.affinity` is set. Allowed values: `soft` or `hard`
     ##
     type: ""
-    ## Node label key to match
+    ## @param proxy.nodeAffinityPreset.key Wavefront proxy node label key to match Ignored if `proxy.affinity` is set.
     ## E.g.
     ## key: "kubernetes.io/e2e-az-name"
     ##
     key: ""
-    ## Node label values to match
+    ## @param proxy.nodeAffinityPreset.values Wavefront proxy node label values to match. Ignored if `proxy.affinity` is set.
     ## E.g.
     ## values:
     ##   - e2e-az1
@@ -489,43 +559,49 @@ proxy:
     ##
     values: []
 
-  ## Wavefront Proxy Affinity for pod assignment
+  ## @param proxy.affinity Wavefront proxy affinity for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ## Note: proxy.podAffinityPreset, proxy.podAntiAffinityPreset, and proxy.nodeAffinityPreset will be ignored when it's set
   ##
   affinity: {}
 
-  ## Wavefront Proxy Node labels for pod assignment
+  ## @param proxy.nodeSelector Wavefront proxy node labels for pod assignment
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
   nodeSelector: {}
 
-  ## Wavefront Proxy Tolerations for pod assignment
+  ## @param proxy.tolerations Wavefront proxy tolerations for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
   tolerations: []
 
-  ## Pod extra labels
+  ## @param proxy.podLabels Wavefront proxy pod extra labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   ##
   podLabels: {}
 
-  ## Annotations for server pods.
+  ## @param proxy.podAnnotations Annotations for Wavefront proxy pods
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##
   podAnnotations: {}
 
-  ## Wavefront proxy pods' priority.
+  ## @param proxy.priorityClassName Wavefront proxy pods' priority class name
   ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   ##
-  # priorityClassName: ""
+  priorityClassName: ""
 
-  ## lifecycleHooks for the Wavefront proxy container to automate configuration before or after startup.
+  ## @param proxy.lifecycleHooks Lifecycle hooks for the Wavefront proxy container to automate configuration before or after startup
   ##
   lifecycleHooks: {}
 
-  ## Wavefront Proxy liveness and readiness probes. Evaluated as a template.
+  ## Wavefront Proxy liveness probe. Evaluated as a template.
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ## @param proxy.livenessProbe.enabled Enable livenessProbe
+  ## @param proxy.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+  ## @param proxy.livenessProbe.periodSeconds Period seconds for livenessProbe
+  ## @param proxy.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+  ## @param proxy.livenessProbe.failureThreshold Failure threshold for livenessProbe
+  ## @param proxy.livenessProbe.successThreshold Success threshold for livenessProbe
   ##
   livenessProbe:
     enabled: true
@@ -534,6 +610,15 @@ proxy:
     periodSeconds: 20
     failureThreshold: 6
     successThreshold: 1
+  ## Wavefront Proxy readiness probe. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ## @param proxy.readinessProbe.enabled Enable readinessProbe
+  ## @param proxy.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+  ## @param proxy.readinessProbe.periodSeconds Period seconds for readinessProbe
+  ## @param proxy.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+  ## @param proxy.readinessProbe.failureThreshold Failure threshold for readinessProbe
+  ## @param proxy.readinessProbe.successThreshold Success threshold for readinessProbe
+  ##
   readinessProbe:
     enabled: true
     initialDelaySeconds: 10
@@ -542,15 +627,15 @@ proxy:
     failureThreshold: 6
     successThreshold: 1
 
-  ## Custom Liveness probes for Wavefront Proxy
+  ## @param proxy.customLivenessProbe Override default liveness probe
   ##
   customLivenessProbe: {}
 
-  ## Custom Rediness probes Wavefront Proxy
+  ## @param proxy.customReadinessProbe Override default readiness probe
   ##
   customReadinessProbe: {}
 
-  ## Update strategy - only really applicable for deployments with RWO PVs attached
+  ## @param proxy.updateStrategy.type Update strategy - only really applicable for deployments with RWO PVs attached
   ## If replicas = 1, an update can get "stuck", as the previous pod remains attached to the
   ## PV, and the "incoming" pod can never start. Changing the strategy to "Recreate" will
   ## terminate the single previous pod, so that the new, incoming pod can attach to the PV
@@ -558,30 +643,30 @@ proxy:
   updateStrategy:
     type: RollingUpdate
 
-  ## An array to add extra env vars
+  ## @param proxy.extraEnvVars Extra environment variables to be set on proxy container
   ## For example:
+  ##  - name: BEARER_AUTH
+  ##    value: true
   ##
   extraEnvVars: []
-  #  - name: BEARER_AUTH
-  #    value: true
 
-  ## ConfigMap with extra environment variables
+  ## @param proxy.extraEnvVarsCM Name of existing ConfigMap containing extra environment variables
   ##
   extraEnvVarsCM:
 
-  ## Secret with extra environment variables
+  ## @param proxy.extraEnvVarsSecret Name of existing Secret containing extra environment variables
   ##
   extraEnvVarsSecret:
 
-  ## Extra volumes to add to the deployment
+  ## @param proxy.extraVolumes Optionally specify extra list of additional volumes for proxy container
   ##
   extraVolumes: []
 
-  ## Extra volume mounts to add to the container
+  ## @param proxy.extraVolumeMounts Optionally specify extra list of additional volumeMounts for proxy container
   ##
   extraVolumeMounts: []
 
-  ## Add init containers to the Wavefront proxy pods.
+  ## @param proxy.initContainers Add init containers to the Wavefront proxy pods
   ## Example:
   ## initContainers:
   ##   - name: your-image-name
@@ -593,7 +678,7 @@ proxy:
   ##
   initContainers: {}
 
-  ## Add sidecars to the Wavefront proxy pods.
+  ## @param proxy.sidecars Add sidecars to the Wavefront proxy pods
   ## Example:
   ## sidecars:
   ##   - name: your-image-name
@@ -605,144 +690,173 @@ proxy:
   ##
   sidecars: {}
 
-  ## The number of pod replicas to run for the Wavefront Proxy deployment
+  ## @param proxy.replicas Replicas to deploy for Wavefront proxy (usually 1)
   ##
   replicas: 1
 
-  ## The port number the proxy will listen on for metrics in Wavefront data format.
+  ## @param proxy.port The port number the proxy will listen on for metrics in Wavefront data format
   ##
   port: 2878
 
-  ## The port number the proxy will listen on for tracing spans in Wavefront trace data format.
+  ## @param proxy.tracePort The port number the proxy will listen on for tracing spans in Wavefront trace data format (usually 30000)
+  ## e.g:
+  ## tracePort: 30000
   ##
-  # tracePort: 30000
+  tracePort:
 
-  ## The port number the proxy will listen on for tracing spans in Jaeger data format.
+  ## @param proxy.jaegerPort The port number the proxy will listen on for tracing spans in Jaeger data format (usually 30001)
+  ## e.g:
+  ## jaegerPort: 30001
   ##
-  # jaegerPort: 30001
+  jaegerPort:
 
-  ## TCP ports to receive Jaeger Thrift formatted data via HTTP. The data is then sent to Wavefront in Wavefront span format.
+  ## @param proxy.traceJaegerHttpListenerPort TCP ports to receive Jaeger Thrift formatted data via HTTP. The data is then sent to Wavefront in Wavefront span format (usually 30080)
+  ## e.g:
+  ## traceJaegerHttpListenerPort: 30080
   ##
-  # traceJaegerHttpListenerPort: 30080
+  traceJaegerHttpListenerPort:
 
-  ## TCP ports to receive Jaeger GRPC formatted data via HTTP.
+  ## @param proxy.traceJaegerGrpcListenerPort TCP ports to receive Jaeger GRPC formatted data via HTTP (usually 14250)
+  ## e.g:
+  ## traceJaegerGrpcListenerPort: 14250
   ##
-  # traceJaegerGrpcListenerPort: 14250
+  traceJaegerGrpcListenerPort:
 
-  ## The port number the proxy will listen on for tracing spans in Zipkin data format.
+  ## @param proxy.zipkinPort The port number the proxy will listen on for tracing spans in Zipkin data format (usually 9411)
+  ## e.g:
+  ## zipkinPort: 9411
   ##
-  # zipkinPort: 9411
+  zipkinPort:
 
-  ## Sampling rate to apply to tracing spans sent to the proxy.
+  ## @param proxy.traceSamplingRate Sampling rate to apply to tracing spans sent to the proxy
   ## This rate is applied to all data formats the proxy is listening on.
   ## Value should be between 0.0 and 1.0
+  ## e.g:
+  ## traceSamplingRate: 0.25
   ##
-  # traceSamplingRate: 0.25
+  traceSamplingRate:
 
-  ## When this is set to a value greater than 0,
+  ## @param proxy.traceSamplingDuration When set to greater than 0, spans that exceed this duration will force trace to be sampled (ms)
   ## spans that are greater than or equal to this value will be sampled.
+  ## e.g:
+  ## traceSamplingDuration: 500
   ##
-  # traceSamplingDuration: 500
+  traceSamplingDuration:
 
-  ## Custom application name for traces received on Jaeger's traceJaegerListenerPorts or traceJaegerHttpListenerPorts.
+  ## @param proxy.traceJaegerApplicationName Custom application name for traces received on Jaeger's traceJaegerListenerPorts or traceJaegerHttpListenerPorts.
+  ## e.g:
+  ## traceJaegerApplicationName: MyJaegerDemo
   ##
-  # traceJaegerApplicationName: MyJaegerDemo
+  traceJaegerApplicationName:
 
-  ## Custom application name for traces received on Zipkin's traceZipkinListenerPorts.
+  ## @param proxy.traceZipkinApplicationName Custom application name for traces received on Zipkin's traceZipkinListenerPorts.
+  ## e.g:
+  ## traceZipkinApplicationName: MyZipkinDemo
   ##
-  # traceZipkinApplicationName: MyZipkinDemo
+  traceZipkinApplicationName:
 
-  ## The port number the proxy will listen on for histogram distributions in Wavefront Distribution format.
+  ## @param proxy.histogramPort Port for histogram distribution format data (usually 40000)
+  ## e.g:
+  ## histogramPort: 40000
   ##
-  # histogramPort: 40000
+  histogramPort:
 
-  ## The port number the proxy will listen on for minute acculumated histograms in Wavefront Data format.
+  ## @param proxy.histogramMinutePort Port to accumulate 1-minute based histograms on Wavefront data format (usually 40001)
+  ## e.g:
+  ## histogramMinutePort: 40001
   ##
-  # histogramMinutePort: 40001
+  histogramMinutePort:
 
-  ## The port number the proxy will listen on for hour acculumated histograms in Wavefront Data format.
+  ## @param proxy.histogramHourPort Port to accumulate 1-hour based histograms on Wavefront data format (usually 40002)
+  ## e.g:
+  ## histogramHourPort: 40002
   ##
-  # histogramHourPort: 40002
+  histogramHourPort:
 
-  ## The port number the proxy will listen on for day acculumated histograms in Wavefront Data format.
+  ## @param proxy.histogramDayPort Port to accumulate 1-day based histograms on Wavefront data format (usually 40003)
+  ## e.g:
+  ## histogramDayPort: 40003
   ##
-  # histogramDayPort: 40003
+  histogramDayPort:
 
-  ## The port number the proxy will listen on for minute acculumated delta counters in Wavefront Data format.
+  ## @param proxy.deltaCounterPort Port to accumulate 1-minute delta counters on Wavefront data format (usually 50000)
+  ## e.g:
+  ## deltaCounterPort: 50000
   ##
-  # deltaCounterPort: 50000
+  deltaCounterPort:
 
-  ## Any configuration property can be passed to the proxy via command line args in
-  ## in the format: `--<property_name> <value>`. Multiple properties can be specified
-  ## separated by whitespace.
+  ## @param proxy.args Any configuration property can be passed to the proxy via command line args in the format: `--<property_name> <value>`
+  ## Multiple properties can be specified separated by whitespace
   ## Ref: https://docs.wavefront.com/proxies_configuring.html
   ##
-  # args:
+  args:
 
-  ## Proxy is a Java application. By default Java will consume up to 4G of heap memory.
-  ## This can be used to override the default. Uses the `-Xmx` command line option for java
+  ## @param proxy.heap Wavefront proxy Java heap maximum usage (java -Xmx command line option)
+  ## By default Java will consume up to 4G of heap memory
+  ## e.g:
+  ## heap: 1024m
   ##
-  # heap: 1024m
+  heap:
 
-  ## ConfigMap with Proxy preprocessor Configuration
+  ## @param proxy.existingConfigmap Name of existing ConfigMap with Proxy preprocessor configuration
   ##
-  # existingConfigmap:
+  existingConfigmap:
 
-  ## Preprocessor rules is a powerful way to apply filtering or to enhance metrics as they flow
+  ## @param proxy.preprocessor Preprocessor rules is a powerful way to apply filtering or to enhance metrics as they flow
   ## through the proxy. You can configure the rules here. By default a rule to drop Kubernetes
   ## generated labels is applied to remove unnecessary and often noisy tags.
   ## Ref: https://docs.wavefront.com/proxies_preprocessor_rules.html
+  ## e.g:
+  ## preprocessor:
+  ##   rules.yaml: |
+  ##     '2878':
+  ##     # fix %2F to be a / instead.  May be required on EKS.
+  ##     - rule    : fix-forward-slash
+  ##       action  : replaceRegex
+  ##       scope   : pointLine
+  ##       search  : "%2F"
+  ##       replace : "/"
+  ##     # replace bad characters ("&", "$", "!", "@") with underscores in the entire point line string
+  ##     - rule    : replace-badchars
+  ##       action  : replaceRegex
+  ##       scope   : pointLine
+  ##       search  : "[&\\$!@]"
+  ##       replace : "_"
   ##
-  # preprocessor:
-  #   rules.yaml: |
-  #     '2878':
-  #     # fix %2F to be a / instead.  May be required on EKS.
-  #     - rule    : fix-forward-slash
-  #       action  : replaceRegex
-  #       scope   : pointLine
-  #       search  : "%2F"
-  #       replace : "/"
-  #     # replace bad characters ("&", "$", "!", "@") with underscores in the entire point line string
-  #     - rule    : replace-badchars
-  #       action  : replaceRegex
-  #       scope   : pointLine
-  #       search  : "[&\\$!@]"
-  #       replace : "_"
+  preprocessor: {}
 
-## Specifies whether PodSecurityPolicy resources should be created
+## @param podSecurityPolicy.create Specifies whether PodSecurityPolicy resources should be created
 ##
 podSecurityPolicy:
   create: false
 
-## Specifies whether RBAC resources should be created
+## @param rbac.create Specifies whether RBAC resources should be created
 ##
 rbac:
   create: true
 
-## Specifies whether a ServiceAccount should be created
-##
 serviceAccount:
+  ## @param serviceAccount.create Create Wavefront service account
+  ##
   create: true
-  ## The name of the ServiceAccount to use.
+  ## @param serviceAccount.name Name of Wavefront service account
   ## If not set and create is true, a name is generated using the fullname template
   ##
   name:
 
 ## kube-state-metrics are used to get metrics about the state of the Kubernetes scheduler
-## If enabled the kube-state-metrics chart will be installed as a subchart and the collector
-## will be configured to capture metrics.
+## @param kube-state-metrics.enabled If enabled the kube-state-metrics chart will be installed as a subchart and the collector will be configured to capture metrics.
 ##
 kube-state-metrics:
   enabled: false
 
-## Required for Project Pacific Kubernetes clusters.
-## If enabled, a role binding to handle pod security policy will be installed within the Kubernetes cluster.
+## @param projectPacific.enabled Enable and create role binding for Tanzu Kubernetes cluster
+## If enabled, a role binding to handle pod security policy will be installed within the Kubernetes cluster
 ##
 projectPacific:
   enabled: false
 
-## Properties for TKGI environments
-## If enabled, a role binding to handle pod security policy will be installed within the TKGI cluster.
+## @param tkgi.enabled Properties for TKGI environments. If enabled, a role binding to handle pod security policy will be installed within the TKGI cluster
 ##
 tkgi:
   enabled: false

--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -21,4 +21,4 @@ name: zookeeper
 sources:
   - https://github.com/bitnami/bitnami-docker-zookeeper
   - https://zookeeper.apache.org/
-version: 7.0.7
+version: 7.0.8

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -46,180 +46,203 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Parameters
 
-The following tables lists the configurable parameters of the ZooKeeper chart and their default values per section/component:
+### Global parameters
 
-| Parameter                 | Description                                     | Default                                                 |
-|---------------------------|-------------------------------------------------|---------------------------------------------------------|
-| `global.imageRegistry`    | Global Docker image registry                    | `nil`                                                   |
-| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
-| `global.storageClass`     | Global storage class for dynamic provisioning   | `nil`                                                   |
+| Name                      | Description                                     | Value |
+| ------------------------- | ----------------------------------------------- | ----- |
+| `global.imageRegistry`    | Global Docker image registry                    | `nil` |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
+| `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `nil` |
+
 
 ### Common parameters
 
-| Parameter           | Description                                        | Default                           |
-|---------------------|----------------------------------------------------|-----------------------------------|
-| `nameOverride`      | String to partially override common.names.fullname | `nil`                             |
-| `fullnameOverride`  | String to fully override common.names.fullname     | `nil`                             |
-| `clusterDomain`     | Default Kubernetes cluster domain                  | `cluster.local`                   |
-| `extraDeploy`       | Array of extra objects to deploy with the release  | `[]` (evaluated as a template)    |
-| `commonLabels`      | Labels to add to all deployed objects              | `{}`                              |
-| `commonAnnotations` | Annotations to add to all deployed objects         | `{}`                              |
-| `schedulerName`     | Kubernetes pod scheduler registry                  | `nil` (use the default-scheduler) |
+| Name                | Description                                                                                  | Value           |
+| ------------------- | -------------------------------------------------------------------------------------------- | --------------- |
+| `nameOverride`      | String to partially override common.names.fullname template (will maintain the release name) | `nil`           |
+| `fullnameOverride`  | String to fully override common.names.fullname template                                      | `nil`           |
+| `clusterDomain`     | Kubernetes Cluster Domain                                                                    | `cluster.local` |
+| `extraDeploy`       | Extra objects to deploy (value evaluated as a template)                                      | `[]`            |
+| `commonLabels`      | Add labels to all the deployed resources                                                     | `{}`            |
+| `commonAnnotations` | Add annotations to all the deployed resources                                                | `{}`            |
+
 
 ### Zookeeper chart parameters
 
-| Parameter                   | Description                                                                                 | Default                                                 |
-|-----------------------------|---------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `image.registry`            | ZooKeeper image registry                                                                    | `docker.io`                                             |
-| `image.repository`          | ZooKeeper Image name                                                                        | `bitnami/zookeeper`                                     |
-| `image.tag`                 | ZooKeeper Image tag                                                                         | `{TAG_NAME}`                                            |
-| `image.pullPolicy`          | ZooKeeper image pull policy                                                                 | `IfNotPresent`                                          |
-| `image.pullSecrets`         | Specify docker-registry secret names as an array                                            | `[]` (does not add image pull secrets to deployed pods) |
-| `image.debug`               | Specify if debug values should be set                                                       | `false`                                                 |
-| `tickTime`                  | Basic time unit in milliseconds used by ZooKeeper for heartbeats                            | `2000`                                                  |
-| `initLimit`                 | Time the ZooKeeper servers in quorum have to connect to a leader                            | `10`                                                    |
-| `syncLimit`                 | How far out of date a server can be from a leader                                           | `5`                                                     |
-| `maxClientCnxns`            | Number of concurrent connections that a single client may make to a single member           | `60`                                                    |
-| `maxSessionTimeout`         | Maximum session timeout in milliseconds that the server will allow the client to negotiate. | `40000`                                                 |
-| `autopurge.snapRetainCount` | Number of retains snapshots for autopurge                                                   | `3`                                                     |
-| `autopurge.purgeInterval`   | The time interval in hours for which the purge task has to be triggered                     | `0`                                                     |
-| `fourlwCommandsWhitelist`   | A list of comma separated Four Letter Words commands to use                                 | `srvr, mntr`                                            |
-| `listenOnAllIPs`            | Allow Zookeeper to listen for connections from its peers on all available IP addresses.     | `false`                                                 |
-| `allowAnonymousLogin`       | Allow to accept connections from unauthenticated users                                      | `yes`                                                   |
-| `auth.existingSecret`       | Use existing secret (ignores previous password)                                             | `nil`                                                   |
-| `auth.enabled`              | Enable ZooKeeper auth                                                                       | `false`                                                 |
-| `auth.clientUser`           | User that will use ZooKeeper clients to auth                                                | `nil`                                                   |
-| `auth.clientPassword`       | Password that will use ZooKeeper clients to auth                                            | `nil`                                                   |
-| `auth.serverUsers`          | List of user to be created                                                                  | `nil`                                                   |
-| `auth.serverPasswords`      | List of passwords to assign to users when created                                           | `nil`                                                   |
-| `hostAliases`               | Add deployment host aliases                                                                 | `[]`                                                    |
-| `heapSize`                  | Size in MB for the Java Heap options (Xmx and XMs)                                          | `[]`                                                    |
-| `logLevel`                  | Log level of ZooKeeper server                                                               | `ERROR`                                                 |
-| `jvmFlags`                  | Default JVMFLAGS for the ZooKeeper process                                                  | `nil`                                                   |
-| `config`                    | Configure ZooKeeper with a custom zoo.conf file                                             | `nil`                                                   |
-| `dataLogDir`                | Data log directory                                                                          | `""`                                                    |
-| `namespaceOverride`         | Namespace for ZooKeeper resources. Overrides the release namespace.                         | The Release Namespace                                   |
+| Name                        | Description                                                                                                                              | Value                 |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| `image.registry`            | ZooKeeper image registry                                                                                                                 | `docker.io`           |
+| `image.repository`          | ZooKeeper image repository                                                                                                               | `bitnami/zookeeper`   |
+| `image.tag`                 | ZooKeeper Image tag (immutable tags are recommended)                                                                                     | `3.7.0-debian-10-r70` |
+| `image.pullPolicy`          | ZooKeeper image pull policy                                                                                                              | `IfNotPresent`        |
+| `image.pullSecrets`         | Specify docker-registry secret names as an array                                                                                         | `[]`                  |
+| `image.debug`               | Specify if debug values should be set                                                                                                    | `false`               |
+| `tickTime`                  | Basic time unit in milliseconds used by ZooKeeper for heartbeats                                                                         | `2000`                |
+| `initLimit`                 | ZooKeeper uses to limit the length of time the ZooKeeper servers in quorum have to connect to a leader                                   | `10`                  |
+| `syncLimit`                 | How far out of date a server can be from a leader                                                                                        | `5`                   |
+| `maxClientCnxns`            | Limits the number of concurrent connections that a single client may make to a single member of the ZooKeeper ensemble                   | `60`                  |
+| `fourlwCommandsWhitelist`   | A list of comma separated Four Letter Words commands to use                                                                              | `srvr, mntr, ruok`    |
+| `listenOnAllIPs`            | Allow Zookeeper to listen for connections from its peers on all available IP addresses                                                   | `false`               |
+| `allowAnonymousLogin`       | Allow to accept connections from unauthenticated users                                                                                   | `true`                |
+| `autopurge.snapRetainCount` | Retains the snapRetainCount most recent snapshots and the corresponding transaction logs and deletes the rest                            | `3`                   |
+| `autopurge.purgeInterval`   | The time interval in hours for which the purge task has to be triggered                                                                  | `0`                   |
+| `maxSessionTimeout`         | Maximum session timeout in milliseconds that the server will allow the client to negotiate                                               | `40000`               |
+| `auth.existingSecret`       | Use existing secret (ignores previous password)                                                                                          | `nil`                 |
+| `auth.enabled`              | Enable Zookeeper auth. It uses SASL/Digest-MD5                                                                                           | `false`               |
+| `auth.clientUser`           | User that will use ZooKeeper clients to auth                                                                                             | `nil`                 |
+| `auth.clientPassword`       | Password that will use ZooKeeper clients to auth                                                                                         | `nil`                 |
+| `auth.serverUsers`          | Comma, semicolon or whitespace separated list of user to be created                                                                      | `nil`                 |
+| `auth.serverPasswords`      | Comma, semicolon or whitespace separated list of passwords to assign to users when created                                               | `nil`                 |
+| `heapSize`                  | Size in MB for the Java Heap options (Xmx and XMs)                                                                                       | `1024`                |
+| `logLevel`                  | Log level for the Zookeeper server. ERROR by default                                                                                     | `ERROR`               |
+| `dataLogDir`                | Data log directory. Specifying this option will direct zookeeper to write the transaction log to the dataLogDir rather than the dataDir. | `""`                  |
+| `jvmFlags`                  | Default JVMFLAGS for the ZooKeeper process                                                                                               | `nil`                 |
+| `config`                    | Configure ZooKeeper with a custom zoo.cfg file                                                                                           | `nil`                 |
+| `namespaceOverride`         | Namespace for ZooKeeper resources                                                                                                        | `nil`                 |
+| `hostAliases`               | Deployment pod host aliases                                                                                                              | `[]`                  |
+
 
 ### Statefulset parameters
 
-| Parameter                            | Description                                                                               | Default                        |
-|:-------------------------------------|:------------------------------------------------------------------------------------------|:-------------------------------|
-| `replicaCount`                       | Number of ZooKeeper nodes                                                                 | `1`                            |
-| `minServerId`                        | Minimal SERVER_ID value, nodes increment their IDs respectively                           | `1`                            |
-| `updateStrategy`                     | Update strategy for the statefulset                                                       | `RollingUpdate`                |
-| `rollingUpdatePartition`             | Partition update strategy                                                                 | `nil`                          |
-| `podManagementPolicy`                | Pod management policy                                                                     | `Parallel`                     |
-| `podLabels`                          | ZooKeeper pod labels                                                                      | `{}` (evaluated as a template) |
-| `podAnnotations`                     | ZooKeeper Pod annotations                                                                 | `{}` (evaluated as a template) |
-| `podAffinityPreset`                  | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                           |
-| `podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                         |
-| `nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                           |
-| `nodeAffinityPreset.key`             | Node label key to match Ignored if `affinity` is set.                                     | `""`                           |
-| `nodeAffinityPreset.values`          | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                           |
-| `affinity`                           | Affinity for pod assignment                                                               | `{}` (evaluated as a template) |
-| `nodeSelector`                       | Node labels for pod assignment                                                            | `{}` (evaluated as a template) |
-| `tolerations`                        | Tolerations for pod assignment                                                            | `[]` (evaluated as a template) |
-| `priorityClassName`                  | Name of the existing priority class to be used by ZooKeeper pods                          | `""`                           |
-| `securityContext.enabled`            | Enable security context (ZooKeeper master pod)                                            | `true`                         |
-| `securityContext.fsGroup`            | Group ID for the container (ZooKeeper master pod)                                         | `1001`                         |
-| `securityContext.runAsUser`          | User ID for the container (ZooKeeper master pod)                                          | `1001`                         |
-| `resources`                          | CPU/Memory resource requests/limits                                                       | Memory: `256Mi`, CPU: `250m`   |
-| `livenessProbe`                      | Liveness probe configuration for ZooKeeper                                                | Check `values.yaml` file       |
-| `readinessProbe`                     | Readiness probe configuration for ZooKeeper                                               | Check `values.yaml` file       |
-| `customLivenessProbe`                | Override default liveness probe                                                           | `nil`                          |
-| `customReadinessProbe`               | Override default readiness probe                                                          | `nil`                          |
-| `extraVolumes`                       | Extra volumes                                                                             | `nil`                          |
-| `extraVolumeMounts`                  | Mount extra volume(s)                                                                     | `nil`                          |
-| `initContainers`                     | Extra init container to add to the statefulset                                            | `nil`                          |
-| `podDisruptionBudget.maxUnavailable` | Max number of pods down simultaneously                                                    | `1`                            |
+| Name                                 | Description                                                                                                                                                                                       | Value           |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| `extraVolumes`                       | Extra volumes                                                                                                                                                                                     | `[]`            |
+| `extraVolumeMounts`                  | Mount extra volume(s)                                                                                                                                                                             | `[]`            |
+| `updateStrategy`                     | StatefulSet controller supports automated updates. There are two valid update strategies: `RollingUpdate` and `OnDelete`                                                                          | `RollingUpdate` |
+| `podDisruptionBudget.maxUnavailable` | Max number of pods down simultaneously                                                                                                                                                            | `1`             |
+| `rollingUpdatePartition`             | Partition update strategy                                                                                                                                                                         | `nil`           |
+| `podManagementPolicy`                | StatefulSet controller supports relax its ordering guarantees while preserving its uniqueness and identity guarantees. There are two valid pod management policies: `OrderedReady` and `Parallel` | `Parallel`      |
+| `replicaCount`                       | Number of ZooKeeper nodes                                                                                                                                                                         | `1`             |
+| `minServerId`                        | Minimal SERVER_ID value, nodes increment their IDs respectively                                                                                                                                   | `1`             |
+| `securityContext.enabled`            | Enable security context (ZooKeeper master pod)                                                                                                                                                    | `true`          |
+| `securityContext.fsGroup`            | Group ID for the container (ZooKeeper master pod)                                                                                                                                                 | `1001`          |
+| `securityContext.runAsUser`          | User ID for the container (ZooKeeper master pod)                                                                                                                                                  | `1001`          |
+| `initContainers`                     | Extra init container to add to the statefulset                                                                                                                                                    | `[]`            |
+| `podAffinityPreset`                  | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                                                                               | `""`            |
+| `podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                                                                          | `soft`          |
+| `nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                                                                         | `""`            |
+| `nodeAffinityPreset.key`             | Node label key to match Ignored if `affinity` is set.                                                                                                                                             | `""`            |
+| `nodeAffinityPreset.values`          | Node label values to match. Ignored if `affinity` is set.                                                                                                                                         | `[]`            |
+| `affinity`                           | Affinity for pod assignment                                                                                                                                                                       | `{}`            |
+| `nodeSelector`                       | Node labels for pod assignment                                                                                                                                                                    | `{}`            |
+| `tolerations`                        | Tolerations for pod assignment                                                                                                                                                                    | `[]`            |
+| `podLabels`                          | ZooKeeper pod labels                                                                                                                                                                              | `{}`            |
+| `podAnnotations`                     | ZooKeeper Pod annotations                                                                                                                                                                         | `{}`            |
+| `priorityClassName`                  | Name of the existing priority class to be used by ZooKeeper pods, priority class needs to be created beforehand                                                                                   | `""`            |
+| `schedulerName`                      | Kubernetes pod scheduler registry                                                                                                                                                                 | `nil`           |
+| `resources.requests`                 | The requested resources for the container                                                                                                                                                         | `{}`            |
+| `livenessProbe.enabled`              | Enable livenessProbe                                                                                                                                                                              | `true`          |
+| `livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                                                                                                                           | `30`            |
+| `livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                                                                                                                  | `10`            |
+| `livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                                                                                                                 | `5`             |
+| `livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                                                                                                                               | `6`             |
+| `livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                                                                                                                               | `1`             |
+| `livenessProbe.probeCommandTimeout`  | Probe command timeout for livenessProbe                                                                                                                                                           | `2`             |
+| `readinessProbe.enabled`             | Enable readinessProbe                                                                                                                                                                             | `true`          |
+| `readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                                                                                                                          | `5`             |
+| `readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                                                                                                                 | `10`            |
+| `readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                                                                                                                | `5`             |
+| `readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                                                                                                              | `6`             |
+| `readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                                                                                                              | `1`             |
+| `readinessProbe.probeCommandTimeout` | Probe command timeout for readinessProbe                                                                                                                                                          | `2`             |
+| `customLivenessProbe`                | Override default liveness probe                                                                                                                                                                   | `{}`            |
+| `customReadinessProbe`               | Override default readiness probe                                                                                                                                                                  | `{}`            |
 
-### Exposure parameters
 
-| Parameter                                | Description                                                                                        | Default                                              |
-|------------------------------------------|----------------------------------------------------------------------------------------------------|------------------------------------------------------|
-| `service.type`                           | Kubernetes Service type                                                                            | `ClusterIP`                                          |
-| `service.loadBalancerIP`                 | Use with service.type `LoadBalancer` to assign static IP to Load Balancer instance                 | `""`                                                 |
-| `service.port`                           | ZooKeeper port                                                                                     | `2181`                                               |
-| `service.followerPort`                   | ZooKeeper follower port                                                                            | `2888`                                               |
-| `service.electionPort`                   | ZooKeeper election port                                                                            | `3888`                                               |
-| `service.nodePorts.client`               | Nodeport for client connections                                                                    | `""`                                                 |
-| `service.nodePorts.clientTls`            | Nodeport for tls client connections                                                                | `""`                                                 | 
-| `service.publishNotReadyAddresses`       | If the ZooKeeper headless service should publish DNS records for not ready pods                    | `true`                                               |
-| `serviceAccount.create`                  | Enable creation of ServiceAccount for zookeeper pod                                                | `false`                                              |
-| `serviceAccount.name`                    | The name of the service account to use. If not set and `create` is `true`, a name is generated     | Generated using the `common.names.fullname` template |
-| `serviceAccount.automountServiceAccountToken` | Enable/Disable automountServiceAccountToken  for Service Account                                   | `true`                                               |
-| `service.disableBaseClientPort`               | Remove client port from service definitions.                                                       | `false`                                              |
-| `service.tlsClientPort`                       | Service port for tls client connections                                                            | `3181`                                               |
-| `service.annotations`                    | Annotations for the Service                                                                        | `{}`                                                 |
-| `service.headless.annotations`           | Annotations for the Headless Service                                                               | `{}`                                                 |
-| `networkPolicy.enabled`                  | Enable NetworkPolicy                                                                               | `false`                                              |
-| `networkPolicy.allowExternal`            | Don't require client label for connections                                                         | `true`                                               |
+### Traffic Exposure parameters
+
+| Name                                          | Description                                                                     | Value       |
+| --------------------------------------------- | ------------------------------------------------------------------------------- | ----------- |
+| `service.type`                                | Kubernetes Service type                                                         | `ClusterIP` |
+| `service.loadBalancerIP`                      | Load balancer IP for the Zookeper Service (optional, cloud specific)            | `nil`       |
+| `service.port`                                | ZooKeeper port                                                                  | `2181`      |
+| `service.followerPort`                        | ZooKeeper follower port                                                         | `2888`      |
+| `service.electionPort`                        | ZooKeeper election port                                                         | `3888`      |
+| `service.nodePorts`                           | Specify the nodePort value for the LoadBalancer and NodePort service types.     | `{}`        |
+| `service.publishNotReadyAddresses`            | If the ZooKeeper headless service should publish DNS records for not ready pods | `true`      |
+| `service.tlsClientPort`                       | Service port for tls client connections                                         | `3181`      |
+| `service.disableBaseClientPort`               | Remove client port from service definitions.                                    | `false`     |
+| `service.annotations`                         | Annotations for the Service                                                     | `{}`        |
+| `service.headless.annotations`                | Annotations for the Headless Service                                            | `{}`        |
+| `serviceAccount.create`                       | Enable creation of ServiceAccount for Zookeeper pod                             | `false`     |
+| `serviceAccount.name`                         | The name of the ServiceAccount to use.                                          | `nil`       |
+| `serviceAccount.automountServiceAccountToken` | Allows auto mount of ServiceAccountToken on the serviceAccount created          | `true`      |
+| `networkPolicy.enabled`                       | Specifies whether a NetworkPolicy should be created                             | `false`     |
+| `networkPolicy.allowExternal`                 | Don't require client label for connections                                      | `nil`       |
+
 
 ### Persistence parameters
 
-| Parameter                              | Description                                                                    | Default                         |
-|----------------------------------------|--------------------------------------------------------------------------------|---------------------------------|
-| `persistence.enabled`                  | Enable Zookeeper data persistence using PVC                                    | `true`                          |
-| `persistence.existingClaim`            | Provide an existing `PersistentVolumeClaim`                                    | `nil` (evaluated as a template) |
-| `persistence.storageClass`             | PVC Storage Class for ZooKeeper data volume                                    | `nil`                           |
-| `persistence.accessMode`               | PVC Access Mode for ZooKeeper data volume                                      | `ReadWriteOnce`                 |
-| `persistence.size`                     | PVC Storage Request for ZooKeeper data volume                                  | `8Gi`                           |
-| `persistence.annotations`              | Annotations for the PVC                                                        | `{}` (evaluated as a template)  |
-| `persistence.selector`                 | Selector to match an existing Persistent Volume for Zookeeper's data PVC. If set, the PVC can't have a PV dynamically provisioned for it                                                                        | `{}` (evaluated as a template)  |
-| `persistence.dataLogDir.size`          | PVC Storage Request for ZooKeeper's Data log directory                         | `8Gi`                           |
-| `persistence.dataLogDir.existingClaim` | Provide an existing `PersistentVolumeClaim` for Zookeeper's Data log directory | `nil` (evaluated as a template) |
-| `persistence.dataLogDir.selector`      | Selector to match an existing Persistent Volume for Zookeeper's Data log PVC. If set, the PVC can't have a PV dynamically provisioned for it                                                                    | `{}` (evaluated as a template)  |
+| Name                                   | Description                                                                    | Value  |
+| -------------------------------------- | ------------------------------------------------------------------------------ | ------ |
+| `persistence.existingClaim`            | Provide an existing `PersistentVolumeClaim`                                    | `nil`  |
+| `persistence.enabled`                  | Enable Zookeeper data persistence using PVC                                    | `true` |
+| `persistence.storageClass`             | PVC Storage Class for ZooKeeper data volume                                    | `nil`  |
+| `persistence.accessModes`              | PVC Access modes                                                               | `[]`   |
+| `persistence.size`                     | PVC Storage Request for ZooKeeper data volume                                  | `8Gi`  |
+| `persistence.annotations`              | Annotations for the PVC                                                        | `{}`   |
+| `persistence.selector`                 | Selector to match an existing Persistent Volume for Zookeeper's data PVC       | `{}`   |
+| `persistence.dataLogDir.size`          | PVC Storage Request for ZooKeeper's Data log directory                         | `8Gi`  |
+| `persistence.dataLogDir.existingClaim` | Provide an existing `PersistentVolumeClaim` for Zookeeper's Data log directory | `nil`  |
+| `persistence.dataLogDir.selector`      | Selector to match an existing Persistent Volume for Zookeeper's Data log PVC   | `{}`   |
+
 
 ### Volume Permissions parameters
 
-| Parameter                            | Description                                                                                                          | Default                 |
-|--------------------------------------|----------------------------------------------------------------------------------------------------------------------|-------------------------|
-| `volumePermissions.enabled`          | Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup` | `false`                 |
-| `volumePermissions.image.registry`   | Init container volume-permissions image registry                                                                     | `docker.io`             |
-| `volumePermissions.image.repository` | Init container volume-permissions image name                                                                         | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`        | Init container volume-permissions image tag                                                                          | `"10"`                  |
-| `volumePermissions.image.pullPolicy` | Init container volume-permissions image pull policy                                                                  | `Always`                |
-| `volumePermissions.resources`        | Init container resource requests/limit                                                                               | `nil`                   |
+| Name                                  | Description                                                                                                          | Value                   |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `volumePermissions.enabled`           | Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup` | `false`                 |
+| `volumePermissions.image.registry`    | Init container volume-permissions image registry                                                                     | `docker.io`             |
+| `volumePermissions.image.repository`  | Init container volume-permissions image repository                                                                   | `bitnami/bitnami-shell` |
+| `volumePermissions.image.tag`         | Init container volume-permissions image tag (immutable tags are recommended)                                         | `10-debian-10-r115`     |
+| `volumePermissions.image.pullPolicy`  | Init container volume-permissions image pull policy                                                                  | `Always`                |
+| `volumePermissions.image.pullSecrets` | Init container volume-permissions image pull secrets                                                                 | `[]`                    |
+| `volumePermissions.resources`         | Init container resource requests/limit                                                                               | `{}`                    |
+
 
 ### Metrics parameters
 
-| Parameter                              | Description                                                                                                                               | Default                                                      |
-|----------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `metrics.enabled`                      | Enable prometheus to access zookeeper metrics endpoint                                                                                    | `false`                                                      |
-| `metrics.containerPort`                | Port where a Jetty server will expose Prometheus metrics                                                                                  | `9141`                                                       |
-| `metrics.service.type`                 | Kubernetes service type (`ClusterIP`, `NodePort` or `LoadBalancer`) for Jetty server exposing Prometheus metrics                          | `ClusterIP`                                                  |
-| `metrics.service.port`                 | Prometheus metrics service port                                                                                                           | `9141`                                                       |
-| `metrics.service.annotations`          | Service annotations for Prometheus to auto-discover the metrics endpoint                                                                  | `{prometheus.io/scrape: "true", prometheus.io/port: "9141"}` |
-| `metrics.serviceMonitor.enabled`       | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)                                    | `false`                                                      |
-| `metrics.serviceMonitor.namespace`     | Namespace for the ServiceMonitor Resource                                                                                                 | The Release Namespace                                        |
-| `metrics.serviceMonitor.interval`      | Interval at which metrics should be scraped.                                                                                              | `nil` (Prometheus Operator default value)                    |
-| `metrics.serviceMonitor.scrapeTimeout` | Timeout after which the scrape is ended                                                                                                   | `nil` (Prometheus Operator default value)                    |
-| `metrics.serviceMonitor.selector`      | Prometheus instance selector labels                                                                                                       | `nil`                                                        |
-| `metrics.prometheusRule.enabled`       | if `true`, creates a Prometheus Operator PrometheusRule (also requires `metrics.enabled` to be `true` and `metrics.prometheusRule.rules`) | `false`                                                      |
-| `metrics.prometheusRule.namespace`     | Namespace for the PrometheusRule Resource                                                                                                 | The Release Namespace                                        |
-| `metrics.prometheusRule.selector`      | Prometheus instance selector labels                                                                                                       | `nil`                                                        |
-| `metrics.prometheusRule.rules`         | Prometheus Rule definitions (see values.yaml for examples)                                                                                | `[]`                                                         |
+| Name                                   | Description                                                                                                                               | Value       |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `metrics.enabled`                      | Enable prometheus to access zookeeper metrics endpoint                                                                                    | `false`     |
+| `metrics.containerPort`                | Zookeeper Prometheus Exporter container port                                                                                              | `9141`      |
+| `metrics.service.type`                 | Zookeeper Prometheus Exporter service type                                                                                                | `ClusterIP` |
+| `metrics.service.port`                 | Prometheus metrics service port                                                                                                           | `9141`      |
+| `metrics.service.annotations`          | Annotations for the Zookeeper to auto-discover the metrics endpoint                                                                       | `{}`        |
+| `metrics.serviceMonitor.enabled`       | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)                                    | `false`     |
+| `metrics.serviceMonitor.namespace`     | Namespace for the ServiceMonitor Resource (defaults to the Release Namespace)                                                             | `nil`       |
+| `metrics.serviceMonitor.interval`      | Interval at which metrics should be scraped.                                                                                              | `nil`       |
+| `metrics.serviceMonitor.scrapeTimeout` | Timeout after which the scrape is ended                                                                                                   | `nil`       |
+| `metrics.serviceMonitor.selector`      | Prometheus instance selector labels                                                                                                       | `nil`       |
+| `metrics.prometheusRule.enabled`       | if `true`, creates a Prometheus Operator PrometheusRule (also requires `metrics.enabled` to be `true` and `metrics.prometheusRule.rules`) | `false`     |
+| `metrics.prometheusRule.namespace`     | Namespace for the PrometheusRule Resource (defaults to the Release Namespace)                                                             | `nil`       |
+| `metrics.prometheusRule.selector`      | Prometheus instance selector labels                                                                                                       | `nil`       |
+| `metrics.prometheusRule.rules`         | Prometheus Rule definitions                                                                                                               | `[]`        |
+
 
 ### TLS/SSL parameters
 
-| Parameter                        | Description                                                                                                                        | Default                                                               |
-|----------------------------------|------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------|
-| `tls.client.enabled`             | Enable TLS for client connections                                                                                                  | `false`                                                               |
-| `tls.client.autoGenerated`       | Generate automatically self-signed TLS certificates for Zookeeper client communications. Currently only supports PEM certificates. | `false`                                                               |
-| `tls.client.existingSecret`      | Name of the existing secret containing the TLS certificates for Zookeper client communications                                     | `nil`                                                                 |
-| `tls.client.keystorePath`        | Location of the KeyStore file used for Client connections                                                                          | `/opt/bitnami/zookeeper/config/certs/client/zookeeper.keystore.jks`   |
-| `tls.client.truststorePath`      | Location of the TrustStore file used for Client connections                                                                        | `/opt/bitnami/zookeeper/config/certs/client/zookeeper.truststore.jks` |
-| `tls.client.keystorePassword`    | Password to access KeyStore if needed                                                                                              | `nil`                                                                 |
-| `tls.client.truststorePassword`  | Password to access TrustStore if needed                                                                                            | `nil`                                                                 |
-| `tls.quorum.enabled`             | Enable TLS for quorum protocol                                                                                                     | `false`                                                               |
-| `tls.quorum.autoGenerated`       | Generate automatically self-signed TLS certificates for Zookeeper quorum protocol. Currently only supports PEM certificates.       | `false`                                                               |
-| `tls.quorum.existingSecret`      | Name of the existing secret containing the TLS certificates for Zookeper quorum protocol                                           | `nil`                                                                 |
-| `tls.quorum.keystorePath`        | Location of the KeyStore file used for Quorum protocol                                                                             | `/opt/bitnami/zookeeper/config/certs/quorum/zookeeper.keystore.jks`   |
-| `tls.quorum.truststorePath`      | Location of the TrustStore file used for Quorum protocol                                                                           | `/opt/bitnami/zookeeper/config/certs/quorum/zookeeper.truststore.jks` |
-| `tls.quorum.keystorePassword`    | Password to access KeyStore if needed                                                                                              | `nil`                                                                 |
-| `tls.quorum.truststorePassword`  | Password to access TrustStore if needed                                                                                            | `nil`                                                                 |
-| `tls.resources.limits`           | The resources limits for the TLS init container                                                                                    | `{}`                                                                  |
-| `tls.resources.requests`         | The requested resources for the TLS init container                                                                                 | `{}`                                                                  |
+| Name                             | Description                                                                                    | Value                                                                 |
+| -------------------------------- | ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `tls.client.enabled`             | Enable TLS for client connections                                                              | `false`                                                               |
+| `tls.client.autoGenerated`       | Generate automatically self-signed TLS certificates for Zookeeper client communications        | `false`                                                               |
+| `tls.client.existingSecret`      | Name of the existing secret containing the TLS certificates for Zookeper client communications | `nil`                                                                 |
+| `tls.client.keystorePath`        | Location of the KeyStore file used for Client connections                                      | `/opt/bitnami/zookeeper/config/certs/client/zookeeper.keystore.jks`   |
+| `tls.client.truststorePath`      | Location of the TrustStore file used for Client connections                                    | `/opt/bitnami/zookeeper/config/certs/client/zookeeper.truststore.jks` |
+| `tls.client.passwordsSecretName` | Existing secret containing Keystore and truststore passwords                                   | `nil`                                                                 |
+| `tls.client.keystorePassword`    | Password to access KeyStore if needed                                                          | `""`                                                                  |
+| `tls.client.truststorePassword`  | Password to access TrustStore if needed                                                        | `""`                                                                  |
+| `tls.quorum.enabled`             | Enable TLS for quorum protocol                                                                 | `false`                                                               |
+| `tls.quorum.autoGenerated`       | Create self-signed TLS certificates. Currently only supports PEM certificates.                 | `false`                                                               |
+| `tls.quorum.existingSecret`      | Name of the existing secret containing the TLS certificates for Zookeper quorum protocol       | `nil`                                                                 |
+| `tls.quorum.keystorePath`        | Location of the KeyStore file used for Quorum protocol                                         | `/opt/bitnami/zookeeper/config/certs/quorum/zookeeper.keystore.jks`   |
+| `tls.quorum.truststorePath`      | Location of the TrustStore file used for Quorum protocol                                       | `/opt/bitnami/zookeeper/config/certs/quorum/zookeeper.truststore.jks` |
+| `tls.quorum.passwordsSecretName` | Existing secret containing Keystore and truststore passwords                                   | `nil`                                                                 |
+| `tls.quorum.keystorePassword`    | Password to access KeyStore if needed                                                          | `""`                                                                  |
+| `tls.quorum.truststorePassword`  | Password to access TrustStore if needed                                                        | `""`                                                                  |
+| `tls.resources.limits`           | The resources limits for the TLS init container                                                | `{}`                                                                  |
+| `tls.resources.requests`         | The requested resources for the TLS init container                                             | `{}`                                                                  |
+
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -16,6 +16,29 @@ global:
   imagePullSecrets: []
   storageClass:
 
+## @section Common parameters
+
+## @param nameOverride String to partially override common.names.fullname template (will maintain the release name)
+##
+nameOverride:
+## @param fullnameOverride String to fully override common.names.fullname template
+##
+fullnameOverride:
+## @param clusterDomain Kubernetes Cluster Domain
+##
+clusterDomain: cluster.local
+## @param extraDeploy Extra objects to deploy (value evaluated as a template)
+##
+extraDeploy: []
+## @param commonLabels Add labels to all the deployed resources
+##
+commonLabels: {}
+## @param commonAnnotations Add annotations to all the deployed resources
+##
+commonAnnotations: {}
+
+## @section Zookeeper chart parameters
+
 ## Bitnami Zookeeper image version
 ## ref: https://hub.docker.com/r/bitnami/zookeeper/tags/
 ## @param image.registry ZooKeeper image registry
@@ -29,7 +52,6 @@ image:
   registry: docker.io
   repository: bitnami/zookeeper
   tag: 3.7.0-debian-10-r70
-
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -47,65 +69,89 @@ image:
   ## It turns BASH and/or NAMI debugging in the image
   ##
   debug: false
-
-## @param nameOverride String to partially override common.names.fullname template (will maintain the release name)
+## @param tickTime Basic time unit in milliseconds used by ZooKeeper for heartbeats
 ##
-nameOverride:
-
-## @param fullnameOverride String to fully override common.names.fullname template
+tickTime: 2000
+## @param initLimit ZooKeeper uses to limit the length of time the ZooKeeper servers in quorum have to connect to a leader
 ##
-fullnameOverride:
-
+initLimit: 10
+## @param syncLimit How far out of date a server can be from a leader
+##
+syncLimit: 5
+## @param maxClientCnxns Limits the number of concurrent connections that a single client may make to a single member of the ZooKeeper ensemble
+##
+maxClientCnxns: 60
+## @param fourlwCommandsWhitelist A list of comma separated Four Letter Words commands to use
+##
+fourlwCommandsWhitelist: srvr, mntr, ruok
+## @param listenOnAllIPs Allow Zookeeper to listen for connections from its peers on all available IP addresses
+##
+listenOnAllIPs: false
+## @param allowAnonymousLogin Allow to accept connections from unauthenticated users
+##
+allowAnonymousLogin: true
+autopurge:
+  ## @param autopurge.snapRetainCount Retains the snapRetainCount most recent snapshots and the corresponding transaction logs and deletes the rest
+  ##
+  snapRetainCount: 3
+  ## @param autopurge.purgeInterval The time interval in hours for which the purge task has to be triggered
+  ## Set to a positive integer (1 and above) to enable the auto purging
+  ##
+  purgeInterval: 0
+## @param maxSessionTimeout Maximum session timeout in milliseconds that the server will allow the client to negotiate
+## Defaults to 20 times the tickTime
+##
+maxSessionTimeout: 40000
+auth:
+  ## @param auth.existingSecret Use existing secret (ignores previous password)
+  ##
+  existingSecret:
+  ## @param auth.enabled Enable Zookeeper auth. It uses SASL/Digest-MD5
+  ##
+  enabled: false
+  ## @param auth.clientUser User that will use ZooKeeper clients to auth
+  ##
+  clientUser:
+  ## @param auth.clientPassword Password that will use ZooKeeper clients to auth
+  ##
+  clientPassword:
+  ## @param auth.serverUsers Comma, semicolon or whitespace separated list of user to be created
+  ## Specify them as a string, for example: "user1,user2,admin"
+  ##
+  serverUsers:
+  ## @param auth.serverPasswords Comma, semicolon or whitespace separated list of passwords to assign to users when created
+  ## Specify them as a string, for example: "pass4user1, pass4user2, pass4admin"
+  ##
+  serverPasswords:
+## @param heapSize Size in MB for the Java Heap options (Xmx and XMs)
+## This env var is ignored if Xmx an Xms are configured via JVMFLAGS
+##
+heapSize: 1024
+## @param logLevel Log level for the Zookeeper server. ERROR by default
+## Have in mind if you set it to INFO or WARN the ReadinessProve will produce a lot of logs
+##
+logLevel: ERROR
+## @param dataLogDir Data log directory. Specifying this option will direct zookeeper to write the transaction log to the dataLogDir rather than the dataDir.
+## This allows a dedicated log device to be used, and helps avoid competition between logging and snaphots.
+## Example:
+## dataLogDir: /bitnami/zookeeper/dataLog
+##
+dataLogDir: ''
+## @param jvmFlags Default JVMFLAGS for the ZooKeeper process
+##
+jvmFlags:
+## @param config Configure ZooKeeper with a custom zoo.cfg file
+##
+config:
+## @param namespaceOverride Namespace for ZooKeeper resources
+##
+namespaceOverride:
 ## @param hostAliases Deployment pod host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
 hostAliases: []
 
-## @param clusterDomain Kubernetes Cluster Domain
-##
-clusterDomain: cluster.local
-
-## @param extraDeploy Extra objects to deploy (value evaluated as a template)
-##
-extraDeploy: []
-
-## @param commonLabels Add labels to all the deployed resources
-##
-commonLabels: {}
-
-## @param commonAnnotations Add annotations to all the deployed resources
-##
-commonAnnotations: {}
-
-## Init containers parameters:
-## volumePermissions: Change the owner and group of the persistent volume mountpoint to runAsUser:fsGroup values from the securityContext section.
-##
-volumePermissions:
-  ## @param volumePermissions.enabled Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup`
-  ##
-  enabled: false
-  ## @param volumePermissions.image.registry Init container volume-permissions image registry
-  ## @param volumePermissions.image.repository Init container volume-permissions image repository
-  ## @param volumePermissions.image.tag Init container volume-permissions image tag (immutable tags are recommended)
-  ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
-  ## @param volumePermissions.image.pullSecrets Init container volume-permissions image pull secrets
-  ##
-  image:
-    registry: docker.io
-    repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r115
-    pullPolicy: Always
-    ## Optionally specify an array of imagePullSecrets.
-    ## Secrets must be manually created in the namespace.
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ## Example:
-    ## pullSecrets:
-    ##   - myRegistryKeySecretName
-    ##
-    pullSecrets: []
-  ## @param volumePermissions.resources Init container resource requests/limit
-  ##
-  resources: {}
+## @section Statefulset parameters
 
 ## Extra volumes and extra volume mounts allows you to mount other volumes
 ## Example Use Cases: mount certificates to enable tls
@@ -131,12 +177,10 @@ extraVolumes: []
 ##   mountPath: /certs/truststore
 ##   readOnly: true
 extraVolumeMounts: []
-
 ## @param updateStrategy StatefulSet controller supports automated updates. There are two valid update strategies: `RollingUpdate` and `OnDelete`
 ## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets
 ##
 updateStrategy: RollingUpdate
-
 ## Limits the number of pods of the replicated application that are down simultaneously from voluntary disruptions
 ## The PDB will only be created if replicaCount is greater than 1
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions
@@ -144,263 +188,22 @@ updateStrategy: RollingUpdate
 ##
 podDisruptionBudget:
   maxUnavailable: 1
-
 ## @param rollingUpdatePartition Partition update strategy
 ## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions
 ##
 rollingUpdatePartition:
-
 ## @param podManagementPolicy StatefulSet controller supports relax its ordering guarantees while preserving its uniqueness and identity guarantees. There are two valid pod management policies: `OrderedReady` and `Parallel`
 ## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy
 ##
 podManagementPolicy: Parallel
-
 ## @param replicaCount Number of ZooKeeper nodes
 ##
 replicaCount: 1
-
 ## @param minServerId Minimal SERVER_ID value, nodes increment their IDs respectively
 ## Servers increment their ID starting at this minimal value.
 ## E.g., with `minServerId=10` and 3 replicas, server IDs will be 10, 11, 12 for z-0, z-1 and z-2 respectively.
 ##
 minServerId: 1
-
-## @param tickTime Basic time unit in milliseconds used by ZooKeeper for heartbeats
-##
-tickTime: 2000
-
-## @param initLimit ZooKeeper uses to limit the length of time the ZooKeeper servers in quorum have to connect to a leader
-##
-initLimit: 10
-
-## @param syncLimit How far out of date a server can be from a leader
-##
-syncLimit: 5
-
-## @param maxClientCnxns Limits the number of concurrent connections that a single client may make to a single member of the ZooKeeper ensemble
-##
-maxClientCnxns: 60
-
-## @param fourlwCommandsWhitelist A list of comma separated Four Letter Words commands to use
-##
-fourlwCommandsWhitelist: srvr, mntr, ruok
-
-## @param listenOnAllIPs Allow Zookeeper to listen for connections from its peers on all available IP addresses
-##
-listenOnAllIPs: false
-
-## @param allowAnonymousLogin Allow to accept connections from unauthenticated users
-##
-allowAnonymousLogin: true
-
-autopurge:
-  ## @param autopurge.snapRetainCount Retains the snapRetainCount most recent snapshots and the corresponding transaction logs and deletes the rest
-  ##
-  snapRetainCount: 3
-  ## @param autopurge.purgeInterval The time interval in hours for which the purge task has to be triggered
-  ## Set to a positive integer (1 and above) to enable the auto purging
-  ##
-  purgeInterval: 0
-
-## @param maxSessionTimeout Maximum session timeout in milliseconds that the server will allow the client to negotiate
-## Defaults to 20 times the tickTime
-##
-maxSessionTimeout: 40000
-
-auth:
-  ## @param auth.existingSecret Use existing secret (ignores previous password)
-  ##
-  existingSecret:
-  ## @param auth.enabled Enable Zookeeper auth. It uses SASL/Digest-MD5
-  ##
-  enabled: false
-  ## @param auth.clientUser User that will use ZooKeeper clients to auth
-  ##
-  clientUser:
-  ## @param auth.clientPassword Password that will use ZooKeeper clients to auth
-  ##
-  clientPassword:
-  ## @param auth.serverUsers Comma, semicolon or whitespace separated list of user to be created
-  ## Specify them as a string, for example: "user1,user2,admin"
-  ##
-  serverUsers:
-  ## @param auth.serverPasswords Comma, semicolon or whitespace separated list of passwords to assign to users when created
-  ## Specify them as a string, for example: "pass4user1, pass4user2, pass4admin"
-  ##
-  serverPasswords:
-
-## @param heapSize Size in MB for the Java Heap options (Xmx and XMs)
-## This env var is ignored if Xmx an Xms are configured via JVMFLAGS
-##
-heapSize: 1024
-
-## @param logLevel Log level for the Zookeeper server. ERROR by default
-## Have in mind if you set it to INFO or WARN the ReadinessProve will produce a lot of logs
-##
-logLevel: ERROR
-
-## @param dataLogDir Data log directory. Specifying this option will direct zookeeper to write the transaction log to the dataLogDir rather than the dataDir.
-## This allows a dedicated log device to be used, and helps avoid competition between logging and snaphots.
-## Example:
-## dataLogDir: /bitnami/zookeeper/dataLog
-##
-dataLogDir: ''
-
-## @param jvmFlags Default JVMFLAGS for the ZooKeeper process
-##
-jvmFlags:
-
-## @param config Configure ZooKeeper with a custom zoo.cfg file
-##
-config:
-
-## @param namespaceOverride Namespace for ZooKeeper resources
-namespaceOverride:
-
-## Kubernetes configuration
-## For minikube, set this to NodePort, elsewhere use LoadBalancer
-##
-service:
-  ## @param service.type Kubernetes Service type
-  ##
-  type: ClusterIP
-  ## @param service.loadBalancerIP Load balancer IP for the Zookeper Service (optional, cloud specific)
-  ## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
-  ##
-  loadBalancerIP:
-  ## @param service.port ZooKeeper port
-  ##
-  port: 2181
-  ## @param service.followerPort ZooKeeper follower port
-  ##
-  followerPort: 2888
-  ## @param service.electionPort ZooKeeper election port
-  ##
-  electionPort: 3888
-  ## @param service.nodePorts [object] Specify the nodePort value for the LoadBalancer and NodePort service types.
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
-  ##
-  nodePorts:
-    client: ""
-    clientTls: ""
-  ## @param service.publishNotReadyAddresses If the ZooKeeper headless service should publish DNS records for not ready pods
-  ##
-  publishNotReadyAddresses: true
-
-  ## @param service.tlsClientPort Service port for tls client connections
-  ## Previously service.tls.service_port
-  ##
-  tlsClientPort: 3181
-  ## @param service.disableBaseClientPort Remove client port from service definitions.
-  ##
-  disableBaseClientPort: false
-
-  ## @param service.annotations Annotations for the Service
-  ## Previously service.tls.disable_base_client_port
-  ##
-  annotations: {}
-  ## @param service.headless.annotations Annotations for the Headless Service
-  ##
-  headless:
-    annotations: {}
-
-## Enable SSL/TLS encryption
-##
-tls:
-  client:
-    ## @param tls.client.enabled Enable TLS for client connections
-    ##
-    enabled: false
-
-    ## @param tls.client.autoGenerated Generate automatically self-signed TLS certificates for Zookeeper client communications
-    ## Currently only supports PEM certificates
-    ##
-    autoGenerated: false
-
-    ## @param tls.client.existingSecret Name of the existing secret containing the TLS certificates for Zookeper client communications
-    ##
-    existingSecret:
-
-    ## @param tls.client.keystorePath Location of the KeyStore file used for Client connections
-    ##
-    keystorePath: /opt/bitnami/zookeeper/config/certs/client/zookeeper.keystore.jks
-    ## @param tls.client.truststorePath Location of the TrustStore file used for Client connections
-    ##
-    truststorePath: /opt/bitnami/zookeeper/config/certs/client/zookeeper.truststore.jks
-
-    ## @param tls.client.passwordsSecretName Existing secret containing Keystore and truststore passwords
-    ##
-    passwordsSecretName:
-    ## @param tls.client.keystorePassword Password to access KeyStore if needed
-    ##
-    keystorePassword: ''
-    ## @param tls.client.truststorePassword Password to access TrustStore if needed
-    ##
-    truststorePassword: ''
-
-  quorum:
-    ## @param tls.quorum.enabled Enable TLS for quorum protocol
-    ##
-    enabled: false
-
-    ## @param tls.quorum.autoGenerated Create self-signed TLS certificates. Currently only supports PEM certificates.
-    ##
-    autoGenerated: false
-
-    ## @param tls.quorum.existingSecret Name of the existing secret containing the TLS certificates for Zookeper quorum protocol
-    ##
-    existingSecret:
-
-    ## @param tls.quorum.keystorePath Location of the KeyStore file used for Quorum protocol
-    ##
-    keystorePath: /opt/bitnami/zookeeper/config/certs/quorum/zookeeper.keystore.jks
-    ## @param tls.quorum.truststorePath Location of the TrustStore file used for Quorum protocol
-    ##
-    truststorePath: /opt/bitnami/zookeeper/config/certs/quorum/zookeeper.truststore.jks
-
-    ## @param tls.quorum.passwordsSecretName Existing secret containing Keystore and truststore passwords
-    ##
-    passwordsSecretName:
-    ## @param tls.quorum.keystorePassword Password to access KeyStore if needed
-    ##
-    keystorePassword: ''
-    ## @param tls.quorum.truststorePassword Password to access TrustStore if needed
-    ##
-    truststorePassword: ''
-
-  ## We usually recommend not to specify default resources and to leave this as a conscious
-  ## choice for the user. This also increases chances charts run on environments with little
-  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
-  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  ## @param tls.resources.limits The resources limits for the TLS init container
-  ## @param tls.resources.requests The requested resources for the TLS init container
-  ##
-  resources:
-    ## Example:
-    ## limits:
-    ##    cpu: 100m
-    ##    memory: 128Mi
-    limits: {}
-    ## Examples:
-    ## requests:
-    ##    cpu: 100m
-    ##    memory: 128Mi
-    requests: {}
-
-## Service account for Zookeeper to use.
-## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-##
-serviceAccount:
-  ## @param serviceAccount.create Enable creation of ServiceAccount for Zookeeper pod
-  ##
-  create: false
-  ## @param serviceAccount.name The name of the ServiceAccount to use.
-  ## If not set and create is true, a name is generated using the common.names.fullname template
-  name:
-  ## @param serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
-  ## Can be set to false if pods using this serviceAccount do not need to use K8s API
-  automountServiceAccountToken: true
-
 ## Zookeeper Pod Security Context
 ## @param securityContext.enabled Enable security context (ZooKeeper master pod)
 ## @param securityContext.fsGroup Group ID for the container (ZooKeeper master pod)
@@ -410,7 +213,6 @@ securityContext:
   enabled: true
   fsGroup: 1001
   runAsUser: 1001
-
 ## @param initContainers Extra init container to add to the statefulset
 ## Example:
 ## initContainers:
@@ -422,75 +224,14 @@ securityContext:
 ##         containerPort: 1234
 ##
 initContainers: []
-
-## Zookeeper data Persistent Volume Storage Class
-## If defined, storageClassName: <storageClass>
-## If set to "-", storageClassName: "", which disables dynamic provisioning
-## If undefined (the default) or set to null, no storageClassName spec is
-##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-##   GKE, AWS & OpenStack)
-##
-persistence:
-  ## @param persistence.existingClaim Provide an existing `PersistentVolumeClaim`
-  ## If defined, PVC must be created manually before volume will be bound
-  ## The value is evaluated as a template
-  ##
-  existingClaim:
-
-  ## @param persistence.enabled Enable Zookeeper data persistence using PVC
-  ##
-  enabled: true
-  ## @param persistence.storageClass PVC Storage Class for ZooKeeper data volume
-  ##
-  storageClass:
-  ## @param persistence.accessModes PVC Access modes
-  ##
-  accessModes:
-    - ReadWriteOnce
-  ## @param persistence.size PVC Storage Request for ZooKeeper data volume
-  ##
-  size: 8Gi
-  ## @param persistence.annotations Annotations for the PVC
-  ##
-  annotations: {}
-  ## @param persistence.selector Selector to match an existing Persistent Volume for Zookeeper's data PVC
-  ## If set, the PVC can't have a PV dynamically provisioned for it
-  ## E.g.
-  ## selector:
-  ##   matchLabels:
-  ##     app: my-app
-  ##
-  selector: {}
-
-  dataLogDir:
-    ## @param persistence.dataLogDir.size PVC Storage Request for ZooKeeper's Data log directory
-    ##
-    size: 8Gi
-    ## @param persistence.dataLogDir.existingClaim Provide an existing `PersistentVolumeClaim` for Zookeeper's Data log directory
-    ## If defined, PVC must be created manually before volume will be bound
-    ## The value is evaluated as a template
-    ##
-    existingClaim:
-
-    ## @param persistence.dataLogDir.selector Selector to match an existing Persistent Volume for Zookeeper's Data log PVC
-    ## If set, the PVC can't have a PV dynamically provisioned for it
-    ## E.g.
-    ## selector:
-    ##   matchLabels:
-    ##     app: my-app
-    ##
-    selector: {}
-
 ## @param podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
 ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
 ##
 podAffinityPreset: ''
-
 ## @param podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
 ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
 ##
 podAntiAffinityPreset: soft
-
 ## Node affinity preset
 ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
 ##
@@ -510,43 +251,35 @@ nodeAffinityPreset:
   ##   - e2e-az2
   ##
   values: []
-
 ## @param affinity Affinity for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 ## Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
 ##
 affinity: {}
-
 ## @param nodeSelector Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##
 nodeSelector: {}
-
 ## @param tolerations Tolerations for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
 tolerations: []
-
 ## @param podLabels ZooKeeper pod labels
 ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ##
 podLabels: {}
-
 ## @param podAnnotations ZooKeeper Pod annotations
 ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 ##
 podAnnotations: {}
-
 ## @param priorityClassName Name of the existing priority class to be used by ZooKeeper pods, priority class needs to be created beforehand
 ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
 ##
 priorityClassName: ''
-
 ## @param schedulerName Kubernetes pod scheduler registry
 ## https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
 ##
 schedulerName:
-
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ## @param resources.requests [object] The requested resources for the container
@@ -555,7 +288,6 @@ resources:
   requests:
     memory: 256Mi
     cpu: 250m
-
 ## Configure extra options for liveness probe
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
 ## @param livenessProbe.enabled Enable livenessProbe
@@ -592,15 +324,72 @@ readinessProbe:
   failureThreshold: 6
   successThreshold: 1
   probeCommandTimeout: 2
-
 ## @param customLivenessProbe Override default liveness probe
 ##
 customLivenessProbe: {}
-
 ## @param customReadinessProbe Override default readiness probe
 ##
 customReadinessProbe: {}
 
+## @section Traffic Exposure parameters
+
+## Kubernetes configuration
+## For minikube, set this to NodePort, elsewhere use LoadBalancer
+##
+service:
+  ## @param service.type Kubernetes Service type
+  ##
+  type: ClusterIP
+  ## @param service.loadBalancerIP Load balancer IP for the Zookeper Service (optional, cloud specific)
+  ## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
+  ##
+  loadBalancerIP:
+  ## @param service.port ZooKeeper port
+  ##
+  port: 2181
+  ## @param service.followerPort ZooKeeper follower port
+  ##
+  followerPort: 2888
+  ## @param service.electionPort ZooKeeper election port
+  ##
+  electionPort: 3888
+  ## @param service.nodePorts [object] Specify the nodePort value for the LoadBalancer and NodePort service types.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+  ##
+  nodePorts:
+    client: ""
+    clientTls: ""
+  ## @param service.publishNotReadyAddresses If the ZooKeeper headless service should publish DNS records for not ready pods
+  ##
+  publishNotReadyAddresses: true
+  ## @param service.tlsClientPort Service port for tls client connections
+  ## Previously service.tls.service_port
+  ##
+  tlsClientPort: 3181
+  ## @param service.disableBaseClientPort Remove client port from service definitions.
+  ##
+  disableBaseClientPort: false
+  ## @param service.annotations Annotations for the Service
+  ## Previously service.tls.disable_base_client_port
+  ##
+  annotations: {}
+  ## @param service.headless.annotations Annotations for the Headless Service
+  ##
+  headless:
+    annotations: {}
+## Service account for Zookeeper to use.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  ## @param serviceAccount.create Enable creation of ServiceAccount for Zookeeper pod
+  ##
+  create: false
+  ## @param serviceAccount.name The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the common.names.fullname template
+  name:
+  ## @param serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+  ## Can be set to false if pods using this serviceAccount do not need to use K8s API
+  automountServiceAccountToken: true
 ## Network policies
 ## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 ##
@@ -608,12 +397,102 @@ networkPolicy:
   ## @param networkPolicy.enabled Specifies whether a NetworkPolicy should be created
   ##
   enabled: false
-
   ## @param networkPolicy.allowExternal Don't require client label for connections
   ## When set to false, only pods with the correct client label will have network access to the port Redis(TM) is
   ## listening on. When true, zookeeper accept connections from any source (with the correct destination port).
   ##
   allowExternal:
+
+## @section Persistence parameters
+
+## Zookeeper data Persistent Volume Storage Class
+## If defined, storageClassName: <storageClass>
+## If set to "-", storageClassName: "", which disables dynamic provisioning
+## If undefined (the default) or set to null, no storageClassName spec is
+##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+##   GKE, AWS & OpenStack)
+##
+persistence:
+  ## @param persistence.existingClaim Provide an existing `PersistentVolumeClaim`
+  ## If defined, PVC must be created manually before volume will be bound
+  ## The value is evaluated as a template
+  ##
+  existingClaim:
+  ## @param persistence.enabled Enable Zookeeper data persistence using PVC
+  ##
+  enabled: true
+  ## @param persistence.storageClass PVC Storage Class for ZooKeeper data volume
+  ##
+  storageClass:
+  ## @param persistence.accessModes PVC Access modes
+  ##
+  accessModes:
+    - ReadWriteOnce
+  ## @param persistence.size PVC Storage Request for ZooKeeper data volume
+  ##
+  size: 8Gi
+  ## @param persistence.annotations Annotations for the PVC
+  ##
+  annotations: {}
+  ## @param persistence.selector Selector to match an existing Persistent Volume for Zookeeper's data PVC
+  ## If set, the PVC can't have a PV dynamically provisioned for it
+  ## E.g.
+  ## selector:
+  ##   matchLabels:
+  ##     app: my-app
+  ##
+  selector: {}
+  dataLogDir:
+    ## @param persistence.dataLogDir.size PVC Storage Request for ZooKeeper's Data log directory
+    ##
+    size: 8Gi
+    ## @param persistence.dataLogDir.existingClaim Provide an existing `PersistentVolumeClaim` for Zookeeper's Data log directory
+    ## If defined, PVC must be created manually before volume will be bound
+    ## The value is evaluated as a template
+    ##
+    existingClaim:
+    ## @param persistence.dataLogDir.selector Selector to match an existing Persistent Volume for Zookeeper's Data log PVC
+    ## If set, the PVC can't have a PV dynamically provisioned for it
+    ## E.g.
+    ## selector:
+    ##   matchLabels:
+    ##     app: my-app
+    ##
+    selector: {}
+
+## @section Volume Permissions parameters
+
+## Init containers parameters:
+## volumePermissions: Change the owner and group of the persistent volume mountpoint to runAsUser:fsGroup values from the securityContext section.
+##
+volumePermissions:
+  ## @param volumePermissions.enabled Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup`
+  ##
+  enabled: false
+  ## @param volumePermissions.image.registry Init container volume-permissions image registry
+  ## @param volumePermissions.image.repository Init container volume-permissions image repository
+  ## @param volumePermissions.image.tag Init container volume-permissions image tag (immutable tags are recommended)
+  ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
+  ## @param volumePermissions.image.pullSecrets Init container volume-permissions image pull secrets
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/bitnami-shell
+    tag: 10-debian-10-r115
+    pullPolicy: Always
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+  ## @param volumePermissions.resources Init container resource requests/limit
+  ##
+  resources: {}
+
+## @section Metrics parameters
 
 ## Zookeeper Prometheus Exporter configuration
 ##
@@ -621,11 +500,9 @@ metrics:
   ## @param metrics.enabled Enable prometheus to access zookeeper metrics endpoint
   ##
   enabled: false
-
   ## @param metrics.containerPort Zookeeper Prometheus Exporter container port
   ##
   containerPort: 9141
-
   ## Service configuration
   ##
   service:
@@ -641,7 +518,6 @@ metrics:
       prometheus.io/scrape: 'true'
       prometheus.io/port: '{{ .Values.metrics.service.port }}'
       prometheus.io/path: '/metrics'
-
   ## Prometheus Operator ServiceMonitor configuration
   ##
   serviceMonitor:
@@ -651,7 +527,6 @@ metrics:
     ## @param metrics.serviceMonitor.namespace Namespace for the ServiceMonitor Resource (defaults to the Release Namespace)
     ##
     namespace:
-
     ## @param metrics.serviceMonitor.interval Interval at which metrics should be scraped.
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
     ## e.g:
@@ -671,7 +546,6 @@ metrics:
     ##   prometheus: my-prometheus
     ##
     selector:
-
   ## Prometheus Operator PrometheusRule configuration
   ##
   prometheusRule:
@@ -681,7 +555,6 @@ metrics:
     ## @param metrics.prometheusRule.namespace Namespace for the PrometheusRule Resource (defaults to the Release Namespace)
     ##
     namespace:
-
     ## @param metrics.prometheusRule.selector Prometheus instance selector labels
     ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
     ## e.g:
@@ -689,7 +562,6 @@ metrics:
     ##   prometheus: my-prometheus
     ##
     selector:
-
     ## @param metrics.prometheusRule.rules Prometheus Rule definitions
     ##  - alert: ZookeeperSyncedFollowers
     ##    annotations:
@@ -707,3 +579,78 @@ metrics:
     ##      severity: critical
     ##
     rules: []
+
+## @section TLS/SSL parameters
+
+## Enable SSL/TLS encryption
+##
+tls:
+  client:
+    ## @param tls.client.enabled Enable TLS for client connections
+    ##
+    enabled: false
+    ## @param tls.client.autoGenerated Generate automatically self-signed TLS certificates for Zookeeper client communications
+    ## Currently only supports PEM certificates
+    ##
+    autoGenerated: false
+    ## @param tls.client.existingSecret Name of the existing secret containing the TLS certificates for Zookeper client communications
+    ##
+    existingSecret:
+    ## @param tls.client.keystorePath Location of the KeyStore file used for Client connections
+    ##
+    keystorePath: /opt/bitnami/zookeeper/config/certs/client/zookeeper.keystore.jks
+    ## @param tls.client.truststorePath Location of the TrustStore file used for Client connections
+    ##
+    truststorePath: /opt/bitnami/zookeeper/config/certs/client/zookeeper.truststore.jks
+    ## @param tls.client.passwordsSecretName Existing secret containing Keystore and truststore passwords
+    ##
+    passwordsSecretName:
+    ## @param tls.client.keystorePassword Password to access KeyStore if needed
+    ##
+    keystorePassword: ''
+    ## @param tls.client.truststorePassword Password to access TrustStore if needed
+    ##
+    truststorePassword: ''
+  quorum:
+    ## @param tls.quorum.enabled Enable TLS for quorum protocol
+    ##
+    enabled: false
+    ## @param tls.quorum.autoGenerated Create self-signed TLS certificates. Currently only supports PEM certificates.
+    ##
+    autoGenerated: false
+    ## @param tls.quorum.existingSecret Name of the existing secret containing the TLS certificates for Zookeper quorum protocol
+    ##
+    existingSecret:
+    ## @param tls.quorum.keystorePath Location of the KeyStore file used for Quorum protocol
+    ##
+    keystorePath: /opt/bitnami/zookeeper/config/certs/quorum/zookeeper.keystore.jks
+    ## @param tls.quorum.truststorePath Location of the TrustStore file used for Quorum protocol
+    ##
+    truststorePath: /opt/bitnami/zookeeper/config/certs/quorum/zookeeper.truststore.jks
+    ## @param tls.quorum.passwordsSecretName Existing secret containing Keystore and truststore passwords
+    ##
+    passwordsSecretName:
+    ## @param tls.quorum.keystorePassword Password to access KeyStore if needed
+    ##
+    keystorePassword: ''
+    ## @param tls.quorum.truststorePassword Password to access TrustStore if needed
+    ##
+    truststorePassword: ''
+  ## We usually recommend not to specify default resources and to leave this as a conscious
+  ## choice for the user. This also increases chances charts run on environments with little
+  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ## @param tls.resources.limits The resources limits for the TLS init container
+  ## @param tls.resources.requests The requested resources for the TLS init container
+  ##
+  resources:
+    ## Example:
+    ## limits:
+    ##    cpu: 100m
+    ##    memory: 128Mi
+    limits: {}
+    ## Examples:
+    ## requests:
+    ##    cpu: 100m
+    ##    memory: 128Mi
+    requests: {}

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -1,15 +1,29 @@
+## @section Global parameters
 ## Global Docker image parameters
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value
-## Current available global Docker image parameters: imageRegistry and imagePullSecrets
+## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
+
+## @param global.imageRegistry Global Docker image registry
+## @param global.imagePullSecrets Global Docker registry secret names as an array
+## @param global.storageClass Global StorageClass for Persistent Volume(s)
 ##
-# global:
-#   imageRegistry: myRegistryName
-#   imagePullSecrets:
-#     - myRegistryKeySecretName
-#   storageClass: myStorageClass
+global:
+  imageRegistry:
+  ## E.g.
+  ## imagePullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
+  storageClass:
 
 ## Bitnami Zookeeper image version
 ## ref: https://hub.docker.com/r/bitnami/zookeeper/tags/
+## @param image.registry ZooKeeper image registry
+## @param image.repository ZooKeeper image repository
+## @param image.tag ZooKeeper Image tag (immutable tags are recommended)
+## @param image.pullPolicy ZooKeeper image pull policy
+## @param image.pullSecrets Specify docker-registry secret names as an array
+## @param image.debug Specify if debug values should be set
 ##
 image:
   registry: docker.io
@@ -24,38 +38,42 @@ image:
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## Example:
+  ## pullSecrets:
+  ##   - myRegistryKeySecretName
   ##
-  # pullSecrets:
-  #   - myRegistryKeySecretName
+  pullSecrets: []
   ## Set to true if you would like to see extra information on logs
   ## It turns BASH and/or NAMI debugging in the image
   ##
   debug: false
 
-## String to partially override common.names.fullname template (will maintain the release name)
-# nameOverride:
+## @param nameOverride String to partially override common.names.fullname template (will maintain the release name)
+##
+nameOverride:
 
-## String to fully override common.names.fullname template
-# fullnameOverride:
+## @param fullnameOverride String to fully override common.names.fullname template
+##
+fullnameOverride:
 
-## Deployment pod host aliases
+## @param hostAliases Deployment pod host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
 hostAliases: []
 
-## Kubernetes Cluster Domain
+## @param clusterDomain Kubernetes Cluster Domain
 ##
 clusterDomain: cluster.local
 
-## Extra objects to deploy (value evaluated as a template)
+## @param extraDeploy Extra objects to deploy (value evaluated as a template)
 ##
 extraDeploy: []
 
-## Add labels to all the deployed resources
+## @param commonLabels Add labels to all the deployed resources
 ##
 commonLabels: {}
 
-## Add annotations to all the deployed resources
+## @param commonAnnotations Add annotations to all the deployed resources
 ##
 commonAnnotations: {}
 
@@ -63,7 +81,15 @@ commonAnnotations: {}
 ## volumePermissions: Change the owner and group of the persistent volume mountpoint to runAsUser:fsGroup values from the securityContext section.
 ##
 volumePermissions:
+  ## @param volumePermissions.enabled Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup`
+  ##
   enabled: false
+  ## @param volumePermissions.image.registry Init container volume-permissions image registry
+  ## @param volumePermissions.image.repository Init container volume-permissions image repository
+  ## @param volumePermissions.image.tag Init container volume-permissions image tag (immutable tags are recommended)
+  ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
+  ## @param volumePermissions.image.pullSecrets Init container volume-permissions image pull secrets
+  ##
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
@@ -72,32 +98,41 @@ volumePermissions:
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
     ##
-    # pullSecrets:
-    #   - myRegistryKeySecretName
+    pullSecrets: []
+  ## @param volumePermissions.resources Init container resource requests/limit
+  ##
   resources: {}
 
-## extraVolumes and extraVolumeMounts allows you to mount other volumes
-## Example Use Cases:
-##  mount certificates to enable tls
-# extraVolumes:
-# - name: zookeeper-keystore
-#   secret:
-#     defaultMode: 288
-#     secretName: zookeeper-keystore
-# - name: zookeeper-trustsore
-#   secret:
-#     defaultMode: 288
-#     secretName: zookeeper-truststore
-# extraVolumeMounts:
-# - name: zookeeper-keystore
-#   mountPath: /certs/keystore
-#   readOnly: true
-# - name: zookeeper-truststore
-#   mountPath: /certs/truststore
-#   readOnly: true
+## Extra volumes and extra volume mounts allows you to mount other volumes
+## Example Use Cases: mount certificates to enable tls
+## @param extraVolumes Extra volumes
+## e.g:
+## extraVolumes:
+## - name: zookeeper-keystore
+##   secret:
+##     defaultMode: 288
+##     secretName: zookeeper-keystore
+## - name: zookeeper-trustsore
+##   secret:
+##     defaultMode: 288
+##     secretName: zookeeper-truststore
+##
+extraVolumes: []
+## @param extraVolumeMounts Mount extra volume(s)
+## e.g:
+## - name: zookeeper-keystore
+##   mountPath: /certs/keystore
+##   readOnly: true
+## - name: zookeeper-truststore
+##   mountPath: /certs/truststore
+##   readOnly: true
+extraVolumeMounts: []
 
-## StatefulSet controller supports automated updates. There are two valid update strategies: RollingUpdate and OnDelete
+## @param updateStrategy StatefulSet controller supports automated updates. There are two valid update strategies: `RollingUpdate` and `OnDelete`
 ## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets
 ##
 updateStrategy: RollingUpdate
@@ -105,142 +140,167 @@ updateStrategy: RollingUpdate
 ## Limits the number of pods of the replicated application that are down simultaneously from voluntary disruptions
 ## The PDB will only be created if replicaCount is greater than 1
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions
+## @param podDisruptionBudget.maxUnavailable Max number of pods down simultaneously
 ##
 podDisruptionBudget:
   maxUnavailable: 1
 
-## Partition update strategy
+## @param rollingUpdatePartition Partition update strategy
 ## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions
 ##
-# rollingUpdatePartition:
+rollingUpdatePartition:
 
-## StatefulSet controller supports relax its ordering guarantees while preserving its uniqueness and identity guarantees. There are two valid pod management policies: OrderedReady and Parallel
+## @param podManagementPolicy StatefulSet controller supports relax its ordering guarantees while preserving its uniqueness and identity guarantees. There are two valid pod management policies: `OrderedReady` and `Parallel`
 ## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy
 ##
 podManagementPolicy: Parallel
 
-## Number of ZooKeeper nodes
+## @param replicaCount Number of ZooKeeper nodes
 ##
 replicaCount: 1
 
-## Minimal server ID (ZooKeeper myid) value
-## servers increment their ID starting at this minimal value.
+## @param minServerId Minimal SERVER_ID value, nodes increment their IDs respectively
+## Servers increment their ID starting at this minimal value.
 ## E.g., with `minServerId=10` and 3 replicas, server IDs will be 10, 11, 12 for z-0, z-1 and z-2 respectively.
 ##
 minServerId: 1
 
-## Basic time unit in milliseconds used by ZooKeeper for heartbeats
+## @param tickTime Basic time unit in milliseconds used by ZooKeeper for heartbeats
 ##
 tickTime: 2000
 
-## ZooKeeper uses to limit the length of time the ZooKeeper servers in quorum have to connect to a leader
+## @param initLimit ZooKeeper uses to limit the length of time the ZooKeeper servers in quorum have to connect to a leader
 ##
 initLimit: 10
 
-## How far out of date a server can be from a leader
+## @param syncLimit How far out of date a server can be from a leader
 ##
 syncLimit: 5
 
-## Limits the number of concurrent connections that a single client may make to a single member of the ZooKeeper ensemble
+## @param maxClientCnxns Limits the number of concurrent connections that a single client may make to a single member of the ZooKeeper ensemble
 ##
 maxClientCnxns: 60
 
-## A list of comma separated Four Letter Words commands to use
+## @param fourlwCommandsWhitelist A list of comma separated Four Letter Words commands to use
 ##
 fourlwCommandsWhitelist: srvr, mntr, ruok
 
-## Allow zookeeper to listen for peers on all IPs
+## @param listenOnAllIPs Allow Zookeeper to listen for connections from its peers on all available IP addresses
 ##
 listenOnAllIPs: false
 
-## Allow to accept connections from unauthenticated users
+## @param allowAnonymousLogin Allow to accept connections from unauthenticated users
 ##
 allowAnonymousLogin: true
 
 autopurge:
-  ## Retains the snapRetainCount most recent snapshots and the corresponding transaction logs and deletes the rest
+  ## @param autopurge.snapRetainCount Retains the snapRetainCount most recent snapshots and the corresponding transaction logs and deletes the rest
   ##
   snapRetainCount: 3
-  ## The time interval in hours for which the purge task has to be triggered. Set to a positive integer (1 and above) to enable the auto purging.
+  ## @param autopurge.purgeInterval The time interval in hours for which the purge task has to be triggered
+  ## Set to a positive integer (1 and above) to enable the auto purging
   ##
   purgeInterval: 0
 
-## Maximum session timeout in milliseconds that the server will allow the client to negotiate. Defaults to 20 times the tickTime.
+## @param maxSessionTimeout Maximum session timeout in milliseconds that the server will allow the client to negotiate
+## Defaults to 20 times the tickTime
 ##
 maxSessionTimeout: 40000
 
 auth:
-  ## Use existing secret (ignores previous password)
+  ## @param auth.existingSecret Use existing secret (ignores previous password)
   ##
-  # existingSecret:
-  ## Enable Zookeeper auth. It uses SASL/Digest-MD5
+  existingSecret:
+  ## @param auth.enabled Enable Zookeeper auth. It uses SASL/Digest-MD5
   ##
   enabled: false
-  ## User that will use Zookeeper clients to auth
+  ## @param auth.clientUser User that will use ZooKeeper clients to auth
   ##
   clientUser:
-  ## Password that will use Zookeeper clients to auth
+  ## @param auth.clientPassword Password that will use ZooKeeper clients to auth
   ##
   clientPassword:
-  ## Comma, semicolon or whitespace separated list of user to be created. Specify them as a string, for example: "user1,user2,admin"
+  ## @param auth.serverUsers Comma, semicolon or whitespace separated list of user to be created
+  ## Specify them as a string, for example: "user1,user2,admin"
   ##
   serverUsers:
-  ## Comma, semicolon or whitespace separated list of passwords to assign to users when created. Specify them as a string, for example: "pass4user1, pass4user2, pass4admin"
+  ## @param auth.serverPasswords Comma, semicolon or whitespace separated list of passwords to assign to users when created
+  ## Specify them as a string, for example: "pass4user1, pass4user2, pass4admin"
   ##
   serverPasswords:
 
-## Size in MB for the Java Heap options (Xmx and XMs). This env var is ignored if Xmx an Xms are configured via JVMFLAGS
+## @param heapSize Size in MB for the Java Heap options (Xmx and XMs)
+## This env var is ignored if Xmx an Xms are configured via JVMFLAGS
 ##
 heapSize: 1024
 
-## Log level for the Zookeeper server. ERROR by default. Have in mind if you set it to INFO or WARN the ReadinessProve will produce a lot of logs.
+## @param logLevel Log level for the Zookeeper server. ERROR by default
+## Have in mind if you set it to INFO or WARN the ReadinessProve will produce a lot of logs
 ##
 logLevel: ERROR
 
-## Data log directory. Specifying this option will direct zookeeper to write the transaction log to the dataLogDir rather than the dataDir.
+## @param dataLogDir Data log directory. Specifying this option will direct zookeeper to write the transaction log to the dataLogDir rather than the dataDir.
 ## This allows a dedicated log device to be used, and helps avoid competition between logging and snaphots.
 ## Example:
 ## dataLogDir: /bitnami/zookeeper/dataLog
 ##
 dataLogDir: ''
 
-## Default JVMFLAGS for the ZooKeeper process
+## @param jvmFlags Default JVMFLAGS for the ZooKeeper process
 ##
-# jvmFlags:
+jvmFlags:
 
-## Configure ZooKeeper with a custom zoo.cfg file
+## @param config Configure ZooKeeper with a custom zoo.cfg file
 ##
-# config:
+config:
 
-## Namespace for ZooKeeper resources
-# namespaceOverride:
+## @param namespaceOverride Namespace for ZooKeeper resources
+namespaceOverride:
 
 ## Kubernetes configuration
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer
 ##
 service:
+  ## @param service.type Kubernetes Service type
+  ##
   type: ClusterIP
-  ## loadBalancerIP for the Zookeper Service (optional, cloud specific)
+  ## @param service.loadBalancerIP Load balancer IP for the Zookeper Service (optional, cloud specific)
   ## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
   ##
-  # loadBalancerIP:
+  loadBalancerIP:
+  ## @param service.port ZooKeeper port
+  ##
   port: 2181
+  ## @param service.followerPort ZooKeeper follower port
+  ##
   followerPort: 2888
+  ## @param service.electionPort ZooKeeper election port
+  ##
   electionPort: 3888
-  ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+  ## @param service.nodePorts [object] Specify the nodePort value for the LoadBalancer and NodePort service types.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
   ##
   nodePorts:
     client: ""
     clientTls: ""
+  ## @param service.publishNotReadyAddresses If the ZooKeeper headless service should publish DNS records for not ready pods
+  ##
   publishNotReadyAddresses: true
 
-  ## TLS port settings. Previously service.tls.service_port and service.tls.disable_base_client_port
+  ## @param service.tlsClientPort Service port for tls client connections
+  ## Previously service.tls.service_port
   ##
   tlsClientPort: 3181
+  ## @param service.disableBaseClientPort Remove client port from service definitions.
+  ##
   disableBaseClientPort: false
 
+  ## @param service.annotations Annotations for the Service
+  ## Previously service.tls.disable_base_client_port
+  ##
   annotations: {}
+  ## @param service.headless.annotations Annotations for the Headless Service
+  ##
   headless:
     annotations: {}
 
@@ -248,92 +308,110 @@ service:
 ##
 tls:
   client:
+    ## @param tls.client.enabled Enable TLS for client connections
+    ##
     enabled: false
 
-    ## Create self-signed TLS certificates. Currently only supports PEM certificates.
+    ## @param tls.client.autoGenerated Generate automatically self-signed TLS certificates for Zookeeper client communications
+    ## Currently only supports PEM certificates
     ##
     autoGenerated: false
 
-    ## Name of the existing secret containing Kibana server certificates
+    ## @param tls.client.existingSecret Name of the existing secret containing the TLS certificates for Zookeper client communications
     ##
     existingSecret:
 
-    ## Keystore and Truststore Path
+    ## @param tls.client.keystorePath Location of the KeyStore file used for Client connections
     ##
     keystorePath: /opt/bitnami/zookeeper/config/certs/client/zookeeper.keystore.jks
+    ## @param tls.client.truststorePath Location of the TrustStore file used for Client connections
+    ##
     truststorePath: /opt/bitnami/zookeeper/config/certs/client/zookeeper.truststore.jks
 
-    ## Existing secret containing Keystore and truststore passwords
+    ## @param tls.client.passwordsSecretName Existing secret containing Keystore and truststore passwords
     ##
     passwordsSecretName:
-    ## Keystore and Truststore Password
+    ## @param tls.client.keystorePassword Password to access KeyStore if needed
     ##
     keystorePassword: ''
+    ## @param tls.client.truststorePassword Password to access TrustStore if needed
+    ##
     truststorePassword: ''
 
   quorum:
-    ## Enable TLS for quorum protocol
+    ## @param tls.quorum.enabled Enable TLS for quorum protocol
     ##
     enabled: false
 
-    ## Create self-signed TLS certificates. Currently only supports PEM certificates.
+    ## @param tls.quorum.autoGenerated Create self-signed TLS certificates. Currently only supports PEM certificates.
     ##
     autoGenerated: false
 
-    ## Name of the existing secret containing Kibana server certificates
+    ## @param tls.quorum.existingSecret Name of the existing secret containing the TLS certificates for Zookeper quorum protocol
     ##
     existingSecret:
 
-    ## Keystore and Truststore Path
+    ## @param tls.quorum.keystorePath Location of the KeyStore file used for Quorum protocol
     ##
     keystorePath: /opt/bitnami/zookeeper/config/certs/quorum/zookeeper.keystore.jks
+    ## @param tls.quorum.truststorePath Location of the TrustStore file used for Quorum protocol
+    ##
     truststorePath: /opt/bitnami/zookeeper/config/certs/quorum/zookeeper.truststore.jks
 
-    ## Existing secret containing Keystore and truststore passwords
+    ## @param tls.quorum.passwordsSecretName Existing secret containing Keystore and truststore passwords
     ##
     passwordsSecretName:
-    ## Keystore and Truststore Password
+    ## @param tls.quorum.keystorePassword Password to access KeyStore if needed
     ##
     keystorePassword: ''
+    ## @param tls.quorum.truststorePassword Password to access TrustStore if needed
+    ##
     truststorePassword: ''
 
+  ## We usually recommend not to specify default resources and to leave this as a conscious
+  ## choice for the user. This also increases chances charts run on environments with little
+  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ## @param tls.resources.limits The resources limits for the TLS init container
+  ## @param tls.resources.requests The requested resources for the TLS init container
+  ##
   resources:
-    ## We usually recommend not to specify default resources and to leave this as a conscious
-    ## choice for the user. This also increases chances charts run on environments with little
-    ## resources, such as Minikube. If you do want to specify resources, uncomment the following
-    ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    ##
+    ## Example:
+    ## limits:
+    ##    cpu: 100m
+    ##    memory: 128Mi
     limits: {}
-    ##   cpu: 100m
-    ##   memory: 128Mi
-    ##
+    ## Examples:
+    ## requests:
+    ##    cpu: 100m
+    ##    memory: 128Mi
     requests: {}
-    ##   cpu: 100m
-    ##   memory: 128Mi
-    ##
 
 ## Service account for Zookeeper to use.
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 ##
 serviceAccount:
-  ## Specifies whether a ServiceAccount should be created
+  ## @param serviceAccount.create Enable creation of ServiceAccount for Zookeeper pod
   ##
   create: false
-  ## The name of the ServiceAccount to use.
+  ## @param serviceAccount.name The name of the ServiceAccount to use.
   ## If not set and create is true, a name is generated using the common.names.fullname template
-  # name:
-  # Allows auto mount of ServiceAccountToken on the serviceAccount created
-  # Can be set to false if pods using this serviceAccount do not need to use K8s API
+  name:
+  ## @param serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+  ## Can be set to false if pods using this serviceAccount do not need to use K8s API
   automountServiceAccountToken: true
 
 ## Zookeeper Pod Security Context
+## @param securityContext.enabled Enable security context (ZooKeeper master pod)
+## @param securityContext.fsGroup Group ID for the container (ZooKeeper master pod)
+## @param securityContext.runAsUser User ID for the container (ZooKeeper master pod)
 ##
 securityContext:
   enabled: true
   fsGroup: 1001
   runAsUser: 1001
 
-## Add initContainers to the web pods.
+## @param initContainers Extra init container to add to the statefulset
 ## Example:
 ## initContainers:
 ##   - name: your-image-name
@@ -353,19 +431,30 @@ initContainers: []
 ##   GKE, AWS & OpenStack)
 ##
 persistence:
-  ## A manually managed Persistent Volume and Claim
+  ## @param persistence.existingClaim Provide an existing `PersistentVolumeClaim`
   ## If defined, PVC must be created manually before volume will be bound
   ## The value is evaluated as a template
   ##
-  # existingClaim:
+  existingClaim:
 
+  ## @param persistence.enabled Enable Zookeeper data persistence using PVC
+  ##
   enabled: true
-  # storageClass: "-"
+  ## @param persistence.storageClass PVC Storage Class for ZooKeeper data volume
+  ##
+  storageClass:
+  ## @param persistence.accessModes PVC Access modes
+  ##
   accessModes:
     - ReadWriteOnce
+  ## @param persistence.size PVC Storage Request for ZooKeeper data volume
+  ##
   size: 8Gi
+  ## @param persistence.annotations Annotations for the PVC
+  ##
   annotations: {}
-  ## Selector to match an existing PersistentVolume
+  ## @param persistence.selector Selector to match an existing Persistent Volume for Zookeeper's data PVC
+  ## If set, the PVC can't have a PV dynamically provisioned for it
   ## E.g.
   ## selector:
   ##   matchLabels:
@@ -374,14 +463,17 @@ persistence:
   selector: {}
 
   dataLogDir:
+    ## @param persistence.dataLogDir.size PVC Storage Request for ZooKeeper's Data log directory
+    ##
     size: 8Gi
-    ## A manually managed Persistent Volume and Claim
+    ## @param persistence.dataLogDir.existingClaim Provide an existing `PersistentVolumeClaim` for Zookeeper's Data log directory
     ## If defined, PVC must be created manually before volume will be bound
     ## The value is evaluated as a template
     ##
-    # existingClaim:
+    existingClaim:
 
-    ## Selector to match an existing PersistentVolume
+    ## @param persistence.dataLogDir.selector Selector to match an existing Persistent Volume for Zookeeper's Data log PVC
+    ## If set, the PVC can't have a PV dynamically provisioned for it
     ## E.g.
     ## selector:
     ##   matchLabels:
@@ -389,33 +481,29 @@ persistence:
     ##
     selector: {}
 
-## Pod affinity preset
+## @param podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
 ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
-## Allowed values: soft, hard
 ##
 podAffinityPreset: ''
 
-## Pod anti-affinity preset
+## @param podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
 ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
-## Allowed values: soft, hard
 ##
 podAntiAffinityPreset: soft
 
 ## Node affinity preset
 ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
-## Allowed values: soft, hard
 ##
 nodeAffinityPreset:
-  ## Node affinity type
-  ## Allowed values: soft, hard
+  ## @param nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
   ##
   type: ''
-  ## Node label key to match
+  ## @param nodeAffinityPreset.key Node label key to match Ignored if `affinity` is set.
   ## E.g.
   ## key: "kubernetes.io/e2e-az-name"
   ##
   key: ''
-  ## Node label values to match
+  ## @param nodeAffinityPreset.values Node label values to match. Ignored if `affinity` is set.
   ## E.g.
   ## values:
   ##   - e2e-az1
@@ -423,52 +511,60 @@ nodeAffinityPreset:
   ##
   values: []
 
-## Affinity for pod assignment
+## @param affinity Affinity for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 ## Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
 ##
 affinity: {}
 
-## Node labels for pod assignment
+## @param nodeSelector Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##
 nodeSelector: {}
 
-## Tolerations for pod assignment
+## @param tolerations Tolerations for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
 tolerations: []
 
-## Labels
+## @param podLabels ZooKeeper pod labels
 ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ##
 podLabels: {}
 
-## Annotations
+## @param podAnnotations ZooKeeper Pod annotations
 ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 ##
 podAnnotations: {}
 
-## Name of the priority class to be used by zookeeper pods, priority class needs to be created beforehand
+## @param priorityClassName Name of the existing priority class to be used by ZooKeeper pods, priority class needs to be created beforehand
 ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
 ##
 priorityClassName: ''
 
-## Scheduler name
+## @param schedulerName Kubernetes pod scheduler registry
 ## https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
 ##
-# schedulerName: stork
+schedulerName:
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+## @param resources.requests [object] The requested resources for the container
 ##
 resources:
   requests:
     memory: 256Mi
     cpu: 250m
 
-## Configure extra options for liveness and readiness probes
-## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+## Configure extra options for liveness probe
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+## @param livenessProbe.enabled Enable livenessProbe
+## @param livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+## @param livenessProbe.periodSeconds Period seconds for livenessProbe
+## @param livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+## @param livenessProbe.failureThreshold Failure threshold for livenessProbe
+## @param livenessProbe.successThreshold Success threshold for livenessProbe
+## @param livenessProbe.probeCommandTimeout Probe command timeout for livenessProbe
 ##
 livenessProbe:
   enabled: true
@@ -478,7 +574,16 @@ livenessProbe:
   failureThreshold: 6
   successThreshold: 1
   probeCommandTimeout: 2
-
+## Configure extra options for readiness probe
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+## @param readinessProbe.enabled Enable readinessProbe
+## @param readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+## @param readinessProbe.periodSeconds Period seconds for readinessProbe
+## @param readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+## @param readinessProbe.failureThreshold Failure threshold for readinessProbe
+## @param readinessProbe.successThreshold Success threshold for readinessProbe
+## @param readinessProbe.probeCommandTimeout Probe command timeout for readinessProbe
+##
 readinessProbe:
   enabled: true
   initialDelaySeconds: 5
@@ -488,11 +593,11 @@ readinessProbe:
   successThreshold: 1
   probeCommandTimeout: 2
 
-## Custom Liveness probes for ZooKeeper
+## @param customLivenessProbe Override default liveness probe
 ##
 customLivenessProbe: {}
 
-## Custom Readiness probes for ZooKeeper
+## @param customReadinessProbe Override default readiness probe
 ##
 customReadinessProbe: {}
 
@@ -500,36 +605,37 @@ customReadinessProbe: {}
 ## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 ##
 networkPolicy:
-  ## Specifies whether a NetworkPolicy should be created
+  ## @param networkPolicy.enabled Specifies whether a NetworkPolicy should be created
   ##
   enabled: false
 
-  ## The Policy model to apply. When set to false, only pods with the correct
-  ## client label will have network access to the port Redis(TM) is listening
-  ## on. When true, zookeeper accept connections from any source
-  ## (with the correct destination port).
+  ## @param networkPolicy.allowExternal Don't require client label for connections
+  ## When set to false, only pods with the correct client label will have network access to the port Redis(TM) is
+  ## listening on. When true, zookeeper accept connections from any source (with the correct destination port).
   ##
-  # allowExternal: true
+  allowExternal:
 
 ## Zookeeper Prometheus Exporter configuration
 ##
 metrics:
+  ## @param metrics.enabled Enable prometheus to access zookeeper metrics endpoint
+  ##
   enabled: false
 
-  ## Zookeeper Prometheus Exporter container port
+  ## @param metrics.containerPort Zookeeper Prometheus Exporter container port
   ##
   containerPort: 9141
 
   ## Service configuration
   ##
   service:
-    ## Zookeeper Prometheus Exporter service type
+    ## @param metrics.service.type Zookeeper Prometheus Exporter service type
     ##
     type: ClusterIP
-    ## Zookeeper Prometheus Exporter service port
+    ## @param metrics.service.port Prometheus metrics service port
     ##
     port: 9141
-    ## Annotations for the Zookeeper Prometheus Exporter metrics service
+    ## @param metrics.service.annotations [object] Annotations for the Zookeeper to auto-discover the metrics endpoint
     ##
     annotations:
       prometheus.io/scrape: 'true'
@@ -539,53 +645,65 @@ metrics:
   ## Prometheus Operator ServiceMonitor configuration
   ##
   serviceMonitor:
+    ## @param metrics.serviceMonitor.enabled if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)
+    ##
     enabled: false
-    ## Namespace for the ServiceMonitor Resource (defaults to the Release Namespace)
+    ## @param metrics.serviceMonitor.namespace Namespace for the ServiceMonitor Resource (defaults to the Release Namespace)
     ##
     namespace:
 
-    ## Interval at which metrics should be scraped.
+    ## @param metrics.serviceMonitor.interval Interval at which metrics should be scraped.
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ## e.g:
+    ## interval: 10s
     ##
-    # interval: 10s
-    ## Timeout after which the scrape is ended
+    interval:
+    ## @param metrics.serviceMonitor.scrapeTimeout Timeout after which the scrape is ended
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ## e.g:
+    ## scrapeTimeout: 10s
     ##
-    # scrapeTimeout: 10s
-    ## ServiceMonitor selector labels
+    scrapeTimeout:
+    ## @param metrics.serviceMonitor.selector Prometheus instance selector labels
     ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
+    ## e.g:
+    ## selector:
+    ##   prometheus: my-prometheus
     ##
-    # selector:
-    #   prometheus: my-prometheus
+    selector:
 
   ## Prometheus Operator PrometheusRule configuration
   ##
   prometheusRule:
+    ## @param metrics.prometheusRule.enabled if `true`, creates a Prometheus Operator PrometheusRule (also requires `metrics.enabled` to be `true` and `metrics.prometheusRule.rules`)
+    ##
     enabled: false
-    ## Namespace for the PrometheusRule Resource (defaults to the Release Namespace)
+    ## @param metrics.prometheusRule.namespace Namespace for the PrometheusRule Resource (defaults to the Release Namespace)
     ##
     namespace:
 
-    ## PrometheusRule selector labels
+    ## @param metrics.prometheusRule.selector Prometheus instance selector labels
     ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
+    ## e.g:
+    ## selector:
+    ##   prometheus: my-prometheus
     ##
-    # selector:
-    #   prometheus: my-prometheus
+    selector:
 
-    ## Some example rules.
+    ## @param metrics.prometheusRule.rules Prometheus Rule definitions
+    ##  - alert: ZookeeperSyncedFollowers
+    ##    annotations:
+    ##      message: The number of synced followers for the leader node in Zookeeper deployment my-release is less than 2. This usually means that some of the Zookeeper nodes aren't communicating properly. If it doesn't resolve itself you can try killing the pods (one by one).
+    ##    expr: max(synced_followers{service="my-release-metrics"}) < 2
+    ##    for: 5m
+    ##    labels:
+    ##      severity: critical
+    ##  - alert: ZookeeperOutstandingRequests
+    ##    annotations:
+    ##      message: The number of outstanding requests for Zookeeper pod {{ $labels.pod }} is greater than 10. This can indicate a performance issue with the Pod or cluster a whole.
+    ##    expr: outstanding_requests{service="my-release-metrics"} > 10
+    ##    for: 5m
+    ##    labels:
+    ##      severity: critical
     ##
     rules: []
-    #  - alert: ZookeeperSyncedFollowers
-    #    annotations:
-    #      message: The number of synced followers for the leader node in Zookeeper deployment my-release is less than 2. This usually means that some of the Zookeeper nodes aren't communicating properly. If it doesn't resolve itself you can try killing the pods (one by one).
-    #    expr: max(synced_followers{service="my-release-metrics"}) < 2
-    #    for: 5m
-    #    labels:
-    #      severity: critical
-    #  - alert: ZookeeperOutstandingRequests
-    #    annotations:
-    #      message: The number of outstanding requests for Zookeeper pod {{ $labels.pod }} is greater than 10. This can indicate a performance issue with the Pod or cluster a whole.
-    #    expr: outstanding_requests{service="my-release-metrics"} > 10
-    #    for: 5m
-    #    labels:
-    #      severity: critical


### PR DESCRIPTION
**Description of the change**

Add metadata to `values.yaml` in order to be used by [readme-generator](https://github.com/bitnami-labs/readme-generator-for-helm) to automatically generate the "Parameters" section of the `README.md`.

General rules followed:
- If `values.yaml` doesn't have a description for a key in a comment → Use `README.md` description
- If `values.yaml` does have a description for a key in a comment but the `README.md` description provides more info → Use `README.md` description
- Else → Leave the `values.yaml` description

**Benefits**

Less manual work and consistency between `values.yaml` and `README.md`.

**Additional information**

Commented keys are not picked by readme-generator so some had to be uncommented in order to appear in the README, however none of them affect the default installation of the chart, verified comparing the output before and after the changes of
```bash
helm install chart . -f values.yaml --dry-run --debug
```

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])