### PR TITLE
[bitnami/jupyterhub] Fix default value for extraIngress/extraEgress

### DIFF
--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -26,4 +26,4 @@ name: jupyterhub
 sources:
   - https://github.com/bitnami/bitnami-docker-jupyterhub
   - https://github.com/jupyterhub/jupyterhub
-version: 0.1.13
+version: 0.1.14

--- a/bitnami/jupyterhub/README.md
+++ b/bitnami/jupyterhub/README.md
@@ -158,8 +158,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | ----------------------------------------- | -------------------------------------------------------- | ----------- |
 | `hub.networkPolicy.enabled`               | Deploy Hub network policies                              | `true`      |
 | `hub.networkPolicy.allowInterspaceAccess` | Allow communication between pods in different namespaces | `true`      |
-| `hub.networkPolicy.extraIngress`          | Add extra ingress rules to the NetworkPolicy             | `{}`        |
-| `hub.networkPolicy.extraEgress`           | Add extra ingress rules to the NetworkPolicy             | `{}`        |
+| `hub.networkPolicy.extraIngress`          | Add extra ingress rules to the NetworkPolicy             | `""`        |
+| `hub.networkPolicy.extraEgress`           | Add extra ingress rules to the NetworkPolicy             | `""`        |
 | `hub.service.type`                        | Hub service type                                         | `ClusterIP` |
 | `hub.service.port`                        | Hub service HTTP port                                    | `8081`      |
 | `hub.service.loadBalancerIP`              | Hub service LoadBalancer IP (optional, cloud specific)   | `""`        |
@@ -243,8 +243,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | ----------------------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------ |
 | `proxy.networkPolicy.enabled`                   | Deploy Proxy network policies                                                                | `true`                   |
 | `proxy.networkPolicy.allowInterspaceAccess`     | Allow communication between pods in different namespaces                                     | `true`                   |
-| `proxy.networkPolicy.extraIngress`              | Add extra ingress rules to the NetworkPolicy                                                 | `{}`                     |
-| `proxy.networkPolicy.extraEgress`               | Add extra egress rules to the NetworkPolicy                                                  | `{}`                     |
+| `proxy.networkPolicy.extraIngress`              | Add extra ingress rules to the NetworkPolicy                                                 | `""`                     |
+| `proxy.networkPolicy.extraEgress`               | Add extra egress rules to the NetworkPolicy                                                  | `""`                     |
 | `proxy.service.api.type`                        | API service type                                                                             | `ClusterIP`              |
 | `proxy.service.api.port`                        | API service port                                                                             | `8001`                   |
 | `proxy.service.api.loadBalancerIP`              | API service LoadBalancer IP (optional, cloud specific)                                       | `""`                     |
@@ -366,8 +366,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `singleuser.networkPolicy.enabled`                  | Deploy Single User network policies                      | `true`  |
 | `singleuser.networkPolicy.allowInterspaceAccess`    | Allow communication between pods in different namespaces | `true`  |
 | `singleuser.networkPolicy.allowCloudMetadataAccess` | Allow Single User pods to access Cloud Metada endpoints  | `false` |
-| `singleuser.networkPolicy.extraIngress`             | Add extra ingress rules to the NetworkPolicy             | `{}`    |
-| `singleuser.networkPolicy.extraEgress`              | Add extra egress rules to the NetworkPolicy              | `{}`    |
+| `singleuser.networkPolicy.extraIngress`             | Add extra ingress rules to the NetworkPolicy             | `""`    |
+| `singleuser.networkPolicy.extraEgress`              | Add extra egress rules to the NetworkPolicy              | `""`    |
 
 
 ### Auxiliary image parameters

--- a/bitnami/jupyterhub/README.md
+++ b/bitnami/jupyterhub/README.md
@@ -158,8 +158,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | ----------------------------------------- | -------------------------------------------------------- | ----------- |
 | `hub.networkPolicy.enabled`               | Deploy Hub network policies                              | `true`      |
 | `hub.networkPolicy.allowInterspaceAccess` | Allow communication between pods in different namespaces | `true`      |
-| `hub.networkPolicy.extraIngress`          | Add extra ingress rules to the NetworkPolicy             | `[]`        |
-| `hub.networkPolicy.extraEgress`           | Add extra ingress rules to the NetworkPolicy             | `[]`        |
+| `hub.networkPolicy.extraIngress`          | Add extra ingress rules to the NetworkPolicy             | `{}`        |
+| `hub.networkPolicy.extraEgress`           | Add extra ingress rules to the NetworkPolicy             | `{}`        |
 | `hub.service.type`                        | Hub service type                                         | `ClusterIP` |
 | `hub.service.port`                        | Hub service HTTP port                                    | `8081`      |
 | `hub.service.loadBalancerIP`              | Hub service LoadBalancer IP (optional, cloud specific)   | `""`        |
