### PR TITLE
[bitnami/mediawiki] Corrected generated notes for MariaDB.

### DIFF
--- a/bitnami/mediawiki/Chart.yaml
+++ b/bitnami/mediawiki/Chart.yaml
@@ -32,4 +32,4 @@ name: mediawiki
 sources:
   - https://github.com/bitnami/bitnami-docker-mediawiki
   - http://www.mediawiki.org/
-version: 12.3.4
+version: 12.3.5

--- a/bitnami/mediawiki/templates/NOTES.txt
+++ b/bitnami/mediawiki/templates/NOTES.txt
@@ -22,8 +22,8 @@ host. To configure Mediawiki with the URL of your service:
 
   export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
   export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} -o jsonpath="{.data.mediawiki-password}" | base64 --decode)
-  export MARIADB_ROOT_PASSWORD=$(kubectl get secret --namespace default {{ .Release.Namespace }}-mariadb -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)  {{- end }}
-  export MARIADB_PASSWORD=$(kubectl get secret --namespace default {{ .Release.Namespace }}-mariadb -o jsonpath="{.data.mariadb-password}" | base64 --decode)
+  export MARIADB_ROOT_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "mediawiki.mariadb.fullname" . }} -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)  {{- end }}
+  export MARIADB_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "mediawiki.mariadb.fullname" . }} -o jsonpath="{.data.mariadb-password}" | base64 --decode)
 
 2. Complete your Mediawiki deployment by running:
 

--- a/bitnami/mediawiki/templates/NOTES.txt
+++ b/bitnami/mediawiki/templates/NOTES.txt
@@ -22,8 +22,8 @@ host. To configure Mediawiki with the URL of your service:
 
   export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
   export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} -o jsonpath="{.data.mediawiki-password}" | base64 --decode)
-  export MARIADB_ROOT_PASSWORD=$(kubectl get secret --namespace default mediawiki-mariadb -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)  {{- end }}
-  export MARIADB_PASSWORD=$(kubectl get secret --namespace default mediawiki-mariadb -o jsonpath="{.data.mariadb-password}" | base64 --decode)
+  export MARIADB_ROOT_PASSWORD=$(kubectl get secret --namespace default {{ .Release.Namespace }}-mariadb -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)  {{- end }}
+  export MARIADB_PASSWORD=$(kubectl get secret --namespace default {{ .Release.Namespace }}-mariadb -o jsonpath="{.data.mariadb-password}" | base64 --decode)
 
 2. Complete your Mediawiki deployment by running:
 


### PR DESCRIPTION
**Description of the change**
The notes generated when using helm to install **bitnami/mediawiki** are incorrect as far as the MariaDB exported variables are concerned. This change will fix the problem with the definition of MARIADB_ROOT_PASSWORD and MARIADB_PASSWORD.

**Benefits**
Manual edits of the generated notes will no longer be required.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
