### PR TITLE
[bitnami/several] Simplify image definition logic removing duplications

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -25,4 +25,4 @@ name: grafana-operator
 sources:
   - https://github.com/integr8ly/grafana-operator
   - https://github.com/bitnami/bitnami-docker-grafana-operator
-version: 0.8.2
+version: 1.0.0

--- a/bitnami/grafana-operator/README.md
+++ b/bitnami/grafana-operator/README.md
@@ -274,16 +274,6 @@ This solution allows to easily deploy multiple Grafana instances compared to the
 | `grafana.sidecars`                                          | Add additional sidecar containers to the grafana pod(s)                                       | `[]`                  |
 
 
-### PluginInit parameters
-
-| Name                                  | Description                            | Value                 |
-| ------------------------------------- | -------------------------------------- | --------------------- |
-| `grafanaPluginInit.image.registry`    | Grafana Plugin Init image registry     | `docker.io`           |
-| `grafanaPluginInit.image.repository`  | Grafana Plugin Init image name         | `bitnami/grafana`     |
-| `grafanaPluginInit.image.tag`         | Grafana Plugin Init image tag          | `7.5.10-debian-10-r9` |
-| `grafanaPluginInit.image.pullSecrets` | Grafana Plugin Init image pull secrets | `[]`                  |
-
-
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
@@ -365,3 +355,29 @@ Find more information about how to deal with common errors related to Bitnami’
 ```bash
 $ helm upgrade my-release bitnami/grafana-operator
 ```
