### PR TITLE
[bitnami/thanos] Thanos receiver dualmode

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 5.4.1
+version: 5.5.0

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 5.4.0
+version: 5.4.1

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -1005,6 +1005,10 @@ Find more information about how to deal with common errors related to Bitnami’
 
 ## Upgrading
 
+### To 5.4.0
+
+This version introduces support for the receiver dual-mode implementation for Thanos [v0.22+](https://github.com/thanos-io/thanos/releases/tag/v0.22.0)
+
 ### To 5.3.0
 
 This version introduces hash and time partitioning for the store gateway.

--- a/bitnami/thanos/templates/receive/distributor.yaml
+++ b/bitnami/thanos/templates/receive/distributor.yaml
@@ -1,62 +1,60 @@
-{{- if .Values.receive.enabled }}
-apiVersion: apps/v1
-kind: StatefulSet
+{{- if and .Values.receive.enabled ( eq .Values.receive.mode "dual-mode" )}}
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+kind: Deployment
 metadata:
-  name: {{ include "common.names.fullname" . }}-receive
+  name: {{ include "common.names.fullname" . }}-receive-distributor
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: receive
+    app.kubernetes.io/component: receive-distributor
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
 spec:
-  replicas: {{ .Values.receive.replicaCount }}
-  podManagementPolicy: {{ .Values.receive.podManagementPolicy }}
-  serviceName: {{ include "common.names.fullname" . }}-receive-headless
-  updateStrategy:
-    type: {{ .Values.receive.updateStrategyType }}
-    {{- if (eq "OnDelete" .Values.receive.updateStrategyType) }}
+  replicas: {{ .Values.receive.distributor.replicaCount }}
+  strategy:
+    type: {{ .Values.receive.distributor.strategyType }}
+    {{- if (eq "Recreate" .Values.receive.distributor.strategyType) }}
     rollingUpdate: null
     {{- end }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: receive
+      app.kubernetes.io/component: receive-distributor
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
-        app.kubernetes.io/component: receive
+        app.kubernetes.io/component: receive-distributor
         {{- if .Values.commonLabels }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 8 }}
         {{- end }}
-        {{- if .Values.receive.podLabels }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.receive.podLabels "context" $) | nindent 8 }}
+        {{- if .Values.receive.distributor.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.receive.distributor.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
         checksum/ojbstore-configuration: {{ include (print $.Template.BasePath "/objstore-secret.yaml") . | sha256sum }}
         {{- if (include "thanos.receive.createConfigmap" .) }}
         checksum/receive-configuration: {{ include (print $.Template.BasePath "/receive/configmap.yaml") . | sha256sum }}
         {{- end }}
-        {{- if .Values.receive.podAnnotations }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.receive.podAnnotations "context" $) | nindent 8 }}
+        {{- if .Values.receive.distributor.podAnnotations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.receive.distributor.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
     spec:
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       serviceAccount: {{ include "thanos.serviceaccount.name" (dict "component" "receive" "context" $) }}
-      {{- if .Values.receive.hostAliases }}
-      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.receive.hostAliases "context" $) | nindent 8 }}
+      {{- if .Values.receive.distributor.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.receive.distributor.hostAliases "context" $) | nindent 8 }}
       {{- end }}
-      {{- if .Values.receive.affinity }}
-      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.receive.affinity "context" $) | nindent 8 }}
+      {{- if .Values.receive.distributor.affinity }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.receive.distributor.affinity "context" $) | nindent 8 }}
       {{- else }}
       affinity:
         podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.receive.podAffinityPreset "component" "receive" "context" $) | nindent 10 }}
         podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.receive.podAntiAffinityPreset "component" "receive" "context" $) | nindent 10 }}
-        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.receive.nodeAffinityPreset.type "key" .Values.receive.nodeAffinityPreset.key "values" .Values.receive.nodeAffinityPreset.values) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.receive.nodeAffinityPreset.type "key" .Values.receive.nodeAffinityPreset.key "values" .Values.receive.distributor.values) | nindent 10 }}
       {{- end }}
