### PR TITLE
[bitnami/kubernetes-event-exporter] Add extraEnvVars support

### DIFF
--- a/bitnami/kubernetes-event-exporter/Chart.yaml
+++ b/bitnami/kubernetes-event-exporter/Chart.yaml
@@ -26,4 +26,4 @@ name: kubernetes-event-exporter
 sources:
   - https://github.com/bitnami/bitnami-docker-kubernetes-event-exporter
   - https://github.com/opsgenie/kubernetes-event-exporter
-version: 1.1.11
+version: 1.1.12

--- a/bitnami/kubernetes-event-exporter/templates/deployment.yaml
+++ b/bitnami/kubernetes-event-exporter/templates/deployment.yaml
@@ -58,9 +58,19 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - -conf=/data/config.yaml
-          {{- if .Values.extraEnvVars }}
-          env:
-            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+          {{- if .Values.extraEnv }}
+          env: {{- include "common.tplvalues.render" (dict "value" .Values.extraEnv "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if or .Values.extraEnvVarsCM .Values.extraEnvVarsSecret }}
+          envFrom:
+            {{- if .Values.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
+            {{- end }}
           {{- end }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.containerSecurityContext.enabled }}

--- a/bitnami/kubernetes-event-exporter/templates/deployment.yaml
+++ b/bitnami/kubernetes-event-exporter/templates/deployment.yaml
@@ -58,6 +58,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - -conf=/data/config.yaml
+          {{- if .Values.extraEnvVars }}
+          env:
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.containerSecurityContext.enabled }}
           # yamllint disable rule:indentation

--- a/bitnami/kubernetes-event-exporter/templates/deployment.yaml
+++ b/bitnami/kubernetes-event-exporter/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
           {{- if .Values.extraEnvVars }}
           env:
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
-            {{- end }}
+          {{- end }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.containerSecurityContext.enabled }}
           # yamllint disable rule:indentation


### PR DESCRIPTION
**Description of the change**

`extraEnvVars` variable is described in README/documentation but isn't supported in chart itself.

**Benefits**

We can inject ENV variables into containers from now on.

**Possible drawbacks**

None.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
