### PR TITLE
[bitnami/redis]: hotfix, regenerate sentinel config at each boot-up

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -25,4 +25,4 @@ name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 15.0.3
+version: 15.0.4

--- a/bitnami/redis/templates/scripts-configmap.yaml
+++ b/bitnami/redis/templates/scripts-configmap.yaml
@@ -164,10 +164,6 @@ data:
     sentinel_conf_add() {
         echo $'\n'"$@" >> "/opt/bitnami/redis-sentinel/etc/sentinel.conf"
     }
-    sentinel_conf_remove() {
-        sed -e '/^$1-/d' -e '/^$/d' /opt/bitnami/redis-sentinel/etc/sentinel.conf > /opt/bitnami/redis-sentinel/etc/sentinel.conf.tmp
-        mv /opt/bitnami/redis-sentinel/etc/sentinel.conf.tmp /opt/bitnami/redis-sentinel/etc/sentinel.conf
-    }
     host_id() {
         echo "$1" | openssl sha1 | awk '{print $2}'
     }
@@ -193,16 +189,14 @@ data:
 
     [[ -f $REDIS_PASSWORD_FILE ]] && export REDIS_PASSWORD="$(< "${REDIS_PASSWORD_FILE}")"
 
-    if [[ ! -f /opt/bitnami/redis-sentinel/etc/sentinel.conf ]]; then
-        cp /opt/bitnami/redis-sentinel/mounted-etc/sentinel.conf /opt/bitnami/redis-sentinel/etc/sentinel.conf
-        {{- if .Values.auth.enabled }}
-        printf "\nsentinel auth-pass %s %s" "{{ .Values.sentinel.masterSet }}" "$REDIS_PASSWORD" >> /opt/bitnami/redis-sentinel/etc/sentinel.conf
-        {{- if .Values.auth.sentinel }}
-        printf "\nrequirepass %s" "$REDIS_PASSWORD" >> /opt/bitnami/redis-sentinel/etc/sentinel.conf
-        {{- end }}
-        {{- end }}
-        printf "\nsentinel myid %s" "$(host_id "$HOSTNAME")" >> /opt/bitnami/redis-sentinel/etc/sentinel.conf
-    fi
+    cp /opt/bitnami/redis-sentinel/mounted-etc/sentinel.conf /opt/bitnami/redis-sentinel/etc/sentinel.conf
+    {{- if .Values.auth.enabled }}
+    printf "\nsentinel auth-pass %s %s" "{{ .Values.sentinel.masterSet }}" "$REDIS_PASSWORD" >> /opt/bitnami/redis-sentinel/etc/sentinel.conf
+    {{- if .Values.auth.sentinel }}
+    printf "\nrequirepass %s" "$REDIS_PASSWORD" >> /opt/bitnami/redis-sentinel/etc/sentinel.conf
+    {{- end }}
+    {{- end }}
+    printf "\nsentinel myid %s" "$(host_id "$HOSTNAME")" >> /opt/bitnami/redis-sentinel/etc/sentinel.conf
 
     if [[ -z "$(getent ahosts "$HEADLESS_SERVICE" | grep -v "^${myip}")" ]]; then
         # Only node available on the network, master by default
@@ -236,9 +230,6 @@ data:
             sentinel_conf_add "sentinel known-replica {{ .Values.sentinel.masterSet }} $ip {{ .Values.replica.containerPort }}"
         fi
     }
-
-    # removes generated known sentinels and replicas
-    sentinel_conf_remove "sentinel known"
 
     # Add available hosts on the network as known replicas & sentinels
     for node in $(seq 0 {{ .Values.replica.replicaCount }}); do


### PR DESCRIPTION
**Description of the change**

After upgrading to 15.0.0 we realized there was an issue with sentinel. If the service is restarted within its running container, the sentinel config remained unchanged. The script is supposed to prune the known sentinels and replicas and regenerate them when fetching the available hosts on the network. This part of the script was not working as expected which caused this error:

```
>>> 'sentinel known-sentinel rt-collector-master 10.8.5.30 26379 ecac44470a643ce5d853d166ad8abc2135e4bdbf'
Duplicate runid for sentinel.
```

Our proposed solution is to override the existing configuration _(if it exists)_ with the original configuration at each bootup. This ensures all replicas start with the expected configuration file.

**Benefits**

- Fixes CrashBackLoop state if the service is restarted in a running container.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
