### PR TITLE
[bitnami/etcd] Add support for custom terminationGracePeriodSeconds

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -25,4 +25,4 @@ name: etcd
 sources:
   - https://github.com/bitnami/bitnami-docker-etcd
   - https://coreos.com/etcd/
-version: 6.5.0
+version: 6.6.0

--- a/bitnami/etcd/README.md
+++ b/bitnami/etcd/README.md
@@ -167,6 +167,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `affinity`                              | Affinity for pod assignment                                                               | `{}`            |
 | `nodeSelector`                          | Node labels for pod assignment                                                            | `{}`            |
 | `tolerations`                           | Tolerations for pod assignment                                                            | `[]`            |
+| `terminationGracePeriodSeconds`         | Seconds the pod needs to gracefully terminate                                             | `""`            |
 | `priorityClassName`                     | Name of the priority class to be used by etcd pods                                        | `""`            |
 
 

--- a/bitnami/etcd/templates/statefulset.yaml
+++ b/bitnami/etcd/templates/statefulset.yaml
@@ -49,6 +49,9 @@ spec:
       {{- if .Values.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}

--- a/bitnami/etcd/values.yaml
+++ b/bitnami/etcd/values.yaml
@@ -4,7 +4,7 @@
 ## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
 
 ## @param global.imageRegistry Global Docker image registry
-## @param global.imagePullSecrets Global Docker registry secret names as an array
+## @param global.imagePullSecrets [array] Global Docker registry secret names as an array
 ## @param global.storageClass Global StorageClass for Persistent Volume(s)
 ##
 global:
@@ -27,16 +27,16 @@ nameOverride: ""
 ## @param fullnameOverride String to fully override common.names.fullname template
 ##
 fullnameOverride: ""
-## @param commonLabels Labels to add to all deployed objects
+## @param commonLabels [object] Labels to add to all deployed objects
 ##
 commonLabels: {}
-## @param commonAnnotations Annotations to add to all deployed objects
+## @param commonAnnotations [object] Annotations to add to all deployed objects
 ##
 commonAnnotations: {}
 ## @param clusterDomain Default Kubernetes cluster domain
 ##
 clusterDomain: cluster.local
-## @param extraDeploy Array of extra objects to deploy with the release
+## @param extraDeploy [array] Array of extra objects to deploy with the release
 ##
 extraDeploy: []
 
@@ -63,7 +63,7 @@ diagnosticMode:
 ## @param image.repository etcd image name
 ## @param image.tag etcd image tag
 ## @param image.pullPolicy etcd image pull policy
-## @param image.pullSecrets etcd image pull secrets
+## @param image.pullSecrets [array] etcd image pull secrets
 ## @param image.debug Enable image debug mode
 ##
 image:
@@ -195,7 +195,7 @@ configuration: ""
 ## NOTE: When it's set the configuration parameter is ignored
 ##
 existingConfigmap: ""
-## @param extraEnvVars Extra environment variables to be set on etcd container
+## @param extraEnvVars [array] Extra environment variables to be set on etcd container
 ## e.g:
 ## extraEnvVars:
 ##   - name: FOO
@@ -208,10 +208,10 @@ extraEnvVarsCM: ""
 ## @param extraEnvVarsSecret Name of existing Secret containing extra env vars
 ##
 extraEnvVarsSecret: ""
-## @param command Default container command (useful when using custom images)
+## @param command [array] Default container command (useful when using custom images)
 ##
 command: []
-## @param args Default container args (useful when using custom images)
+## @param args [array] Default container args (useful when using custom images)
 ##
 args: []
 
@@ -230,11 +230,11 @@ updateStrategy:
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
 ##
 podManagementPolicy: Parallel
-## @param hostAliases etcd pod host aliases
+## @param hostAliases [array] etcd pod host aliases
 ## ref: https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
 hostAliases: []
-## @param lifecycleHooks Override default etcd container hooks
+## @param lifecycleHooks [object] Override default etcd container hooks
 ##
 lifecycleHooks: {}
 ## etcd container ports to open
@@ -268,8 +268,8 @@ containerSecurityContext:
 ## choice for the user. This also increases chances charts run on environments with little
 ## resources, such as Minikube. If you do want to specify resources, uncomment the following
 ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-## @param resources.limits The resources limits for the etcd container
-## @param resources.requests The requested resources for the etcd container
+## @param resources.limits [object] The resources limits for the etcd container
+## @param resources.requests [object] The requested resources for the etcd container
 ##
 resources:
   ## Example:
@@ -326,22 +326,22 @@ startupProbe:
   timeoutSeconds: 5
   successThreshold: 1
   failureThreshold: 60
-## @param customLivenessProbe Override default liveness probe
+## @param customLivenessProbe [object] Override default liveness probe
 ##
 customLivenessProbe: {}
-## @param customReadinessProbe Override default readiness probe
+## @param customReadinessProbe [object] Override default readiness probe
 ##
 customReadinessProbe: {}
-## @param customStartupProbe Override default startup probe
+## @param customStartupProbe [object] Override default startup probe
 ##
 customStartupProbe: {}
-## @param extraVolumes Optionally specify extra list of additional volumes for etcd pods
+## @param extraVolumes [array] Optionally specify extra list of additional volumes for etcd pods
 ##
 extraVolumes: []
-## @param extraVolumeMounts Optionally specify extra list of additional volumeMounts for etcd container(s)
+## @param extraVolumeMounts [array] Optionally specify extra list of additional volumeMounts for etcd container(s)
 ##
 extraVolumeMounts: []
-## @param initContainers Add additional init containers to the etcd pods
+## @param initContainers [array] Add additional init containers to the etcd pods
 ## e.g:
 ## initContainers:
 ##   - name: your-image-name
@@ -352,7 +352,7 @@ extraVolumeMounts: []
 ##         containerPort: 1234
 ##
 initContainers: []
-## @param sidecars Add additional sidecar containers to the etcd pods
+## @param sidecars [array] Add additional sidecar containers to the etcd pods
 ## e.g:
 ## sidecars:
 ##   - name: your-image-name
@@ -363,11 +363,11 @@ initContainers: []
 ##         containerPort: 1234
 ##
 sidecars: []
-## @param podAnnotations Annotations for etcd pods
+## @param podAnnotations [object] Annotations for etcd pods
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 ##
 podAnnotations: {}
-## @param podLabels Extra labels for etcd pods
+## @param podLabels [object] Extra labels for etcd pods
 ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ##
 podLabels: {}
@@ -383,7 +383,7 @@ podAntiAffinityPreset: soft
 ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
 ## @param nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
 ## @param nodeAffinityPreset.key Node label key to match. Ignored if `affinity` is set.
-## @param nodeAffinityPreset.values Node label values to match. Ignored if `affinity` is set.
+## @param nodeAffinityPreset.values [array] Node label values to match. Ignored if `affinity` is set.
 ##
 nodeAffinityPreset:
   type: ""
@@ -397,19 +397,23 @@ nodeAffinityPreset:
   ##   - e2e-az2
   ##
   values: []
-## @param affinity Affinity for pod assignment
+## @param affinity [object] Affinity for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 ## Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
 ##
 affinity: {}
-## @param nodeSelector Node labels for pod assignment
+## @param nodeSelector [object] Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##
 nodeSelector: {}
-## @param tolerations Tolerations for pod assignment
+## @param tolerations [array] Tolerations for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
 tolerations: []
+## @param terminationGracePeriodSeconds Seconds the pod needs to gracefully terminate
+## ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution
+##
+terminationGracePeriodSeconds: ""
 ## @param priorityClassName Name of the priority class to be used by etcd pods
 ## Priority class needs to be created beforehand
 ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
@@ -444,18 +448,18 @@ service:
   ## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
   ##
   loadBalancerIP: ""
-  ## @param service.loadBalancerSourceRanges Load Balancer source ranges
+  ## @param service.loadBalancerSourceRanges [array] Load Balancer source ranges
   ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
   ## e.g:
   ## loadBalancerSourceRanges:
   ##   - 10.10.10.0/24
   ##
   loadBalancerSourceRanges: []
-  ## @param service.externalIPs External IPs
+  ## @param service.externalIPs [array] External IPs
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips
   ##
   externalIPs: []
-  ## @param service.annotations Additional annotations for the etcd service
+  ## @param service.annotations [object] Additional annotations for the etcd service
   ##
   annotations: {}
 
@@ -477,7 +481,7 @@ persistence:
   ##
   storageClass: ""
   ##
-  ## @param persistence.annotations Annotations for the PVC
+  ## @param persistence.annotations [object] Annotations for the PVC
   ##
   annotations: {}
   ## @param persistence.accessModes Persistent Volume Access Modes
@@ -487,7 +491,7 @@ persistence:
   ## @param persistence.size PVC Storage Request for etcd data volume
   ##
   size: 8Gi
-  ## @param persistence.selector Selector to match an existing Persistent Volume
+  ## @param persistence.selector [object] Selector to match an existing Persistent Volume
   ## ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#selector
   ##
   selector: {}
@@ -505,7 +509,7 @@ volumePermissions:
   ## @param volumePermissions.image.repository Init container volume-permissions image name
   ## @param volumePermissions.image.tag Init container volume-permissions image tag
   ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
-  ## @param volumePermissions.image.pullSecrets Specify docker-registry secret names as an array
+  ## @param volumePermissions.image.pullSecrets [array] Specify docker-registry secret names as an array
   ##
   image:
     registry: docker.io
@@ -526,8 +530,8 @@ volumePermissions:
   ## choice for the user. This also increases chances charts run on environments with little
   ## resources, such as Minikube. If you do want to specify resources, uncomment the following
   ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  ## @param volumePermissions.resources.limits Init container volume-permissions resource  limits
-  ## @param volumePermissions.resources.requests Init container volume-permissions resource  requests
+  ## @param volumePermissions.resources.limits [object] Init container volume-permissions resource  limits
+  ## @param volumePermissions.resources.requests [object] Init container volume-permissions resource  requests
   ##
   resources:
     ## Example:
@@ -550,7 +554,7 @@ networkPolicy:
   ## (with the correct destination port).
   ##
   allowExternal: true
-  ## @param networkPolicy.extraIngress Add extra ingress rules to the NetworkPolicy
+  ## @param networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolicy
   ## e.g:
   ## extraIngress:
   ##   - ports:
@@ -567,7 +571,7 @@ networkPolicy:
   ##                   - frontend
   ##
   extraIngress: []
-  ## @param networkPolicy.extraEgress Add extra ingress rules to the NetworkPolicy
+  ## @param networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
   ## e.g:
   ## extraEgress:
   ##   - ports:
@@ -584,8 +588,8 @@ networkPolicy:
   ##                   - frontend
   ##
   extraEgress: []
-  ## @param networkPolicy.ingressNSMatchLabels Labels to match to allow traffic from other namespaces
-  ## @param networkPolicy.ingressNSPodMatchLabels Pod labels to match to allow traffic from other namespaces
+  ## @param networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
+  ## @param networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
   ##
   ingressNSMatchLabels: {}
   ingressNSPodMatchLabels: {}
@@ -617,14 +621,14 @@ metrics:
     ## @param metrics.podMonitor.scrapeTimeout Specify the timeout after which the scrape is ended
     ##
     scrapeTimeout: 30s
-    ## @param metrics.podMonitor.additionalLabels Additional labels that can be used so PodMonitors will be discovered by Prometheus
+    ## @param metrics.podMonitor.additionalLabels [object] Additional labels that can be used so PodMonitors will be discovered by Prometheus
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
     ##
     additionalLabels: {}
     ## @param metrics.podMonitor.scheme Scheme to use for scraping
     ##
     scheme: http
-    ## @param metrics.podMonitor.tlsConfig TLS configuration used for scrape endpoints used by Prometheus
+    ## @param metrics.podMonitor.tlsConfig [object] TLS configuration used for scrape endpoints used by Prometheus
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#tlsconfig
     ## e.g:
     ## tlsConfig:
@@ -669,7 +673,7 @@ disasterRecovery:
     ## @param disasterRecovery.cronjob.snapshotHistoryLimit Number of etcd snapshots to retain, tagged by date
     ##
     snapshotHistoryLimit: 1
-    ## @param disasterRecovery.cronjob.podAnnotations Pod annotations for cronjob pods
+    ## @param disasterRecovery.cronjob.podAnnotations [object] Pod annotations for cronjob pods
     ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
     ##
     podAnnotations: {}
@@ -679,8 +683,8 @@ disasterRecovery:
     ## choice for the user. This also increases chances charts run on environments with little
     ## resources, such as Minikube. If you do want to specify resources, uncomment the following
     ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    ## @param disasterRecovery.cronjob.resources.limits Cronjob container resource limits
-    ## @param disasterRecovery.cronjob.resources.requests Cronjob container resource requests
+    ## @param disasterRecovery.cronjob.resources.limits [object] Cronjob container resource limits
+    ## @param disasterRecovery.cronjob.resources.requests [object] Cronjob container resource requests
     ##
     resources:
       ## Example:
@@ -715,10 +719,10 @@ serviceAccount:
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server
   ##
   automountServiceAccountToken: true
-  ## @param serviceAccount.annotations Additional annotations to be included on the service account
+  ## @param serviceAccount.annotations [object] Additional annotations to be included on the service account
   ##
   annotations: {}
-  ## @param serviceAccount.labels Additional labels to be included on the service account
+  ## @param serviceAccount.labels [object] Additional labels to be included on the service account
   ##
   labels: {}
 


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR adds a new parameter **terminationGracePeriodSeconds** so this property can be easily customized.

**Benefits**

Flexibility

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
