### PR TITLE
Fix template replicaCount

### DIFF
--- a/template/CHART_NAME/templates/deployment.yaml
+++ b/template/CHART_NAME/templates/deployment.yaml
@@ -12,7 +12,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.%%MAIN_OBJECT_BLOCK%%.replicaCount }}
   {{- if .Values.%%MAIN_OBJECT_BLOCK%%.updateStrategy }}
   strategy: {{- toYaml .Values.%%MAIN_OBJECT_BLOCK%%.updateStrategy | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
**Description of the change**
There should be a typo around `replicaCount` in the template.  The `%%MAIN_OBJECT_BLOCK%%` placeholder was missing in `template/CHART_NAME/templates/deployment.yaml` for some reason, though it's documented in `template/CHART_NAME/values.yaml`.