### PR TITLE
[bitnami/rabbitmq] add extraDeploy support (#6926)

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -23,4 +23,4 @@ name: rabbitmq
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq
   - https://www.rabbitmq.com
-version: 8.17.0
+version: 8.18.0

--- a/bitnami/rabbitmq/README.md
+++ b/bitnami/rabbitmq/README.md
@@ -251,6 +251,7 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 | `clusterDomain`     | Default Kubernetes cluster domain                                    | `cluster.local`                |
 | `kubeVersion`       | Force target Kubernetes version (using Helm capabilities if not set) | `nil`                          |
 | `commonAnnotations` | Annotations to add to all deployed objects                           | `{}` (evaluated as a template) |
+| `extraDeploy`       | Array of extra objects to deploy with the release                    | `[]`                           |
 
 ### RabbitMQ parameters
 

--- a/bitnami/rabbitmq/templates/extra-list.yaml
+++ b/bitnami/rabbitmq/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -64,6 +64,10 @@ kubeVersion:
 ##
 clusterDomain: cluster.local
 
+## @param extraDeploy Array of extra objects to deploy with the release
+##
+extraDeploy: []
+
 ## @param hostAliases Deployment pod host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##


### PR DESCRIPTION
**Description of the change**

Add extraDeploy feature as in others bitnami charts.

**Benefits**

Allow users to create any extra k8s resources (such like configmap or secrets to use with extraVolume and extraVolumeMounts)

**Possible drawbacks**

N/A

**Applicable issues**

  - fixes #6926

**Additional information**

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
