### PR TITLE
[bitnami/redmine] Fix port number setting for PostgreSQL database

### DIFF
--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -36,4 +36,4 @@ name: redmine
 sources:
   - https://github.com/bitnami/bitnami-docker-redmine
   - http://www.redmine.org/
-version: 17.0.2
+version: 17.0.3

--- a/bitnami/redmine/templates/NOTES.txt
+++ b/bitnami/redmine/templates/NOTES.txt
@@ -57,8 +57,12 @@ You have 4 alternatives:
   echo Username: $REDMINE_USERNAME
   echo Password: $REDMINE_PASSWORD
 
-   You can access the DB using the following password:
-   {{ include "common.utils.secret.getvalue" (dict "secret" $dbSecretName "field" "mariadb-password" "context" $) }}
+  You can access the DB using the following password:
+  {{- if eq .Values.databaseType "mariadb" }}
+  {{ include "common.utils.secret.getvalue" (dict "secret" $dbSecretName "field" "mariadb-password" "context" $) }}
+  {{- else if eq .Values.databaseType "postgresql" }}
+  {{ include "common.utils.secret.getvalue" (dict "secret" $dbSecretName "field" "postgresql-password" "context" $) }}
+  {{ end }}
 {{- end }}
 
 {{- include "common.warnings.rollingTag" .Values.image }}

--- a/bitnami/redmine/templates/_helpers.tpl
+++ b/bitnami/redmine/templates/_helpers.tpl
@@ -106,6 +106,19 @@ Return the database host for Redmine
 {{- end -}}
 
 {{/*
+Return the database port for Redmine
+*/}}
+{{- define "redmine.database.port" -}}
+{{- if and (eq .Values.databaseType "mariadb") (.Values.mariadb.enabled) -}}
+    {{- printf "3306" -}}
+{{- else if and (eq .Values.databaseType "postgresql") (.Values.postgresql.enabled) -}}
+    {{- printf "5432" -}}
+{{- else }}
+    {{- .Values.externalDatabase.port }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the database name for Redmine
 */}}
 {{- define "redmine.database.name" -}}

--- a/bitnami/redmine/templates/deployment.yaml
+++ b/bitnami/redmine/templates/deployment.yaml
@@ -121,10 +121,8 @@ spec:
                   {{- else }}
                   key: postgresql-password
                   {{- end }}
-            {{- if (include "redmine.useExternalDB" .) }}
             - name: REDMINE_DATABASE_PORT_NUMBER
-              value: {{ .Values.externalDatabase.port | quote }}
-            {{- end }}
+              value: {{ include "redmine.database.port" . | quote }}
             - name: REDMINE_USERNAME
               value: {{ default "" .Values.redmineUsername | quote }}
             - name: REDMINE_PASSWORD


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

The current configuration assumes the database port is 3306 in case an external database is not configured so it breaks in case the embedded database selected is PostgreSQL. This makes the chart set the default port for MariaDB at 3306 and for PostgreSQL at 5432.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #7219

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
