### PR TITLE
[bitnami/kafka] Fix missing "component" "%COMPONENT_NAME%"

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 14.0.2
+version: 14.0.3

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -75,8 +75,8 @@ spec:
       affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- else }}
       affinity:
-        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAffinityPreset "context" $) | nindent 10 }}
-        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAntiAffinityPreset "context" $) | nindent 10 }}
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAffinityPreset "component" "kafka" "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAntiAffinityPreset "component" "kafka" "context" $) | nindent 10 }}
         nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
       {{- if .Values.nodeSelector }}


### PR DESCRIPTION
**Description of the change**
Add app.kubernetes.io/component to matchLabels in podAntiAffinity section

**Benefits**
Avoids metrics pod (kafka exporter) to have same app.kubernetes.io/name and force k8s to schedule kafka-exporter on separate node.

**Possible drawbacks**
None ?

**Applicable issues**
fixes #

Additional information

**Checklist**
- [X] Chart version bumped in Chart.yaml according to semver.
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
