### PR TITLE
[bitnami/mongodb-sharded] Fix wrong index in servicePerReplica context

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb-sharded
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb-sharded
   - https://mongodb.org
-version: 3.7.4
+version: 3.7.5

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-service-per-replica.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-service-per-replica.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.mongos.useStatefulSet .Values.mongos.servicePerReplica.enabled }}
 {{- range $i := until (.Values.mongos.replicas | int) }}
-{{- $context := merge $ (dict "index" $i) }}
+{{- $context := deepCopy $ | merge (dict "index" $i) }}
 ---
 apiVersion: v1
 kind: Service
@@ -8,7 +8,7 @@ metadata:
   name: {{ include "mongodb-sharded.serviceName" $ }}-{{ $i }}
   labels: {{ include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: mongos
-  annotations: {{- include "common.tplvalues.render" (dict "value" $.Values.mongos.servicePerReplica.annotations "context" $context) | nindent 4 }}  
+  annotations: {{- include "common.tplvalues.render" (dict "value" $.Values.mongos.servicePerReplica.annotations "context" $context) | nindent 4 }}
 spec:
   type: {{ $.Values.mongos.servicePerReplica.type }}
   {{- if and $.Values.mongos.servicePerReplica.loadBalancerIP (eq $.Values.mongos.servicePerReplica.type "LoadBalancer") }}


### PR DESCRIPTION
**Description of the change**

This PR fixes an issue with the `$index` that keeps the value `1` after the first 2 iterations because of the way the precedence is done in Helm when using `merge`, causing things like : 

```yaml
metadata:
  name: RELEASE-NAME-mongodb-sharded-3
  labels: 
    app.kubernetes.io/name: mongodb-sharded
  annotations:
    external-dns.alpha.kubernetes.io/hostname: mongo-1.test # The .index used here is wrong
```

**Benefits**

**Possible drawbacks**

**Applicable issues**

**Additional information**

I thought it would better to create a copy of the object instead of mutating it throughout the loops, but using `mergeOverwrite` would work too 🤷

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
