### PR TITLE
Mongo Credentials using credential file injected using vault. #5948

### DIFF
--- a/bitnami/common/templates/validations/_mongodb.tpl
+++ b/bitnami/common/templates/validations/_mongodb.tpl
@@ -19,29 +19,33 @@ Params:
   {{- $valueKeyPassword := printf "%s.password" $authPrefix -}}
   {{- $valueKeyReplicaSetKey := printf "%s.replicaSetKey" $authPrefix -}}
   {{- $valueKeyAuthEnabled := printf "%s.enabled" $authPrefix -}}
+  {{- $bypassUpgradeValidation := include "common.mongodb.values.bypassUpgradeValidation" . -}}
 
   {{- $authEnabled := include "common.utils.getValueFromKey" (dict "key" $valueKeyAuthEnabled "context" .context) -}}
 
-  {{- if and (not $existingSecret) (eq $enabled "true") (eq $authEnabled "true") -}}
-    {{- $requiredPasswords := list -}}
+  {{- if eq $bypassUpgradeValidation "false" -}}
 
-    {{- $requiredRootPassword := dict "valueKey" $valueKeyRootPassword "secret" .secret "field" "mongodb-root-password" -}}
-    {{- $requiredPasswords = append $requiredPasswords $requiredRootPassword -}}
+    {{- if and (not $existingSecret) (eq $enabled "true") (eq $authEnabled "true") -}}
+      {{- $requiredPasswords := list -}}
 
-    {{- $valueUsername := include "common.utils.getValueFromKey" (dict "key" $valueKeyUsername "context" .context) }}
-    {{- $valueDatabase := include "common.utils.getValueFromKey" (dict "key" $valueKeyDatabase "context" .context) }}
-    {{- if and $valueUsername $valueDatabase -}}
-        {{- $requiredPassword := dict "valueKey" $valueKeyPassword "secret" .secret "field" "mongodb-password" -}}
-        {{- $requiredPasswords = append $requiredPasswords $requiredPassword -}}
+      {{- $requiredRootPassword := dict "valueKey" $valueKeyRootPassword "secret" .secret "field" "mongodb-root-password" -}}
+      {{- $requiredPasswords = append $requiredPasswords $requiredRootPassword -}}
+
+      {{- $valueUsername := include "common.utils.getValueFromKey" (dict "key" $valueKeyUsername "context" .context) }}
+      {{- $valueDatabase := include "common.utils.getValueFromKey" (dict "key" $valueKeyDatabase "context" .context) }}
+      {{- if and $valueUsername $valueDatabase -}}
+          {{- $requiredPassword := dict "valueKey" $valueKeyPassword "secret" .secret "field" "mongodb-password" -}}
+          {{- $requiredPasswords = append $requiredPasswords $requiredPassword -}}
+      {{- end -}}
+
+      {{- if (eq $architecture "replicaset") -}}
+          {{- $requiredReplicaSetKey := dict "valueKey" $valueKeyReplicaSetKey "secret" .secret "field" "mongodb-replica-set-key" -}}
+          {{- $requiredPasswords = append $requiredPasswords $requiredReplicaSetKey -}}
+      {{- end -}}
+
+      {{- include "common.validations.values.multiple.empty" (dict "required" $requiredPasswords "context" .context) -}}
+
     {{- end -}}
-
-    {{- if (eq $architecture "replicaset") -}}
-        {{- $requiredReplicaSetKey := dict "valueKey" $valueKeyReplicaSetKey "secret" .secret "field" "mongodb-replica-set-key" -}}
-        {{- $requiredPasswords = append $requiredPasswords $requiredReplicaSetKey -}}
-    {{- end -}}
-
-    {{- include "common.validations.values.multiple.empty" (dict "required" $requiredPasswords "context" .context) -}}
-
   {{- end -}}
 {{- end -}}
 
@@ -104,5 +108,18 @@ Params:
     {{- .context.Values.mongodb.architecture -}}
   {{- else -}}
     {{- .context.Values.architecture -}}
+  {{- end -}}
+{{- end -}}
+
+Usage:
+{{ include "common.mongodb.values.bypassUpgradeValidation" }}
+Params:
+  - subchart - Boolean - Optional. Whether to bypassUpgradeValidation for password environment variables. Default: false
+*/}}
+{{- define "common.mongodb.values.bypassUpgradeValidation" -}}
+  {{- if .subchart -}}
+    {{- .context.Values.mongodb.bypassUpgradeValidation -}}
+  {{- else -}}
+    {{- .context.Values.bypassUpgradeValidation -}}
   {{- end -}}
 {{- end -}}

