### PR TITLE
[bitnami/discourse] fixed indentation of sidecars containers on discourse

### DIFF
--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-discourse
   - https://github.com/spinnaker
   - https://www.discourse.org/
-version: 4.2.5
+version: 4.2.6

--- a/bitnami/discourse/templates/deployment.yaml
+++ b/bitnami/discourse/templates/deployment.yaml
@@ -259,7 +259,7 @@ spec:
           resources: {{- toYaml .Values.sidekiq.resources | nindent 12 }}
           {{- end }}
         {{- if .Values.sidecars }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | indent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | nindent 8 }}
         {{- end }}
       volumes:
         - name: discourse-data


### PR DESCRIPTION
**Description of the change**

I fixed the indentation function used for sidecars container from ` indent` to `nindent`, because that was causing a `YAML parse error`.

To test it run the following command:

```
helm install --dry-run --debug discourse bitnami/discourse --set discourse.host=example.com --set "sidecars[0].name=example,sidecars[0].image=example:latest"
```

You should see the following error:
```
Error: YAML parse error on discourse/templates/deployment.yaml: error converting YAML to JSON: yaml: line 152: mapping values are not allowed in this context
helm.go:88: [debug] error converting YAML to JSON: yaml: line 152: mapping values are not allowed in this context
```

**Benefits**

This PR fixes the `YAML parse error` described above.

**Possible drawbacks**

**Applicable issues**

**Additional information**

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])