### PR TITLE
[bitnami/keycloak] Default postgresql.postgresqlPassword to a random …

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 5.0.1
+version: 6.0.0

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 6.0.0
+version: 5.0.2

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -277,7 +277,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | --------------------------------- | ----------------------------------------------------------------------------- | ------------------ |
 | `postgresql.enabled`              | Deploy a PostgreSQL server to satisfy the applications database requirements  | `true`             |
 | `postgresql.postgresqlUsername`   | Keycloak PostgreSQL user (has superuser privileges if username is `postgres`) | `bn_keycloak`      |
-| `postgresql.postgresqlPassword`   | Keycloak PostgreSQL password - ignored if existingSecret is provided          | `some-password`    |
+| `postgresql.postgresqlPassword`   | Keycloak PostgreSQL password - ignored if existingSecret is provided          | `""`               |
 | `postgresql.postgresqlDatabase`   | Name of the database to create                                                | `bitnami_keycloak` |
 | `postgresql.existingSecret`       | Use an existing secret file with the PostgreSQL password                      | `""`               |
 | `postgresql.persistence.enabled`  | Enable database persistence using PVC                                         | `true`             |

--- a/bitnami/keycloak/templates/_helpers.tpl
+++ b/bitnami/keycloak/templates/_helpers.tpl
@@ -155,7 +155,7 @@ Return the Database encrypted password
 */}}
 {{- define "keycloak.databaseEncryptedPassword" -}}
 {{- if .Values.postgresql.enabled }}
-    {{- .Values.postgresql.postgresqlPassword | b64enc | quote -}}
+    {{- (.Values.postgresql.postgresqlPassword | default (randAlphaNum 10)) | b64enc | quote -}}
 {{- else -}}
     {{- .Values.externalDatabase.password | b64enc | quote -}}
 {{- end -}}

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -870,7 +870,7 @@ postgresql:
   ## Defaults to a random 10-character alphanumeric string if not set
   ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#setting-the-root-password-on-first-run
   ##
-  postgresqlPassword: some-password
+  postgresqlPassword: ""
   ## @param postgresql.postgresqlDatabase Name of the database to create
   ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#creating-a-database-on-first-run
   ##


### PR DESCRIPTION
…10-character string

**Description of the change**
This change and its motivation is described in https://github.com/bitnami/charts/issues/7279. Essentially, it sets the `postgresql.postgresqlPassword` to `""` in the values file and then updates the `keycloak.databaseEncryptedPassword` function so that the default value of `""` is mapped to a random 10-character alphanumeric string.

**Benefits**
The postgres password will not default to the same password for every installation. This improves the chart's security.

**Possible drawbacks**
This is likely a breaking change. However, I'm not familiar enough with postgres to know for sure. My commit bumps the major version. I'd appreciate insight from the chart maintainers to confirm that this requires a major version bump. If it is only a minor bump, I can update the commit.

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/7279

**Additional information**
I tested this commit by running the following from within the keycloak directory for this repository:

```
$ helm template test . | grep database
  database-password: "Z1Vpb1VWdFcxZw=="
                  key: database-password
$ echo Z1Vpb1VWdFcxZw== | base64 --decode
gUioUVtW1g
```

Before this change, the same test results in the following:

```
$ helm template test . | grep database
  database-password: "c29tZS1wYXNzd29yZA=="
                  key: database-password
$ echo c29tZS1wYXNzd29yZA== | base64 --decode
some-password
```

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
