### PR TITLE
[bitnami/thanos] Update thanos query to read sharded service

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 5.3.0
+version: 5.3.1

--- a/bitnami/thanos/templates/query/deployment.yaml
+++ b/bitnami/thanos/templates/query/deployment.yaml
@@ -102,7 +102,7 @@ spec:
             {{- if and $query.dnsDiscovery.enabled $query.dnsDiscovery.sidecarsService $query.dnsDiscovery.sidecarsNamespace }}
             - --store=dnssrv+_grpc._tcp.{{- include "common.tplvalues.render" ( dict "value" $query.dnsDiscovery.sidecarsService "context" $) -}}.{{- include "common.tplvalues.render"  ( dict "value" $query.dnsDiscovery.sidecarsNamespace "context" $) -}}.svc.{{ .Values.clusterDomain }}
             {{- end }}
-            {{- if .Values.storegateway.sharded.enabled }}
+            {{- if and .Values.storegateway.enabled .Values.storegateway.sharded.enabled }}
             {{- range $index, $_ := until $shards }}
             - --store=dnssrv+_grpc._tcp.{{ include "common.names.fullname" $ }}-storegateway-{{ toString $index }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}
             {{- end }}

--- a/bitnami/thanos/templates/query/deployment.yaml
+++ b/bitnami/thanos/templates/query/deployment.yaml
@@ -1,5 +1,14 @@
 {{- $query := (include "thanos.query.values" . | fromYaml) -}}
 {{- if $query.enabled }}
+
+{{- $shards := int 0 }}
+
+{{- if .Values.storegateway.sharded.hashPartitioning.shards }}
+  {{- $shards = int .Values.storegateway.sharded.hashPartitioning.shards }}
+{{- else }}
+  {{- $shards = len .Values.storegateway.sharded.timePartitioning }}
+{{- end }}
+
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
@@ -93,7 +102,11 @@ spec:
             {{- if and $query.dnsDiscovery.enabled $query.dnsDiscovery.sidecarsService $query.dnsDiscovery.sidecarsNamespace }}
             - --store=dnssrv+_grpc._tcp.{{- include "common.tplvalues.render" ( dict "value" $query.dnsDiscovery.sidecarsService "context" $) -}}.{{- include "common.tplvalues.render"  ( dict "value" $query.dnsDiscovery.sidecarsNamespace "context" $) -}}.svc.{{ .Values.clusterDomain }}
             {{- end }}
-            {{- if and .Values.storegateway.enabled $query.dnsDiscovery.enabled }}
+            {{- if .Values.storegateway.sharded.enabled }}
+            {{- range $index, $_ := until $shards }}
+            - --store=dnssrv+_grpc._tcp.{{ include "common.names.fullname" $ }}-storegateway-{{ toString $index }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}
+            {{- end }}
+            {{- if and .Values.storegateway.enabled $query.dnsDiscovery.enabled (not .Values.storegateway.sharded.enabled )}}
             - --store=dnssrv+_grpc._tcp.{{ include "common.names.fullname" . }}-storegateway{{ if .Values.storegateway.service.additionalHeadless }}-headless{{ end }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
             {{- end }}
             {{- if and .Values.ruler.enabled $query.dnsDiscovery.enabled }}
@@ -224,4 +237,5 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.query.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
 
+{{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/query/deployment.yaml
+++ b/bitnami/thanos/templates/query/deployment.yaml
@@ -106,6 +106,7 @@ spec:
             {{- range $index, $_ := until $shards }}
             - --store=dnssrv+_grpc._tcp.{{ include "common.names.fullname" $ }}-storegateway-{{ toString $index }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}
             {{- end }}
+            {{- end }}
             {{- if and .Values.storegateway.enabled $query.dnsDiscovery.enabled (not .Values.storegateway.sharded.enabled )}}
             - --store=dnssrv+_grpc._tcp.{{ include "common.names.fullname" . }}-storegateway{{ if .Values.storegateway.service.additionalHeadless }}-headless{{ end }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
             {{- end }}
@@ -237,5 +238,4 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.query.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
 
-{{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/storegateway/service-sharded.yaml
+++ b/bitnami/thanos/templates/storegateway/service-sharded.yaml
@@ -27,13 +27,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ $.Values.storegateway.service.type }}
-  {{- if ne "false" (include "thanos.validateProperty" (dict "property" $.Values.storegateway.sharded.service.clusterIPs "context" $) ) }}
+  {{- if ne "false" (include "thanos.validateValues.storegateway.sharded.length" (dict "property" $.Values.storegateway.sharded.service.clusterIPs "context" $) ) }}
   clusterIP: {{ index $.Values.storegateway.sharded.service.clusterIPs $index }}
   {{- end }}
   {{- if ne $.Values.storegateway.service.type "ClusterIP" }}
   externalTrafficPolicy: {{ $.Values.storegateway.service.externalTrafficPolicy }}
   {{- end }}
-  {{- if ne "false" (include "thanos.validateProperty" (dict "property" $.Values.storegateway.sharded.service.loadBalancerIPs "context" $) ) }}
+  {{- if ne "false" (include "thanos.validateValues.storegateway.sharded.length" (dict "property" $.Values.storegateway.sharded.service.loadBalancerIPs "context" $) ) }}
   loadBalancerIP: {{ $.Values.storegateway.sharded.service.loadBalancerIPs }}
   {{- end }}
   {{- if and (eq $.Values.storegateway.service.type "LoadBalancer") $.Values.storegateway.service.loadBalancerSourceRanges }}
@@ -44,7 +44,7 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-      {{- if ne "false" (include "thanos.validateProperty" (dict "property" $.Values.storegateway.sharded.service.http.nodePorts "context" $) ) }}
+      {{- if ne "false" (include "thanos.validateValues.storegateway.sharded.length" (dict "property" $.Values.storegateway.sharded.service.http.nodePorts "context" $) ) }}
       nodePort: {{ index $.Values.storegateway.sharded.service.http.nodePorts $index }}
       {{- else if eq $.Values.storegateway.service.type "ClusterIP" }}
       nodePort: null
@@ -53,7 +53,7 @@ spec:
       targetPort: grpc
       protocol: TCP
       name: grpc
-      {{- if ne "false" (include "thanos.validateProperty" (dict "property" $.Values.storegateway.sharded.service.grpc.nodePorts "context" $) ) }}
+      {{- if ne "false" (include "thanos.validateValues.storegateway.sharded.length" (dict "property" $.Values.storegateway.sharded.service.grpc.nodePorts "context" $) ) }}
       nodePort: {{ index $.Values.storegateway.sharded.service.grpc.nodePorts $index }}
       {{- else if eq $.Values.storegateway.service.type "ClusterIP" }}
       nodePort: null


### PR DESCRIPTION

**Description of the change**

This is a continued effort on #7049 the thanos query needs to read from the different sharded services 

**Benefits**

This will enable the thanos query to read on the service shardes


**Applicable issues**

fixes #7049

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
