### PR TITLE
[bitnami/grafana-operator] Fix missing RBAC rules in case of cluster-wide installation

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -25,4 +25,4 @@ name: grafana-operator
 sources:
   - https://github.com/integr8ly/grafana-operator
   - https://github.com/bitnami/bitnami-docker-grafana-operator
-version: 1.0.1
+version: 1.0.2

--- a/bitnami/grafana-operator/templates/rbac.yaml
+++ b/bitnami/grafana-operator/templates/rbac.yaml
@@ -136,26 +136,95 @@ metadata:
   {{- end }}
 rules:
   - apiGroups:
-      - integreatly.org
-    resources:
-      - grafanadashboards
-      - grafanadashboards/status
-      - grafanadatasources
-      - grafanadatasources/status
-    verbs: ['get', 'list', 'update', 'watch']
-  - apiGroups:
       - ""
     resources:
-      - namespaces
+      - pods
+      - services
+      - endpoints
+      - persistentvolumeclaims
       - configmaps
-    verbs: ['get', 'list', 'watch']
+      - secrets
+      - serviceaccounts
+      - configmaps
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - deletecollection
+      - watch
   - apiGroups:
       - ""
     resources:
       - events
     verbs:
+      - get
+      - list
+      - watch
       - create
+      - delete
+      - update
       - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - deployments/finalizers
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - deletecollection
+      - watch
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+      - routes/custom-host
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - deletecollection
+      - watch
+      - create
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - deletecollection
+      - watch
+  - apiGroups:
+      - integreatly.org
+    resources:
+      - grafanas
+      - grafanas/status
+      - grafanas/finalizers
+      - grafanadashboards
+      - grafanadatasources
+      - grafanadatasources/status
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - deletecollection
+      - watch
 ---
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding


### PR DESCRIPTION
For the operator to be able to scan all namespaces, it must have these rules.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Added more rules to RBAC ClusterRole.

**Benefits**

It will allow the operator to listen to all namespaces.

**Possible drawbacks**

None.

**Applicable issues**

None.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
