### PR TITLE
[bitnami/cert-manager] Fix leader election RBAC

### DIFF
--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -26,4 +26,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-cert-manager-webhook
   - https://github.com/bitnami/bitnami-docker-cainjector
   - https://github.com/jetstack/cert-manager
-version: 0.1.8
+version: 0.1.9

--- a/bitnami/cert-manager/templates/controller/rbac.yaml
+++ b/bitnami/cert-manager/templates/controller/rbac.yaml
@@ -21,6 +21,13 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["create"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    resourceNames: ["cert-manager-controller"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create"]
 ---
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding


### PR DESCRIPTION
**Description of the change**

Add missing RBAC permissions to allow cert-manager do its leader election.

**Benefits**

**Possible drawbacks**

**Applicable issues**

- fixes leader election when cert-manager controller starts.

**Additional information**

Cf. https://github.com/jetstack/cert-manager/blob/master/deploy/charts/cert-manager/templates/rbac.yaml

**Checklist**

- [x] Chart version bumped in Chart.yaml according to semver.
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])

