### PR TITLE
[bitnami/kubernetes-event-exporter] Fix variable name to extraEnvVars

### DIFF
--- a/bitnami/kubernetes-event-exporter/Chart.yaml
+++ b/bitnami/kubernetes-event-exporter/Chart.yaml
@@ -26,4 +26,4 @@ name: kubernetes-event-exporter
 sources:
   - https://github.com/bitnami/bitnami-docker-kubernetes-event-exporter
   - https://github.com/opsgenie/kubernetes-event-exporter
-version: 1.1.12
+version: 1.1.13

--- a/bitnami/kubernetes-event-exporter/templates/deployment.yaml
+++ b/bitnami/kubernetes-event-exporter/templates/deployment.yaml
@@ -58,8 +58,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - -conf=/data/config.yaml
-          {{- if .Values.extraEnv }}
-          env: {{- include "common.tplvalues.render" (dict "value" .Values.extraEnv "context" $) | nindent 12 }}
+          {{- if .Values.extraEnvVars }}
+          env: {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
           {{- end }}
           {{- if or .Values.extraEnvVarsCM .Values.extraEnvVarsSecret }}
           envFrom:


### PR DESCRIPTION
**Description of the change**

A typo was made in #7238. Variable `extraEnvVars` was misspelled to `extraEnv`.

**Benefits**

Fix typo.

**Possible drawbacks**

None.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
