### PR TITLE
[bitnami/contour] Add additional volume for admin sock

### DIFF
--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Infrastructure
 apiVersion: v2
-appVersion: 1.18.0
+appVersion: 1.18.1
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami

--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/bitnami-docker-contour
   - https://projectcontour.io
-version: 5.4.0
+version: 5.5.0

--- a/bitnami/contour/templates/envoy/daemonset.yaml
+++ b/bitnami/contour/templates/envoy/daemonset.yaml
@@ -191,6 +191,8 @@ spec:
               mountPath: /config
             - name: envoycert
               mountPath: /certs
+            - name: envoy-admin
+              mountPath: /admin
             {{- if .Values.envoy.extraVolumeMounts }}
               {{- include "common.tplvalues.render" ( dict "value" .Values.envoy.extraVolumeMounts "context" $ ) | nindent 12 }}
             {{- end }}
@@ -222,6 +224,8 @@ spec:
             - name: envoycert
               mountPath: /certs
               readOnly: true
+            - name: envoy-admin
+              mountPath: /admin
             {{- if .Values.envoy.extraVolumeMounts }}
               {{- include "common.tplvalues.render" ( dict "value" .Values.envoy.extraVolumeMounts "context" $ ) | nindent 12 }}
             {{- end }}
@@ -250,6 +254,8 @@ spec:
       automountServiceAccountToken: {{ .Values.envoy.serviceAccount.automountServiceAccountToken }}
       serviceAccountName: {{ include "envoy.envoyServiceAccountName" . }}
       volumes:
+        - name: envoy-admin
+          emptyDir: {}
         - name: envoy-config
           emptyDir: {}
         - name: envoycert

--- a/bitnami/contour/templates/envoy/deployment.yaml
+++ b/bitnami/contour/templates/envoy/deployment.yaml
@@ -200,6 +200,8 @@ spec:
               mountPath: /config
             - name: envoycert
               mountPath: /certs
+            - name: envoy-admin
+              mountPath: /admin
             {{- if .Values.envoy.extraVolumeMounts }}
               {{- include "common.tplvalues.render" ( dict "value" .Values.envoy.extraVolumeMounts "context" $ ) | nindent 12 }}
             {{- end }}
@@ -231,6 +233,8 @@ spec:
             - name: envoycert
               mountPath: /certs
               readOnly: true
+            - name: envoy-admin
+              mountPath: /admin
             {{- if .Values.envoy.extraVolumeMounts }}
               {{- include "common.tplvalues.render" ( dict "value" .Values.envoy.extraVolumeMounts "context" $ ) | nindent 12 }}
             {{- end }}
@@ -259,6 +263,8 @@ spec:
       automountServiceAccountToken: {{ .Values.envoy.serviceAccount.automountServiceAccountToken }}
       serviceAccountName: {{ include "envoy.envoyServiceAccountName" . }}
       volumes:
+        - name: envoy-admin
+          emptyDir: {}
         - name: envoy-config
           emptyDir: {}
         - name: envoycert

--- a/bitnami/contour/values.yaml
+++ b/bitnami/contour/values.yaml
@@ -72,7 +72,7 @@ contour:
   image:
     registry: docker.io
     repository: bitnami/contour
-    tag: 1.18.0-debian-10-r29
+    tag: 1.18.1-debian-10-r0
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -280,7 +280,7 @@ envoy:
   image:
     registry: docker.io
     repository: bitnami/envoy
-    tag: 1.19.1-debian-10-r1
+    tag: 1.19.1-debian-10-r6
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -588,7 +588,7 @@ defaultBackend:
   image:
     registry: docker.io
     repository: bitnami/nginx
-    tag: 1.21.1-debian-10-r46
+    tag: 1.21.1-debian-10-r51
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
**Description of the change**

From version 1.18.1, Contour requires an admin socket to be created under the default path of `/admin/admin.sock`. This PR implements a new volume that creates that path in both `shutdown-manager` and `envoy` containers. 

**Benefits**

Prepares the chart for the new Contour version 1.18.1

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

Contour does no longer expose the entire Envoy administration interface and instead, it does only show read-only options through it. This is in order to mitigate CVE-2021-32783. 

Envoy now listens on a Unix domain socket for such options.

https://github.com/projectcontour/contour/releases/tag/v1.18.1

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
