### PR TITLE
[bitnami/redis]: fix CrashLoopBackOff with sentinel enabled

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -25,4 +25,4 @@ name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 14.8.9
+version: 14.8.10

--- a/bitnami/redis/templates/scripts-configmap.yaml
+++ b/bitnami/redis/templates/scripts-configmap.yaml
@@ -70,22 +70,6 @@ data:
         REDIS_SENTINEL_INFO=($($sentinel_info_command))
         REDIS_MASTER_HOST=${REDIS_SENTINEL_INFO[0]}
         REDIS_MASTER_PORT_NUMBER=${REDIS_SENTINEL_INFO[1]}
-
-        # Immediately attempt to connect to the reported master. If it doesn't exist the connection attempt will either hang
-        # or fail with "port unreachable" and give no data. The liveness check will then timeout waiting for the redis
-        # container to be ready and restart the it. By then the new master will likely have been elected
-        if is_boolean_yes "$REDIS_TLS_ENABLED"; then
-            sentinel_info_command="redis-cli {{- if .Values.auth.enabled }} -a $REDIS_PASSWORD {{- end }} -h $REDIS_MASTER_HOST -p {{ .Values.sentinel.service.sentinelPort }} --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
-        else
-            sentinel_info_command="redis-cli {{- if .Values.auth.enabled }} -a $REDIS_PASSWORD {{- end }} -h $REDIS_MASTER_HOST -p {{ .Values.sentinel.service.sentinelPort }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
-        fi
-
-        if [[ ! ($($sentinel_info_command)) ]]; then
-            # master doesn't actually exist, this probably means the remaining pods haven't elected a new one yet
-            # and are reporting the old one still. Once this happens the container will get stuck and never see the new
-            # master. We stop here to allow the container to not pass the liveness check and be restarted.
-            exit 1
-        fi
     fi
 
     if [[ ! -f /opt/bitnami/redis/etc/redis.conf ]];then
@@ -219,22 +203,6 @@ data:
         REDIS_SENTINEL_INFO=($($sentinel_info_command))
         REDIS_MASTER_HOST=${REDIS_SENTINEL_INFO[0]}
         REDIS_MASTER_PORT_NUMBER=${REDIS_SENTINEL_INFO[1]}
-
-        # Immediately attempt to connect to the reported master. If it doesn't exist the connection attempt will either hang
-        # or fail with "port unreachable" and give no data. The liveness check will then timeout waiting for the sentinel
-        # container to be ready and restart the it. By then the new master will likely have been elected
-        if is_boolean_yes "$REDIS_SENTINEL_TLS_ENABLED"; then
-            sentinel_info_command="redis-cli {{- if .Values.auth.enabled }} -a $REDIS_PASSWORD {{- end }} -h $REDIS_MASTER_HOST -p {{ .Values.sentinel.service.sentinelPort }} --tls --cert ${REDIS_SENTINEL_TLS_CERT_FILE} --key ${REDIS_SENTINEL_TLS_KEY_FILE} --cacert ${REDIS_SENTINEL_TLS_CA_FILE} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
-        else
-            sentinel_info_command="redis-cli {{- if .Values.auth.enabled }} -a $REDIS_PASSWORD {{- end }} -h $REDIS_MASTER_HOST -p {{ .Values.sentinel.service.sentinelPort }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
-        fi
-
-        if [[ ! ($($sentinel_info_command)) ]]; then
-            # master doesn't actually exist, this probably means the remaining pods haven't elected a new one yet
-            # and are reporting the old one still. Once this happens the container will get stuck and never see the new
-            # master. We stop here to allow the container to not pass the liveness check and be restarted.
-            exit 1
-        fi
     fi
 
     # Clean sentineles from the current sentinel nodes after failover completed.


### PR DESCRIPTION
**Description of the change**

After upgrading to the latest Redis chart version from `12.0.1` we noticed that sentinel behaviour was broken.

When sentinel was enabled there was a check that would ensure a new master was elected before starting the redis & sentinel processes, otherwise, it would exit with status code 1, causing workers to stay in a CrashLoopBackOff while the remaining workers were unable to elect a new master.

We removed this check in both the`start-node` and `start-sentinel` scripts as it will eventually lead to this CrashLoopBackOff state.

We should not enforce a master check before starting the processes. In a configuration of 3 sentinel replicas with a quorum of 2, if we lose 2 nodes at the same time (including the master), the last remaining node won't be able to elect a new master while the two others will keep failing as no master is available.

However, if we let the nodes fully restart, they will join the quorum and participate in the election.

The check has been added with https://github.com/bitnami/charts/pull/4478 claiming that when the previous master node was restarted it will still see the previous master on bootup. But this behaviour should be expected because if your node restarts faster than your `sentinel.downAfterMilliseconds` value, the other nodes might not have started a failover just yet. The newly connected node will be able to participate in the election regardless. 

**Benefits**
- Fixes the CrashLoopBackOff state that some of us have experienced when using sentinel mode

**Possible drawbacks**
- The newly created node might still see the previous master as the current master, but as mentioned above, if the quorum is reached, a new master will be elected and this new node will participate in the election. How fast a new master will be elected will depend on your `sentinel.downAfterMilliseconds` and `sentinel.failoverTimeout` config. 

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes https://github.com/bitnami/charts/issues/5181

**Additional information**
It is possible (and I have seen it happen) that when not using `sentinel.staticID = true` (which was a feature introduced by me https://github.com/helm/charts/pull/19059) sentinels are not able to elect a new master after a few restarts. The reason being is that every time a new worker is created its sentinel will be given a random ID which will be added to the list of sentinel peers. If a node has been running for longer than others, they might keep the list of old sentinel instances in their list of peers which compromises the election process. I see that in the `start-sentinel` script the command `sentinel reset "*"` is sent to all sentinels on the network which should technically alleviate this problem, but somehow I still had issues when running without `sentinel.staticID = true`.

My opinion is that `staticID = true` should be the default behaviour because I don't see how it could work without in k8s, though that is a different discussion. In the meantime, all configs using `staticID = true` should see their CrashLoopBackOff resolved.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
