### PR TITLE
[bitnami/wildfly] Add support for exposing WildFly Management console outside the cluster

### DIFF
--- a/bitnami/wildfly/Chart.yaml
+++ b/bitnami/wildfly/Chart.yaml
@@ -26,4 +26,4 @@ name: wildfly
 sources:
   - https://github.com/bitnami/bitnami-docker-wildfly
   - http://wildfly.org
-version: 11.0.5
+version: 11.1.0

--- a/bitnami/wildfly/README.md
+++ b/bitnami/wildfly/README.md
@@ -83,15 +83,16 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### WildFly Configuration parameters
 
-| Name                 | Description                                                            | Value  |
-| -------------------- | ---------------------------------------------------------------------- | ------ |
-| `wildflyUsername`    | WildFly username                                                       | `user` |
-| `wildflyPassword`    | WildFly user password                                                  | `""`   |
-| `command`            | Override default container command (useful when using custom images)   | `[]`   |
-| `args`               | Override default container args (useful when using custom images)      | `[]`   |
-| `extraEnvVars`       | Array with extra environment variables to add to the WildFly container | `[]`   |
-| `extraEnvVarsCM`     | Name of existing ConfigMap containing extra env vars                   | `""`   |
-| `extraEnvVarsSecret` | Name of existing Secret containing extra env vars                      | `""`   |
+| Name                      | Description                                                            | Value   |
+| ------------------------- | ---------------------------------------------------------------------- | ------- |
+| `wildflyUsername`         | WildFly username                                                       | `user`  |
+| `wildflyPassword`         | WildFly user password                                                  | `""`    |
+| `exposeManagementConsole` | Allows exposing the WildFly Management console outside the cluster     | `false` |
+| `command`                 | Override default container command (useful when using custom images)   | `[]`    |
+| `args`                    | Override default container args (useful when using custom images)      | `[]`    |
+| `extraEnvVars`            | Array with extra environment variables to add to the WildFly container | `[]`    |
+| `extraEnvVarsCM`          | Name of existing ConfigMap containing extra env vars                   | `""`    |
+| `extraEnvVarsSecret`      | Name of existing Secret containing extra env vars                      | `""`    |
 
 
 ### WildFly deployment parameters
@@ -146,7 +147,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ---------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------ |
 | `service.type`                     | WildFly service type                                                                                  | `LoadBalancer`           |
 | `service.port`                     | WildFly service HTTP port                                                                             | `80`                     |
-| `service.mgmtPort`                 | WildFly service management console port                                                               | `443`                    |
+| `service.mgmtPort`                 | WildFly service management console port                                                               | `9990`                   |
 | `service.nodePorts.http`           | Node port for HTTP                                                                                    | `""`                     |
 | `service.nodePorts.mgmt`           | Node port for Management console                                                                      | `""`                     |
 | `service.clusterIP`                | WildFly service Cluster IP                                                                            | `""`                     |
@@ -154,7 +155,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `service.loadBalancerSourceRanges` | WildFly service Load Balancer sources                                                                 | `[]`                     |
 | `service.externalTrafficPolicy`    | WildFly service external traffic policy                                                               | `Cluster`                |
 | `service.annotations`              | Additional custom annotations for WildFly service                                                     | `{}`                     |
-| `service.extraPorts`               | Extra port to expose on WildFly service                                                               | `[]`                     |
+| `service.extraPorts`               | Extra ports to expose on WildFly service                                                              | `[]`                     |
 | `ingress.enabled`                  | Enable ingress record generation for WildFly                                                          | `false`                  |
 | `ingress.certManager`              | Add the corresponding annotations for cert-manager integration                                        | `false`                  |
 | `ingress.pathType`                 | Ingress path type                                                                                     | `ImplementationSpecific` |
