### PR TITLE
[bitnami/argo-cd] Simplify image definition logic removing duplications

### DIFF
--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/argoproj/argo-cd/
   - https://github.com/bitnami/bitnami-docker-dex
   - https://github.com/dexidp/dex
-version: 0.1.6
+version: 1.0.0

--- a/bitnami/argo-cd/README.md
+++ b/bitnami/argo-cd/README.md
@@ -619,3 +619,5 @@ repoServer:
     repository: bitnami/argo-cd
     tag: 2.0.5
 ```
+
+See [PR#7113](https://github.com/bitnami/charts/pull/7113) for more info about the implemented changes

--- a/bitnami/argo-cd/README.md
+++ b/bitnami/argo-cd/README.md
@@ -68,106 +68,107 @@ The command removes all the Kubernetes components associated with the chart and 
 | `extraDeploy`       | Array of extra objects to deploy with the release  | `[]`            |
 
 
+### Argo CD image parameters
+
+| Name                | Description                                        | Value                |
+| ------------------- | -------------------------------------------------- | -------------------- |
+| `image.registry`    | Argo CD image registry                             | `docker.io`          |
+| `image.repository`  | Argo CD image repository                           | `bitnami/argo-cd`    |
+| `image.tag`         | Argo CD image tag (immutable tags are recommended) | `2.0.5-debian-10-r6` |
+| `image.pullPolicy`  | Argo CD image pull policy                          | `IfNotPresent`       |
+| `image.pullSecrets` | Argo CD image pull secrets                         | `[]`                 |
+
+
 ### Argo CD application controller parameters
 
-| Name                                                     | Description                                                                                          | Value                 |
-| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | --------------------- |
-| `controller.image.registry`                              | Argo CD controller image registry                                                                    | `docker.io`           |
-| `controller.image.repository`                            | Argo CD controller image repository                                                                  | `bitnami/argo-cd`     |
-| `controller.image.tag`                                   | Argo CD controller image tag (immutable tags are recommended)                                        | `2.0.4-debian-10-r21` |
-| `controller.image.pullPolicy`                            | Argo CD controller image pull policy                                                                 | `IfNotPresent`        |
-| `controller.image.pullSecrets`                           | Argo CD controller image pull secrets                                                                | `[]`                  |
-| `controller.replicaCount`                                | Number of Argo CD replicas to deploy                                                                 | `1`                   |
-| `controller.livenessProbe.enabled`                       | Enable livenessProbe on Argo CD nodes                                                                | `true`                |
-| `controller.livenessProbe.initialDelaySeconds`           | Initial delay seconds for livenessProbe                                                              | `10`                  |
-| `controller.livenessProbe.periodSeconds`                 | Period seconds for livenessProbe                                                                     | `10`                  |
-| `controller.livenessProbe.timeoutSeconds`                | Timeout seconds for livenessProbe                                                                    | `1`                   |
-| `controller.livenessProbe.failureThreshold`              | Failure threshold for livenessProbe                                                                  | `3`                   |
-| `controller.livenessProbe.successThreshold`              | Success threshold for livenessProbe                                                                  | `1`                   |
-| `controller.readinessProbe.enabled`                      | Enable readinessProbe on Argo CD nodes                                                               | `true`                |
-| `controller.readinessProbe.initialDelaySeconds`          | Initial delay seconds for readinessProbe                                                             | `10`                  |
-| `controller.readinessProbe.periodSeconds`                | Period seconds for readinessProbe                                                                    | `10`                  |
-| `controller.readinessProbe.timeoutSeconds`               | Timeout seconds for readinessProbe                                                                   | `1`                   |
-| `controller.readinessProbe.failureThreshold`             | Failure threshold for readinessProbe                                                                 | `3`                   |
-| `controller.readinessProbe.successThreshold`             | Success threshold for readinessProbe                                                                 | `1`                   |
-| `controller.customLivenessProbe`                         | Custom livenessProbe that overrides the default one                                                  | `{}`                  |
-| `controller.customReadinessProbe`                        | Custom readinessProbe that overrides the default one                                                 | `{}`                  |
-| `controller.resources.limits`                            | The resources limits for the Argo CD containers                                                      | `{}`                  |
-| `controller.resources.requests`                          | The requested resources for the Argo CD containers                                                   | `{}`                  |
-| `controller.podSecurityContext.enabled`                  | Enabled Argo CD pods' Security Context                                                               | `true`                |
-| `controller.podSecurityContext.fsGroup`                  | Set Argo CD pod's Security Context fsGroup                                                           | `1001`                |
-| `controller.containerSecurityContext.enabled`            | Enabled Argo CD containers' Security Context                                                         | `true`                |
-| `controller.containerSecurityContext.runAsUser`          | Set Argo CD containers' Security Context runAsUser                                                   | `1001`                |
-| `controller.serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                                                 | `true`                |
-| `controller.serviceAccount.name`                         | The name of the ServiceAccount to use.                                                               | `""`                  |
-| `controller.serviceAccount.automountServiceAccountToken` | Automount service account token for the application controller service account                       | `true`                |
-| `controller.clusterAdminAccess`                          | Enable K8s cluster admin access for the application controller                                       | `true`                |
-| `controller.clusterRoleRules`                            | Use custom rules for the application controller's cluster role                                       | `[]`                  |
-| `controller.logFormat`                                   | Format for the Argo CD application controller logs. Options: [text, json]                            | `text`                |
-| `controller.logLevel`                                    | Log level for the Argo CD application controller                                                     | `info`                |
-| `controller.containerPorts.controller`                   | Argo CD application controller port number                                                           | `8082`                |
-| `controller.containerPorts.metrics`                      | Argo CD application controller metrics port number                                                   | `8082`                |
-| `controller.service.type`                                | Argo CD service type                                                                                 | `ClusterIP`           |
-| `controller.service.port`                                | Argo CD application controller service port                                                          | `8082`                |
-| `controller.service.nodePort`                            | Node port for Argo CD application controller service                                                 | `""`                  |
-| `controller.service.loadBalancerIP`                      | Argo CD application controller service Load Balancer IP                                              | `""`                  |
-| `controller.service.loadBalancerSourceRanges`            | Argo CD application controller service Load Balancer sources                                         | `[]`                  |
-| `controller.service.externalTrafficPolicy`               | Argo CD application controller service external traffic policy                                       | `Cluster`             |
-| `controller.service.annotations`                         | Additional custom annotations for Argo CD application controller service                             | `{}`                  |
-| `controller.metrics.enabled`                             | Enable Argo CD application controller metrics                                                        | `false`               |
-| `controller.metrics.service.type`                        | Argo CD application controller service type                                                          | `ClusterIP`           |
-| `controller.metrics.service.port`                        | Argo CD application controller metrics service port                                                  | `8082`                |
-| `controller.metrics.service.nodePort`                    | Node port for the application controller service                                                     | `""`                  |
-| `controller.metrics.service.loadBalancerIP`              | Argo CD application controller service Load Balancer IP                                              | `""`                  |
-| `controller.metrics.service.loadBalancerSourceRanges`    | Argo CD application controller service Load Balancer sources                                         | `[]`                  |
-| `controller.metrics.service.externalTrafficPolicy`       | Argo CD application controller service external traffic policy                                       | `Cluster`             |
-| `controller.metrics.service.annotations`                 | Additional custom annotations for Argo CD application controller service                             | `{}`                  |
-| `controller.metrics.serviceMonitor.enabled`              | Enable service monirot for Argo CD application controller                                            | `false`               |
-| `controller.metrics.serviceMonitor.interval`             | Interval for the Argo CD application controller service monitor                                      | `30s`                 |
-| `controller.metrics.rules.enabled`                       | Enable render extra rules for PrometheusRule object                                                  | `false`               |
-| `controller.metrics.rules.spec`                          | Rules to render into the PrometheusRule object                                                       | `[]`                  |
-| `controller.metrics.rules.selector`                      | Selector for the PrometheusRule object                                                               | `{}`                  |
-| `controller.metrics.rules.namespace`                     | Namespace where to create the PrometheusRule object                                                  | `monitoring`          |
-| `controller.metrics.rules.additionalLabels`              | Additional lables to add to the PrometheusRule object                                                | `{}`                  |
-| `controller.command`                                     | Override default container command (useful when using custom images)                                 | `[]`                  |
-| `controller.defaultArgs.statusProcessors`                | Default status processors for Argo CD controller                                                     | `20`                  |
-| `controller.defaultArgs.operationProcessors`             | Default operation processors for Argo CD controller                                                  | `10`                  |
-| `controller.defaultArgs.appResyncPeriod`                 | Default application resync period for Argo CD controller                                             | `180`                 |
-| `controller.defaultArgs.selfHealTimeout`                 | Default self heal timeout for Argo CD controller                                                     | `5`                   |
-| `controller.args`                                        | Override default container args (useful when using custom images). Overrides the defaultArgs.        | `[]`                  |
-| `controller.extraArgs`                                   | Add extra arguments to the default arguments for the Argo CD controller                              | `[]`                  |
-| `controller.hostAliases`                                 | Argo CD pods host aliases                                                                            | `[]`                  |
-| `controller.podLabels`                                   | Extra labels for Argo CD pods                                                                        | `{}`                  |
-| `controller.podAnnotations`                              | Annotations for Argo CD pods                                                                         | `{}`                  |
-| `controller.podAffinityPreset`                           | Pod affinity preset. Ignored if `controller.affinity` is set. Allowed values: `soft` or `hard`       | `""`                  |
-| `controller.podAntiAffinityPreset`                       | Pod anti-affinity preset. Ignored if `controller.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                |
-| `controller.nodeAffinityPreset.type`                     | Node affinity preset type. Ignored if `controller.affinity` is set. Allowed values: `soft` or `hard` | `""`                  |
-| `controller.nodeAffinityPreset.key`                      | Node label key to match. Ignored if `controller.affinity` is set                                     | `""`                  |
-| `controller.nodeAffinityPreset.values`                   | Node label values to match. Ignored if `controller.affinity` is set                                  | `[]`                  |
-| `controller.affinity`                                    | Affinity for Argo CD pods assignment                                                                 | `{}`                  |
-| `controller.nodeSelector`                                | Node labels for Argo CD pods assignment                                                              | `{}`                  |
-| `controller.tolerations`                                 | Tolerations for Argo CD pods assignment                                                              | `[]`                  |
-| `controller.updateStrategy.type`                         | Argo CD statefulset strategy type                                                                    | `RollingUpdate`       |
-| `controller.priorityClassName`                           | Argo CD pods' priorityClassName                                                                      | `""`                  |
-| `controller.lifecycleHooks`                              | for the Argo CD container(s) to automate configuration before or after startup                       | `{}`                  |
-| `controller.extraEnvVars`                                | Array with extra environment variables to add to Argo CD nodes                                       | `[]`                  |
-| `controller.extraEnvVarsCM`                              | Name of existing ConfigMap containing extra env vars for Argo CD nodes                               | `""`                  |
-| `controller.extraEnvVarsSecret`                          | Name of existing Secret containing extra env vars for Argo CD nodes                                  | `""`                  |
-| `controller.extraVolumes`                                | Optionally specify extra list of additional volumes for the Argo CD pod(s)                           | `[]`                  |
-| `controller.extraVolumeMounts`                           | Optionally specify extra list of additional volumeMounts for the Argo CD container(s)                | `[]`                  |
-| `controller.sidecars`                                    | Add additional sidecar containers to the Argo CD pod(s)                                              | `[]`                  |
-| `controller.initContainers`                              | Add additional init containers to the Argo CD pod(s)                                                 | `[]`                  |
+| Name                                                     | Description                                                                                          | Value           |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | --------------- |
+| `controller.replicaCount`                                | Number of Argo CD replicas to deploy                                                                 | `1`             |
+| `controller.livenessProbe.enabled`                       | Enable livenessProbe on Argo CD nodes                                                                | `true`          |
+| `controller.livenessProbe.initialDelaySeconds`           | Initial delay seconds for livenessProbe                                                              | `10`            |
+| `controller.livenessProbe.periodSeconds`                 | Period seconds for livenessProbe                                                                     | `10`            |
+| `controller.livenessProbe.timeoutSeconds`                | Timeout seconds for livenessProbe                                                                    | `1`             |
+| `controller.livenessProbe.failureThreshold`              | Failure threshold for livenessProbe                                                                  | `3`             |
+| `controller.livenessProbe.successThreshold`              | Success threshold for livenessProbe                                                                  | `1`             |
+| `controller.readinessProbe.enabled`                      | Enable readinessProbe on Argo CD nodes                                                               | `true`          |
+| `controller.readinessProbe.initialDelaySeconds`          | Initial delay seconds for readinessProbe                                                             | `10`            |
+| `controller.readinessProbe.periodSeconds`                | Period seconds for readinessProbe                                                                    | `10`            |
+| `controller.readinessProbe.timeoutSeconds`               | Timeout seconds for readinessProbe                                                                   | `1`             |
+| `controller.readinessProbe.failureThreshold`             | Failure threshold for readinessProbe                                                                 | `3`             |
+| `controller.readinessProbe.successThreshold`             | Success threshold for readinessProbe                                                                 | `1`             |
+| `controller.customLivenessProbe`                         | Custom livenessProbe that overrides the default one                                                  | `{}`            |
+| `controller.customReadinessProbe`                        | Custom readinessProbe that overrides the default one                                                 | `{}`            |
+| `controller.resources.limits`                            | The resources limits for the Argo CD containers                                                      | `{}`            |
+| `controller.resources.requests`                          | The requested resources for the Argo CD containers                                                   | `{}`            |
+| `controller.podSecurityContext.enabled`                  | Enabled Argo CD pods' Security Context                                                               | `true`          |
+| `controller.podSecurityContext.fsGroup`                  | Set Argo CD pod's Security Context fsGroup                                                           | `1001`          |
+| `controller.containerSecurityContext.enabled`            | Enabled Argo CD containers' Security Context                                                         | `true`          |
+| `controller.containerSecurityContext.runAsUser`          | Set Argo CD containers' Security Context runAsUser                                                   | `1001`          |
+| `controller.serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                                                 | `true`          |
+| `controller.serviceAccount.name`                         | The name of the ServiceAccount to use.                                                               | `""`            |
+| `controller.serviceAccount.automountServiceAccountToken` | Automount service account token for the application controller service account                       | `true`          |
+| `controller.clusterAdminAccess`                          | Enable K8s cluster admin access for the application controller                                       | `true`          |
+| `controller.clusterRoleRules`                            | Use custom rules for the application controller's cluster role                                       | `[]`            |
+| `controller.logFormat`                                   | Format for the Argo CD application controller logs. Options: [text, json]                            | `text`          |
+| `controller.logLevel`                                    | Log level for the Argo CD application controller                                                     | `info`          |
+| `controller.containerPorts.controller`                   | Argo CD application controller port number                                                           | `8082`          |
+| `controller.containerPorts.metrics`                      | Argo CD application controller metrics port number                                                   | `8082`          |
+| `controller.service.type`                                | Argo CD service type                                                                                 | `ClusterIP`     |
+| `controller.service.port`                                | Argo CD application controller service port                                                          | `8082`          |
+| `controller.service.nodePort`                            | Node port for Argo CD application controller service                                                 | `""`            |
+| `controller.service.loadBalancerIP`                      | Argo CD application controller service Load Balancer IP                                              | `""`            |
+| `controller.service.loadBalancerSourceRanges`            | Argo CD application controller service Load Balancer sources                                         | `[]`            |
+| `controller.service.externalTrafficPolicy`               | Argo CD application controller service external traffic policy                                       | `Cluster`       |
+| `controller.service.annotations`                         | Additional custom annotations for Argo CD application controller service                             | `{}`            |
+| `controller.metrics.enabled`                             | Enable Argo CD application controller metrics                                                        | `false`         |
+| `controller.metrics.service.type`                        | Argo CD application controller service type                                                          | `ClusterIP`     |
+| `controller.metrics.service.port`                        | Argo CD application controller metrics service port                                                  | `8082`          |
+| `controller.metrics.service.nodePort`                    | Node port for the application controller service                                                     | `""`            |
+| `controller.metrics.service.loadBalancerIP`              | Argo CD application controller service Load Balancer IP                                              | `""`            |
+| `controller.metrics.service.loadBalancerSourceRanges`    | Argo CD application controller service Load Balancer sources                                         | `[]`            |
+| `controller.metrics.service.externalTrafficPolicy`       | Argo CD application controller service external traffic policy                                       | `Cluster`       |
+| `controller.metrics.service.annotations`                 | Additional custom annotations for Argo CD application controller service                             | `{}`            |
+| `controller.metrics.serviceMonitor.enabled`              | Enable service monirot for Argo CD application controller                                            | `false`         |
+| `controller.metrics.serviceMonitor.interval`             | Interval for the Argo CD application controller service monitor                                      | `30s`           |
+| `controller.metrics.rules.enabled`                       | Enable render extra rules for PrometheusRule object                                                  | `false`         |
+| `controller.metrics.rules.spec`                          | Rules to render into the PrometheusRule object                                                       | `[]`            |
+| `controller.metrics.rules.selector`                      | Selector for the PrometheusRule object                                                               | `{}`            |
+| `controller.metrics.rules.namespace`                     | Namespace where to create the PrometheusRule object                                                  | `monitoring`    |
+| `controller.metrics.rules.additionalLabels`              | Additional lables to add to the PrometheusRule object                                                | `{}`            |
+| `controller.command`                                     | Override default container command (useful when using custom images)                                 | `[]`            |
+| `controller.defaultArgs.statusProcessors`                | Default status processors for Argo CD controller                                                     | `20`            |
+| `controller.defaultArgs.operationProcessors`             | Default operation processors for Argo CD controller                                                  | `10`            |
+| `controller.defaultArgs.appResyncPeriod`                 | Default application resync period for Argo CD controller                                             | `180`           |
+| `controller.defaultArgs.selfHealTimeout`                 | Default self heal timeout for Argo CD controller                                                     | `5`             |
+| `controller.args`                                        | Override default container args (useful when using custom images). Overrides the defaultArgs.        | `[]`            |
+| `controller.extraArgs`                                   | Add extra arguments to the default arguments for the Argo CD controller                              | `[]`            |
+| `controller.hostAliases`                                 | Argo CD pods host aliases                                                                            | `[]`            |
+| `controller.podLabels`                                   | Extra labels for Argo CD pods                                                                        | `{}`            |
+| `controller.podAnnotations`                              | Annotations for Argo CD pods                                                                         | `{}`            |
+| `controller.podAffinityPreset`                           | Pod affinity preset. Ignored if `controller.affinity` is set. Allowed values: `soft` or `hard`       | `""`            |
+| `controller.podAntiAffinityPreset`                       | Pod anti-affinity preset. Ignored if `controller.affinity` is set. Allowed values: `soft` or `hard`  | `soft`          |
+| `controller.nodeAffinityPreset.type`                     | Node affinity preset type. Ignored if `controller.affinity` is set. Allowed values: `soft` or `hard` | `""`            |
+| `controller.nodeAffinityPreset.key`                      | Node label key to match. Ignored if `controller.affinity` is set                                     | `""`            |
+| `controller.nodeAffinityPreset.values`                   | Node label values to match. Ignored if `controller.affinity` is set                                  | `[]`            |
+| `controller.affinity`                                    | Affinity for Argo CD pods assignment                                                                 | `{}`            |
+| `controller.nodeSelector`                                | Node labels for Argo CD pods assignment                                                              | `{}`            |
+| `controller.tolerations`                                 | Tolerations for Argo CD pods assignment                                                              | `[]`            |
+| `controller.updateStrategy.type`                         | Argo CD statefulset strategy type                                                                    | `RollingUpdate` |
+| `controller.priorityClassName`                           | Argo CD pods' priorityClassName                                                                      | `""`            |
+| `controller.lifecycleHooks`                              | for the Argo CD container(s) to automate configuration before or after startup                       | `{}`            |
+| `controller.extraEnvVars`                                | Array with extra environment variables to add to Argo CD nodes                                       | `[]`            |
+| `controller.extraEnvVarsCM`                              | Name of existing ConfigMap containing extra env vars for Argo CD nodes                               | `""`            |
+| `controller.extraEnvVarsSecret`                          | Name of existing Secret containing extra env vars for Argo CD nodes                                  | `""`            |
+| `controller.extraVolumes`                                | Optionally specify extra list of additional volumes for the Argo CD pod(s)                           | `[]`            |
+| `controller.extraVolumeMounts`                           | Optionally specify extra list of additional volumeMounts for the Argo CD container(s)                | `[]`            |
+| `controller.sidecars`                                    | Add additional sidecar containers to the Argo CD pod(s)                                              | `[]`            |
+| `controller.initContainers`                              | Add additional init containers to the Argo CD pod(s)                                                 | `[]`            |
 
 
 ### Argo CD server Parameters
 
 | Name                                                 | Description                                                                                      | Value                    |
 | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------ |
