### PR TITLE
Kibana chart should have service account

### DIFF
--- a/bitnami/kibana/templates/deployment.yaml
+++ b/bitnami/kibana/templates/deployment.yaml
@@ -73,6 +73,7 @@ spec:
           securityContext:
             runAsUser: {{ .Values.securityContext.runAsUser }}
           {{- end }}
+          serviceAccountName: {{ .Values.serviceAccount.name }}
           env:
             - name: KIBANA_PORT_NUMBER
               value: {{ .Values.containerPort | quote }}

--- a/bitnami/kibana/templates/serviceaccount.yaml
+++ b/bitnami/kibana/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+{{- if.Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name:  {{ required .Values.serviceAccount.name }}
+{{- end }}

--- a/bitnami/kibana/values.yaml
+++ b/bitnami/kibana/values.yaml
@@ -321,6 +321,11 @@ ingress:
   ##   certificate:
   ##
   secrets: []
+## @param serviceAccount.name Name of serviceAccount
+## @param serviceAccount.create Enable creation of ServiceAccount for Kibana
+serviceAccount:
+  name: default
+  create: false
 ## @param containerPort Port to expose at container level
 ##
 containerPort: 5601


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

This allows the specification of a service account for Kibana.  See also https://github.com/bitnami/charts/issues/7059

**Benefits**

<!-- What benefits will be realized by the code change? -->

You should now be able to specify security contexts to a particular service account, not just defaults.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

None that I can think of.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #7059 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
