### PR TITLE
[bitnami/odoo] Fix external database secret

### DIFF
--- a/bitnami/odoo/Chart.yaml
+++ b/bitnami/odoo/Chart.yaml
@@ -27,4 +27,4 @@ name: odoo
 sources:
   - https://github.com/bitnami/bitnami-docker-odoo
   - https://www.odoo.com/
-version: 19.0.4
+version: 19.0.5

--- a/bitnami/odoo/templates/_helpers.tpl
+++ b/bitnami/odoo/templates/_helpers.tpl
@@ -107,7 +107,7 @@ Return the PostgreSQL Secret Name
 {{- else if .Values.externalDatabase.existingSecret }}
     {{- printf "%s" .Values.externalDatabase.existingSecret -}}
 {{- else -}}
-    {{- printf "%s-%s" .Release.Name "externaldb" -}}
+    {{- printf "%s-externaldb" (include "common.names.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/odoo/templates/externaldb-secrets.yaml
+++ b/bitnami/odoo/templates/externaldb-secrets.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-externaldb" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-externaldb" (include "common.names.fullname" .) }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
<!-- Describe the scope of your change - i.e. what the change does. -->
Change external DB secret name because Odoo can't find it.
```
Warning  Failed   0s (x3 over 15s)   kubelet   Error: secret "my-release-externaldb" not found
------------
my-release-odoo-7cfd4fdc6b-vxr6f   0/1     CreateContainerConfigError   0          10m
```

Steps to reproduce the issue:
- Create a helm chart with an external database.
```
helm install my-release bitnami/odoo \
  --set odooPassword=password \
  --set postgresql.enabled=false \
  --set externalDatabase.host=myexternalhost \
  --set externalDatabase.user=myuser \
  --set externalDatabase.password=mypassword
```
- Describe a pod from Odoo.
```
kubectl describe po my-release-odoo-7cfd4fdc6b-vxr6f
Events:
  Type     Reason                  Age                From                     Message
  ----     ------                  ----               ----                     -------
  Normal   Pulled                  0s (x3 over 15s)   kubelet                  Container image "docker.io/bitnami/odoo:14.0.20210810-debian-10-r0" already present on machine
  Warning  Failed                  0s (x3 over 15s)   kubelet                  Error: secret "my-release-externaldb" not found
```

- Lists secrets and can't found the secret with the right name.
```
kubectl get secret
NAME                               TYPE                                  DATA   AGE
my-release-odoo                    Opaque                                1      3m7s
my-release-odoo-externaldb         Opaque                                2      3m7s
my-release-odoo-token-pg4v9        kubernetes.io/service-account-token   3      3m7s
sh.helm.release.v1.my-release.v1   helm.sh/release.v1                    1      3m8s
```

**Benefits**
<!-- What benefits will be realized by the code change? -->
Start Odoo correctly when using external database.
```
helm upgrade my-release ./odoo \
  --set odooPassword=password \
  --set postgresql.enabled=false \
  --set externalDatabase.host=myexternalhost \
  --set externalDatabase.user=myuser \
  --set externalDatabase.password=mypassword
```

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])