-      {{- if .Values.receive.nodeSelector }}
-      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.receive.nodeSelector "context" $) | nindent 8 }}
+      {{- if .Values.receive.distributor.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.receive.distributor.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
-      {{- if .Values.receive.tolerations }}
-      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.receive.tolerations "context" $) | nindent 8 }}
+      {{- if .Values.receive.distributor.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.receive.distributor.tolerations "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.receive.priorityClassName }}
       priorityClassName: {{ .Values.receive.priorityClassName | quote }}
@@ -65,8 +63,8 @@ spec:
       securityContext: {{- omit .Values.receive.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       containers:
-        {{- if .Values.receive.extraContainers }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.receive.extraContainers "context" $) | nindent 8 }}
+        {{- if .Values.receive.distributor.extraContainers }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.receive.distributor.extraContainers "context" $) | nindent 8 }}
         {{- end }}
         - name: receive
           image: {{ include "thanos.image" . }}
@@ -81,22 +79,11 @@ spec:
             - --grpc-address=0.0.0.0:10901
             - --http-address=0.0.0.0:10902
             - --remote-write.address=0.0.0.0:19291
-            - --receive.replication-factor={{ .Values.receive.replicationFactor }}
-            - --objstore.config=$(OBJSTORE_CONFIG)
-            - --tsdb.path=/var/thanos/receive
             - --label={{ .Values.receive.replicaLabel }}="$(NAME)"
             - --label=receive="true"
-            - --tsdb.retention={{ .Values.receive.tsdbRetention }}
-            {{- if not .Values.receive.service.additionalHeadless }}
-            - --receive.local-endpoint=127.0.0.1:10901
-            {{- else }}
-            - --receive.local-endpoint=$(NAME).{{ include "common.names.fullname" . }}-receive-headless.$(NAMESPACE).svc.{{ .Values.clusterDomain }}:10901
-            {{- end }}
-            {{- if eq .Values.receive.mode "standalone" }}
             - --receive.hashrings-file=/var/lib/thanos-receive/hashrings.json
-            {{- end }}
-            {{- if .Values.receive.extraFlags }}
-            {{- .Values.receive.extraFlags | toYaml | nindent 12 }}
+            {{- if .Values.receive.distributor.extraFlags }}
+            {{- .Values.receive.distributor.extraFlags | toYaml | nindent 12 }}
             {{- end }}
           env:
             - name: NAME
@@ -112,8 +99,8 @@ spec:
                 secretKeyRef:
                   key: objstore.yml
                   name: {{ include "thanos.objstoreSecretName" . }}
-            {{- if .Values.receive.extraEnv }}
-            {{- toYaml .Values.receive.extraEnv | nindent 12 }}
+            {{- if .Values.receive.distributor.extraEnv }}
+            {{- toYaml .Values.receive.distributor.extraEnv | nindent 12 }}
             {{- end }}
           ports:
             - containerPort: 10901
@@ -147,43 +134,20 @@ spec:
             successThreshold: {{ .Values.receive.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.receive.readinessProbe.failureThreshold }}
           {{- end }}
