### PR TITLE
[bitnami/kafka] Adapt env. variables to new format

### DIFF
--- a/bitnami/kafka/Chart.lock
+++ b/bitnami/kafka/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.7.0
+  version: 1.7.1
 - name: zookeeper
   repository: https://charts.bitnami.com/bitnami
-  version: 7.0.7
-digest: sha256:28de9d31aa65bea1addb5493662b699df8b24309cf6d5f1966419258ca43dda5
-generated: "2021-07-13T00:50:04.83855671Z"
+  version: 7.1.1
+digest: sha256:70cad48b2d7940383d66724f68658678d541ab519c1b540fe609e54fd7980bed
+generated: "2021-07-30T06:38:05.059402501Z"

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 13.1.2
+version: 13.1.3

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -257,11 +257,11 @@ spec:
                   key: zookeeper-password
             {{- end }}
             {{- if (include "kafka.tlsEncryption" .) }}
-            - name: KAFKA_CFG_TLS_TYPE
+            - name: KAFKA_TLS_TYPE
               value: {{ upper .Values.auth.tls.type | quote }}
             - name: KAFKA_CFG_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM
               value: {{ default "" (coalesce .Values.auth.tls.endpointIdentificationAlgorithm .Values.auth.tlsEndpointIdentificationAlgorithm) | quote }}
-            - name: KAFKA_CFG_TLS_CLIENT_AUTH
+            - name: KAFKA_TLS_CLIENT_AUTH
               value: {{ ternary "required" "none" (eq .Values.auth.clientProtocol "mtls") | quote }}
             {{- $tlsPassword := coalesce .Values.auth.tls.password .Values.auth.jksPassword }}
             - name: KAFKA_CERTIFICATE_PASSWORD

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -66,7 +66,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/kafka
-  tag: 2.8.0-debian-10-r55
+  tag: 2.8.0-debian-10-r57
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -657,7 +657,7 @@ externalAccess:
     image:
       registry: docker.io
       repository: bitnami/kubectl
-      tag: 1.19.12-debian-10-r20
+      tag: 1.19.13-debian-10-r12
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -857,7 +857,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r131
+    tag: 10-debian-10-r146
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -913,7 +913,7 @@ metrics:
     image:
       registry: docker.io
       repository: bitnami/kafka-exporter
-      tag: 1.3.1-debian-10-r45
+      tag: 1.3.1-debian-10-r61
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1049,7 +1049,7 @@ metrics:
     image:
       registry: docker.io
       repository: bitnami/jmx-exporter
-      tag: 0.16.0-debian-10-r7
+      tag: 0.16.1-debian-10-r14
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1194,7 +1194,7 @@ provisioning:
   image:
     registry: docker.io
     repository: bitnami/kafka
-    tag: 2.8.0-debian-10-r54
+    tag: 2.8.0-debian-10-r56
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

We included in the Kafka image a new function (`kafka_configure_from_environment_variable`) that maps every env. variable with the "KAFKA_CFG" prefix to the configuration file. However, there are a couple of env. vars used by the container logic to configure TLS that have no associated property. We'll release a new container revision removing the `_CFG_` appendix to `KAFKA_CFG_TLS_TYPE` and `KAFKA_CFG_TLS_CLIENT_AUTH`.

**Benefits**

Correct configuration files

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