+
+### To 1.0.0
+
+In this version, the `image` block is defined once and is used in the different templates, while in the previous version, the `image` block was duplicated for the grafana container and the grafana plugin init one
+
+```yaml
+image:
+  registry: docker.io
+  repository: bitnami/grafana
+  tag: 7.5.10
+```
+VS
+```yaml
+image:
+  registry: docker.io
+  repository: bitnami/grafana
+  tag: 7.5.10
+...
+grafanaPluginInit:
+  image:
+    registry: docker.io
+    repository: bitnami/grafana
+    tag: 7.5.10
+```
+
+See [PR#foobar](https://github.com/bitnami/charts/pull/foobar) for more info about the implemented changes

--- a/bitnami/grafana-operator/README.md
+++ b/bitnami/grafana-operator/README.md
@@ -380,4 +380,4 @@ grafanaPluginInit:
     tag: 7.5.10
 ```
 
-See [PR#foobar](https://github.com/bitnami/charts/pull/foobar) for more info about the implemented changes
+See [PR#7114](https://github.com/bitnami/charts/pull/7114) for more info about the implemented changes

--- a/bitnami/grafana-operator/templates/NOTES.txt
+++ b/bitnami/grafana-operator/templates/NOTES.txt
@@ -10,4 +10,3 @@ Watch the Grafana Operator Deployment status using the command:
 {{- if .Values.grafana.enabled }}
 {{ include "common.warnings.rollingTag" .Values.grafana.image }}
 {{- end }}
-{{ include "common.warnings.rollingTag" .Values.grafanaPluginInit.image }}

--- a/bitnami/grafana-operator/templates/_helpers.tpl
+++ b/bitnami/grafana-operator/templates/_helpers.tpl
@@ -23,28 +23,6 @@ Also, we can't use a single if because lazy evaluation is not an option
 {{- end -}}
 
 {{/*
-Return the proper grafana-operator grafana PluginInit baseImage name
-*/}}
-{{- define "grafana-operator.pluginInit.baseImage" -}}
-{{- $registryName := .Values.grafanaPluginInit.image.registry -}}
-{{- $repositoryName := .Values.grafanaPluginInit.image.repository -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s" .Values.global.imageRegistry $repositoryName -}}
-    {{- else -}}
-        {{- printf "%s/%s" $registryName $repositoryName -}}
-    {{- end -}}
-{{- else -}}
-    {{- printf "%s/%s" $registryName $repositoryName -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Create the name of the grafana-operator service account to use
 */}}
 {{- define "grafana-operator.serviceAccountName" -}}

--- a/bitnami/grafana-operator/templates/deployment.yaml
+++ b/bitnami/grafana-operator/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       annotations: {{- include "common.tplvalues.render" (dict "value" .Values.operator.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
     spec:
-      {{- include "common.images.pullSecrets" (dict "images" (list .Values.operator.image .Values.grafana.image .Values.grafanaPluginInit.image ) "global" .Values.global) | nindent 6 }}
+      {{- include "common.images.pullSecrets" (dict "images" (list .Values.operator.image .Values.grafana.image ) "global" .Values.global) | nindent 6 }}
       {{- if .Values.operator.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.operator.hostAliases "context" $) | nindent 8 }}
       {{- end }}
@@ -61,8 +61,8 @@ spec:
           args:
             - --grafana-image={{ include "grafana-operator.grafana.baseImage" . }}
             - --grafana-image-tag={{ .Values.grafana.image.tag | trim }}
-            - --grafana-plugins-init-container-image={{ include "grafana-operator.pluginInit.baseImage" . }}
-            - --grafana-plugins-init-container-tag={{ .Values.grafanaPluginInit.image.tag | trim }}
+            - --grafana-plugins-init-container-image={{ include "grafana-operator.grafana.baseImage" . }}
+            - --grafana-plugins-init-container-tag={{ .Values.grafana.image.tag | trim }}
             {{- if (and .Values.operator.args.scanAllNamespaces (not .Values.operator.args.scanNamespaces)) }}
             - --scan-all=True
             {{- else if .Values.operator.args.scanNamespaces }}

--- a/bitnami/grafana-operator/templates/grafana.yaml
+++ b/bitnami/grafana-operator/templates/grafana.yaml
@@ -38,7 +38,7 @@ spec:
     {{- if .Values.commonAnnotations }}
     annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 6 }}
     {{- end }}
-  {{- $imagePullSecrets := include "common.images.pullSecrets" (dict "images" (list .Values.operator.image .Values.grafana.image .Values.grafanaPluginInit.image) "global" .Values.global) }}
+  {{- $imagePullSecrets := include "common.images.pullSecrets" (dict "images" (list .Values.operator.image .Values.grafana.image) "global" .Values.global) }}
   {{- if (not (empty ($imagePullSecrets))) | or .Values.grafana.serviceAccount }}
   serviceAccount:
   {{- with .Values.grafana.serviceAccount }}

--- a/bitnami/grafana-operator/values.yaml
+++ b/bitnami/grafana-operator/values.yaml
@@ -570,23 +570,3 @@ grafana:
   ##
   sidecars: []
 
-## @section PluginInit parameters
-
-grafanaPluginInit:
-  ## @param grafanaPluginInit.image.registry Grafana Plugin Init image registry
-  ## @param grafanaPluginInit.image.repository Grafana Plugin Init image name
-  ## @param grafanaPluginInit.image.tag Grafana Plugin Init image tag
-  ## @param grafanaPluginInit.image.pullSecrets Grafana Plugin Init image pull secrets
-  ##
-  image:
-    registry: docker.io
-    repository: bitnami/grafana
-    tag: 7.5.10-debian-10-r9
-    ## Optionally specify an array of imagePullSecrets.
-    ## Secrets must be manually created in the namespace.
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ## e.g:
-    ## pullSecrets:
-    ##   - myRegistryKeySecretName
-    ##
-    pullSecrets: []

--- a/bitnami/grafana-operator/values.yaml
+++ b/bitnami/grafana-operator/values.yaml
@@ -569,4 +569,3 @@ grafana:
   ##         containerPort: 1234
   ##
   sidecars: []
-

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 13.1.5
+version: 14.0.0

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -334,24 +334,18 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Kafka provisioning parameters
 
-| Name                              | Description                                                           | Value                 |
-| --------------------------------- | --------------------------------------------------------------------- | --------------------- |
-| `provisioning.enabled`            | Enable kafka provisioning Job                                         | `false`               |
-| `provisioning.image.registry`     | Kafka image registry                                                  | `docker.io`           |
-| `provisioning.image.repository`   | Kafka image repository                                                | `bitnami/kafka`       |
-| `provisioning.image.tag`          | Kafka image tag (immutable tags are recommended)                      | `2.8.0-debian-10-r56` |
-| `provisioning.image.pullPolicy`   | Kafka image pull policy                                               | `IfNotPresent`        |
-| `provisioning.image.pullSecrets`  | Specify docker-registry secret names as an array                      | `[]`                  |
-| `provisioning.image.debug`        | Set to true if you would like to see extra information on logs        | `false`               |
-| `provisioning.numPartitions`      | Default number of partitions for topics when unspecified.             | `1`                   |
-| `provisioning.replicationFactor`  | Default replication factor for topics when unspecified.               | `1`                   |
-| `provisioning.schedulerName`      | Name of the k8s scheduler (other than default) for kafka provisioning | `""`                  |
-| `provisioning.podAnnotations`     | Provisioning Pod annotations.                                         | `{}`                  |
-| `provisioning.resources.limits`   | The resources limits for the container                                | `{}`                  |
-| `provisioning.resources.requests` | The requested resources for the container                             | `{}`                  |
-| `provisioning.command`            | Override provisioning container command                               | `[]`                  |
-| `provisioning.args`               | Override provisioning container arguments                             | `[]`                  |
-| `provisioning.topics`             | Kafka provisioning topics                                             | `[]`                  |
+| Name                              | Description                                                           | Value   |
+| --------------------------------- | --------------------------------------------------------------------- | ------- |
+| `provisioning.enabled`            | Enable kafka provisioning Job                                         | `false` |
+| `provisioning.numPartitions`      | Default number of partitions for topics when unspecified.             | `1`     |
+| `provisioning.replicationFactor`  | Default replication factor for topics when unspecified.               | `1`     |
+| `provisioning.schedulerName`      | Name of the k8s scheduler (other than default) for kafka provisioning | `""`    |
+| `provisioning.podAnnotations`     | Provisioning Pod annotations.                                         | `{}`    |
+| `provisioning.resources.limits`   | The resources limits for the container                                | `{}`    |
+| `provisioning.resources.requests` | The requested resources for the container                             | `{}`    |
+| `provisioning.command`            | Override provisioning container command                               | `[]`    |
+| `provisioning.args`               | Override provisioning container arguments                             | `[]`    |
+| `provisioning.topics`             | Kafka provisioning topics                                             | `[]`    |
 
 
 ### Zookeeper chart parameters
@@ -674,6 +668,32 @@ Find more information about how to deal with common errors related to Bitnami’
 
 ## Upgrading
 
+### To 14.0.0
+
+In this version, the `image` block is defined once and is used in the different templates, while in the previous version, the `image` block was duplicated for the main container and the provisioning one
+
+```yaml
+image:
+  registry: docker.io
+  repository: bitnami/kafka
+  tag: 2.8.0
+```
+VS
+```yaml
+image:
+  registry: docker.io
+  repository: bitnami/kafka
+  tag: 2.8.0
+...
+provisioning:
+  image:
+    registry: docker.io
+    repository: bitnami/kafka
+    tag: 2.8.0
+```
+
+See [PR#foobar](https://github.com/bitnami/charts/pull/foobar) for more info about the implemented changes
+
 ### To 13.0.0
 
 This major updates the Zookeeper subchart to it newest major, 7.0.0, which renames all TLS-related settings. For more information on this subchart's major, please refer to [zookeeper upgrade notes](https://github.com/bitnami/charts/tree/master/bitnami/zookeeper#to-700).
@@ -711,14 +731,14 @@ External access to brokers can now be achieved through the cluster's Kafka servi
 
 - `service.nodePort` -> deprecated  in favor of `service.nodePorts.client` and `service.nodePorts.external`
 
-### 11.7.0
+### To 11.7.0
 
 The way to configure the users and passwords changed. Now it is allowed to create multiple users during the installation by providing the list of users and passwords.
 
 - `auth.jaas.clientUser` (string) -> deprecated  in favor of `auth.jaas.clientUsers` (array).
 - `auth.jaas.clientPassword` (string) -> deprecated  in favor of `auth.jaas.clientPasswords` (array).
 
-### 11.0.0
+### To 11.0.0
 
 The way to configure listeners and athentication on Kafka is totally refactored allowing users to configure different authentication protocols on different listeners. Please check the sections [Listeners Configuration](listeners-configuration) and [Listeners Configuration](enable-kafka-for-kafka-and-zookeeper) for more information.
 
@@ -739,11 +759,11 @@ Backwards compatibility is not guaranteed you adapt your values.yaml to the new 
 - `metrics.kafka.extraFlag` -> new parameter
 - `metrics.kafka.certificatesSecret` -> new parameter
 
-### 10.0.0
+### To 10.0.0
 
 If you are setting the `config` or `log4j` parameter, backwards compatibility is not guaranteed, because the `KAFKA_MOUNTED_CONFDIR` has moved from `/opt/bitnami/kafka/conf` to `/bitnami/kafka/config`. In order to continue using these parameters, you must also upgrade your image to `docker.io/bitnami/kafka:2.4.1-debian-10-r38` or later.
 
-### 9.0.0
+### To 9.0.0
 
 Backwards compatibility is not guaranteed you adapt your values.yaml to the new format. Here you can find some parameters that were renamed on this major version:
 
@@ -765,11 +785,11 @@ Backwards compatibility is not guaranteed you adapt your values.yaml to the new 
 
 Ports names were prefixed with the protocol to comply with Istio (see https://istio.io/docs/ops/deployment/requirements/).
 
-### 8.0.0
+### To 8.0.0
 
 There is not backwards compatibility since the brokerID changes to the POD_NAME. For more information see [this PR](https://github.com/bitnami/charts/pull/2028).
 
-### 7.0.0
+### To 7.0.0
 
 Backwards compatibility is not guaranteed when Kafka metrics are enabled, unless you modify the labels used on the exporter deployments.
 Use the workaround below to upgrade from versions previous to 7.0.0. The following example assumes that the release name is kafka:
@@ -779,7 +799,7 @@ helm upgrade kafka bitnami/kafka --version 6.1.8 --set metrics.kafka.enabled=fal
 helm upgrade kafka bitnami/kafka --version 7.0.0 --set metrics.kafka.enabled=true
 ```
 
-### 2.0.0
+### To 2.0.0
 
 Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
 Use the workaround below to upgrade from versions previous to 2.0.0. The following example assumes that the release name is kafka:
@@ -789,7 +809,7 @@ kubectl delete statefulset kafka-kafka --cascade=false
 kubectl delete statefulset kafka-zookeeper --cascade=false
 ```
 
-### 1.0.0
+### To 1.0.0
 
 Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
 Use the workaround below to upgrade from versions previous to 1.0.0. The following example assumes that the release name is kafka:

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -692,7 +692,7 @@ provisioning:
     tag: 2.8.0
 ```
 
-See [PR#foobar](https://github.com/bitnami/charts/pull/foobar) for more info about the implemented changes
+See [PR#7114](https://github.com/bitnami/charts/pull/7114) for more info about the implemented changes
 
 ### To 13.0.0
 

--- a/bitnami/kafka/templates/_helpers.tpl
+++ b/bitnami/kafka/templates/_helpers.tpl
@@ -47,13 +47,6 @@ Return the proper Kafka image name
 {{- end -}}
 
 {{/*
-Return the proper Kafka provisioning image name
-*/}}
-{{- define "kafka.provisioning.image" -}}
-{{ include "common.images.image" (dict "imageRoot" .Values.provisioning.image "global" .Values.global) }}
-{{- end -}}
-
-{{/*
 Return the proper image name (for the init container auto-discovery image)
 */}}
 {{- define "kafka.externalAccess.autoDiscovery.image" -}}

--- a/bitnami/kafka/templates/kafka-provisioning.yaml
+++ b/bitnami/kafka/templates/kafka-provisioning.yaml
@@ -35,8 +35,8 @@ spec:
       terminationGracePeriodSeconds: 0
       initContainers:
         - name: wait-for-available-kafka
-          image: {{ include "kafka.provisioning.image" . }}
-          imagePullPolicy: {{ .Values.provisioning.image.pullPolicy | quote }}
+          image: {{ include "kafka.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           command:
             - /bin/bash
             - -c
@@ -50,8 +50,8 @@ spec:
               echo "Kafka is available";
       containers:
         - name: kafka-provisioning
-          image: {{ include "kafka.provisioning.image" . }}
-          imagePullPolicy: {{ .Values.provisioning.image.pullPolicy | quote }}
+          image: {{ include "kafka.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           {{- if .Values.diagnosticMode.enabled }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
           {{- else }}

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -1184,32 +1184,6 @@ provisioning:
   ## @param provisioning.enabled Enable kafka provisioning Job
   ##
   enabled: false
-  ## @param provisioning.image.registry Kafka image registry
-  ## @param provisioning.image.repository Kafka image repository
-  ## @param provisioning.image.tag Kafka image tag (immutable tags are recommended)
-  ## @param provisioning.image.pullPolicy Kafka image pull policy
-  ## @param provisioning.image.pullSecrets Specify docker-registry secret names as an array
-  ## @param provisioning.image.debug Set to true if you would like to see extra information on logs
-  ##
-  image:
-    registry: docker.io
-    repository: bitnami/kafka
-    tag: 2.8.0-debian-10-r56
-    ## Specify a imagePullPolicy
-    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-    ##
-    pullPolicy: IfNotPresent
-    ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ## Example:
-    ## pullSecrets:
-    ##   - myRegistryKeySecretName
-    ##
-    pullSecrets: []
-    ## Set to true if you would like to see extra information on logs
-    ##
-    debug: false
   ## @param provisioning.numPartitions Default number of partitions for topics when unspecified.
   numPartitions: 1
   ## @param provisioning.replicationFactor Default replication factor for topics when unspecified.

--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -36,4 +36,4 @@ name: redmine
 sources:
   - https://github.com/bitnami/bitnami-docker-redmine
   - http://www.redmine.org/
-version: 16.0.2
+version: 17.0.0

--- a/bitnami/redmine/README.md
+++ b/bitnami/redmine/README.md
@@ -67,20 +67,20 @@ helm install my-release bitnami/redmine --set databaseType=postgresql
 
 ### Common parameters
 
-| Name                | Description                                        | Value                 |
-| ------------------- | -------------------------------------------------- | --------------------- |
-| `kubeVersion`       | Override Kubernetes version                        | `""`                  |
-| `nameOverride`      | String to partially override common.names.fullname | `""`                  |
-| `fullnameOverride`  | String to fully override common.names.fullname     | `""`                  |
-| `commonLabels`      | Labels to add to all deployed objects              | `{}`                  |
-| `commonAnnotations` | Annotations to add to all deployed objects         | `{}`                  |
-| `extraDeploy`       | Array of extra objects to deploy with the release  | `[]`                  |
-| `image.registry`    | Redmine image registry                             | `docker.io`           |
-| `image.repository`  | Redmine image repository                           | `bitnami/redmine`     |
-| `image.tag`         | Redmine image tag (immutable tags are recommended) | `4.2.1-debian-10-r71` |
-| `image.pullPolicy`  | Redmine image pull policy                          | `IfNotPresent`        |
-| `image.pullSecrets` | Redmine image pull secrets                         | `[]`                  |
-| `image.debug`       | Enable image debug mode                            | `false`               |
+| Name                | Description                                        | Value                |
+| ------------------- | -------------------------------------------------- | -------------------- |
+| `kubeVersion`       | Override Kubernetes version                        | `""`                 |
+| `nameOverride`      | String to partially override common.names.fullname | `""`                 |
+| `fullnameOverride`  | String to fully override common.names.fullname     | `""`                 |
+| `commonLabels`      | Labels to add to all deployed objects              | `{}`                 |
+| `commonAnnotations` | Annotations to add to all deployed objects         | `{}`                 |
+| `extraDeploy`       | Array of extra objects to deploy with the release  | `[]`                 |
+| `image.registry`    | Redmine image registry                             | `docker.io`          |
+| `image.repository`  | Redmine image repository                           | `bitnami/redmine`    |
+| `image.tag`         | Redmine image tag (immutable tags are recommended) | `4.2.2-debian-10-r0` |
+| `image.pullPolicy`  | Redmine image pull policy                          | `IfNotPresent`       |
+| `image.pullSecrets` | Redmine image pull secrets                         | `[]`                 |
+| `image.debug`       | Enable image debug mode                            | `false`              |
 
 
 ### Redmine Configuration parameters
@@ -260,63 +260,58 @@ helm install my-release bitnami/redmine --set databaseType=postgresql
 
 ### Mail Receiver/Cron Job Parameters
 
-| Name                                                 | Description                                                                                                                                   | Value                 |
-| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
-| `mailReceiver.enabled`                               | Whether to enable scheduled mail-to-task CronJob                                                                                              | `false`               |
-| `mailReceiver.schedule`                              | Kubernetes CronJob schedule                                                                                                                   | `*/5 * * * *`         |
-| `mailReceiver.suspend`                               | Whether to create suspended CronJob                                                                                                           | `true`                |
-| `mailReceiver.image.registry`                        | Redmine MailReceiver image registry                                                                                                           | `docker.io`           |
-| `mailReceiver.image.repository`                      | Redmine MailReceiver image repository                                                                                                         | `bitnami/redmine`     |
-| `mailReceiver.image.tag`                             | Redmine MailReceiver image tag (immutable tags are recommended)                                                                               | `4.2.1-debian-10-r70` |
-| `mailReceiver.image.pullPolicy`                      | Redmine MailReceiver image pull policy                                                                                                        | `IfNotPresent`        |
-| `mailReceiver.image.pullSecrets`                     | Redmine MailReceiver image pull secrets                                                                                                       | `[]`                  |
-| `mailReceiver.podAnnotations`                        | Additional pod annotations                                                                                                                    | `{}`                  |
-| `mailReceiver.podLabels`                             | Additional pod labels                                                                                                                         | `{}`                  |
-| `mailReceiver.priorityClassName`                     | Redmine pods' priority.                                                                                                                       | `""`                  |
-| `mailReceiver.mailProtocol`                          | Mail protocol to use for reading emails. Allowed values: `IMAP` and `POP3`                                                                    | `IMAP`                |
-| `mailReceiver.host`                                  | Server to receive emails from                                                                                                                 | `""`                  |
-| `mailReceiver.port`                                  | TCP port on the `host`                                                                                                                        | `993`                 |
-| `mailReceiver.username`                              | Login to authenticate on the `host`                                                                                                           | `""`                  |
-| `mailReceiver.password`                              | Password to authenticate on the `host`                                                                                                        | `""`                  |
-| `mailReceiver.ssl`                                   | Whether use SSL/TLS to connect to the `host`                                                                                                  | `true`                |
-| `mailReceiver.startTLS`                              | Whether use StartTLS to connect to the `host`                                                                                                 | `false`               |
-| `mailReceiver.imapFolder`                            | IMAP only. Folder to read emails from                                                                                                         | `INBOX`               |
-| `mailReceiver.moveOnSuccess`                         | IMAP only. Folder to move processed emails to                                                                                                 | `""`                  |
-| `mailReceiver.moveOnFailure`                         | IMAP only. Folder to move emails with processing errors to                                                                                    | `""`                  |
-| `mailReceiver.unknownUserAction`                     | Action to perform is an email received from unregistered user                                                                                 | `ignore`              |
-| `mailReceiver.noPermissionCheck`                     | Whether skip permission check during creating a new task                                                                                      | `0`                   |
-| `mailReceiver.noAccountNotice`                       | Whether send an email to an unregistered user created during a new task creation                                                              | `1`                   |
-| `mailReceiver.defaultGroup`                          | Defines a group list to add created user to                                                                                                   | `""`                  |
-| `mailReceiver.project`                               | Defines identifier of the target project for a new task                                                                                       | `""`                  |
-| `mailReceiver.projectFromSubaddress`                 | Defines email address to select project from subaddress                                                                                       | `""`                  |
-| `mailReceiver.status`                                | Defines a new task status                                                                                                                     | `""`                  |
-| `mailReceiver.tracker`                               | Defines a new task tracker                                                                                                                    | `""`                  |
-| `mailReceiver.category`                              | Defines a new task category                                                                                                                   | `""`                  |
-| `mailReceiver.priority`                              | Defines a new task priority                                                                                                                   | `""`                  |
-| `mailReceiver.assignedTo`                            | Defines a new task assignee                                                                                                                   | `""`                  |
-| `mailReceiver.allowOverride`                         | Defines if email content is allowed to set attributes values. Values is a comma separated list of attributes or `all` to allow all attributes | `""`                  |
-| `mailReceiver.extraEnvVars`                          | Extra environment variables to be set on mailReceiver container                                                                               | `[]`                  |
-| `mailReceiver.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars                                                                                          | `""`                  |
-| `mailReceiver.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars                                                                                             | `""`                  |
-| `mailReceiver.extraVolumes`                          | Optionally specify extra list of additional volumes for mailReceiver container                                                                | `[]`                  |
-| `mailReceiver.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for mailReceiver container                                                           | `[]`                  |
-| `mailReceiver.command`                               | Override default container command (useful when using custom images)                                                                          | `[]`                  |
-| `mailReceiver.args`                                  | Override default container args (useful when using custom images)                                                                             | `[]`                  |
-| `mailReceiver.podSecurityContext.enabled`            | Enabled Redmine pods' Security Context                                                                                                        | `true`                |
-| `mailReceiver.podSecurityContext.fsGroup`            | Set Redmine pod's Security Context fsGroup                                                                                                    | `1001`                |
-| `mailReceiver.containerSecurityContext.enabled`      | mailReceiver Container securityContext                                                                                                        | `false`               |
-| `mailReceiver.containerSecurityContext.runAsUser`    | User ID for the mailReceiver container                                                                                                        | `1001`                |
-| `mailReceiver.containerSecurityContext.runAsNonRoot` | Whether to run the mailReceiver container as a non-root user                                                                                  | `true`                |
-| `mailReceiver.initContainers`                        | Add additional init containers to the mailReceiver pods                                                                                       | `[]`                  |
-| `mailReceiver.sidecars`                              | Add additional sidecar containers to the mailReceiver pods                                                                                    | `[]`                  |
-| `mailReceiver.podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                           | `""`                  |
-| `mailReceiver.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                      | `soft`                |
-| `mailReceiver.nodeAffinityPreset.type`               | Node affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                          | `""`                  |
-| `mailReceiver.nodeAffinityPreset.key`                | Node label key to match. Ignored if `affinity` is set.                                                                                        | `""`                  |
-| `mailReceiver.nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                                                                     | `[]`                  |
-| `mailReceiver.affinity`                              | Affinity for pod assignment                                                                                                                   | `{}`                  |
-| `mailReceiver.nodeSelector`                          | Node labels for pod assignment                                                                                                                | `{}`                  |
-| `mailReceiver.tolerations`                           | Tolerations for pod assignment                                                                                                                | `[]`                  |
+| Name                                                 | Description                                                                                                                                   | Value         |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `mailReceiver.enabled`                               | Whether to enable scheduled mail-to-task CronJob                                                                                              | `false`       |
+| `mailReceiver.schedule`                              | Kubernetes CronJob schedule                                                                                                                   | `*/5 * * * *` |
+| `mailReceiver.suspend`                               | Whether to create suspended CronJob                                                                                                           | `true`        |
+| `mailReceiver.podAnnotations`                        | Additional pod annotations                                                                                                                    | `{}`          |
+| `mailReceiver.podLabels`                             | Additional pod labels                                                                                                                         | `{}`          |
+| `mailReceiver.priorityClassName`                     | Redmine pods' priority.                                                                                                                       | `""`          |
+| `mailReceiver.mailProtocol`                          | Mail protocol to use for reading emails. Allowed values: `IMAP` and `POP3`                                                                    | `IMAP`        |
+| `mailReceiver.host`                                  | Server to receive emails from                                                                                                                 | `""`          |
+| `mailReceiver.port`                                  | TCP port on the `host`                                                                                                                        | `993`         |
+| `mailReceiver.username`                              | Login to authenticate on the `host`                                                                                                           | `""`          |
+| `mailReceiver.password`                              | Password to authenticate on the `host`                                                                                                        | `""`          |
+| `mailReceiver.ssl`                                   | Whether use SSL/TLS to connect to the `host`                                                                                                  | `true`        |
+| `mailReceiver.startTLS`                              | Whether use StartTLS to connect to the `host`                                                                                                 | `false`       |
+| `mailReceiver.imapFolder`                            | IMAP only. Folder to read emails from                                                                                                         | `INBOX`       |
+| `mailReceiver.moveOnSuccess`                         | IMAP only. Folder to move processed emails to                                                                                                 | `""`          |
+| `mailReceiver.moveOnFailure`                         | IMAP only. Folder to move emails with processing errors to                                                                                    | `""`          |
+| `mailReceiver.unknownUserAction`                     | Action to perform is an email received from unregistered user                                                                                 | `ignore`      |
+| `mailReceiver.noPermissionCheck`                     | Whether skip permission check during creating a new task                                                                                      | `0`           |
+| `mailReceiver.noAccountNotice`                       | Whether send an email to an unregistered user created during a new task creation                                                              | `1`           |
+| `mailReceiver.defaultGroup`                          | Defines a group list to add created user to                                                                                                   | `""`          |
+| `mailReceiver.project`                               | Defines identifier of the target project for a new task                                                                                       | `""`          |
+| `mailReceiver.projectFromSubaddress`                 | Defines email address to select project from subaddress                                                                                       | `""`          |
+| `mailReceiver.status`                                | Defines a new task status                                                                                                                     | `""`          |
+| `mailReceiver.tracker`                               | Defines a new task tracker                                                                                                                    | `""`          |
+| `mailReceiver.category`                              | Defines a new task category                                                                                                                   | `""`          |
+| `mailReceiver.priority`                              | Defines a new task priority                                                                                                                   | `""`          |
+| `mailReceiver.assignedTo`                            | Defines a new task assignee                                                                                                                   | `""`          |
+| `mailReceiver.allowOverride`                         | Defines if email content is allowed to set attributes values. Values is a comma separated list of attributes or `all` to allow all attributes | `""`          |
+| `mailReceiver.extraEnvVars`                          | Extra environment variables to be set on mailReceiver container                                                                               | `[]`          |
+| `mailReceiver.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars                                                                                          | `""`          |
+| `mailReceiver.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars                                                                                             | `""`          |
+| `mailReceiver.extraVolumes`                          | Optionally specify extra list of additional volumes for mailReceiver container                                                                | `[]`          |
+| `mailReceiver.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for mailReceiver container                                                           | `[]`          |
+| `mailReceiver.command`                               | Override default container command (useful when using custom images)                                                                          | `[]`          |
+| `mailReceiver.args`                                  | Override default container args (useful when using custom images)                                                                             | `[]`          |
+| `mailReceiver.podSecurityContext.enabled`            | Enabled Redmine pods' Security Context                                                                                                        | `true`        |
+| `mailReceiver.podSecurityContext.fsGroup`            | Set Redmine pod's Security Context fsGroup                                                                                                    | `1001`        |
+| `mailReceiver.containerSecurityContext.enabled`      | mailReceiver Container securityContext                                                                                                        | `false`       |
+| `mailReceiver.containerSecurityContext.runAsUser`    | User ID for the mailReceiver container                                                                                                        | `1001`        |
+| `mailReceiver.containerSecurityContext.runAsNonRoot` | Whether to run the mailReceiver container as a non-root user                                                                                  | `true`        |
+| `mailReceiver.initContainers`                        | Add additional init containers to the mailReceiver pods                                                                                       | `[]`          |
+| `mailReceiver.sidecars`                              | Add additional sidecar containers to the mailReceiver pods                                                                                    | `[]`          |
+| `mailReceiver.podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                           | `""`          |
+| `mailReceiver.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                      | `soft`        |
+| `mailReceiver.nodeAffinityPreset.type`               | Node affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                          | `""`          |
+| `mailReceiver.nodeAffinityPreset.key`                | Node label key to match. Ignored if `affinity` is set.                                                                                        | `""`          |
+| `mailReceiver.nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                                                                     | `[]`          |
+| `mailReceiver.affinity`                              | Affinity for pod assignment                                                                                                                   | `{}`          |
+| `mailReceiver.nodeSelector`                          | Node labels for pod assignment                                                                                                                | `{}`          |
+| `mailReceiver.tolerations`                           | Tolerations for pod assignment                                                                                                                | `[]`          |
 
 
 ### Custom Certificates parameters
@@ -332,7 +327,7 @@ helm install my-release bitnami/redmine --set databaseType=postgresql
 | `certificates.customCA`                              | Defines a list of secrets to import into the container trust store | `[]`                                     |
 | `certificates.image.registry`                        | Redmine image registry                                             | `docker.io`                              |
 | `certificates.image.repository`                      | Redmine image repository                                           | `bitnami/bitnami-shell`                  |
-| `certificates.image.tag`                             | Redmine image tag (immutable tags are recommended)                 | `10-debian-10-r133`                      |
+| `certificates.image.tag`                             | Redmine image tag (immutable tags are recommended)                 | `10-debian-10-r148`                      |
 | `certificates.image.pullPolicy`                      | Redmine image pull policy                                          | `IfNotPresent`                           |
 | `certificates.image.pullSecrets`                     | Redmine image pull secrets                                         | `[]`                                     |
 | `certificates.extraEnvVars`                          | Container sidecar extra environment variables (e.g. proxy)         | `[]`                                     |
@@ -534,7 +529,33 @@ Find more information about how to deal with common errors related to Bitnami’
 
 ## Upgrading
 
-### 16.0.0
+### To 17.0.0
+
+In this version, the `image` block is defined once and is used in the different templates, while in the previous version, the `image` block was duplicated for the main container and the mail receiver one
+
+```yaml
+image:
+  registry: docker.io
+  repository: bitnami/redmine
+  tag: 4.2.2
+```
+VS
+```yaml
+image:
+  registry: docker.io
+  repository: bitnami/redmine
+  tag: 4.2.2
+...
+metrics:
+  image:
+    registry: docker.io
+    repository: bitnami/redmine
+    tag: 4.2.2
+```
+
+See [PR#foobar](https://github.com/bitnami/charts/pull/foobar) for more info about the implemented changes
+
+### To 16.0.0
 
 The [Bitnami Redmine](https://github.com/bitnami/bitnami-docker-redmine) image was refactored and now the source code is published in GitHub in the [`rootfs`](https://github.com/bitnami/bitnami-docker-redmine/tree/master/4/debian-10/rootfs) folder of the container image repository.
 
@@ -548,7 +569,7 @@ In addition, the `replicas` parameter was renamed to `replicaCount`.
 
 Full compatibility is not guaranteed due to the amount of involved changes, however no breaking changes are expected aside from the ones mentioned above.
 
-### 15.0.0
+### To 15.0.0
 
 [On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version includes all the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
 

--- a/bitnami/redmine/README.md
+++ b/bitnami/redmine/README.md
@@ -546,7 +546,7 @@ image:
   repository: bitnami/redmine
   tag: 4.2.2
 ...
-metrics:
+mailReceiver:
   image:
     registry: docker.io
     repository: bitnami/redmine

--- a/bitnami/redmine/README.md
+++ b/bitnami/redmine/README.md
@@ -553,7 +553,7 @@ mailReceiver:
     tag: 4.2.2
 ```
 
-See [PR#foobar](https://github.com/bitnami/charts/pull/foobar) for more info about the implemented changes
+See [PR#7114](https://github.com/bitnami/charts/pull/7114) for more info about the implemented changes
 
 ### To 16.0.0
 

--- a/bitnami/redmine/templates/NOTES.txt
+++ b/bitnami/redmine/templates/NOTES.txt
@@ -62,9 +62,6 @@ You have 4 alternatives:
 {{- end }}
 
 {{- include "common.warnings.rollingTag" .Values.image }}
-{{- if .Values.mailReceiver.enabled }}
-{{- include "common.warnings.rollingTag" .Values.mailReceiver.image }}
-{{- end }}
 
 {{- $passwordValidationErrors := list }}
 

--- a/bitnami/redmine/templates/_helpers.tpl
+++ b/bitnami/redmine/templates/_helpers.tpl
@@ -26,7 +26,7 @@ Return the proper Redmine image name
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "redmine.imagePullSecrets" -}}
-{{- include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.mailReceiver.image .Values.certificates.image) "global" .Values.global) -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.certificates.image) "global" .Values.global) -}}
 {{- end -}}
 
 {{/*
@@ -71,13 +71,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "redmine.mailReceiver.fullname" -}}
 {{- printf "%s-mail-receiver" (include "common.names.fullname" .) -}}
-{{- end -}}
-
-{{/*
-Return the proper Redmine mail Receiver image name
-*/}}
-{{- define "redmine.mailReceiver.image" -}}
-{{ include "common.images.image" (dict "imageRoot" .Values.mailReceiver.image "global" .Values.global) }}
 {{- end -}}
 
 {{/*

--- a/bitnami/redmine/templates/cronjob.yaml
+++ b/bitnami/redmine/templates/cronjob.yaml
@@ -65,8 +65,8 @@ spec:
           {{- end }}
           containers:
             - name: {{ template "redmine.mailReceiver.fullname" . }}
-              image: {{ template "redmine.mailReceiver.image" . }}
-              imagePullPolicy: {{ .Values.mailReceiver.image.pullPolicy | quote }}
+              image: {{ template "redmine.image" . }}
+              imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
               {{- if .Values.mailReceiver.containerSecurityContext.enabled }}
               securityContext: {{- omit .Values.mailReceiver.containerSecurityContext "enabled" | toYaml | nindent 16 }}
               {{- end }}

--- a/bitnami/redmine/values.yaml
+++ b/bitnami/redmine/values.yaml
@@ -702,22 +702,6 @@ mailReceiver:
   ## @param mailReceiver.suspend Whether to create suspended CronJob
   ##
   suspend: true
-  ## @param mailReceiver.image.registry Redmine MailReceiver image registry
-  ## @param mailReceiver.image.repository Redmine MailReceiver image repository
-  ## @param mailReceiver.image.tag Redmine MailReceiver image tag (immutable tags are recommended)
-  ## @param mailReceiver.image.pullPolicy Redmine MailReceiver image pull policy
-  ## @param mailReceiver.image.pullSecrets [array] Redmine MailReceiver image pull secrets
-  ##
-  image:
-    registry: docker.io
-    repository: bitnami/redmine
-    tag: 4.2.1-debian-10-r85
-    ## Specify a imagePullPolicy
-    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-    ##
-    pullPolicy: IfNotPresent
-    pullSecrets: []
   ## @param mailReceiver.podAnnotations Additional pod annotations
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##

--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -27,4 +27,4 @@ name: solr
 sources:
   - https://github.com/bitnami/bitnami-docker-solr
   - https://lucene.apache.org/solr/
-version: 1.0.5
+version: 2.0.0

--- a/bitnami/solr/README.md
+++ b/bitnami/solr/README.md
@@ -224,11 +224,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                                             | Description                                                                                                                     | Value                                                                         |
 | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
 | `exporter.enabled`                               | Start a side-car prometheus exporter                                                                                            | `false`                                                                       |
-| `exporter.image.registry`                        | Solr exporter image registry                                                                                                    | `docker.io`                                                                   |
-| `exporter.image.repository`                      | Solr exporter image name                                                                                                        | `bitnami/solr`                                                                |
-| `exporter.image.tag`                             | Solr exporter image tag                                                                                                         | `8.9.0-debian-10-r14`                                                         |
-| `exporter.image.pullPolicy`                      | Image pull policy                                                                                                               | `IfNotPresent`                                                                |
-| `exporter.image.pullSecrets`                     | Specify docker-registry secret names as an array                                                                                | `[]`                                                                          |
 | `exporter.livenessProbe.enabled`                 | Enable livenessProbe                                                                                                            | `true`                                                                        |
 | `exporter.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                                         | `10`                                                                          |
 | `exporter.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                                | `5`                                                                           |
@@ -368,3 +363,29 @@ Find more information about how to deal with common errors related to Bitnami’
 ### To 1.0.0
 
 This major updates the Zookeeper subchart to it newest major, 7.0.0, which renames all TLS-related settings. For more information on this subchart's major, please refer to [zookeeper upgrade notes](https://github.com/bitnami/charts/tree/master/bitnami/zookeeper#to-700).
+
+### To 2.0.0
+
+In this version, the `image` block is defined once and is used in the different templates, while in the previous version, the `image` block was duplicated for the main container and the metrics one
+
+```yaml
+image:
+  registry: docker.io
+  repository: bitnami/solr
+  tag: 8.9.0
+```
+VS
+```yaml
+image:
+  registry: docker.io
+  repository: bitnami/solr
+  tag: 8.9.0
+...
+metrics:
+  image:
+    registry: docker.io
+    repository: bitnami/solr
+    tag: 8.9.0
+```
+
+See [PR#foobar](https://github.com/bitnami/charts/pull/foobar) for more info about the implemented changes

--- a/bitnami/solr/README.md
+++ b/bitnami/solr/README.md
@@ -360,10 +360,6 @@ Find more information about how to deal with common errors related to Bitnami’
 
 ## Upgrading
 
-### To 1.0.0
-
-This major updates the Zookeeper subchart to it newest major, 7.0.0, which renames all TLS-related settings. For more information on this subchart's major, please refer to [zookeeper upgrade notes](https://github.com/bitnami/charts/tree/master/bitnami/zookeeper#to-700).
-
 ### To 2.0.0
 
 In this version, the `image` block is defined once and is used in the different templates, while in the previous version, the `image` block was duplicated for the main container and the metrics one
@@ -389,3 +385,7 @@ metrics:
 ```
 
 See [PR#foobar](https://github.com/bitnami/charts/pull/foobar) for more info about the implemented changes
+
+### To 1.0.0
+
+This major updates the Zookeeper subchart to it newest major, 7.0.0, which renames all TLS-related settings. For more information on this subchart's major, please refer to [zookeeper upgrade notes](https://github.com/bitnami/charts/tree/master/bitnami/zookeeper#to-700).

--- a/bitnami/solr/README.md
+++ b/bitnami/solr/README.md
@@ -384,7 +384,7 @@ metrics:
     tag: 8.9.0
 ```
 
-See [PR#foobar](https://github.com/bitnami/charts/pull/foobar) for more info about the implemented changes
+See [PR#7114](https://github.com/bitnami/charts/pull/7114) for more info about the implemented changes
 
 ### To 1.0.0
 

--- a/bitnami/solr/templates/NOTES.txt
+++ b/bitnami/solr/templates/NOTES.txt
@@ -63,7 +63,6 @@ To connect to your Solr from outside the cluster execute the following commands:
 {{- end }}
 
 {{- include "common.warnings.rollingTag" .Values.image }}
-{{- include "common.warnings.rollingTag" .Values.exporter.image }}
 
 {{- if .Values.authentication.enabled -}}
 {{- $requiredPasswords := list -}}

--- a/bitnami/solr/templates/_helpers.tpl
+++ b/bitnami/solr/templates/_helpers.tpl
@@ -38,13 +38,6 @@ Return the proper Apache Solr image name
 {{- end -}}
 
 {{/*
-Return the proper Solr Exporter image name
-*/}}
-{{- define "exporter.image" -}}
-{{- include "common.images.image" (dict "imageRoot" .Values.exporter.image "global" .Values.global) -}}
-{{- end -}}
-
-{{/*
 Return the proper image name (for the init container volume-permissions image)
 */}}
 {{- define "volumePermissions.image" -}}

--- a/bitnami/solr/templates/exporter-deployment.yaml
+++ b/bitnami/solr/templates/exporter-deployment.yaml
@@ -66,8 +66,8 @@ spec:
         {{- end }}
       containers:
         - name: solr-exporter
-          image: {{ include "exporter.image" . }}
-          imagePullPolicy: {{ .Values.exporter.image.pullPolicy }}
+          image: {{ include "solr.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           {{- if .Values.exporter.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.exporter.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}

--- a/bitnami/solr/values.yaml
+++ b/bitnami/solr/values.yaml
@@ -590,29 +590,6 @@ exporter:
   ## @param exporter.enabled Start a side-car prometheus exporter
   ##
   enabled: false
-  ## @param exporter.image.registry Solr exporter image registry
-  ## @param exporter.image.repository Solr exporter image name
-  ## @param exporter.image.tag Solr exporter image tag
-  ## @param exporter.image.pullPolicy Image pull policy
-  ## @param exporter.image.pullSecrets Specify docker-registry secret names as an array
-  ##
-  image:
-    registry: docker.io
-    repository: bitnami/solr
-    tag: 8.9.0-debian-10-r14
-    ## Specify a imagePullPolicy
-    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-    ##
-    pullPolicy: IfNotPresent
-    ## Optionally specify an array of imagePullSecrets.
-    ## Secrets must be manually created in the namespace.
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ## e.g:
-    ## pullSecrets:
-    ##   - myRegistryKeySecretName
-    ##
-    pullSecrets: []
   ## Configure extra options for liveness probe
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
   ## @param exporter.livenessProbe.enabled Enable livenessProbe


### PR DESCRIPTION
**Description of the change**

In this version, the `image` block is defined once and is used in the different templates, while in the previous version, the `image` block was duplicated for every component

```yaml
image:
  registry: docker.io
  repository: bitnami/xxx
  tag: A.B.C
```
VS
```yaml
foo:
  image:
    registry: docker.io
    repository: bitnami/xxx
    tag: A.B.C
...
bar:
  image:
    registry: docker.io
    repository: bitnami/xxx
    tag: A.B.C
```

**Possible drawbacks**

The chart version was bumped in a major

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
