### PR TITLE
[bitnami/haproxy] Add Configmap checksum annotation

### DIFF
--- a/bitnami/haproxy/Chart.yaml
+++ b/bitnami/haproxy/Chart.yaml
@@ -23,4 +23,4 @@ name: haproxy
 sources:
   - https://github.com/bitnami/bitnami-docker-haproxy
   - https://github.com/haproxytech/haproxy
-version: 0.2.2
+version: 0.2.3

--- a/bitnami/haproxy/templates/deployment.yaml
+++ b/bitnami/haproxy/templates/deployment.yaml
@@ -21,9 +21,13 @@ spec:
       app.kubernetes.io/component: haproxy
   template:
     metadata:
-      {{- if .Values.podAnnotations }}
-      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
-      {{- end }}
+      annotations:
+        {{- if not .Values.existingConfigmap }}
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.podAnnotations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: haproxy
         {{- if .Values.podLabels }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

By adding an annotation including the checksum of the Configmap, we ensure that every time the configuration is updated by Helm the HA Proxy deployment will run a rolling update since this annotation will change.

**Benefits**

Pods are updated when the configuration changes.

**Possible drawbacks**

None

**Applicable issues**

Reported at https://github.com/bitnami/charts/issues/5424

**Additional information**

None

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
