### PR TITLE
[bitnami/redis] Update README for default disableCommands values

### DIFF
--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -116,7 +116,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                                        | Description                                                                                      | Value           |
 | ------------------------------------------- | ------------------------------------------------------------------------------------------------ | --------------- |
 | `master.configuration`                      | Configuration for Redis(TM) master nodes                                                         | `nil`           |
-| `master.disableCommands`                    | Array with Redis(TM) commands to disable on master nodes                                         | `[]`            |
+| `master.disableCommands`                    | Array with Redis(TM) commands to disable on master nodes                                         | `[FLUSHDB, FLUSHALL]`            |
 | `master.command`                            | Override default container command (useful when using custom images)                             | `[]`            |
 | `master.args`                               | Override default container args (useful when using custom images)                                | `[]`            |
 | `master.preExecCmds`                        | Additional commands to run prior to starting Redis(TM) master                                    | `[]`            |
@@ -192,7 +192,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | -------------------------------------------- | ------------------------------------------------------------------------------------------------- | --------------- |
 | `replica.replicaCount`                       | Number of Redis(TM) replicas to deploy                                                            | `3`             |
 | `replica.configuration`                      | Configuration for Redis(TM) replicas nodes                                                        | `nil`           |
-| `replica.disableCommands`                    | Array with Redis(TM) commands to disable on replicas nodes                                        | `[]`            |
+| `replica.disableCommands`                    | Array with Redis(TM) commands to disable on replicas nodes                                        | `[FLUSHDB, FLUSHALL]`            |
 | `replica.command`                            | Override default container command (useful when using custom images)                              | `[]`            |
 | `replica.args`                               | Override default container args (useful when using custom images)                                 | `[]`            |
 | `replica.preExecCmds`                        | Additional commands to run prior to starting Redis(TM) replicas                                   | `[]`            |


### PR DESCRIPTION
The values.yaml has FLUSHDB and FLUSHALL instead of an empty list as the readme suggests

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
