### PR TITLE
#7334 Missing line-break for external database

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 5.0.4
+version: 5.0.5

--- a/bitnami/keycloak/templates/secrets.yaml
+++ b/bitnami/keycloak/templates/secrets.yaml
@@ -24,7 +24,7 @@ data:
   {{- else }}
   management-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
-  {{- if and (not .Values.postgresql.enabled) (not .Values.externalDatabase.existingSecret) -}}
+  {{- if and (not .Values.postgresql.enabled) (not .Values.externalDatabase.existingSecret) }}
   postgresql-password: {{ .Values.externalDatabase.password | b64enc | quote }}
   {{- end }}
   {{- if .Values.auth.tls.enabled }}


### PR DESCRIPTION
Linebreak within secrets.yaml is not realized. Checking the rest of the file, it looks like the change will fix the linebreak, which breaks all helm deployments:

data:
  admin-password: "xxxx"
  management-password: "xxxxx"postgresql-password: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"