### PR TITLE
bitnami/testlink-7242-Update-ingress.yaml-to-fix-bad-ingress-behavior

### DIFF
--- a/bitnami/testlink/Chart.yaml
+++ b/bitnami/testlink/Chart.yaml
@@ -28,4 +28,4 @@ name: testlink
 sources:
   - https://github.com/bitnami/bitnami-docker-testlink
   - http://www.testlink.org/
-version: 9.2.17
+version: 9.2.18

--- a/bitnami/testlink/templates/ingress.yaml
+++ b/bitnami/testlink/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "common.names.fullname" . }}


### PR DESCRIPTION
**Description of the change**

Added {{ include "common.capabilities.ingress.apiVersion" . }} instead of hardcoded extensions/v1beta1

**Benefits**

The Ingresses of this chart will work in more cluster / work at all.

**Possible drawbacks**

Hopefully none. Because it is keeping track off in the bitnami/common chart.

**Applicable issues**

[bitnami/testlink] Ingress is broken #7242