-          {{- if .Values.receive.resources }}
-          resources: {{- toYaml .Values.receive.resources | nindent 12 }}
+          {{- if .Values.receive.distributor.resources }}
+          resources: {{- toYaml .Values.receive.distributor.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: hashring-config
               mountPath: /var/lib/thanos-receive
-            - name: data
-              mountPath: /var/thanos/receive
-            {{- if .Values.receive.extraVolumeMounts }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.receive.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- if .Values.receive.distributor.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.receive.distributor.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
       volumes:
         - name: hashring-config
           configMap:
             name: {{ include "common.names.fullname" . }}-receive
-        {{- if .Values.receive.extraVolumes }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.receive.extraVolumes "context" $) | nindent 8 }}
+        {{- if .Values.receive.distributor.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.receive.distributor.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
-  {{- if and .Values.receive.persistence.enabled .Values.receive.persistence.existingClaim }}
-        - name: data
-          persistentVolumeClaim:
-            claimName: {{ .Values.receive.persistence.existingClaim }}
-  {{- else if not .Values.receive.persistence.enabled }}
-        - name: data
-          emptyDir: {}
-  {{- else if and .Values.receive.persistence.enabled (not .Values.receive.persistence.existingClaim) }}
-  volumeClaimTemplates:
-    - metadata:
-        name: data
-      spec:
-        accessModes:
-        {{- range .Values.receive.persistence.accessModes }}
-          - {{ . | quote }}
-        {{- end }}
-        resources:
-          requests:
-            storage: {{ .Values.receive.persistence.size | quote }}
-        {{- include "common.storage.class" (dict "persistence" .Values.receive.persistence "global" .Values.global) | nindent 8 }}
-  {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/receive/distributor.yaml
+++ b/bitnami/thanos/templates/receive/distributor.yaml
@@ -29,7 +29,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.receive.distributor.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
-        checksum/ojbstore-configuration: {{ include (print $.Template.BasePath "/objstore-secret.yaml") . | sha256sum }}
+        checksum/objstore-configuration: {{ include (print $.Template.BasePath "/objstore-secret.yaml") . | sha256sum }}
         {{- if (include "thanos.receive.createConfigmap" .) }}
         checksum/receive-configuration: {{ include (print $.Template.BasePath "/receive/configmap.yaml") . | sha256sum }}
         {{- end }}
@@ -76,9 +76,9 @@ spec:
             - receive
             - --log.level={{ .Values.receive.logLevel }}
             - --log.format={{ .Values.receive.logFormat }}
-            - --grpc-address=0.0.0.0:10901
-            - --http-address=0.0.0.0:10902
-            - --remote-write.address=0.0.0.0:19291
+            - --grpc-address=0.0.0.0:{{ .Values.receive.service.grpc.port }}
+            - --http-address=0.0.0.0:{{ .Values.receive.service.http.port }}
+            - --remote-write.address=0.0.0.0:{{ .Values.receive.service.remoteWrite.port }}
             - --label={{ .Values.receive.replicaLabel }}="$(NAME)"
             - --label=receive="true"
             - --receive.hashrings-file=/var/lib/thanos-receive/hashrings.json

--- a/bitnami/thanos/templates/receive/distributor.yaml
+++ b/bitnami/thanos/templates/receive/distributor.yaml
@@ -103,13 +103,13 @@ spec:
             {{- toYaml .Values.receive.distributor.extraEnv | nindent 12 }}
             {{- end }}
           ports:
-            - containerPort: 10901
+            - containerPort: {{ .Values.receive.service.grpc.port }}
               name: grpc
               protocol: TCP
-            - containerPort: 10902
+            - containerPort: {{ .Values.receive.service.http.port }}
               name: http
               protocol: TCP
-            - containerPort: 19291
+            - containerPort: {{ .Values.receive.service.remoteWrite.port }}
               name: remote-write
               protocol: TCP
           {{- if .Values.receive.livenessProbe.enabled }}

--- a/bitnami/thanos/templates/receive/service.yaml
+++ b/bitnami/thanos/templates/receive/service.yaml
@@ -58,6 +58,10 @@ spec:
     {{- include "common.tplvalues.render" (dict "value" .Values.receive.service.labelSelectorsOverride "context" $) | nindent 4 }}
     {{- else }}
     {{- include "common.labels.matchLabels" . | nindent 4 }}
+    {{- if eq .Values.receive.mode "dual-mode"}}
+    app.kubernetes.io/component: receive-distributor
+    {{ else }}
     app.kubernetes.io/component: receive
+    {{ end }}
     {{- end }}
 {{- end }}

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -2469,18 +2469,18 @@ receive:
     ## @param receive.distributor.resources.requests The requested resources for the Thanos Receive container
     ##
     resources:
-    ## Example:
-    ## limits:
-    ##    cpu: 100m
-    ##    memory: 128Mi
-    ##
-    limits: {}
-    ## Examples:
-    ## requests:
-    ##    cpu: 100m
-    ##    memory: 128Mi
-    ##
-    requests: {}
+      ## Example:
+      ## limits:
+      ##    cpu: 100m
+      ##    memory: 128Mi
+      ##
+      limits: {}
+      ## Examples:
+      ## requests:
+      ##    cpu: 100m
+      ##    memory: 128Mi
+      ##
+      requests: {}
     ## @param receive.distributor.extraContainers Extra containers running as sidecars to Thanos Receive Distributor container
     ## Example:
     ## - name: oAuth2-proxy

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -2452,6 +2452,94 @@ receive:
   ## @param receive.enabled Enable/disable Thanos Receive component
   ##
   enabled: false
+  ## @param Mode to run receiver in. Valid options are "standalone" or "dual-mode"
+  ##
+  mode: standalone
+
+  distributor:
+    ## Thanos Receive Distributor containers' resource requests and limits
+    ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+    ## We usually recommend not to specify default resources and to leave this as a conscious
+    ## choice for the user. This also increases chances charts run on environments with little
+    ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+    ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    ## @param receive.resources.limits The resources limits for the Thanos Receive container
+    ## @param receive.resources.requests The requested resources for the Thanos Receive container
+    ##
+    resources:
+    ## Example:
+    ## limits:
+    ##    cpu: 100m
+    ##    memory: 128Mi
+    limits: {}
+    ## Examples:
+    ## requests:
+    ##    cpu: 100m
+    ##    memory: 128Mi
+    requests: {}
+    ## @param receive.extraContainers Extra containers running as sidecars to Thanos Receive Distributor container
+    ## Example:
+    ## - name: oAuth2-proxy
+    ##   args:
+    ##     - -https-address=:9092
+    ##     - -upstream=http://localhost:9091
+    ##     - -skip-auth-regex=^/metrics
+    ##   image: openshift/oauth-proxy:v1.1.0
+    ##   ports:
+    ##       - containerPort: 9092
+    ##         name: proxy
+    ##   resources:
+    ##       limits:
+    ##         memory: 16Mi
+    ##       requests:
+    ##         memory: 4Mi
+    ##         cpu: 20m
+    ##   volumeMounts:
+    ##     - mountPath: /secrets/proxy-tls
+    ##       name: secret-proxy-tls
+    ##
+    extraContainers: []
+    ## @param receive.extraEnv Extra environment variables for Thanos Receive Distributor container
+    ##
+    ## extraEnv:
+    ## - name: VARNAME1
+    ##   value: value1
+    ## - name: VARNAME2
+    ##   valueFrom:
+    ##     secretKeyRef:
+    ##       name: existing-secret
+    ##       key: varname2-key
+    ##
+    extraEnv: []
+    ## @param receive.extraVolumes Extra volumes to add to Thanos Receive Distributor
+    ##
+    extraVolumes: []
+    ## @param receive.extraVolumeMounts Extra volume mounts to add to the receive distributor container
+    ##
+    extraVolumeMounts: []
+    ## @param receive.extraFlags Extra Flags to passed to Thanos Receive Distributor
+    ##
+    extraFlags: []
+    ## @param receive.replicaCount Number of Thanos Receive Distributor replicas to deploy
+    ##
+    replicaCount: 1
+    ## @param receive.strategyType StrategyType, can be set to RollingUpdate or Recreate by default.
+    ##
+    strategyType: RollingUpdate
+    ## @param receive.affinity Thanos Receive Distributor affinity for pod assignment
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    ## Note: receive.podAffinityPreset, receive.podAntiAffinityPreset, and receive.nodeAffinityPreset will be ignored when it's set
+    ##
+    affinity: {}
+    ## @param receive.nodeSelector Thanos Receive Distributor node labels for pod assignment
+    ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+    ##
+    nodeSelector: {}
+    ## @param receive.tolerations Thanos Receive Distributor tolerations for pod assignment
+    ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    ##
+    tolerations: []
+
   ## @param receive.logLevel Thanos Receive log level
   ##
   logLevel: info
@@ -2875,6 +2963,7 @@ receive:
     ## @param receive.ingress.pathType Ingress Path type
     ##
     pathType: ImplementationSpecific
+
 
 ## @section Metrics parameters
 

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -2453,7 +2453,9 @@ receive:
   ##
   enabled: false
   ## @param Mode to run receiver in. Valid options are "standalone" or "dual-mode"
-  ##
+  ## ref: https://github.com/thanos-io/thanos/blob/release-0.22/docs/proposals-accepted/202012-receive-split.md
+  ## Enables running the Thanos Receiver in dual mode. Setting this to "dual-mode" will create a deployment for 
+  ## the stateless thanos distributor.
   mode: standalone
 
   distributor:

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -2463,8 +2463,8 @@ receive:
     ## choice for the user. This also increases chances charts run on environments with little
     ## resources, such as Minikube. If you do want to specify resources, uncomment the following
     ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    ## @param receive.resources.limits The resources limits for the Thanos Receive container
-    ## @param receive.resources.requests The requested resources for the Thanos Receive container
+    ## @param receive.distributor.resources.limits The resources limits for the Thanos Receive container
+    ## @param receive.distributor.resources.requests The requested resources for the Thanos Receive container
     ##
     resources:
     ## Example:
@@ -2477,7 +2477,7 @@ receive:
     ##    cpu: 100m
     ##    memory: 128Mi
     requests: {}
-    ## @param receive.extraContainers Extra containers running as sidecars to Thanos Receive Distributor container
+    ## @param receive.distributor.extraContainers Extra containers running as sidecars to Thanos Receive Distributor container
     ## Example:
     ## - name: oAuth2-proxy
     ##   args:
@@ -2499,7 +2499,7 @@ receive:
     ##       name: secret-proxy-tls
     ##
     extraContainers: []
-    ## @param receive.extraEnv Extra environment variables for Thanos Receive Distributor container
+    ## @param receive.distributor.extraEnv Extra environment variables for Thanos Receive Distributor container
     ##
     ## extraEnv:
     ## - name: VARNAME1
@@ -2511,31 +2511,31 @@ receive:
     ##       key: varname2-key
     ##
     extraEnv: []
-    ## @param receive.extraVolumes Extra volumes to add to Thanos Receive Distributor
+    ## @param receive.distributor.extraVolumes Extra volumes to add to Thanos Receive Distributor
     ##
     extraVolumes: []
-    ## @param receive.extraVolumeMounts Extra volume mounts to add to the receive distributor container
+    ## @param receive.distributor.extraVolumeMounts Extra volume mounts to add to the receive distributor container
     ##
     extraVolumeMounts: []
-    ## @param receive.extraFlags Extra Flags to passed to Thanos Receive Distributor
+    ## @param receive.distributor.extraFlags Extra Flags to passed to Thanos Receive Distributor
     ##
     extraFlags: []
-    ## @param receive.replicaCount Number of Thanos Receive Distributor replicas to deploy
+    ## @param receive.distributor.replicaCount Number of Thanos Receive Distributor replicas to deploy
     ##
     replicaCount: 1
-    ## @param receive.strategyType StrategyType, can be set to RollingUpdate or Recreate by default.
+    ## @param receive.distributor.strategyType StrategyType, can be set to RollingUpdate or Recreate by default.
     ##
     strategyType: RollingUpdate
-    ## @param receive.affinity Thanos Receive Distributor affinity for pod assignment
+    ## @param receive.distributor.affinity Thanos Receive Distributor affinity for pod assignment
     ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
     ## Note: receive.podAffinityPreset, receive.podAntiAffinityPreset, and receive.nodeAffinityPreset will be ignored when it's set
     ##
     affinity: {}
-    ## @param receive.nodeSelector Thanos Receive Distributor node labels for pod assignment
+    ## @param receive.distributor.nodeSelector Thanos Receive Distributor node labels for pod assignment
     ## ref: https://kubernetes.io/docs/user-guide/node-selection/
     ##
     nodeSelector: {}
-    ## @param receive.tolerations Thanos Receive Distributor tolerations for pod assignment
+    ## @param receive.distributor.tolerations Thanos Receive Distributor tolerations for pod assignment
     ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
     ##
     tolerations: []

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -2502,7 +2502,7 @@ receive:
     ##
     extraContainers: []
     ## @param receive.distributor.extraEnv Extra environment variables for Thanos Receive Distributor container
-    ##
+    ## Example:
     ## extraEnv:
     ## - name: VARNAME1
     ##   value: value1

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -2471,11 +2471,13 @@ receive:
     ## limits:
     ##    cpu: 100m
     ##    memory: 128Mi
+    ##
     limits: {}
     ## Examples:
     ## requests:
     ##    cpu: 100m
     ##    memory: 128Mi
+    ##
     requests: {}
     ## @param receive.distributor.extraContainers Extra containers running as sidecars to Thanos Receive Distributor container
     ## Example:
@@ -2963,7 +2965,6 @@ receive:
     ## @param receive.ingress.pathType Ingress Path type
     ##
     pathType: ImplementationSpecific
-
 
 ## @section Metrics parameters
 

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -2454,7 +2454,7 @@ receive:
   enabled: false
   ## @param receive.mode Mode to run receiver in. Valid options are "standalone" or "dual-mode"
   ## ref: https://github.com/thanos-io/thanos/blob/release-0.22/docs/proposals-accepted/202012-receive-split.md
-  ## Enables running the Thanos Receiver in dual mode. Setting this to "dual-mode" will create a deployment for 
+  ## Enables running the Thanos Receiver in dual mode. Setting this to "dual-mode" will create a deployment for
   ## the stateless thanos distributor.
   mode: standalone
 

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -2452,7 +2452,7 @@ receive:
   ## @param receive.enabled Enable/disable Thanos Receive component
   ##
   enabled: false
-  ## @param Mode to run receiver in. Valid options are "standalone" or "dual-mode"
+  ## @param receive.mode Mode to run receiver in. Valid options are "standalone" or "dual-mode"
   ## ref: https://github.com/thanos-io/thanos/blob/release-0.22/docs/proposals-accepted/202012-receive-split.md
   ## Enables running the Thanos Receiver in dual mode. Setting this to "dual-mode" will create a deployment for 
   ## the stateless thanos distributor.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This change enables users of this chart to leverage the new deployment model of Thanos Receiver implemented in [Thanos v0.22](https://github.com/thanos-io/thanos/releases/tag/v0.22.0) by adding a `recevier.mode` to the `values.yaml` and additional configurations for the `distributor` deployment. 

**Benefits**

See [this](https://github.com/thanos-io/thanos/blob/release-0.22/docs/proposals-accepted/202012-receive-split.md) for benefits of the receiver dual-mode implementation. 

**Possible drawbacks**

Turning on the dual-mode implementation will reroute the receive service to point to the distributor. This means that there would be no service in front of the ingestor receive pods (i.e. the StatefulSet), although the headless service will still exist. This shouldn't have any impact on users correctly using the dual-mode setup as all remote_write calls need to be made to the distributor. 

**Additional information**

Small nit but I noticed that there are Github Actions to add the new values to the README on push. I updated the values.yaml with the appropriate comments, do I need to manually add it in the README or will it be auto generated on merge? 

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
