### PR TITLE
[kibana] change healthcheck endpoint to /api/status

### DIFF
--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -25,4 +25,4 @@ name: kibana
 sources:
   - https://github.com/bitnami/bitnami-docker-kibana
   - https://www.elastic.co/products/kibana
-version: 8.1.9
+version: 8.1.10

--- a/bitnami/kibana/templates/deployment.yaml
+++ b/bitnami/kibana/templates/deployment.yaml
@@ -104,9 +104,9 @@ spec:
           livenessProbe:
             httpGet:
             {{- if .Values.configuration.server.rewriteBasePath }}
-              path: {{ .Values.configuration.server.basePath }}/app/kibana
+              path: {{ .Values.configuration.server.basePath }}/api/status
             {{- else }}
-              path: /app/kibana
+              path: /api/status
             {{- end }}
               port: http
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
@@ -119,9 +119,9 @@ spec:
           readinessProbe:
             httpGet:
             {{- if .Values.configuration.server.rewriteBasePath }}
-              path: {{ .Values.configuration.server.basePath }}/app/kibana
+              path: {{ .Values.configuration.server.basePath }}/api/status
             {{- else }}
-              path: /app/kibana
+              path: /api/status
             {{- end }}
               port: http
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}


### PR DESCRIPTION
Currently, kibana healthcheck using `/app/kibana` which regularly lead to 503 or 429 (Too many requests).
So I suggest that change healthcheck endpoint to `/api/status` to avoid this issue.
![Screenshot from 2021-07-16 19-55-50](https://user-images.githubusercontent.com/6848311/125951754-f8397c64-336b-4844-b8c7-d541fb09fd1f.png)
