### PR TITLE
[bitnami/wordpress]: fix flag for wp-config.php permission change in post-init script

### DIFF
--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -35,4 +35,4 @@ name: wordpress
 sources:
   - https://github.com/bitnami/bitnami-docker-wordpress
   - https://wordpress.org/
-version: 12.0.0
+version: 12.0.1

--- a/bitnami/wordpress/templates/postinit-configmap.yaml
+++ b/bitnami/wordpress/templates/postinit-configmap.yaml
@@ -36,7 +36,7 @@ data:
     wp total-cache flush all
 
     # Revoke permissions to edit wp-config.php
-    chmod -w bitnami/wordpress/wp-config.php
+    chmod a-w bitnami/wordpress/wp-config.php
   {{- end }}
   {{- if .Values.customPostInitScripts }}
   {{- include "common.tplvalues.render" (dict "value" .Values.customPostInitScripts "context" $) | nindent 2 }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This change is to avoid error during wp-config.php permission change.
```
+ chmod -w bitnami/wordpress/wp-config.php
chmod: bitnami/wordpress/wp-config.php: new permissions are r--rw-r--, not r--r--r--
```

**Benefits**

It makes post-init script more stable.

**Possible drawbacks**

None


**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