--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -543,6 +543,15 @@ $ helm upgrade my-release bitnami/mongodb --set auth.rootPassword=[PASSWORD] (--
 ```
 
 > Note: you need to substitute the placeholders [PASSWORD] and [REPLICASETKEY] with the values obtained in the installation notes.
+## Reading credentials from Vault File
+Vault can be mounted as a file system to the POD. If authentication is enabled and vault credential path is set then the credentials will be read from this file.
+Format of vault file is expected as below.
+
+MONGODB_DATABASE: database 
+MONGODB_PASSWORD: password
+MONGODB_ROOT_PASSWORD: rootpassword
+MONGODB_USERNAME: username
+MONGODB_USER_ROLE: userrole
 
 ### To 10.0.0
 

--- a/bitnami/mongodb/templates/arbiter/statefulset.yaml
+++ b/bitnami/mongodb/templates/arbiter/statefulset.yaml
@@ -136,6 +136,8 @@ spec:
           {{- else if .Values.arbiter.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.arbiter.command "context" $) | nindent 12 }}
           {{- end }}
+          command:
+            - /scripts/setup-arbiter.sh
           {{- if .Values.diagnosticMode.enabled }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
           {{- else if .Values.arbiter.args }}
@@ -162,17 +164,23 @@ spec:
               value: {{ .Values.replicaSetName | quote }}
             - name: MONGODB_ADVERTISED_HOSTNAME
               value: "$(MY_POD_NAME).$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.{{ .Values.clusterDomain }}"
-            {{- if .Values.auth.enabled }}
+            {{- if (and .Values.auth.enabled (not .Values.auth.vaultCredentials)) }}
             - name: MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "mongodb.secretName" . }}
                   key: mongodb-root-password
+            {{- end }}
+            {{- if .Values.auth.enabled }}
             - name: MONGODB_REPLICA_SET_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "mongodb.secretName" . }}
                   key: mongodb-replica-set-key
+            {{- end }}
+            {{- if .Values.auth.vaultCredentials }}
+            - name: VAULT_CREDENTIAL_FILE
+              value: {{ .Values.auth.vaultCredentials | quote }}
             {{- end }}
             - name: ALLOW_EMPTY_PASSWORD
               value: {{ ternary "no" "yes" .Values.auth.enabled | quote }}
@@ -234,8 +242,10 @@ spec:
           {{- if .Values.arbiter.resources }}
           resources: {{- toYaml .Values.arbiter.resources | nindent 12 }}
           {{- end }}
-          {{- if or .Values.arbiter.configuration .Values.arbiter.existingConfigmap .Values.arbiter.extraVolumeMounts .Values.tls.enabled }}
           volumeMounts:
+            - name: scripts
+              mountPath: /scripts/setup-arbiter.sh
+              subPath: setup-arbiter.sh          
             {{- if or .Values.arbiter.configuration .Values.arbiter.existingConfigmap }}
             - name: config
               mountPath: /opt/bitnami/mongodb/conf/mongodb.conf
@@ -248,12 +258,14 @@ spec:
             {{- if .Values.arbiter.extraVolumeMounts }}
             {{- toYaml .Values.arbiter.extraVolumeMounts | nindent 12 }}
             {{- end }}
-          {{- end }}
         {{- if .Values.arbiter.sidecars }}
         {{- include "common.tplvalues.render" (dict "value" .Values.arbiter.sidecars "context" $) | nindent 8 }}
         {{- end }}
-      {{- if or .Values.arbiter.configuration .Values.arbiter.existingConfigmap .Values.arbiter.extraVolumes .Values.tls.enabled }}
       volumes:
+        - name: scripts
+          configMap:
+            name: {{ include "mongodb.fullname" . }}-scripts
+            defaultMode: 075        
         {{- if or .Values.arbiter.configuration .Values.arbiter.existingConfigmap }}
         - name: config
           configMap:
@@ -276,5 +288,4 @@ spec:
         {{- if .Values.arbiter.extraVolumes }}
         {{- toYaml .Values.arbiter.extraVolumes | nindent 8 }}
         {{- end }}
-      {{- end }}
 {{- end }}

--- a/bitnami/mongodb/templates/replicaset/scripts-configmap.yaml
+++ b/bitnami/mongodb/templates/replicaset/scripts-configmap.yaml
@@ -80,6 +80,17 @@ data:
     {{- end }}
 
     echo "Advertised Hostname: $MONGODB_ADVERTISED_HOSTNAME"
+    if [[ -n "$VAULT_CREDENTIAL_FILE" ]] && [[ -f "$VAULT_CREDENTIAL_FILE" ]]; then
+        while read -r line; do
+        line=$(echo "$line" | sed 's/: /=/g')
+        declare $line; 
+        done < "$VAULT_CREDENTIAL_FILE"
+        export MONGODB_ROOT_PASSWORD="$MONGODB_ROOT_PASSWORD"
+        export MONGODB_USERNAME="$MONGODB_USERNAME"
+        export MONGODB_PASSWORD="$MONGODB_PASSWORD"
+        export MONGODB_DATABASE="$MONGODB_DATABASE"
+        export MONGODB_USER_ROLE="$MONGODB_USER_ROLE"
+    fi    
 
     if [[ "$MY_POD_NAME" = "{{ $fullname }}-0" ]]; then
         echo "Pod name matches initial primary pod name, configuring node as a primary"
@@ -123,4 +134,14 @@ data:
     export MONGODB_ROOT_PASSWORD="" MONGODB_USERNAME="" MONGODB_DATABASE="" MONGODB_PASSWORD=""
     export MONGODB_ROOT_PASSWORD_FILE="" MONGODB_USERNAME_FILE="" MONGODB_DATABASE_FILE="" MONGODB_PASSWORD_FILE=""
     exec /opt/bitnami/scripts/mongodb/entrypoint.sh /opt/bitnami/scripts/mongodb/run.sh
+  setup-arbiter.sh: |-
+    #!/bin/bash
+    if [[ -n "$VAULT_CREDENTIAL_FILE" ]] && [[ -f "$VAULT_CREDENTIAL_FILE" ]]; then
+        while read -r line; do
+        line=$(echo "$line" | sed 's/: /=/g')
+        declare $line; 
+        done < "$VAULT_CREDENTIAL_FILE"
+        export MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD="$MONGODB_ROOT_PASSWORD"
+    fi
+    exec /opt/bitnami/scripts/mongodb/entrypoint.sh /opt/bitnami/scripts/mongodb/run.sh    
 {{- end }}

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -238,10 +238,15 @@ spec:
             - name: MONGODB_ADVERTISED_HOSTNAME
               value: "$(MY_POD_NAME).$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.{{ .Values.clusterDomain }}"
             {{- end }}
+            {{- if (and .Values.auth.enabled (not .Values.auth.vaultCredentials)) }}
             {{- if .Values.auth.username }}
             - name: MONGODB_USERNAME
               value: {{ .Values.auth.username | quote }}
             {{- end }}
+            {{- if .Values.auth.userRole }}
+            - name: MONGODB_USER_ROLE
+              value: {{ .Values.auth.userRole | quote }}
+            {{- end }}   
             {{- if .Values.auth.database }}
             - name: MONGODB_DATABASE
               value: {{ .Values.auth.database | quote }}
@@ -259,12 +264,19 @@ spec:
                 secretKeyRef:
                   name: {{ include "mongodb.secretName" . }}
                   key: mongodb-root-password
+            {{- end }}
+            {{- end }}
+            {{- if .Values.auth.enabled }}
             - name: MONGODB_REPLICA_SET_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "mongodb.secretName" . }}
                   key: mongodb-replica-set-key
-            {{- end }}
+            {{- end}}      
+            {{- if .Values.auth.vaultCredentials }}
+            - name: VAULT_CREDENTIAL_FILE
+              value: {{ .Values.auth.vaultCredentials | quote }}
+            {{- end }} 
             - name: ALLOW_EMPTY_PASSWORD
               value: {{ ternary "no" "yes" .Values.auth.enabled | quote }}
             - name: MONGODB_SYSTEM_LOG_VERBOSITY

--- a/bitnami/mongodb/templates/standalone/dep-sts.yaml
+++ b/bitnami/mongodb/templates/standalone/dep-sts.yaml
@@ -180,6 +180,8 @@ spec:
           {{- else if .Values.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.command "context" $) | nindent 12 }}
           {{- end }}
+          command:
+            - /scripts/setup.sh          
           {{- if .Values.diagnosticMode.enabled }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
           {{- else if .Values.args }}
@@ -187,10 +189,15 @@ spec:
           {{- end }}
           env:
             - name: BITNAMI_DEBUG
-              value: {{ ternary "true" "false" (or .Values.image.debug .Values.diagnosticMode.enabled) | quote }}
+              value: {{ ternary "true" "false" .Values.image.debug | quote }}
+            {{- if (and .Values.auth.enabled (not .Values.auth.vaultCredentials)) }}
             {{- if .Values.auth.username }}
             - name: MONGODB_USERNAME
               value: {{ .Values.auth.username | quote }}
+            {{- end }}
+            {{- if .Values.auth.userRole }}
+            - name: MONGODB_USER_ROLE
+              value: {{ .Values.auth.userRole | quote }}
             {{- end }}
             {{- if .Values.auth.database }}
             - name: MONGODB_DATABASE
@@ -209,6 +216,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "mongodb.secretName" . }}
                   key: mongodb-root-password
+            {{- end }}
+            {{- end }}
+            {{- if .Values.auth.vaultCredentials }}
+            - name: VAULT_CREDENTIAL_FILE
+              value: {{ .Values.auth.vaultCredentials | quote }}
             {{- end }}
             - name: ALLOW_EMPTY_PASSWORD
               value: {{ ternary "no" "yes" .Values.auth.enabled | quote }}
@@ -332,6 +344,9 @@ spec:
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
+            - name: scripts
+              mountPath: /scripts/setup.sh
+              subPath: setup.sh          
             - name: datadir
               mountPath: {{ .Values.persistence.mountPath }}
               subPath: {{ .Values.persistence.subPath }}
@@ -412,6 +427,10 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | nindent 8 }}
         {{- end }}
       volumes:
+        - name: scripts
+          configMap:
+            name: {{ include "mongodb.fullname" . }}-scripts
+            defaultMode: 0755       
         {{- if or .Values.initdbScriptsConfigMap .Values.initdbScripts }}
         - name: custom-init-scripts
           configMap:

--- a/bitnami/mongodb/templates/standalone/scripts-configmap.yaml
+++ b/bitnami/mongodb/templates/standalone/scripts-configmap.yaml
@@ -1,0 +1,26 @@
+{{- if eq .Values.architecture "standalone" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mongodb.fullname" . }}-scripts
+  namespace: {{ include "mongodb.namespace" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: mongodb
+data:
+  {{- $fullname := include "mongodb.fullname" . }}
+  {{- $releaseNamespace := include "mongodb.namespace" . }} 
+  setup.sh: |-
+    #!/bin/bash
+    if [[ -n "$VAULT_CREDENTIAL_FILE" ]] && [[ -f "$VAULT_CREDENTIAL_FILE" ]]; then
+        while read -r line; do
+        line=$(echo "$line" | sed 's/: /=/g')
+        declare $line; 
+        done < "$VAULT_CREDENTIAL_FILE"
+        export MONGODB_ROOT_PASSWORD="$MONGODB_ROOT_PASSWORD"
+        export MONGODB_USERNAME="$MONGODB_USERNAME"
+        export MONGODB_PASSWORD="$MONGODB_PASSWORD"
+        export MONGODB_DATABASE="$MONGODB_DATABASE"
+        export MONGODB_USER_ROLE="${MONGODB_USER_ROLE:-readWrite}"
+    fi
+    exec /opt/bitnami/scripts/mongodb/entrypoint.sh /opt/bitnami/scripts/mongodb/run.sh
+{{- end }}

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -123,6 +123,9 @@ schedulerName: ""
 ## @param architecture MongoDB&reg; architecture (`standalone` or `replicaset`)
 ##
 architecture: standalone
+
+bypassUpgradeValidation: false
+
 ## @param useStatefulSet Set to true to use a StatefulSet instead of a Deployment (only when `architecture=standalone`)
 ##
 useStatefulSet: false
@@ -143,6 +146,14 @@ auth:
   ## @param auth.password MongoDB&reg; custom user password
   ## @param auth.database MongoDB&reg; custom database
   ##
+  # username: username
+  # password: password
+  # database: database
+  ## By default custom user role is readWrite to database configured above
+  # userRole: readWrite
+  #vaultCredentials: /tmp/credentialFile
+  ## Key used for replica set authentication
+  ## Ignored when mongodb.architecture=standalone
   username: ""
   password: ""
   database: ""


### PR DESCRIPTION
Which chart:
bitnami/mongodb

Is your feature request related to a problem? Please describe.
We are trying to get the Vault agent injector to provide the credentials used by Mongo so that there's a single source of truth for the secrets used in the cluster. (https://www.vaultproject.io/docs/platform/k8s/injector)

Describe the solution you'd like
When the CredentialsFile is available, it would be nice if mongo reads the credentials from the file mounted by Vault and then pass it as the required env variables. The format of credentials files can be made generic.

The same request has been made for other charts earlier.
#4422

This PR address reading credentials from the vault.
https://github.com/bitnami/charts/issues/5948