### PR TITLE
[bitnami/wordpress] Set APACHE_HTTP_PORT_NUMBER

### DIFF
--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -35,4 +35,4 @@ name: wordpress
 sources:
   - https://github.com/bitnami/bitnami-docker-wordpress
   - https://wordpress.org/
-version: 12.0.0
+version: 12.0.1

--- a/bitnami/wordpress/templates/deployment.yaml
+++ b/bitnami/wordpress/templates/deployment.yaml
@@ -164,9 +164,9 @@ spec:
             - name: WORDPRESS_PLUGINS
               value: {{ join "," .Values.wordpressPlugins | quote }}
             - name: APACHE_HTTP_PORT_NUMBER
-              containerPort: {{ .Values.containerPorts.http | quote }}
+              value: {{ .Values.containerPorts.http | quote }}
             - name: APACHE_HTTPS_PORT_NUMBER
-              containerPort: {{ .Values.containerPorts.https | quote }}
+              value: {{ .Values.containerPorts.https | quote }}
             {{- if .Values.multisite.enable }}
             - name: WORDPRESS_ENABLE_MULTISITE
               value: "yes"

--- a/bitnami/wordpress/templates/deployment.yaml
+++ b/bitnami/wordpress/templates/deployment.yaml
@@ -163,6 +163,10 @@ spec:
               value: {{ .Values.wordpressAutoUpdateLevel | quote }}
             - name: WORDPRESS_PLUGINS
               value: {{ join "," .Values.wordpressPlugins | quote }}
+            - name: APACHE_HTTP_PORT_NUMBER
+              containerPort: {{ .Values.containerPorts.http | quote }}
+            - name: APACHE_HTTPS_PORT_NUMBER
+              containerPort: {{ .Values.containerPorts.https | quote }}
             {{- if .Values.multisite.enable }}
             - name: WORDPRESS_ENABLE_MULTISITE
               value: "yes"


### PR DESCRIPTION
**Description of the change**

Set `APACHE_HTTPS_PORT_NUMBER` and `APACHE_HTTP_PORT_NUMBER` using the values of `containerPorts.http` and `containerPorts.https`.

**Benefits**

Users won't need to add `extraEnvVars` in addition to `containerPorts` to modify the WordPress ports.

**Possible drawbacks**

None known. 

Maybe conflicts with users that were already setting `APACHE_*_PORT_NUMBER` or were setting a different `containerPorts` with other purposes.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #7130

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
