### PR TITLE
[bitnami/zookeeper] Added preAllocSize and snapCount options

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -21,4 +21,4 @@ name: zookeeper
 sources:
   - https://github.com/bitnami/bitnami-docker-zookeeper
   - https://zookeeper.apache.org/
-version: 7.2.0
+version: 7.3.0

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -83,6 +83,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `tickTime`                  | Basic time unit in milliseconds used by ZooKeeper for heartbeats                                                                         | `2000`                |
 | `initLimit`                 | ZooKeeper uses to limit the length of time the ZooKeeper servers in quorum have to connect to a leader                                   | `10`                  |
 | `syncLimit`                 | How far out of date a server can be from a leader                                                                                        | `5`                   |
+| `preAllocSize`            | Block size for transaction log file | `65536`                  |
+| `snapCount`            | The number of transactions recorded in the transaction log before a snapshot can be taken (and the transaction log rolled) | `100000`                  |
 | `maxClientCnxns`            | Limits the number of concurrent connections that a single client may make to a single member of the ZooKeeper ensemble                   | `60`                  |
 | `fourlwCommandsWhitelist`   | A list of comma separated Four Letter Words commands to use                                                                              | `srvr, mntr, ruok`    |
 | `listenOnAllIPs`            | Allow Zookeeper to listen for connections from its peers on all available IP addresses                                                   | `false`               |

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -286,6 +286,10 @@ spec:
               value: {{ .Values.initLimit | quote }}
             - name: ZOO_SYNC_LIMIT
               value: {{ .Values.syncLimit | quote }}
+            - name: ZOO_PRE_ALLOC_SIZE
+              value: {{ .Values.preAllocSize | quote }}
+            - name: ZOO_SNAPCOUNT
+              value: {{ .Values.snapCount | quote }}
             - name: ZOO_MAX_CLIENT_CNXNS
               value: {{ .Values.maxClientCnxns | quote }}
             - name: ZOO_4LW_COMMANDS_WHITELIST

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -93,6 +93,12 @@ initLimit: 10
 ## @param syncLimit How far out of date a server can be from a leader
 ##
 syncLimit: 5
+## @param preAllocSize Block size for transaction log file
+##
+preAllocSize: 65536
+## @param snapCount The number of transactions recorded in the transaction log before a snapshot can be taken (and the transaction log rolled)
+##
+snapCount: 100000
 ## @param maxClientCnxns Limits the number of concurrent connections that a single client may make to a single member of the ZooKeeper ensemble
 ##
 maxClientCnxns: 60


### PR DESCRIPTION
**Description of the change**

Added preAllocSize and snapCount options to the chart. These correspond to environment variables ZOO_PRE_ALLOC_SIZE and ZOO_SNAPCOUNT. Default values are the same as those in the docker image.

**Benefits**

Allows users to specify preAllocSize and snapCount settings

**Possible drawbacks**

None

**Applicable issues**

 None

**Additional information**

N/A

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
