### PR TITLE
[bitnami/etcd] use existingSecret parameters as a template

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -25,4 +25,4 @@ name: etcd
 sources:
   - https://github.com/bitnami/bitnami-docker-etcd
   - https://coreos.com/etcd/
-version: 6.3.3
+version: 6.3.4

--- a/bitnami/etcd/templates/cronjob.yaml
+++ b/bitnami/etcd/templates/cronjob.yaml
@@ -96,7 +96,7 @@ spec:
             {{- if .Values.auth.client.secureTransport }}
             - name: certs
               secret:
-                secretName: {{ required "A secret containinig the client certificates is required" .Values.auth.client.existingSecret }}
+                secretName: {{ required "A secret containinig the client certificates is required" (tpl .Values.auth.client.existingSecret .) }}
                 defaultMode: 256
             {{- end }}
             - name: snapshot-volume

--- a/bitnami/etcd/templates/statefulset.yaml
+++ b/bitnami/etcd/templates/statefulset.yaml
@@ -336,13 +336,13 @@ spec:
         {{- if or .Values.auth.client.enableAuthentication (and .Values.auth.client.secureTransport (not .Values.auth.client.useAutoTLS )) }}
         - name: etcd-client-certs
           secret:
-            secretName: {{ required "A secret containing the client certificates is required" .Values.auth.client.existingSecret }}
+            secretName: {{ required "A secret containing the client certificates is required" (tpl .Values.auth.client.existingSecret .) }}
             defaultMode: 256
         {{- end }}
         {{- if or .Values.auth.peer.enableAuthentication (and .Values.auth.peer.secureTransport (not .Values.auth.peer.useAutoTLS )) }}
         - name: etcd-peer-certs
           secret:
-            secretName: {{ required "A secret containing the peer certificates is required" .Values.auth.peer.existingSecret }}
+            secretName: {{ required "A secret containing the peer certificates is required" (tpl .Values.auth.peer.existingSecret .) }}
             defaultMode: 256
         {{- end }}
         {{- if .Values.extraVolumes }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Use existingSecret parameters on client/peer certificates as a template. This improve experience when bitnami/etcd is used as a sub-chart.

**Benefits**

Easier to handle when used as a sub-chart.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #7208

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
