### PR TITLE
[bitnami/contour] Sync CRDs with contour release 1.18

### DIFF
--- a/bitnami/contour/Chart.lock
+++ b/bitnami/contour/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.7.0
-digest: sha256:6786bc7fdfc6e4038fd28819c2b07339f232282dbaeab21de8064aaa6814a8d1
-generated: "2021-07-07T06:53:45.969134789Z"
+  version: 1.7.1
+digest: sha256:d05549cd2eb5b99a49655221b8efd09927cc48daca3fa9f19af0257a11e5260f
+generated: "2021-08-02T17:24:22.28379482Z"

--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/bitnami-docker-contour
   - https://projectcontour.io
-version: 5.0.3
+version: 5.0.4

--- a/bitnami/contour/resources/extensionservices.yaml
+++ b/bitnami/contour/resources/extensionservices.yaml
@@ -159,8 +159,8 @@ spec:
                   service's certificate
                 properties:
                   caSecret:
-                    description: Name of the Kubernetes secret be used to validate
-                      the certificate presented by the backend
+                    description: Name or namespaced name of the Kubernetes secret
+                      used to validate the certificate presented by the backend
                     type: string
                   subjectName:
                     description: Key which is expected to be present in the 'subjectAltName'

--- a/bitnami/contour/resources/httpproxies.yaml
+++ b/bitnami/contour/resources/httpproxies.yaml
@@ -132,6 +132,12 @@ spec:
                   - name
                   type: object
                 type: array
+              ingressClassName:
+                description: IngressClassName optionally specifies the ingress class
+                  to use for this HTTPProxy. This replaces the deprecated `kubernetes.io/ingress.class`
+                  annotation. For backwards compatibility, when that annotation is
+                  set, it is given precedence over this field.
+                type: string
               routes:
                 description: Routes are the ingress routes. If TCPProxy is present,
                   Routes is ignored.
@@ -788,8 +794,9 @@ spec:
                               the backend service's certificate
                             properties:
                               caSecret:
-                                description: Name of the Kubernetes secret be used
-                                  to validate the certificate presented by the backend
+                                description: Name or namespaced name of the Kubernetes
+                                  secret used to validate the certificate presented
+                                  by the backend
                                 type: string
                               subjectName:
                                 description: Key which is expected to be present in
@@ -1044,8 +1051,9 @@ spec:
                             backend service's certificate
                           properties:
                             caSecret:
-                              description: Name of the Kubernetes secret be used to
-                                validate the certificate presented by the backend
+                              description: Name or namespaced name of the Kubernetes
+                                secret used to validate the certificate presented
+                                by the backend
                               type: string
                             subjectName:
                               description: Key which is expected to be present in

--- a/bitnami/contour/resources/tlscertificatedeligations.yaml
+++ b/bitnami/contour/resources/tlscertificatedeligations.yaml
@@ -289,3 +289,8 @@ spec:
     subresources:
       status: {}
 status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/bitnami/contour/resources/tlscertificatedeligations.yaml
+++ b/bitnami/contour/resources/tlscertificatedeligations.yaml
@@ -289,8 +289,3 @@ spec:
     subresources:
       status: {}
 status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/bitnami/contour/values.yaml
+++ b/bitnami/contour/values.yaml
@@ -145,7 +145,7 @@ contour:
   image:
     registry: docker.io
     repository: bitnami/contour
-    tag: 1.18.0-debian-10-r0
+    tag: 1.18.0-debian-10-r5
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -342,7 +342,7 @@ envoy:
   image:
     registry: docker.io
     repository: bitnami/envoy
-    tag: 1.17.3-debian-10-r66
+    tag: 1.17.3-debian-10-r71
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -610,7 +610,7 @@ defaultBackend:
   image:
     registry: docker.io
     repository: bitnami/nginx
-    tag: 1.21.1-debian-10-r18
+    tag: 1.21.1-debian-10-r23
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Updates the Contour CRDs to match the recently release Contour 1.18

**Benefits**

Adds `ingressClassName` field

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
