### PR TITLE
[bitnami/minio] fix disk is not writable when persistence disabled (#…

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -25,4 +25,4 @@ name: minio
 sources:
   - https://github.com/bitnami/bitnami-docker-minio
   - https://min.io
-version: 7.1.7
+version: 7.1.8

--- a/bitnami/minio/templates/distributed/statefulset.yaml
+++ b/bitnami/minio/templates/distributed/statefulset.yaml
@@ -237,14 +237,14 @@ spec:
             - name: minio-certs
               mountPath: {{ default "/certs" .Values.tls.mountPath }}
             {{- end }}
-            {{- if and .Values.persistence.enabled (gt $drivesPerNode 1) }}
+            {{- if gt $drivesPerNode 1 }}
             {{- range $diskId := until $drivesPerNode }}
             - name: data-{{ $diskId }}
-              mountPath: {{  $mountPath }}-{{ $diskId }}
+              mountPath: {{ $mountPath }}-{{ $diskId }}
             {{- end }}
             {{- else }}
             - name: data
-              mountPath: {{  $mountPath }}
+              mountPath: {{ $mountPath }}
             {{- end }}
             {{- if .Values.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
@@ -273,7 +273,12 @@ spec:
         {{- if .Values.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
-  {{- if not .Values.persistence.enabled }}
+  {{- if and (not .Values.persistence.enabled) (gt $drivesPerNode 1) }}
+  {{- range $diskId := until $drivesPerNode }}
+        - name: data-{{ $diskId }}
+          emptyDir: {}
+  {{- end }}
+  {{- else if not .Values.persistence.enabled }}
         - name: data
           emptyDir: {}
   {{- else }}


### PR DESCRIPTION
**Description of the change**

Goal - Be able to use several emptyDir volumes per node even when persistence is disabled

*Changes:*
- Several volumes are mounted in the container when $drivesPerNode is greater than 1. Even when persistence is disabled. They are called "data-0", "data-1",... etc. When $driversPerNode is 1 then only one volume is mounted called "data".
- "Volumes:" definition is also updated since it needs to define a range of volumes when more than 1 is requested. Again, only when 1 drive is requested the name is "data" otherwise one definition per volume is created called "data-0", "data-1", .... etc.

**Benefits**

Support users' use cases during development stages where no persistence is needed.

**Possible drawbacks**

none

**Applicable issues**

  - fixes #6736 

**Additional information**

Any of the following commands return any writing errors like in the current version where several writing errors are returned:

```
➜  ~ kubectl -n default get events --sort-by='{.lastTimestamp}'
➜  ~ kubectl logs test-minio-0|grep "Error: disk is not writable "
```

using more than 1 drives per node (e.g. 3) create "data-0", "data-1".... etc dirs even when persistence is disabled:

```
I have no name!@test-minio-0:/opt/bitnami/minio-client$ ls /
bin  boot  certs  data  data-0  data-1  data-2  dev  etc  home  lib  lib64  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var
I have no name!@test-minio-0:/opt/bitnami/minio-client$
```

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
