### PR TITLE
[bitnami/redis-cluster] Fix networkpolicy

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -23,4 +23,4 @@ name: redis-cluster
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 6.3.1
+version: 6.3.2

--- a/bitnami/redis-cluster/templates/networkpolicy.yaml
+++ b/bitnami/redis-cluster/templates/networkpolicy.yaml
@@ -35,28 +35,28 @@ spec:
     - ports:
         - port: {{ .Values.redis.port }}
         - port: {{ .Values.redis.busPort }}
-      {{- if not .Values.networkPolicy.allowExternal }}
       from:
+        {{- if not .Values.networkPolicy.allowExternal }}
         - podSelector:
             matchLabels:
               {{ template "common.names.fullname" . }}-client: "true"
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" . | nindent 14 }}
-      {{- if .Values.networkPolicy.ingressNSMatchLabels }}
-      - namespaceSelector:
-          matchLabels:
-            {{- range $key, $value := .Values.networkPolicy.ingressNSMatchLabels }}
-            {{ $key | quote }}: {{ $value | quote }}
-            {{- end }}
-        {{- if .Values.networkPolicy.ingressNSPodMatchLabels }}
-        podSelector:
-          matchLabels:
-            {{- range $key, $value := .Values.networkPolicy.ingressNSPodMatchLabels }}
-            {{ $key | quote }}: {{ $value | quote }}
-            {{- end }}
         {{- end }}
-      {{- end }}
-      {{- end }}
+        {{- if .Values.networkPolicy.ingressNSMatchLabels }}
+        - namespaceSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.networkPolicy.ingressNSMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+        {{- end }}
+        {{- if .Values.networkPolicy.ingressNSPodMatchLabels }}
+        - podSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.networkPolicy.ingressNSPodMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+        {{- end }}
     {{- if .Values.metrics.enabled }}
     # Allow prometheus scrapes for metrics
     - ports:


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

The networkpolicy template messed up with the indentation and if/else blocks. This PR addresses that problem.

**Benefits**

Users can set custom policies so pods from other namespaces can connect Redis as described below:

- https://github.com/bitnami/charts/tree/master/bitnami/redis-cluster#networkpolicy

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/7097

**Additional information**

N/A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