@@ -243,8 +243,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | ----------------------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------ |
 | `proxy.networkPolicy.enabled`                   | Deploy Proxy network policies                                                                | `true`                   |
 | `proxy.networkPolicy.allowInterspaceAccess`     | Allow communication between pods in different namespaces                                     | `true`                   |
-| `proxy.networkPolicy.extraIngress`              | Add extra ingress rules to the NetworkPolicy                                                 | `[]`                     |
-| `proxy.networkPolicy.extraEgress`               | Add extra egress rules to the NetworkPolicy                                                  | `[]`                     |
+| `proxy.networkPolicy.extraIngress`              | Add extra ingress rules to the NetworkPolicy                                                 | `{}`                     |
+| `proxy.networkPolicy.extraEgress`               | Add extra egress rules to the NetworkPolicy                                                  | `{}`                     |
 | `proxy.service.api.type`                        | API service type                                                                             | `ClusterIP`              |
 | `proxy.service.api.port`                        | API service port                                                                             | `8001`                   |
 | `proxy.service.api.loadBalancerIP`              | API service LoadBalancer IP (optional, cloud specific)                                       | `""`                     |
@@ -366,8 +366,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `singleuser.networkPolicy.enabled`                  | Deploy Single User network policies                      | `true`  |
 | `singleuser.networkPolicy.allowInterspaceAccess`    | Allow communication between pods in different namespaces | `true`  |
 | `singleuser.networkPolicy.allowCloudMetadataAccess` | Allow Single User pods to access Cloud Metada endpoints  | `false` |
-| `singleuser.networkPolicy.extraIngress`             | Add extra ingress rules to the NetworkPolicy             | `[]`    |
-| `singleuser.networkPolicy.extraEgress`              | Add extra egress rules to the NetworkPolicy              | `[]`    |
+| `singleuser.networkPolicy.extraIngress`             | Add extra ingress rules to the NetworkPolicy             | `{}`    |
+| `singleuser.networkPolicy.extraEgress`              | Add extra egress rules to the NetworkPolicy              | `{}`    |
 
 
 ### Auxiliary image parameters

--- a/bitnami/jupyterhub/values.yaml
+++ b/bitnami/jupyterhub/values.yaml
@@ -479,8 +479,8 @@ hub:
     allowInterspaceAccess: true
     ## @param hub.networkPolicy.extraIngress Add extra ingress rules to the NetworkPolicy
     ##
-    extraIngress: {}
-    ## @param hub.networkPolicy.extraEgress [object] Add extra ingress rules to the NetworkPolicy
+    extraIngress: ""
+    ## @param hub.networkPolicy.extraEgress [string] Add extra ingress rules to the NetworkPolicy
     ##
     extraEgress: |
       ## Hub --> Any IP:PORT
@@ -785,7 +785,7 @@ proxy:
     ## @param proxy.networkPolicy.allowInterspaceAccess Allow communication between pods in different namespaces
     ##
     allowInterspaceAccess: true
-    ## @param proxy.networkPolicy.extraIngress [object] Add extra ingress rules to the NetworkPolicy
+    ## @param proxy.networkPolicy.extraIngress [string] Add extra ingress rules to the NetworkPolicy
     ##
     extraIngress: |
       ## Any IP --> Proxy
@@ -794,7 +794,7 @@ proxy:
           - port: {{ .Values.proxy.containerPort.http }}
     ## @param proxy.networkPolicy.extraEgress Add extra egress rules to the NetworkPolicy
     ##
-    extraEgress: {}
+    extraEgress: ""
   service:
     api:
       ## @param proxy.service.api.type API service type
@@ -1273,10 +1273,10 @@ singleuser:
     allowCloudMetadataAccess: false
     ## @param singleuser.networkPolicy.extraIngress Add extra ingress rules to the NetworkPolicy
     ##
-    extraIngress: {}
+    extraIngress: ""
     ## @param singleuser.networkPolicy.extraEgress Add extra egress rules to the NetworkPolicy
     ##
-    extraEgress: {}
+    extraEgress: ""
 
 ## @section Auxiliary image parameters
 

--- a/bitnami/jupyterhub/values.yaml
+++ b/bitnami/jupyterhub/values.yaml
@@ -479,10 +479,10 @@ hub:
     allowInterspaceAccess: true
     ## @param hub.networkPolicy.extraIngress Add extra ingress rules to the NetworkPolicy
     ##
