### PR TITLE
[bitnami/airflow] Add Extra Environment Variables to Metrics Deployment

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -32,4 +32,4 @@ name: airflow
 sources:
   - https://github.com/bitnami/bitnami-docker-airflow
   - https://airflow.apache.org/
-version: 10.2.8
+version: 10.2.9

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -32,4 +32,4 @@ name: airflow
 sources:
   - https://github.com/bitnami/bitnami-docker-airflow
   - https://airflow.apache.org/
-version: 10.2.9
+version: 10.3.0

--- a/bitnami/airflow/README.md
+++ b/bitnami/airflow/README.md
@@ -336,27 +336,27 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Airflow metrics parameters
 
-| Name                                   | Description                                                 | Value                         |
-| -------------------------------------- | ----------------------------------------------------------- | ----------------------------- |
-| `metrics.enabled`                      | Start a side-car prometheus exporter                        | `false`                       |
-| `metrics.image.registry`               | Airflow Exporter image registry                             | `docker.io`                   |
-| `metrics.image.repository`             | Airflow Exporter image repository                           | `bitnami/airflow-exporter`    |
-| `metrics.image.tag`                    | Airflow Exporter image tag (immutable tags are recommended) | `0.20210126.0-debian-10-r171` |
-| `metrics.image.pullPolicy`             | Airflow Exporter image pull policy                          | `IfNotPresent`                |
-| `metrics.image.pullSecrets`            | Airflow Exporter image pull secrets                         | `[]`                          |
-| `metrics.extraEnvVars`                 | Add extra environment variables                             | `[]`                          |
-| `metrics.extraEnvVarsCM`               | ConfigMap with extra environment variables                  | `""`                          |
-| `metrics.extraEnvVarsSecret`           | Secret with extra environment variables                     | `""`                          |
-| `metrics.hostAliases`                  | Deployment pod host aliases                                 | `[]`                          |
-| `metrics.serviceMonitor.enabled`       | Create ServiceMonitor resource                              | `false`                       |
-| `metrics.serviceMonitor.namespace`     | The namespace in which the ServiceMonitor will be created   | `""`                          |
-| `metrics.serviceMonitor.interval`      | Interval in which prometheus scrapes                        | `60s`                         |
-| `metrics.serviceMonitor.scrapeTimeout` | Scrape Timeout duration for prometheus                      | `10s`                         |
-| `metrics.serviceMonitor.labels`        | Additional labels to attach                                 | `{}`                          |
-| `metrics.resources`                    | Metrics exporter resource requests and limits               | `{}`                          |
-| `metrics.tolerations`                  | Metrics exporter labels and tolerations for pod assignment  | `[]`                          |
-| `metrics.podLabels`                    | Metrics exporter pod Annotation and Labels                  | `{}`                          |
-| `metrics.nodeSelector`                 | Node labels for pod assignment                              | `{}`                          |
+| Name                                   | Description                                                               | Value                         |
+| -------------------------------------- | ------------------------------------------------------------------------- | ----------------------------- |
+| `metrics.enabled`                      | Start a side-car prometheus exporter                                      | `false`                       |
+| `metrics.image.registry`               | Airflow Exporter image registry                                           | `docker.io`                   |
+| `metrics.image.repository`             | Airflow Exporter image repository                                         | `bitnami/airflow-exporter`    |
+| `metrics.image.tag`                    | Airflow Exporter image tag (immutable tags are recommended)               | `0.20210126.0-debian-10-r171` |
+| `metrics.image.pullPolicy`             | Airflow Exporter image pull policy                                        | `IfNotPresent`                |
+| `metrics.image.pullSecrets`            | Airflow Exporter image pull secrets                                       | `[]`                          |
+| `metrics.extraEnvVars`                 | Array containing extra environment variables                              | `[]`                          |
+| `metrics.extraEnvVarsCM`               | ConfigMap containing extra environment variables                          | `""`                          |
+| `metrics.extraEnvVarsSecret`           | Secret containing extra environment variables (in case of sensitive data) | `""`                          |
+| `metrics.hostAliases`                  | Deployment pod host aliases                                               | `[]`                          |
+| `metrics.serviceMonitor.enabled`       | Create ServiceMonitor resource                                            | `false`                       |
+| `metrics.serviceMonitor.namespace`     | The namespace in which the ServiceMonitor will be created                 | `""`                          |
+| `metrics.serviceMonitor.interval`      | Interval in which prometheus scrapes                                      | `60s`                         |
+| `metrics.serviceMonitor.scrapeTimeout` | Scrape Timeout duration for prometheus                                    | `10s`                         |
+| `metrics.serviceMonitor.labels`        | Additional labels to attach                                               | `{}`                          |
+| `metrics.resources`                    | Metrics exporter resource requests and limits                             | `{}`                          |
+| `metrics.tolerations`                  | Metrics exporter labels and tolerations for pod assignment                | `[]`                          |
+| `metrics.podLabels`                    | Metrics exporter pod Annotation and Labels                                | `{}`                          |
+| `metrics.nodeSelector`                 | Node labels for pod assignment                                            | `{}`                          |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/bitnami/airflow/README.md
+++ b/bitnami/airflow/README.md
@@ -344,6 +344,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.image.tag`                    | Airflow Exporter image tag (immutable tags are recommended) | `0.20210126.0-debian-10-r171` |
 | `metrics.image.pullPolicy`             | Airflow Exporter image pull policy                          | `IfNotPresent`                |
 | `metrics.image.pullSecrets`            | Airflow Exporter image pull secrets                         | `[]`                          |
+| `metrics.extraEnvVars`                 | Add extra environment variables                             | `[]`                          |
+| `metrics.extraEnvVarsCM`               | ConfigMap with extra environment variables                  | `""`                          |
+| `metrics.extraEnvVarsSecret`           | Secret with extra environment variables                     | `""`                          |
 | `metrics.hostAliases`                  | Deployment pod host aliases                                 | `[]`                          |
 | `metrics.serviceMonitor.enabled`       | Create ServiceMonitor resource                              | `false`                       |
 | `metrics.serviceMonitor.namespace`     | The namespace in which the ServiceMonitor will be created   | `""`                          |

--- a/bitnami/airflow/templates/metrics/deployment.yaml
+++ b/bitnami/airflow/templates/metrics/deployment.yaml
@@ -66,6 +66,18 @@ spec:
                   key: {{ include "airflow.database.existingsecret.key" . }}
             - name: AIRFLOW_PROMETHEUS_DATABASE_NAME
               value: {{ include "airflow.database.name" . }}
+            {{- if .Values.metrics.extraEnvVars }}
+              {{- include "common.tplvalues.render" (dict "value" .Values.metrics.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- if .Values.metrics.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ .Values.metrics.extraEnvVarsCM }}
+            {{- end }}
+            {{- if .Values.metrics.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ .Values.metrics.extraEnvVarsSecret }}
+            {{- end }}
           ports:
             - name: metrics
               containerPort: 9112

--- a/bitnami/airflow/values.yaml
+++ b/bitnami/airflow/values.yaml
@@ -1051,6 +1051,15 @@ metrics:
     scrapeTimeout: 10s
     # ServiceMonitor Labels
     labels: {}
+  ## @param metrics.extraEnvVars Array containing extra environment variables
+  ##
+  extraEnvVars: []
+  ## @param metrics.extraEnvVarsCM ConfigMap containing extra environment variables
+  ##
+  extraEnvVarsCM: ""
+  ## @param metrics.extraEnvVarsSecret Secret containing extra environment variables (in case of sensitive data)
+  ##
+  extraEnvVarsSecret: ""
   ## @param metrics.resources Metrics exporter resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##


### PR DESCRIPTION
**Description of the change**

Add Extra Environment Variables to the Airflow Metrics Deployment.

**Benefits**

Additional configuration of the deployment container.  This allows environment variables like `AIRFLOW_PROMETHEUS_POSTGRES_SSL_MODE` to be injected to the Airflow Metrics Deployment.

**Possible drawbacks**

None foreseen.

**Applicable issues**

  - fixes #6820 

**Additional information**

This does not include `.Values.extraEnvVars` like scheduler, web, and worker as those variables are not relevant to metrics.

This is a quick fix to get additional environment variables into the metrics deployment.  As my original conversation mentioned, ultimately, it would great to have a value (i.e. `externalDatabase.sslMode`) and helper (`airflow.database.sslMode`) that added the appropriate Postgres environment variables in the necessary places.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