-| `server.image.registry`                              | Argo CD server image registry                                                                    | `docker.io`              |
-| `server.image.repository`                            | Argo CD server image repository                                                                  | `bitnami/argo-cd`        |
-| `server.image.tag`                                   | Argo CD server image tag (immutable tags are recommended)                                        | `2.0.5-debian-10-r0`     |
-| `server.image.pullPolicy`                            | Argo CD server image pull policy                                                                 | `IfNotPresent`           |
-| `server.image.pullSecrets`                           | Argo CD server image pull secrets                                                                | `[]`                     |
 | `server.replicaCount`                                | Number of Argo CD server replicas to deploy                                                      | `1`                      |
 | `server.livenessProbe.enabled`                       | Enable livenessProbe on Argo CD server nodes                                                     | `true`                   |
 | `server.livenessProbe.initialDelaySeconds`           | Initial delay seconds for livenessProbe                                                          | `10`                     |
@@ -279,87 +280,82 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Argo CD repo server Parameters
 
-| Name                                                     | Description                                                                                          | Value                 |
-| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | --------------------- |
-| `repoServer.image.registry`                              | Argo CD repo server image registry                                                                   | `docker.io`           |
-| `repoServer.image.repository`                            | Argo CD repo server image repository                                                                 | `bitnami/argo-cd`     |
-| `repoServer.image.tag`                                   | Argo CD repo server image tag (immutable tags are recommended)                                       | `2.0.4-debian-10-r21` |
-| `repoServer.image.pullPolicy`                            | Argo CD repo server image pull policy                                                                | `IfNotPresent`        |
-| `repoServer.image.pullSecrets`                           | Argo CD repo server image pull secrets                                                               | `[]`                  |
-| `repoServer.replicaCount`                                | Number of Argo CD repo server replicas to deploy                                                     | `1`                   |
-| `repoServer.livenessProbe.enabled`                       | Enable livenessProbe on Argo CD repo server nodes                                                    | `true`                |
-| `repoServer.livenessProbe.initialDelaySeconds`           | Initial delay seconds for livenessProbe                                                              | `10`                  |
-| `repoServer.livenessProbe.periodSeconds`                 | Period seconds for livenessProbe                                                                     | `10`                  |
-| `repoServer.livenessProbe.timeoutSeconds`                | Timeout seconds for livenessProbe                                                                    | `1`                   |
-| `repoServer.livenessProbe.failureThreshold`              | Failure threshold for livenessProbe                                                                  | `3`                   |
-| `repoServer.livenessProbe.successThreshold`              | Success threshold for livenessProbe                                                                  | `1`                   |
-| `repoServer.readinessProbe.enabled`                      | Enable readinessProbe on Argo CD repo server nodes                                                   | `true`                |
-| `repoServer.readinessProbe.initialDelaySeconds`          | Initial delay seconds for readinessProbe                                                             | `10`                  |
-| `repoServer.readinessProbe.periodSeconds`                | Period seconds for readinessProbe                                                                    | `10`                  |
-| `repoServer.readinessProbe.timeoutSeconds`               | Timeout seconds for readinessProbe                                                                   | `1`                   |
-| `repoServer.readinessProbe.failureThreshold`             | Failure threshold for readinessProbe                                                                 | `3`                   |
-| `repoServer.readinessProbe.successThreshold`             | Success threshold for readinessProbe                                                                 | `1`                   |
-| `repoServer.customLivenessProbe`                         | Custom livenessProbe that overrides the default one                                                  | `{}`                  |
-| `repoServer.customReadinessProbe`                        | Custom readinessProbe that overrides the default one                                                 | `{}`                  |
-| `repoServer.resources.limits`                            | The resources limits for the Argo CD repo server containers                                          | `{}`                  |
-| `repoServer.resources.requests`                          | The requested resources for the Argo CD repo server containers                                       | `{}`                  |
-| `repoServer.podSecurityContext.enabled`                  | Enabled Argo CD repo server pods' Security Context                                                   | `true`                |
-| `repoServer.podSecurityContext.fsGroup`                  | Set Argo CD repo server pod's Security Context fsGroup                                               | `1001`                |
-| `repoServer.containerSecurityContext.enabled`            | Enabled Argo CD repo server containers' Security Context                                             | `true`                |
-| `repoServer.containerSecurityContext.runAsUser`          | Set Argo CD repo server containers' Security Context runAsUser                                       | `1001`                |
-| `repoServer.service.type`                                | Repo server service type                                                                             | `ClusterIP`           |
-| `repoServer.service.port`                                | Repo server service port                                                                             | `8081`                |
-| `repoServer.service.nodePort`                            | Node port for the repo server service                                                                | `""`                  |
-| `repoServer.service.loadBalancerIP`                      | Repo server service Load Balancer IP                                                                 | `""`                  |
-| `repoServer.service.loadBalancerSourceRanges`            | Repo server service Load Balancer sources                                                            | `[]`                  |
-| `repoServer.service.externalTrafficPolicy`               | Repo server service external traffic policy                                                          | `Cluster`             |
-| `repoServer.service.annotations`                         | Additional custom annotations for Repo server service                                                | `{}`                  |
-| `repoServer.logFormat`                                   | Format for the Argo CD repo server logs. Options: [text, json]                                       | `text`                |
-| `repoServer.logLevel`                                    | Log level for the Argo CD repo server                                                                | `info`                |
-| `repoServer.containerPorts.repoServer`                   | Container port for Argo CD repo server                                                               | `8081`                |
-| `repoServer.containerPorts.metrics`                      | Metrics port for Argo CD repo server                                                                 | `""`                  |
-| `repoServer.metrics.enabled`                             | Enable metrics for the Argo CD repo server                                                           | `false`               |
-| `repoServer.metrics.service.type`                        | Argo CD repo server service type                                                                     | `ClusterIP`           |
-| `repoServer.metrics.service.port`                        | Argo CD repo server metrics service port                                                             | `8084`                |
-| `repoServer.metrics.service.nodePort`                    | Node port for the repo server metrics service                                                        | `""`                  |
-| `repoServer.metrics.service.loadBalancerIP`              | Argo CD repo server service Load Balancer IP                                                         | `""`                  |
-| `repoServer.metrics.service.loadBalancerSourceRanges`    | Argo CD repo server service Load Balancer sources                                                    | `[]`                  |
-| `repoServer.metrics.service.externalTrafficPolicy`       | Argo CD repo server service external traffic policy                                                  | `Cluster`             |
-| `repoServer.metrics.service.annotations`                 | Additional custom annotations for Argo CD repo server service                                        | `{}`                  |
-| `repoServer.metrics.serviceMonitor.enabled`              | Enable service monirot for Argo CD repo server                                                       | `false`               |
-| `repoServer.metrics.serviceMonitor.interval`             | Interval for the Argo CD repo server service monitor                                                 | `30s`                 |
-| `repoServer.autoscaling.enabled`                         | Enable Argo CD repo server deployment autoscaling                                                    | `false`               |
-| `repoServer.autoscaling.minReplicas`                     | Argo CD repo server deployment autoscaling minimum number of replicas                                | `1`                   |
-| `repoServer.autoscaling.maxReplicas`                     | Argo CD repo server deployment autoscaling maximum number of replicas                                | `5`                   |
-| `repoServer.autoscaling.targetCPU`                       | Argo CD repo server deployment autoscaling target CPU percentage                                     | `50`                  |
-| `repoServer.autoscaling.targetMemory`                    | Argo CD repo server deployment autoscaling target CPU memory                                         | `50`                  |
-| `repoServer.serviceAccount.create`                       | Specifies whether a ServiceAccount for repo server should be created                                 | `true`                |
-| `repoServer.serviceAccount.name`                         | The name of the ServiceAccount for repo server to use.                                               | `""`                  |
-| `repoServer.serviceAccount.automountServiceAccountToken` | Automount service account token for the repo server service account                                  | `true`                |
-| `repoServer.command`                                     | Override default container command (useful when using custom images)                                 | `[]`                  |
-| `repoServer.args`                                        | Override default container args (useful when using custom images)                                    | `[]`                  |
-| `repoServer.extraArgs`                                   | Add extra args to the default repo server args                                                       | `[]`                  |
-| `repoServer.hostAliases`                                 | Argo CD repo server pods host aliases                                                                | `[]`                  |
-| `repoServer.podLabels`                                   | Extra labels for Argo CD repo server pods                                                            | `{}`                  |
-| `repoServer.podAnnotations`                              | Annotations for Argo CD repo server pods                                                             | `{}`                  |
-| `repoServer.podAffinityPreset`                           | Pod affinity preset. Ignored if `repoServer.affinity` is set. Allowed values: `soft` or `hard`       | `""`                  |
-| `repoServer.podAntiAffinityPreset`                       | Pod anti-affinity preset. Ignored if `repoServer.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                |
-| `repoServer.nodeAffinityPreset.type`                     | Node affinity preset type. Ignored if `repoServer.affinity` is set. Allowed values: `soft` or `hard` | `""`                  |
-| `repoServer.nodeAffinityPreset.key`                      | Node label key to match. Ignored if `repoServer.affinity` is set                                     | `""`                  |
-| `repoServer.nodeAffinityPreset.values`                   | Node label values to match. Ignored if `repoServer.affinity` is set                                  | `[]`                  |
-| `repoServer.affinity`                                    | Affinity for Argo CD repo server pods assignment                                                     | `{}`                  |
-| `repoServer.nodeSelector`                                | Node labels for Argo CD repo server pods assignment                                                  | `{}`                  |
-| `repoServer.tolerations`                                 | Tolerations for Argo CD repo server pods assignment                                                  | `[]`                  |
-| `repoServer.updateStrategy.type`                         | Argo CD repo server statefulset strategy type                                                        | `RollingUpdate`       |
-| `repoServer.priorityClassName`                           | Argo CD repo server pods' priorityClassName                                                          | `""`                  |
-| `repoServer.lifecycleHooks`                              | for the Argo CD repo server container(s) to automate configuration before or after startup           | `{}`                  |
-| `repoServer.extraEnvVars`                                | Array with extra environment variables to add to Argo CD repo server nodes                           | `[]`                  |
-| `repoServer.extraEnvVarsCM`                              | Name of existing ConfigMap containing extra env vars for Argo CD repo server nodes                   | `""`                  |
-| `repoServer.extraEnvVarsSecret`                          | Name of existing Secret containing extra env vars for Argo CD repo server nodes                      | `""`                  |
-| `repoServer.extraVolumes`                                | Optionally specify extra list of additional volumes for the Argo CD repo server pod(s)               | `[]`                  |
-| `repoServer.extraVolumeMounts`                           | Optionally specify extra list of additional volumeMounts for the Argo CD repo server container(s)    | `[]`                  |
-| `repoServer.sidecars`                                    | Add additional sidecar containers to the Argo CD repo server pod(s)                                  | `[]`                  |
-| `repoServer.initContainers`                              | Add additional init containers to the Argo CD repo server pod(s)                                     | `[]`                  |
+| Name                                                     | Description                                                                                          | Value           |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | --------------- |
+| `repoServer.replicaCount`                                | Number of Argo CD repo server replicas to deploy                                                     | `1`             |
+| `repoServer.livenessProbe.enabled`                       | Enable livenessProbe on Argo CD repo server nodes                                                    | `true`          |
+| `repoServer.livenessProbe.initialDelaySeconds`           | Initial delay seconds for livenessProbe                                                              | `10`            |
+| `repoServer.livenessProbe.periodSeconds`                 | Period seconds for livenessProbe                                                                     | `10`            |
+| `repoServer.livenessProbe.timeoutSeconds`                | Timeout seconds for livenessProbe                                                                    | `1`             |
+| `repoServer.livenessProbe.failureThreshold`              | Failure threshold for livenessProbe                                                                  | `3`             |
+| `repoServer.livenessProbe.successThreshold`              | Success threshold for livenessProbe                                                                  | `1`             |
+| `repoServer.readinessProbe.enabled`                      | Enable readinessProbe on Argo CD repo server nodes                                                   | `true`          |
+| `repoServer.readinessProbe.initialDelaySeconds`          | Initial delay seconds for readinessProbe                                                             | `10`            |
+| `repoServer.readinessProbe.periodSeconds`                | Period seconds for readinessProbe                                                                    | `10`            |
+| `repoServer.readinessProbe.timeoutSeconds`               | Timeout seconds for readinessProbe                                                                   | `1`             |
+| `repoServer.readinessProbe.failureThreshold`             | Failure threshold for readinessProbe                                                                 | `3`             |
+| `repoServer.readinessProbe.successThreshold`             | Success threshold for readinessProbe                                                                 | `1`             |
+| `repoServer.customLivenessProbe`                         | Custom livenessProbe that overrides the default one                                                  | `{}`            |
+| `repoServer.customReadinessProbe`                        | Custom readinessProbe that overrides the default one                                                 | `{}`            |
+| `repoServer.resources.limits`                            | The resources limits for the Argo CD repo server containers                                          | `{}`            |
+| `repoServer.resources.requests`                          | The requested resources for the Argo CD repo server containers                                       | `{}`            |
+| `repoServer.podSecurityContext.enabled`                  | Enabled Argo CD repo server pods' Security Context                                                   | `true`          |
+| `repoServer.podSecurityContext.fsGroup`                  | Set Argo CD repo server pod's Security Context fsGroup                                               | `1001`          |
+| `repoServer.containerSecurityContext.enabled`            | Enabled Argo CD repo server containers' Security Context                                             | `true`          |
+| `repoServer.containerSecurityContext.runAsUser`          | Set Argo CD repo server containers' Security Context runAsUser                                       | `1001`          |
+| `repoServer.service.type`                                | Repo server service type                                                                             | `ClusterIP`     |
+| `repoServer.service.port`                                | Repo server service port                                                                             | `8081`          |
+| `repoServer.service.nodePort`                            | Node port for the repo server service                                                                | `""`            |
+| `repoServer.service.loadBalancerIP`                      | Repo server service Load Balancer IP                                                                 | `""`            |
+| `repoServer.service.loadBalancerSourceRanges`            | Repo server service Load Balancer sources                                                            | `[]`            |
+| `repoServer.service.externalTrafficPolicy`               | Repo server service external traffic policy                                                          | `Cluster`       |
+| `repoServer.service.annotations`                         | Additional custom annotations for Repo server service                                                | `{}`            |
+| `repoServer.logFormat`                                   | Format for the Argo CD repo server logs. Options: [text, json]                                       | `text`          |
+| `repoServer.logLevel`                                    | Log level for the Argo CD repo server                                                                | `info`          |
+| `repoServer.containerPorts.repoServer`                   | Container port for Argo CD repo server                                                               | `8081`          |
+| `repoServer.containerPorts.metrics`                      | Metrics port for Argo CD repo server                                                                 | `""`            |
+| `repoServer.metrics.enabled`                             | Enable metrics for the Argo CD repo server                                                           | `false`         |
+| `repoServer.metrics.service.type`                        | Argo CD repo server service type                                                                     | `ClusterIP`     |
+| `repoServer.metrics.service.port`                        | Argo CD repo server metrics service port                                                             | `8084`          |
+| `repoServer.metrics.service.nodePort`                    | Node port for the repo server metrics service                                                        | `""`            |
+| `repoServer.metrics.service.loadBalancerIP`              | Argo CD repo server service Load Balancer IP                                                         | `""`            |
+| `repoServer.metrics.service.loadBalancerSourceRanges`    | Argo CD repo server service Load Balancer sources                                                    | `[]`            |
+| `repoServer.metrics.service.externalTrafficPolicy`       | Argo CD repo server service external traffic policy                                                  | `Cluster`       |
+| `repoServer.metrics.service.annotations`                 | Additional custom annotations for Argo CD repo server service                                        | `{}`            |
+| `repoServer.metrics.serviceMonitor.enabled`              | Enable service monirot for Argo CD repo server                                                       | `false`         |
+| `repoServer.metrics.serviceMonitor.interval`             | Interval for the Argo CD repo server service monitor                                                 | `30s`           |
+| `repoServer.autoscaling.enabled`                         | Enable Argo CD repo server deployment autoscaling                                                    | `false`         |
+| `repoServer.autoscaling.minReplicas`                     | Argo CD repo server deployment autoscaling minimum number of replicas                                | `1`             |
+| `repoServer.autoscaling.maxReplicas`                     | Argo CD repo server deployment autoscaling maximum number of replicas                                | `5`             |
+| `repoServer.autoscaling.targetCPU`                       | Argo CD repo server deployment autoscaling target CPU percentage                                     | `50`            |
+| `repoServer.autoscaling.targetMemory`                    | Argo CD repo server deployment autoscaling target CPU memory                                         | `50`            |
+| `repoServer.serviceAccount.create`                       | Specifies whether a ServiceAccount for repo server should be created                                 | `true`          |
+| `repoServer.serviceAccount.name`                         | The name of the ServiceAccount for repo server to use.                                               | `""`            |
+| `repoServer.serviceAccount.automountServiceAccountToken` | Automount service account token for the repo server service account                                  | `true`          |
+| `repoServer.command`                                     | Override default container command (useful when using custom images)                                 | `[]`            |
+| `repoServer.args`                                        | Override default container args (useful when using custom images)                                    | `[]`            |
+| `repoServer.extraArgs`                                   | Add extra args to the default repo server args                                                       | `[]`            |
+| `repoServer.hostAliases`                                 | Argo CD repo server pods host aliases                                                                | `[]`            |
+| `repoServer.podLabels`                                   | Extra labels for Argo CD repo server pods                                                            | `{}`            |
+| `repoServer.podAnnotations`                              | Annotations for Argo CD repo server pods                                                             | `{}`            |
+| `repoServer.podAffinityPreset`                           | Pod affinity preset. Ignored if `repoServer.affinity` is set. Allowed values: `soft` or `hard`       | `""`            |
+| `repoServer.podAntiAffinityPreset`                       | Pod anti-affinity preset. Ignored if `repoServer.affinity` is set. Allowed values: `soft` or `hard`  | `soft`          |
+| `repoServer.nodeAffinityPreset.type`                     | Node affinity preset type. Ignored if `repoServer.affinity` is set. Allowed values: `soft` or `hard` | `""`            |
+| `repoServer.nodeAffinityPreset.key`                      | Node label key to match. Ignored if `repoServer.affinity` is set                                     | `""`            |
+| `repoServer.nodeAffinityPreset.values`                   | Node label values to match. Ignored if `repoServer.affinity` is set                                  | `[]`            |
+| `repoServer.affinity`                                    | Affinity for Argo CD repo server pods assignment                                                     | `{}`            |
+| `repoServer.nodeSelector`                                | Node labels for Argo CD repo server pods assignment                                                  | `{}`            |
+| `repoServer.tolerations`                                 | Tolerations for Argo CD repo server pods assignment                                                  | `[]`            |
+| `repoServer.updateStrategy.type`                         | Argo CD repo server statefulset strategy type                                                        | `RollingUpdate` |
+| `repoServer.priorityClassName`                           | Argo CD repo server pods' priorityClassName                                                          | `""`            |
+| `repoServer.lifecycleHooks`                              | for the Argo CD repo server container(s) to automate configuration before or after startup           | `{}`            |
+| `repoServer.extraEnvVars`                                | Array with extra environment variables to add to Argo CD repo server nodes                           | `[]`            |
+| `repoServer.extraEnvVarsCM`                              | Name of existing ConfigMap containing extra env vars for Argo CD repo server nodes                   | `""`            |
+| `repoServer.extraEnvVarsSecret`                          | Name of existing Secret containing extra env vars for Argo CD repo server nodes                      | `""`            |
+| `repoServer.extraVolumes`                                | Optionally specify extra list of additional volumes for the Argo CD repo server pod(s)               | `[]`            |
+| `repoServer.extraVolumeMounts`                           | Optionally specify extra list of additional volumeMounts for the Argo CD repo server container(s)    | `[]`            |
+| `repoServer.sidecars`                                    | Add additional sidecar containers to the Argo CD repo server pod(s)                                  | `[]`            |
+| `repoServer.initContainers`                              | Add additional init containers to the Argo CD repo server pod(s)                                     | `[]`            |
 
 
 ### Dex Parameters
@@ -368,7 +364,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------------------------------------- | --------------------------------------------------------------------------------------------- | ---------------------- |
 | `dex.image.registry`                              | Dex image registry                                                                            | `docker.io`            |
 | `dex.image.repository`                            | Dex image repository                                                                          | `bitnami/dex`          |
-| `dex.image.tag`                                   | Dex image tag (immutable tags are recommended)                                                | `2.29.0-debian-10-r21` |
+| `dex.image.tag`                                   | Dex image tag (immutable tags are recommended)                                                | `2.29.0-debian-10-r27` |
 | `dex.image.pullPolicy`                            | Dex image pull policy                                                                         | `IfNotPresent`         |
 | `dex.image.pullSecrets`                           | Dex image pull secrets                                                                        | `[]`                   |
 | `dex.enabled`                                     | Enable the creation of a Dex deployment for SSO                                               | `false`                |
@@ -492,7 +488,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `rbac.create`                             | Specifies whether RBAC resources should be created                          | `true`               |
 | `redis.image.registry`                    | Argo CD controller image registry                                           | `docker.io`          |
 | `redis.image.repository`                  | Argo CD controller image repository                                         | `bitnami/redis`      |
-| `redis.image.tag`                         | Argo CD controller image tag (immutable tags are recommended)               | `6.2.5-debian-10-r0` |
+| `redis.image.tag`                         | Argo CD controller image tag (immutable tags are recommended)               | `6.2.5-debian-10-r7` |
 | `redis.image.pullPolicy`                  | Argo CD controller image pull policy                                        | `IfNotPresent`       |
 | `redis.image.pullSecrets`                 | Argo CD controller image pull secrets                                       | `[]`                 |
 | `redis.enabled`                           | Enable Redis dependency                                                     | `true`               |
@@ -590,3 +586,36 @@ As an alternative, use one of the preset configurations for pod affinity, pod an
 ## Troubleshooting
 
 Find more information about how to deal with common errors related to Bitnami's Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
+
+## Upgrading
+
+### To 1.0.0
+
+In this version, the `image` block is defined once and is used in the different templates, while in the previous version, the `image` block was duplicated for every component
+
+```yaml
+image:
+  registry: docker.io
+  repository: bitnami/argo-cd
+  tag: 2.0.5
+```
+VS
+```yaml
+controller:
+  image:
+    registry: docker.io
+    repository: bitnami/argo-cd
+    tag: 2.0.5
+...
+server:
+  image:
+    registry: docker.io
+    repository: bitnami/argo-cd
+    tag: 2.0.5
+...
+repoServer:
+  image:
+    registry: docker.io
+    repository: bitnami/argo-cd
+    tag: 2.0.5
+```

--- a/bitnami/argo-cd/templates/NOTES.txt
+++ b/bitnami/argo-cd/templates/NOTES.txt
@@ -48,9 +48,7 @@ WARNING: server.configEnabled is disabled, a config map called "argocd-cm" must 
 WARNING: config.createExtraKnownHosts is disabled, a secret called "argocd-ssh-known-hosts-cm" must exist in your namespace
 {{- end -}}
 
-{{- include "common.warnings.rollingTag" .Values.server.image }}
-{{- include "common.warnings.rollingTag" .Values.controller.image }}
-{{- include "common.warnings.rollingTag" .Values.repoServer.image }}
+{{- include "common.warnings.rollingTag" .Values.image }}
 {{- include "common.warnings.rollingTag" .Values.dex.image }}
 
 {{- include "argocd.validateValues" . }}

--- a/bitnami/argo-cd/templates/_helpers.tpl
+++ b/bitnami/argo-cd/templates/_helpers.tpl
@@ -1,22 +1,8 @@
 {{/*
-Return the proper Argo CD controller image name
+Return the proper Argo CD image name
 */}}
-{{- define "argocd.application-controller.image" -}}
-{{ include "common.images.image" (dict "imageRoot" .Values.controller.image "global" .Values.global) }}
-{{- end -}}
-
-{{/*
-Return the proper Argo CD server image name
-*/}}
-{{- define "argocd.server.image" -}}
-{{ include "common.images.image" (dict "imageRoot" .Values.server.image "global" .Values.global) }}
-{{- end -}}
-
-{{/*
-Return the proper Argo CD repoServer image name
-*/}}
-{{- define "argocd.repo-server.image" -}}
-{{ include "common.images.image" (dict "imageRoot" .Values.repoServer.image "global" .Values.global) }}
+{{- define "argocd.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
 {{- end -}}
 
 {{/*
@@ -37,7 +23,7 @@ Return the proper image name (for the init container volume-permissions image)
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "argocd.imagePullSecrets" -}}
-{{- include "common.images.pullSecrets" (dict "images" (list .Values.controller.image .Values.server.image .Values.repoServer.image .Values.dex.image .Values.volumePermissions.image) "global" .Values.global) -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.dex.image .Values.volumePermissions.image) "global" .Values.global) -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/argo-cd/templates/application-controller/deployment.yaml
+++ b/bitnami/argo-cd/templates/application-controller/deployment.yaml
@@ -98,8 +98,8 @@ spec:
         {{- end }}
       containers:
         - name: controller
-          image: {{ include "argocd.application-controller.image" . }}
-          imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
+          image: {{ include "argocd.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.controller.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.controller.lifecycleHooks "context" $) | nindent 12 }}
           {{- end }}

--- a/bitnami/argo-cd/templates/dex/deployment.yaml
+++ b/bitnami/argo-cd/templates/dex/deployment.yaml
@@ -79,8 +79,8 @@ spec:
               mountPath: /tmp
         {{- end }}
         - name: copyutil
-          image: {{ include "argocd.server.image" . }}
-          imagePullPolicy: {{ .Values.server.image.pullPolicy }}
+          image: {{ include "argocd.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.dex.resources }}
           resources:  {{- toYaml .Values.dex.resources | nindent 12 }}
           {{- end }}

--- a/bitnami/argo-cd/templates/repo-server/deployment.yaml
+++ b/bitnami/argo-cd/templates/repo-server/deployment.yaml
@@ -116,8 +116,8 @@ spec:
         {{- end }}
       containers:
         - name: argocd-repo-server
-          image: {{ include "argocd.repo-server.image" . }}
-          imagePullPolicy: {{ .Values.repoServer.image.pullPolicy }}
+          image: {{ include "argocd.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.repoServer.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.repoServer.lifecycleHooks "context" $) | nindent 12 }}
           {{- end }}

--- a/bitnami/argo-cd/templates/server/deployment.yaml
+++ b/bitnami/argo-cd/templates/server/deployment.yaml
@@ -116,8 +116,8 @@ spec:
                   key: {{ include "argocd.redis.secretPasswordKey" . }}
       containers:
         - name: argocd-server
-          image: {{ include "argocd.server.image" . }}
-          imagePullPolicy: {{ .Values.server.image.pullPolicy }}
+          image: {{ include "argocd.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.server.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.server.lifecycleHooks "context" $) | nindent 12 }}
           {{- end }}

--- a/bitnami/argo-cd/values.yaml
+++ b/bitnami/argo-cd/values.yaml
@@ -53,7 +53,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: bitnami/argo-cd
-  tag: 2.0.5-debian-10-r6
+  tag: 2.0.5-debian-10-r9
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1336,7 +1336,7 @@ dex:
   image:
     registry: docker.io
     repository: bitnami/dex
-    tag: 2.29.0-debian-10-r27
+    tag: 2.29.0-debian-10-r29
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1867,7 +1867,7 @@ redis:
   image:
     registry: docker.io
     repository: bitnami/redis
-    tag: 6.2.5-debian-10-r7
+    tag: 6.2.5-debian-10-r9
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/argo-cd/values.yaml
+++ b/bitnami/argo-cd/values.yaml
@@ -40,37 +40,39 @@ clusterDomain: cluster.local
 ##
 extraDeploy: []
 
+## @section Argo CD image parameters
+
+## Bitnami Argo CD image
+## ref: https://hub.docker.com/r/bitnami/argo-cd/tags/
+## @param image.registry Argo CD image registry
+## @param image.repository Argo CD image repository
+## @param image.tag Argo CD image tag (immutable tags are recommended)
+## @param image.pullPolicy Argo CD image pull policy
+## @param image.pullSecrets Argo CD image pull secrets
+##
+image:
+  registry: docker.io
+  repository: bitnami/argo-cd
+  tag: 2.0.5-debian-10-r6
+  ## Specify a imagePullPolicy
+  ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## e.g:
+  ## pullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  pullSecrets: []
+
 ## @section Argo CD application controller parameters
 
 ## Argo CD Controller
 ##
 controller:
-  ## Bitnami Argo CD controller image
-  ## ref: https://hub.docker.com/r/bitnami/argo-cd/tags/
-  ## @param controller.image.registry Argo CD controller image registry
-  ## @param controller.image.repository Argo CD controller image repository
-  ## @param controller.image.tag Argo CD controller image tag (immutable tags are recommended)
-  ## @param controller.image.pullPolicy Argo CD controller image pull policy
-  ## @param controller.image.pullSecrets Argo CD controller image pull secrets
-  ##
-  image:
-    registry: docker.io
-    repository: bitnami/argo-cd
-    tag: 2.0.5-debian-10-r6
-    ## Specify a imagePullPolicy
-    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-    ##
-    pullPolicy: IfNotPresent
-    ## Optionally specify an array of imagePullSecrets.
-    ## Secrets must be manually created in the namespace.
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ## e.g:
-    ## pullSecrets:
-    ##   - myRegistryKeySecretName
-    ##
-    pullSecrets: []
-
   ## @param controller.replicaCount Number of Argo CD replicas to deploy
   ##
   replicaCount: 1
@@ -432,32 +434,6 @@ controller:
 ## Argo CD server configuration
 ##
 server:
-  ## Bitnami Argo CD server image
-  ## ref: https://hub.docker.com/r/bitnami/argo-cd/tags/
-  ## @param server.image.registry Argo CD server image registry
-  ## @param server.image.repository Argo CD server image repository
-  ## @param server.image.tag Argo CD server image tag (immutable tags are recommended)
-  ## @param server.image.pullPolicy Argo CD server image pull policy
-  ## @param server.image.pullSecrets Argo CD server image pull secrets
-  ##
-  image:
-    registry: docker.io
-    repository: bitnami/argo-cd
-    tag: 2.0.5-debian-10-r7
-    ## Specify a imagePullPolicy
-    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-    ##
-    pullPolicy: IfNotPresent
-    ## Optionally specify an array of imagePullSecrets.
-    ## Secrets must be manually created in the namespace.
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ## e.g:
-    ## pullSecrets:
-    ##   - myRegistryKeySecretName
-    ##
-    pullSecrets: []
-
   ## @param server.replicaCount Number of Argo CD server replicas to deploy
   ##
   replicaCount: 1
@@ -1042,32 +1018,6 @@ server:
 ## Argo CD repository server configuration
 ##
 repoServer:
-  ## Bitnami Argo CD repo server image
-  ## ref: https://hub.docker.com/r/bitnami/argo-cd/tags/
-  ## @param repoServer.image.registry Argo CD repo server image registry
-  ## @param repoServer.image.repository Argo CD repo server image repository
-  ## @param repoServer.image.tag Argo CD repo server image tag (immutable tags are recommended)
-  ## @param repoServer.image.pullPolicy Argo CD repo server image pull policy
-  ## @param repoServer.image.pullSecrets Argo CD repo server image pull secrets
-  ##
-  image:
-    registry: docker.io
-    repository: bitnami/argo-cd
-    tag: 2.0.5-debian-10-r6
-    ## Specify a imagePullPolicy
-    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-    ##
-    pullPolicy: IfNotPresent
-    ## Optionally specify an array of imagePullSecrets.
-    ## Secrets must be manually created in the namespace.
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ## e.g:
-    ## pullSecrets:
-    ##   - myRegistryKeySecretName
-    ##
-    pullSecrets: []
-
   ## @param repoServer.replicaCount Number of Argo CD repo server replicas to deploy
   ##
   replicaCount: 1


### PR DESCRIPTION
**Description of the change**

In this version, the `image` block is defined once and is used in the different templates, while in the previous version, the `image` block was duplicated for every component

```yaml
image:
  registry: docker.io
  repository: bitnami/argo-cd
  tag: 2.0.5
```
VS
```yaml
controller:
  image:
    registry: docker.io
    repository: bitnami/argo-cd
    tag: 2.0.5
...
server:
  image:
    registry: docker.io
    repository: bitnami/argo-cd
    tag: 2.0.5
...
repoServer:
  image:
    registry: docker.io
    repository: bitnami/argo-cd
    tag: 2.0.5
```

**Possible drawbacks**

The chart version was bumped in a major

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
