### PR TITLE
[bitnami/nginx] Added sidecarSingleProcessNamespace parameter

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Infrastructure
 apiVersion: v2
-appVersion: 1.21.1
+appVersion: 1.22.1
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Infrastructure
 apiVersion: v2
-appVersion: 1.22.1
+appVersion: 1.21.1
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -25,4 +25,4 @@ name: nginx
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx
   - http://www.nginx.org
-version: 9.4.3
+version: 9.5.0

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -138,7 +138,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `serviceAccount.annotations`            | Annotations for service account. Evaluated as a template.                                 | `{}`    |
 | `serviceAccount.autoMount`              | Auto-mount the service account token in the pod                                           | `false` |
 | `sidecars`                              | Sidecar parameters                                                                        | `[]`    |
-| `sidecarSingleProcessNamespace`         | Toggle pod.spec.shareProcessNamespace                                                     | `false` |
+| `sidecarSingleProcessNamespace`         | Enable sharing the process namespace with sidecars                                       | `false` |
 | `initContainers`                        | Extra init containers                                                                     | `[]`    |
 | `pdb.create`                            | Created a PodDisruptionBudget                                                             | `false` |
 | `pdb.minAvailable`                      | Min number of pods that must still be available after the eviction                        | `1`     |

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -138,6 +138,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `serviceAccount.annotations`            | Annotations for service account. Evaluated as a template.                                 | `{}`    |
 | `serviceAccount.autoMount`              | Auto-mount the service account token in the pod                                           | `false` |
 | `sidecars`                              | Sidecar parameters                                                                        | `[]`    |
+| `sidecarSingleProcessNamespace`         | Toggle pod.spec.shareProcessNamespace                                                     | `false` |
 | `initContainers`                        | Extra init containers                                                                     | `[]`    |
 | `pdb.create`                            | Created a PodDisruptionBudget                                                             | `false` |
 | `pdb.minAvailable`                      | Min number of pods that must still be available after the eviction                        | `1`     |

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
     spec:
       {{- include "nginx.imagePullSecrets" . | nindent 6 }}
       automountServiceAccountToken: {{ .Values.serviceAccount.autoMount }}
+      shareProcessNamespace: {{ . Values.sidecarSingleProcessNamespace }}
       serviceAccountName: {{ template "nginx.serviceAccountName" . }}
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       {{- include "nginx.imagePullSecrets" . | nindent 6 }}
       automountServiceAccountToken: {{ .Values.serviceAccount.autoMount }}
-      shareProcessNamespace: {{ . Values.sidecarSingleProcessNamespace }}
+      shareProcessNamespace: {{ .Values.sidecarSingleProcessNamespace }}
       serviceAccountName: {{ template "nginx.serviceAccountName" . }}
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -289,7 +289,7 @@ serviceAccount:
 ##
 sidecars: []
 
-## @param sidecarSingleProcessNamespace Enable sharing the process namespace for sidecards
+## @param sidecarSingleProcessNamespace Enable sharing the process namespace with sidecars
 ## This will switch pod.spec.shareProcessNamespace parameter
 ##
 sidecarSingleProcessNamespace: false

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -288,6 +288,12 @@ serviceAccount:
 ##         containerPort: 1234
 ##
 sidecars: []
+
+## @param sidecarSingleProcessNamespace Enable sharing the process namespace for sidecards
+## This will switch pod.spec.shareProcessNamespace parameter
+##
+sidecarSingleProcessNamespace: false
+
 ## @param initContainers Extra init containers
 ##
 initContainers: []


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This chage adds a new bitnami/nginx chart value to toggle shareProcessNamespace for pods.

**Benefits**

This would benefit sidecars which would like to notify nginx configuration changes via signals. 

**Possible drawbacks**

As this is a backwards compatible change, only downside is misuse of the value. That may cause security issues.

**Applicable issues**



**Additional information**


**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
