### PR TITLE
[bitnami/thanos] Fix nil pointer exception when deploying Thanos with bucketweb ingress.

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 5.2.5
+version: 5.2.6

--- a/bitnami/thanos/templates/bucketweb/tls-secrets.yaml
+++ b/bitnami/thanos/templates/bucketweb/tls-secrets.yaml
@@ -6,8 +6,8 @@ metadata:
   name: {{ include "common.names.fullname" $ }}-bucketweb
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: bucketweb
-    {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- if $.Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" $.Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
 type: kubernetes.io/tls
 data:

--- a/bitnami/thanos/templates/query-frontend/tls-secrets.yaml
+++ b/bitnami/thanos/templates/query-frontend/tls-secrets.yaml
@@ -6,8 +6,8 @@ metadata:
   name: {{ include "common.names.fullname" . }}-query-frontend
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: query-frontend
-    {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- if $.Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" $.Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
 type: kubernetes.io/tls
 data:

--- a/bitnami/thanos/templates/query-frontend/tls-secrets.yaml
+++ b/bitnami/thanos/templates/query-frontend/tls-secrets.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "common.names.fullname" . }}-query-frontend
+  name: {{ include "common.names.fullname" $ }}-query-frontend
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: query-frontend
     {{- if $.Values.commonLabels }}

--- a/bitnami/thanos/templates/receive/tls-secrets.yaml
+++ b/bitnami/thanos/templates/receive/tls-secrets.yaml
@@ -6,8 +6,8 @@ metadata:
   name: {{ include "common.names.fullname" $ }}-receive
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: receive
-    {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- if $.Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" $.Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
 type: kubernetes.io/tls
 data:


### PR DESCRIPTION
**Description of the change**

Updates the Values variable reference to global scope in order to not throw a nil pointer exception.

**Benefits**
Thanos:5.2.6 will install properly when ingress is enabled with several specific configurations.

**Applicable issues**
  - fixes #7106 

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X ] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
