### PR TITLE
[bitnami/kubeapps] upgraded app repository CRD to v1 version

### DIFF
--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -25,4 +25,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 7.1.8
+version: 7.2.0

--- a/bitnami/kubeapps/crds/apprepository-crd.yaml
+++ b/bitnami/kubeapps/crds/apprepository-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: apprepositories.kubeapps.com
@@ -10,4 +10,96 @@ spec:
     plural: apprepositories
     shortNames:
       - apprepos
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      storage: true
+      served: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [ "spec" ]
+          properties:
+            spec:
+              type: object
+              required: [ "type", "url" ]
+              properties:
+                type:
+                  type: string
+                  enum: [ "helm", "oci" ]
+                url:
+                  type: string
+                description:
+                  type: string
+                auth:
+                  type: object
+                  properties:
+                    header:
+                      type: object
+                      required: [ "secretKeyRef" ]
+                      properties:
+                        secretKeyRef:
+                          type: object
+                          required: [ "key", "name" ]
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                    customCA:
+                      type: object
+                      required: [ "secretKeyRef" ]
+                      properties:
+                        secretKeyRef:
+                          type: object
+                          required: [ "key", "name" ]
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                dockerRegistrySecrets:
+                  type: array
+                  items:
+                    type: string
+                tlsInsecureSkipVerify:
+                  type: boolean
+                passCredentials:
+                  type: boolean
+                filterRule:
+                  type: object
+                  properties:
+                    jq:
+                      type: string
+                    variables:
+                      type: object
+                      additionalProperties:
+                        type: string
+                ociRepositories:
+                  type: array
+                  items:
+                    type: string
+                resyncRequests:
+                  type: integer
+                syncJobPodTemplate:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    spec:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              properties:
+                status:
+                  type: string
+      additionalPrinterColumns:
+        - name: Type
+          type: string
+          description: The type of this repository.
+          jsonPath: .spec.type
+        - name: URL
+          type: string
+          description: The URL of this repository.
+          jsonPath: .spec.url

--- a/bitnami/kubeapps/crds/apprepository-crd.yaml
+++ b/bitnami/kubeapps/crds/apprepository-crd.yaml
@@ -17,11 +17,14 @@ spec:
       schema:
         openAPIV3Schema:
           type: object
-          required: [ "spec" ]
+          required:
+            - spec
           properties:
             spec:
               type: object
-              required: [ "type", "url" ]
+              required:
+                - type
+                - url
               properties:
                 type:
                   type: string
@@ -35,11 +38,14 @@ spec:
                   properties:
                     header:
                       type: object
-                      required: [ "secretKeyRef" ]
+                      required:
+                        - secretKeyRef
                       properties:
                         secretKeyRef:
                           type: object
-                          required: [ "key", "name" ]
+                          required:
+                            - key
+                            - name
                           properties:
                             key:
                               type: string
@@ -47,11 +53,14 @@ spec:
                               type: string
                     customCA:
                       type: object
-                      required: [ "secretKeyRef" ]
+                      required:
+                        - secretKeyRef
                       properties:
                         secretKeyRef:
                           type: object
-                          required: [ "key", "name" ]
+                          required:
+                            - key
+                            - name
                           properties:
                             key:
                               type: string


### PR DESCRIPTION
**Description of the change**

Upgraded the App Repository CRD from version v1beta1 to v1. v1beta1 is deprecated and is being removed in kubernetes 1.22+.

Updated the definition to comply with the new schema for V1 version.
Added a open API v3 schema.
Also added additional printer columns.

**Benefits**

Allows support for kubeapps in kubernetes 1.22+ 

**Possible drawbacks**

This change breaks support for kubernetes 1.15.

**Applicable issues**

The change is related to Kubeapps issue 2169 (https://github.com/kubeapps/kubeapps/issues/2169)

**Additional information**

N/A

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