@@ -167,6 +168,16 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ingress.extraPaths`               | An array with additional arbitrary paths that may need to be added to the ingress under the main host | `[]`                     |
 | `ingress.extraTls`                 | TLS configuration for additional hostname(s) to be covered with this ingress record                   | `[]`                     |
 | `ingress.secrets`                  | Custom TLS certificates as secrets                                                                    | `[]`                     |
+| `mgmtIngress.enabled`              | Set to true to enable ingress record generation for the Management console                            | `false`                  |
+| `mgmtIngress.certManager`          | Set this to true in order to add the corresponding annotations for cert-manager                       | `false`                  |
+| `mgmtIngress.pathType`             | Ingress path type                                                                                     | `ImplementationSpecific` |
+| `mgmtIngress.hostname`             | When the Management ingress is enabled, a host pointing to this will be created                       | `management.local`       |
+| `mgmtIngress.annotations`          | Health Ingress annotations                                                                            | `undefined`              |
+| `mgmtIngress.tls`                  | Enable TLS configuration for the hostname defined at `mgmtIngress.hostname` parameter                 | `false`                  |
+| `mgmtIngress.extraHosts`           | The list of additional hostnames to be covered with this Management ingress record                    | `undefined`              |
+| `mgmtIngress.extraPaths`           | An array with additional arbitrary paths that may need to be added to the ingress under the main host | `[]`                     |
+| `mgmtIngress.extraTls`             | TLS configuration for additional hostnames to be covered                                              | `undefined`              |
+| `mgmtIngress.secrets`              | TLS Secret configuration                                                                              | `undefined`              |
 
 
 ### Persistence Parameters

--- a/bitnami/wildfly/ci/values-with-ingress-and-initcontainers.yaml
+++ b/bitnami/wildfly/ci/values-with-ingress-and-initcontainers.yaml
@@ -2,9 +2,14 @@
 # the rendering is correct
 service:
   type: ClusterIP
+exposeManagementConsole: true
 ingress:
   enabled: true
   tls: true
   hostname: wildfly.local
+mgmtIngress:
+  enabled: true
+  tls: true
+  hostname: management.hostname
 volumePermissions:
   enabled: true

--- a/bitnami/wildfly/templates/NOTES.txt
+++ b/bitnami/wildfly/templates/NOTES.txt
@@ -1,7 +1,7 @@
 
 ** Please be patient while the chart is being deployed **
 
-{{- if and .Values.exposeManagementConsole (or (eq "NodePort" .Values.service.type) (eq "NodePort" .Values.service.type) .Values.mgmtIngress.enabled) }}
+{{- if and .Values.exposeManagementConsole (or (eq "NodePort" .Values.service.type) (eq "LoadBalancer" .Values.service.type) .Values.mgmtIngress.enabled) }}
 -------------------------------------------------------------------------------
  WARNING
 
@@ -13,14 +13,16 @@
 -------------------------------------------------------------------------------
 {{- end }}
 
-{{- if or .Values.ingress.enabled .Values.mgmtIngress.enabled }}
+{{- if or .Values.ingress.enabled (and .Values.mgmtIngress.enabled .Values.exposeManagementConsole) }}
 
 1. Get the Wildfly URL and associate its hostname to your cluster external IP:
 
    export CLUSTER_IP=$(minikube ip) # On Minikube. Use: `kubectl cluster-info` on others K8s clusters
+   {{- if .Values.ingress.enabled }}
    echo "Wildfly URL: http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.hostname }}"
    echo "$CLUSTER_IP  {{ .Values.ingress.hostname }}" | sudo tee -a /etc/hosts
-   {{- if .Values.exposeManagementConsole }}
+   {{- end }}
+   {{- if and .Values.mgmtIngress.enabled .Values.exposeManagementConsole }}
    echo "Wildfly Management URL: http{{ if .Values.mgmtIngress.tls }}s{{ end }}://{{ .Values.mgmtIngress.hostname }}"
    echo "$CLUSTER_IP  {{ .Values.mgmtIngress.hostname }}" | sudo tee -a /etc/hosts
    {{- end }}

--- a/bitnami/wildfly/templates/NOTES.txt
+++ b/bitnami/wildfly/templates/NOTES.txt
@@ -1,13 +1,29 @@
 
 ** Please be patient while the chart is being deployed **
 
-{{- if .Values.ingress.enabled }}
+{{- if and .Values.exposeManagementConsole (or (eq "NodePort" .Values.service.type) (eq "NodePort" .Values.service.type) .Values.mgmtIngress.enabled) }}
+-------------------------------------------------------------------------------
+ WARNING
+
+    By specifying "exposeManagementConsole=true" you have most likely exposed
+    the WildFly Management console externally.
+
+    Please note this is not recommended for production environments since
+    you are exposing your WildFly server to potential attacks.
+-------------------------------------------------------------------------------
+{{- end }}
+
+{{- if or .Values.ingress.enabled .Values.mgmtIngress.enabled }}
 
 1. Get the Wildfly URL and associate its hostname to your cluster external IP:
 
    export CLUSTER_IP=$(minikube ip) # On Minikube. Use: `kubectl cluster-info` on others K8s clusters
    echo "Wildfly URL: http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.hostname }}"
    echo "$CLUSTER_IP  {{ .Values.ingress.hostname }}" | sudo tee -a /etc/hosts
+   {{- if .Values.exposeManagementConsole }}
+   echo "Wildfly Management URL: http{{ if .Values.mgmtIngress.tls }}s{{ end }}://{{ .Values.mgmtIngress.hostname }}"
+   echo "$CLUSTER_IP  {{ .Values.mgmtIngress.hostname }}" | sudo tee -a /etc/hosts
+   {{- end }}
 
 {{- else }}
 
@@ -16,10 +32,12 @@
 {{- if contains "NodePort" .Values.service.type }}
 
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "common.names.fullname" . }})
-  export NODE_MGMT_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[1].nodePort}" services {{ template "common.names.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo "WildFly URL:            http://$NODE_IP:$NODE_PORT"
+  {{- if .Values.exposeManagementConsole }}
+  export NODE_MGMT_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[1].nodePort}" services {{ template "common.names.fullname" . }})
   echo "WildFly Management URL: http://$NODE_IP:$NODE_MGMT_PORT"
+  {{- end }}
 
 {{- else if contains "LoadBalancer" .Values.service.type }}
 
@@ -28,9 +46,11 @@
 
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   {{- $port:=.Values.service.port | toString }}
-  {{- $mgmtPort:=.Values.service.mgmtPort | toString }}
   echo "WildFly URL:            http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}/
+  {{- if .Values.exposeManagementConsole }}
+  {{- $mgmtPort:=.Values.service.mgmtPort | toString }}
   echo "WildFly Management URL: http://$SERVICE_IP{{- if ne $mgmtPort "80" }}:{{ .Values.service.mgmtPort }}{{ end }}/
+  {{- end }}
 
 {{- else if contains "ClusterIP"  .Values.service.type }}
 

--- a/bitnami/wildfly/templates/deployment.yaml
+++ b/bitnami/wildfly/templates/deployment.yaml
@@ -87,6 +87,8 @@ spec:
           args: {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 12 }}
           {{- end }}
           env:
+            - name: BITNAMI_DEBUG
+              value: {{ ternary "true" "false" .Values.image.debug | quote }}
             - name: WILDFLY_USERNAME
               value: {{ default "" .Values.wildflyUsername | quote }}
             - name: WILDFLY_PASSWORD
@@ -94,8 +96,14 @@ spec:
                 secretKeyRef:
                   name: {{ template "common.names.fullname" . }}
                   key: wildfly-password
+            - name: WILDFLY_HTTP_PORT_NUMBER
+              value: {{ .Values.containerPorts.http | quote }}
+            - name: WILDFLY_MANAGEMENT_PORT_NUMBER
+              value: {{ .Values.containerPorts.mgmt | quote }}
+            - name: WILDFLY_SERVER_LISTEN_ADDRESS
+              value: "0.0.0.0"
             - name: WILDFLY_MANAGEMENT_LISTEN_ADDRESS
-              value: 0.0.0.0
+              value: {{ ternary "0.0.0.0" "127.0.0.1" .Values.exposeManagementConsole | quote }}
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/bitnami/wildfly/templates/management-ingress.yaml
+++ b/bitnami/wildfly/templates/management-ingress.yaml
@@ -1,0 +1,62 @@
+{{- if and .Values.exposeManagementConsole .Values.mgmtIngress.enabled }}
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
+kind: Ingress
+metadata:
+  name: {{ printf "%s-%s" (include "common.names.fullname" .) "management" }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.mgmtIngress.annotations .Values.commonAnnotations .Values.mgmtIngress.certManager }}
+  annotations:
+    {{- if .Values.mgmtIngress.certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- if .Values.mgmtIngress.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.mgmtIngress.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  rules:
+    {{- if .Values.mgmtIngress.hostname }}
+    - host: {{ .Values.mgmtIngress.hostname | quote }}
+      http:
+        paths:
+          {{- if .Values.mgmtIngress.extraPaths }}
+          {{- toYaml .Values.mgmtIngress.extraPaths | nindent 10 }}
+          {{- end }}
+          - path: {{ .Values.mgmtIngress.path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.mgmtIngress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "mgmt" "context" $)  | nindent 14 }}
+    {{- end }}
+    {{- range .Values.mgmtIngress.extraHosts }}
+    - host: {{ .name | quote }}
+      http:
+        paths:
+          - path: {{ default "/" .path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
+            pathType: {{ default "ImplementationSpecific" .pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "mgmt" "context" $) | nindent 14 }}
+    {{- end }}
+  {{- if or .Values.mgmtIngress.tls .Values.mgmtIngress.extraTls }}
+  tls:
+    {{- if .Values.mgmtIngress.tls }}
+    - hosts:
+        - {{ .Values.mgmtIngress.hostname | quote }}
+        {{- range .Values.mgmtIngress.extraHosts }}
+        - {{ .name | quote }}
+        {{- end }}
+      secretName: {{ printf "%s-tls" .Values.mgmtIngress.hostname }}
+    {{- end }}
+    {{- if .Values.mgmtIngress.extraTls }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.mgmtIngress.extraTls "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/bitnami/wildfly/templates/svc.yaml
+++ b/bitnami/wildfly/templates/svc.yaml
@@ -39,6 +39,7 @@ spec:
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    {{- if or (eq .Values.service.type "ClusterIP") .Values.exposeManagementConsole }}
     - name: mgmt
       port: {{ .Values.service.mgmtPort}}
       targetPort: mgmt
@@ -47,4 +48,5 @@ spec:
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/wildfly/templates/tls-secrets.yaml
+++ b/bitnami/wildfly/templates/tls-secrets.yaml
@@ -1,6 +1,27 @@
-{{- if .Values.ingress.enabled }}
+{{- if or .Values.ingress.enabled .Values.mgmtIngress.enabled }}
 {{- if .Values.ingress.secrets }}
 {{- range .Values.ingress.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  namespace: {{ $.Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
+    {{- if $.Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" $.Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if $.Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .certificate | b64enc }}
+  tls.key: {{ .key | b64enc }}
+---
+{{- end }}
+{{- end }}
+{{- if .Values.mgmtIngress.secrets }}
+{{- range .Values.mgmtIngress.secrets }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -27,6 +48,27 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-tls" .Values.ingress.hostname }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $cert.Cert | b64enc | quote }}
+  tls.key: {{ $cert.Key | b64enc | quote }}
+  ca.crt: {{ $ca.Cert | b64enc | quote }}
+{{- end }}
+{{- if and .Values.mgmtIngress.tls (not .Values.mgmtIngress.certManager) }}
+{{- $ca := genCA "wildfly-ca" 365 }}
+{{- $cert := genSignedCert .Values.mgmtIngress.hostname nil (list .Values.mgmtIngress.hostname) 365 $ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-tls" .Values.mgmtIngress.hostname }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/bitnami/wildfly/values.yaml
+++ b/bitnami/wildfly/values.yaml
@@ -4,7 +4,7 @@
 ## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
 
 ## @param global.imageRegistry Global Docker image registry
-## @param global.imagePullSecrets Global Docker registry secret names as an array
+## @param global.imagePullSecrets [array] Global Docker registry secret names as an array
 ## @param global.storageClass Global StorageClass for Persistent Volume(s)
 ##
 global:
@@ -27,16 +27,16 @@ nameOverride: ""
 ## @param fullnameOverride String to fully override common.names.fullname
 ##
 fullnameOverride: ""
-## @param commonLabels Labels to add to all deployed objects
+## @param commonLabels [object] Labels to add to all deployed objects
 ##
 commonLabels: {}
-## @param commonAnnotations Annotations to add to all deployed objects
+## @param commonAnnotations [object] Annotations to add to all deployed objects
 ##
 commonAnnotations: {}
 ## @param clusterDomain Kubernetes cluster domain name
 ##
 clusterDomain: cluster.local
-## @param extraDeploy Array of extra objects to deploy with the release
+## @param extraDeploy [array] Array of extra objects to deploy with the release
 ##
 extraDeploy: []
 
@@ -48,7 +48,7 @@ extraDeploy: []
 ## @param image.repository WildFly image repository
 ## @param image.tag WildFly image tag (immutable tags are recommended)
 ## @param image.pullPolicy WildFly image pull policy
-## @param image.pullSecrets WildFly image pull secrets
+## @param image.pullSecrets [array] WildFly image pull secrets
 ## @param image.debug Enable image debug mode
 ##
 image:
@@ -83,13 +83,16 @@ wildflyUsername: user
 ## Defaults to a random 10-character alphanumeric string if not set
 ##
 wildflyPassword: ""
-## @param command Override default container command (useful when using custom images)
+## @param exposeManagementConsole Allows exposing the WildFly Management console outside the cluster
+##
+exposeManagementConsole: false
+## @param command [array] Override default container command (useful when using custom images)
 ##
 command: []
-## @param args Override default container args (useful when using custom images)
+## @param args [array] Override default container args (useful when using custom images)
 ##
 args: []
-## @param extraEnvVars Array with extra environment variables to add to the WildFly container
+## @param extraEnvVars [array] Array with extra environment variables to add to the WildFly container
 ## e.g:
 ## extraEnvVars:
 ##   - name: FOO
@@ -124,13 +127,13 @@ updateStrategy:
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
 hostAliases: []
-## @param extraVolumes Optionally specify extra list of additional volumes for WildFly pods
+## @param extraVolumes [array] Optionally specify extra list of additional volumes for WildFly pods
 ##
 extraVolumes: []
-## @param extraVolumeMounts Optionally specify extra list of additional volumeMounts for WildFly container(s)
+## @param extraVolumeMounts [array] Optionally specify extra list of additional volumeMounts for WildFly container(s)
 ##
 extraVolumeMounts: []
-## @param sidecars Add additional sidecar containers to the WildFly pod
+## @param sidecars [array] Add additional sidecar containers to the WildFly pod
 ## e.g:
 ## sidecars:
 ##   - name: your-image-name
@@ -141,7 +144,7 @@ extraVolumeMounts: []
 ##         containerPort: 1234
 ##
 sidecars: []
-## @param initContainers Add additional init containers to the WildFly pods
+## @param initContainers [array] Add additional init containers to the WildFly pods
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 ## e.g:
 ## initContainers:
@@ -153,11 +156,11 @@ sidecars: []
 ##        containerPort: 1234
 ##
 initContainers: []
-## @param podLabels Extra labels for WildFly pods
+## @param podLabels [object] Extra labels for WildFly pods
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ##
 podLabels: {}
-## @param podAnnotations Annotations for WildFly pods
+## @param podAnnotations [object] Annotations for WildFly pods
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 ##
 podAnnotations: {}
@@ -179,29 +182,29 @@ nodeAffinityPreset:
   ## @param nodeAffinityPreset.key Node label key to match. Ignored if `affinity` is set
   ##
   key: ""
-  ## @param nodeAffinityPreset.values Node label values to match. Ignored if `affinity` is set
+  ## @param nodeAffinityPreset.values [array] Node label values to match. Ignored if `affinity` is set
   ## E.g.
   ## values:
   ##   - e2e-az1
   ##   - e2e-az2
   ##
   values: []
-## @param affinity Affinity for pod assignment
+## @param affinity [object] Affinity for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 ## NOTE: podAffinityPreset, podAntiAffinityPreset, and  nodeAffinityPreset will be ignored when it's set
 ##
 affinity: {}
-## @param nodeSelector Node labels for pod assignment
+## @param nodeSelector [object] Node labels for pod assignment
 ## ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##
 nodeSelector: {}
-## @param tolerations Tolerations for pod assignment
+## @param tolerations [object] Tolerations for pod assignment
 ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
 tolerations: {}
 ## WildFly containers' resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-## @param resources.limits The resources limits for the WildFly container
+## @param resources.limits [object] The resources limits for the WildFly container
 ## @param resources.requests [object] The requested resources for the WildFly container
 ##
 resources:
@@ -272,10 +275,10 @@ readinessProbe:
   timeoutSeconds: 3
   failureThreshold: 3
   successThreshold: 1
-## @param customLivenessProbe Custom livenessProbe that overrides the default one
+## @param customLivenessProbe [object] Custom livenessProbe that overrides the default one
 ##
 customLivenessProbe: {}
-## @param customReadinessProbe Custom readinessProbe that overrides the default one
+## @param customReadinessProbe [object] Custom readinessProbe that overrides the default one
 ##
 customReadinessProbe: {}
 
@@ -292,7 +295,7 @@ service:
   port: 80
   ## @param service.mgmtPort WildFly service management console port
   ##
-  mgmtPort: 443
+  mgmtPort: 9990
   ## Node ports to expose
   ## @param service.nodePorts.http Node port for HTTP
   ## @param service.nodePorts.mgmt Node port for Management console
@@ -310,7 +313,7 @@ service:
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
   ##
   loadBalancerIP: ""
-  ## @param service.loadBalancerSourceRanges WildFly service Load Balancer sources
+  ## @param service.loadBalancerSourceRanges [array] WildFly service Load Balancer sources
   ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
   ## e.g:
   ## loadBalancerSourceRanges:
@@ -321,10 +324,10 @@ service:
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   ##
   externalTrafficPolicy: Cluster
-  ## @param service.annotations Additional custom annotations for WildFly service
+  ## @param service.annotations [object] Additional custom annotations for WildFly service
   ##
   annotations: {}
-  ## @param service.extraPorts Extra port to expose on WildFly service
+  ## @param service.extraPorts [array] Extra ports to expose on WildFly service
   ##
   extraPorts: []
 ## Configure the ingress resource that allows you to access the WildFly installation
@@ -350,10 +353,11 @@ ingress:
   ## NOTE: You may need to set this to '/*' in order to use this with ALB ingress controllers
   ##
   path: /
-  ## @param ingress.annotations Additional custom annotations for the ingress record
+  ## @param ingress.annotations [object] Additional custom annotations for the ingress record
   ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
   ##
-  annotations: {}
+  annotations:
+    kubernetes.io/ingress.class: nginx
   ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
   ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
   ## You can:
@@ -362,14 +366,14 @@ ingress:
   ##   - Relay on Helm to create self-signed certificates by setting `ingress.tls=true` and `ingress.certManager=false`
   ##
   tls: false
-  ## @param ingress.extraHosts An array with additional hostname(s) to be covered with the ingress record
+  ## @param ingress.extraHosts [array] An array with additional hostname(s) to be covered with the ingress record
   ## e.g:
   ## extraHosts:
   ##   - name: wildfly.local
   ##     path: /
   ##
   extraHosts: []
-  ## @param ingress.extraPaths An array with additional arbitrary paths that may need to be added to the ingress under the main host
+  ## @param ingress.extraPaths [array] An array with additional arbitrary paths that may need to be added to the ingress under the main host
   ## e.g:
   ## extraPaths:
   ## - path: /*
@@ -378,7 +382,7 @@ ingress:
   ##     servicePort: use-annotation
   ##
   extraPaths: []
-  ## @param ingress.extraTls TLS configuration for additional hostname(s) to be covered with this ingress record
+  ## @param ingress.extraTls [array] TLS configuration for additional hostname(s) to be covered with this ingress record
   ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
   ## e.g:
   ## extraTls:
@@ -387,7 +391,7 @@ ingress:
   ##   secretName: wildfly.local-tls
   ##
   extraTls: []
-  ## @param ingress.secrets Custom TLS certificates as secrets
+  ## @param ingress.secrets [array] Custom TLS certificates as secrets
   ## NOTE: 'key' and 'certificate' are expected in PEM format
   ## NOTE: 'name' should line up with a 'secretName' set further up
   ## If it is not set and you're using cert-manager, this is unneeded, as it will create a secret for you with valid certificates
@@ -405,6 +409,77 @@ ingress:
   ##       -----BEGIN CERTIFICATE-----
   ##       ...
   ##       -----END CERTIFICATE-----
+  ##
+  secrets: []
+## Management Console Ingress parameters
+##
+mgmtIngress:
+  ## @param mgmtIngress.enabled Set to true to enable ingress record generation for the Management console
+  ##
+  enabled: false
+  ## @param mgmtIngress.certManager Set this to true in order to add the corresponding annotations for cert-manager
+  ##
+  certManager: false
+  ## @param mgmtIngress.pathType Ingress path type
+  ##
+  pathType: ImplementationSpecific
+  ## @param mgmtIngress.hostname When the Management ingress is enabled, a host pointing to this will be created
+  ##
+  hostname: management.local
+  ## @param mgmtIngress.annotations Health Ingress annotations
+  ## For a full list of possible ingress annotations, please see
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ##
+  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+  ##
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  ## @param mgmtIngress.tls Enable TLS configuration for the hostname defined at `mgmtIngress.hostname` parameter
+  ## TLS certificates will be retrieved from a TLS secret with name: {{- printf "%s-tls" .Values.mgmtIngress.hostname }}
+  ## You can use the mgmtIngress.secrets parameter to create this TLS secret, relay on cert-manager to create it, or
+  ## let the chart create self-signed certificates for you
+  ##
+  tls: false
+  ## @param mgmtIngress.extraHosts The list of additional hostnames to be covered with this Management ingress record
+  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+  ## E.g.
+  ## extraHosts:
+  ##   - name: management.local
+  ##     path: /
+  ##
+  extraHosts: []
+  ## @param mgmtIngress.extraPaths [array] An array with additional arbitrary paths that may need to be added to the ingress under the main host
+  ## e.g:
+  ## extraPaths:
+  ## - path: /*
+  ##   backend:
+  ##     serviceName: ssl-redirect
+  ##     servicePort: use-annotation
+  ##
+  extraPaths: []
+  ## @param mgmtIngress.extraTls TLS configuration for additional hostnames to be covered
+  ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## E.g.
+  ## extraTls:
+  ##   - hosts:
+  ##       - management.local
+  ##     secretName: management.local-tls
+  ##
+  extraTls: []
+  ## @param mgmtIngress.secrets TLS Secret configuration
+  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or -----BEGIN RSA PRIVATE KEY-----
+  ## name should line up with a secretName set further up
+  ## If it is not set and you're using cert-manager, this is unneeded, as it will create the secret for you
+  ## If it is not set and you're NOT using cert-manager either, self-signed certificates will be created
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  ##
+  ## E.g.
+  ## secrets:
+  ##   - name: management.local-tls
+  ##     key:
+  ##     certificate:
   ##
   secrets: []
 
@@ -444,7 +519,7 @@ volumePermissions:
   ## @param volumePermissions.image.repository Bitnami Shell image repository
   ## @param volumePermissions.image.tag Bitnami Shell image tag (immutable tags are recommended)
   ## @param volumePermissions.image.pullPolicy Bitnami Shell image pull policy
-  ## @param volumePermissions.image.pullSecrets Bitnami Shell image pull secrets
+  ## @param volumePermissions.image.pullSecrets [array] Bitnami Shell image pull secrets
   ##
   image:
     registry: docker.io
@@ -461,8 +536,8 @@ volumePermissions:
     pullSecrets: []
   ## Init container's resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-  ## @param volumePermissions.resources.limits The resources limits for the init container
-  ## @param volumePermissions.resources.requests The requested resources for the init container
+  ## @param volumePermissions.resources.limits [object] The resources limits for the init container
+  ## @param volumePermissions.resources.requests [object] The requested resources for the init container
   ##
   resources:
     limits: {}

--- a/bitnami/wildfly/values.yaml
+++ b/bitnami/wildfly/values.yaml
@@ -356,8 +356,7 @@ ingress:
   ## @param ingress.annotations [object] Additional custom annotations for the ingress record
   ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
   ##
-  annotations:
-    kubernetes.io/ingress.class: nginx
+  annotations: {}
   ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
   ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
   ## You can:
@@ -432,8 +431,7 @@ mgmtIngress:
   ##
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
   ##
-  annotations:
-    kubernetes.io/ingress.class: nginx
+  annotations: {}
   ## @param mgmtIngress.tls Enable TLS configuration for the hostname defined at `mgmtIngress.hostname` parameter
   ## TLS certificates will be retrieved from a TLS secret with name: {{- printf "%s-tls" .Values.mgmtIngress.hostname }}
   ## You can use the mgmtIngress.secrets parameter to create this TLS secret, relay on cert-manager to create it, or


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR introduces new parameters to properly manage exposing the WildFly management console outside the cluster.

**Benefits**

Users can properly expose the management console when required.

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/6911

**Additional information**

You can test it using a **values.yaml** like the one below:

```yaml
exposeManagementConsole: true
ingress:
  enabled: true
  hostname: my.wildfly.hostname
mgmtIngress:
  enabled: true
  hostname: my.mgmt.hostname
service:
  type: ClusterIP
```

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
