### PR TITLE
[bitnami/contour] Bump envoy version bundled in contour Helm Chart

### DIFF
--- a/bitnami/contour/Chart.lock
+++ b/bitnami/contour/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.7.1
-digest: sha256:d05549cd2eb5b99a49655221b8efd09927cc48daca3fa9f19af0257a11e5260f
-generated: "2021-08-02T17:24:22.28379482Z"
+  version: 1.8.0
+digest: sha256:3e342a25057f87853e52d83e1d14e6d8727c15fd85aaae22e7594489cc129f15
+generated: "2021-08-24T10:33:16.039179437Z"

--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/bitnami-docker-contour
   - https://projectcontour.io
-version: 5.1.0
+version: 5.2.0

--- a/bitnami/contour/README.md
+++ b/bitnami/contour/README.md
@@ -403,6 +403,10 @@ Find more information about how to deal with common errors related to Bitnami’
 
 Please carefully read through the guide "Upgrading Contour" at https://projectcontour.io/resources/upgrading/.
 
+### To 5.2.0
+
+This version bumps the Envoy container from 1.17.X to 1.19.X; this Envoy version is officially supported by Contour since 1.18.0, see https://github.com/projectcontour/contour/releases/tag/v1.18.0
+
 ### To 5.0.0
 
 In this version it was synchronized CRD with the official [Contour repository](https://github.com/projectcontour/contour/blob/main/examples/render/contour.yaml)

--- a/bitnami/contour/values.yaml
+++ b/bitnami/contour/values.yaml
@@ -145,7 +145,7 @@ contour:
   image:
     registry: docker.io
     repository: bitnami/contour
-    tag: 1.18.0-debian-10-r5
+    tag: 1.18.0-debian-10-r27
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -353,7 +353,7 @@ envoy:
   image:
     registry: docker.io
     repository: bitnami/envoy
-    tag: 1.17.3-debian-10-r71
+    tag: 1.19.0-debian-10-r14
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -621,7 +621,7 @@ defaultBackend:
   image:
     registry: docker.io
     repository: bitnami/nginx
-    tag: 1.21.1-debian-10-r23
+    tag: 1.21.1-debian-10-r44
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <carlosrh@vmware.com>

**Description of the change**

The new Contour version (https://github.com/projectcontour/contour/releases/tag/v1.18.0) support Envoy 1.19, see

> **Envoy Updated to 1.19.0**
> Contour 1.18.0 is compatible with Envoy 1.19.0. For more information, see the Contour compatibility matrix.
> Relevant PRs:
>  [#3887](https://github.com/projectcontour/contour/pull/3887) : update Envoy to 1.19.0