### PR TITLE
[bitnami/nginx-ingress-controller] Fix indentation for prometheusrule.

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -26,4 +26,4 @@ name: nginx-ingress-controller
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx-ingress-controller
   - https://github.com/kubernetes/ingress-nginx
-version: 7.6.18
+version: 7.6.19

--- a/bitnami/nginx-ingress-controller/templates/controller-prometheusrules.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-prometheusrules.yaml
@@ -23,6 +23,6 @@ spec:
   {{- with .Values.metrics.prometheusRule.rules }}
   groups:
     - name: {{ include "common.names.name" $ }}
-      rules: {{- toYaml . | nindent 4 }}
+      rules: {{- toYaml . | nindent 6 }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
**Description of the change**

This PR fixes the prometheusrule template by increasing `nindent` by 2.

**Benefits**

Template renders with correct indentation for rules array.

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
