### PR TITLE
[bitnami/kibana] Fix ServiceAcccount

### DIFF
--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -25,4 +25,4 @@ name: kibana
 sources:
   - https://github.com/bitnami/bitnami-docker-kibana
   - https://www.elastic.co/products/kibana
-version: 8.2.0
+version: 8.2.1

--- a/bitnami/kibana/templates/deployment.yaml
+++ b/bitnami/kibana/templates/deployment.yaml
@@ -43,6 +43,7 @@ spec:
       {{- if .Values.schedulerName }}
       schedulerName: {{ .Values.schedulerName | quote }}
       {{- end }}
+      serviceAccountName: {{ include "kibana.serviceAccountName" . }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
@@ -73,7 +74,6 @@ spec:
           securityContext:
             runAsUser: {{ .Values.securityContext.runAsUser }}
           {{- end }}
-          serviceAccountName: {{ include "kibana.serviceAccountName" . }}
           env:
             - name: KIBANA_PORT_NUMBER
               value: {{ .Values.containerPort | quote }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This fixes a bug introduced at https://github.com/bitnami/charts/pull/7211/files. We included the `serviceAccountName` field under `spec.template.spec.containers[0].serviceAccountName` instead of `spec.template.spec.serviceAccountName`.

**Benefits**

Fixes the Kibana deployment specification.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
