### PR TITLE
[bitnami/kafka] Add missing flag to Kafka exporter to use SASL as authentication

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 13.1.4
+version: 13.1.5

--- a/bitnami/kafka/templates/_helpers.tpl
+++ b/bitnami/kafka/templates/_helpers.tpl
@@ -276,6 +276,21 @@ Return true if a log4j ConfigMap object should be created.
 {{- end -}}
 
 {{/*
+Return the SASL mechanism to use for the Kafka exporter to access Kafka
+The exporter uses a different nomenclature so we need to do this hack
+*/}}
+{{- define "kafka.metrics.kafka.saslMechanism" -}}
+{{- $saslMechanisms := coalesce .Values.auth.sasl.mechanisms .Values.auth.saslMechanisms }}
+{{- if contains "scram-sha-512" $saslMechanisms }}
+    {{- printf "scram-sha512" -}}
+{{- else if contains "scram-sha-256" $saslMechanisms }}
+    {{- printf "scram-sha256" -}}
+{{- else -}}
+    {{- printf "plain" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the Kafka configuration configmap
 */}}
 {{- define "kafka.metrics.jmx.configmapName" -}}

--- a/bitnami/kafka/templates/kafka-metrics-deployment.yaml
+++ b/bitnami/kafka/templates/kafka-metrics-deployment.yaml
@@ -54,6 +54,7 @@ spec:
               --sasl.enabled \
               --sasl.username="$SASL_USERNAME" \
               --sasl.password="${SASL_USER_PASSWORD%%,*}" \
+              --sasl.mechanism="{{ include "kafka.metrics.kafka.saslMechanism" . }}" \
               {{- end }}
               {{- if (include "kafka.client.tlsEncryption" .) }}
               --tls.enabled \


### PR DESCRIPTION
**Description of the change**

The exporter needs now a new flag to work with SASL. This flag indicates the mechanism to use (scram or plain) and uses a slightly different format to the one used by Kafka itself.

More info at https://github.com/danielqsj/kafka_exporter#flags

**Benefits**

Users can use SASL and metrics simoultaneously.

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/7065

**Additional information**

N//A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