-    extraIngress: []
-    ## @param hub.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
+    extraIngress: {}
+    ## @param hub.networkPolicy.extraEgress [object] Add extra ingress rules to the NetworkPolicy
     ##
-    extraEgress:
+    extraEgress: |
       ## Hub --> Any IP:PORT
       ##
       - to:
@@ -785,16 +785,16 @@ proxy:
     ## @param proxy.networkPolicy.allowInterspaceAccess Allow communication between pods in different namespaces
     ##
     allowInterspaceAccess: true
-    ## @param proxy.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolicy
+    ## @param proxy.networkPolicy.extraIngress [object] Add extra ingress rules to the NetworkPolicy
     ##
-    extraIngress:
+    extraIngress: |
       ## Any IP --> Proxy
       ##
       - ports:
-          - port: "{{ .Values.proxy.containerPort.http }}"
+          - port: {{ .Values.proxy.containerPort.http }}
     ## @param proxy.networkPolicy.extraEgress Add extra egress rules to the NetworkPolicy
     ##
-    extraEgress: []
+    extraEgress: {}
   service:
     api:
       ## @param proxy.service.api.type API service type
@@ -1273,10 +1273,10 @@ singleuser:
     allowCloudMetadataAccess: false
     ## @param singleuser.networkPolicy.extraIngress Add extra ingress rules to the NetworkPolicy
     ##
-    extraIngress: []
+    extraIngress: {}
     ## @param singleuser.networkPolicy.extraEgress Add extra egress rules to the NetworkPolicy
     ##
-    extraEgress: []
+    extraEgress: {}
 
 ## @section Auxiliary image parameters
 


### PR DESCRIPTION
**Description of the change**
The default value was modified from:
```yaml
    extraIngress: |
      ## Any IP --> Proxy
      ##
      - ports:
          - port: {{ .Values.proxy.containerPort.http }}
```
to
```yaml
    extraIngress:
      ## Any IP --> Proxy
      ##
      - ports:
          - port: "{{ .Values.proxy.containerPort.http }}"
```
at #7024

Causing the following issue
```console
$ helm install my-jupyter --set hub.adminUser=user --set hub.password=jphubpassword .
Error: NetworkPolicy.extensions "t012909-jupyter-jupyterhub-proxy" is invalid: spec.ingress[0].ports[0].port: Invalid value: "8000": must contain at least one letter or number (a-z, 0-9)
```
that was produced because the port was assigned as a value containing the double quotes:
```console
$ helm template my-jupyter --set hub.adminUser=user --set hub.password=jphubpassword -s templates/proxy/networkpolicy.yaml .
# Source: jupyterhub/templates/proxy/networkpolicy.yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
...
  policyTypes:
    - Ingress
    - Egress
  ingress:
    - ports:
      - port: '8000'
```
please note the single quotes.

With the changes in this PR, the `extraIngress` is rendered as an object so the quotes are gone but also the comment is maintained:
```console
$ helm template my-jupyter --set hub.adminUser=user --set hub.password=jphubpassword -s templates/proxy/networkpolicy.yaml .
# Source: jupyterhub/templates/proxy/networkpolicy.yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
...
  policyTypes:
    - Ingress
    - Egress
  ingress:
    ## Any IP --> Proxy
    ##
    - ports:
        - port: 8000
```

And the installation works fine
```console
$ helm install my-jupyter --set hub.adminUser=user --set hub.password=jphubpassword .
NAME: my-jupyter
LAST DEPLOYED: Thu Jul 29 09:25:25 2021
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
*************************************************************************
*** PLEASE BE PATIENT: JupyterHub may take a few minutes to install   ***
*************************************************************************

1. Get the JupyterHub URL by running:

** Please ensure an external IP is associated to the my-jupyter-jupyterhub-proxy-public service before proceeding **
** Watch the status using: kubectl get svc --namespace default -w my-jupyter-jupyterhub-proxy-public **

  export SERVICE_IP=$(kubectl get svc --namespace default my-jupyter-jupyterhub-proxy-public --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")
  echo "JupyterHub URL: http://$SERVICE_IP/"

2. Login with the following admin user below to create a Notebook:

  echo Admin user: user
  echo Password: $(kubectl get secret --namespace default my-jupyter-jupyterhub-hub -o jsonpath="{.data['values\.yaml']}" | base64 --decode | awk -F: '/password/ {gsub(/[ \t]+/, "", $2);print $2}')
```