### PR TITLE
bitnami/rabbitmq: enable tpl for auth.tls.existingSecret

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -23,4 +23,4 @@ name: rabbitmq
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq
   - https://www.rabbitmq.com
-version: 8.20.1
+version: 8.20.2

--- a/bitnami/rabbitmq/templates/_helpers.tpl
+++ b/bitnami/rabbitmq/templates/_helpers.tpl
@@ -86,7 +86,7 @@ Get the TLS secret.
 */}}
 {{- define "rabbitmq.tlsSecretName" -}}
     {{- if .Values.auth.tls.existingSecret -}}
-        {{- printf "%s" .Values.auth.tls.existingSecret -}}
+        {{- printf "%s" (tpl .Values.auth.tls.existingSecret $) -}}
     {{- else -}}
         {{- printf "%s-certs" (include "rabbitmq.fullname" .) -}}
     {{- end -}}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Enable tpl in `auth.tls.existingSecret` value

**Benefits**

Tpl is useful for existingSecret. It's applied for others existing secrets but not for this one.

**Possible drawbacks**

None ?

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
