### PR TITLE
[bitnami/suitecrm] Fix issue with SMTP password

### DIFF
--- a/bitnami/suitecrm/Chart.yaml
+++ b/bitnami/suitecrm/Chart.yaml
@@ -29,4 +29,4 @@ name: suitecrm
 sources:
   - https://github.com/bitnami/bitnami-docker-suitecrm
   - https://www.suitecrm.com/
-version: 9.3.15
+version: 9.3.16

--- a/bitnami/suitecrm/templates/secrets.yaml
+++ b/bitnami/suitecrm/templates/secrets.yaml
@@ -17,7 +17,7 @@ data:
   {{- else }}
   suitecrm-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
-  {{- if .Values.smtpPassword }}
+  {{- if .Values.suitecrmSmtpPassword }}
   suitecrm-smtp-password: {{ .Values.suitecrmSmtpPassword | b64enc | quote }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
**Description of the change**

Fixes a small typo in SuiteCRM `secrets.yaml` causing the SMTP password to be ignored.

**Possible drawbacks**

None known.

**Applicable issues**

  - fixes #6999

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
