### PR TITLE
[bitnami/etcd] add service.clusterIP parameter

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -25,4 +25,4 @@ name: etcd
 sources:
   - https://github.com/bitnami/bitnami-docker-etcd
   - https://coreos.com/etcd/
-version: 6.6.1
+version: 6.6.2

--- a/bitnami/etcd/README.md
+++ b/bitnami/etcd/README.md
@@ -176,6 +176,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                               | Description                                                                       | Value       |
 | ---------------------------------- | --------------------------------------------------------------------------------- | ----------- |
 | `service.type`                     | Kubernetes Service type                                                           | `ClusterIP` |
+| `service.clusterIP`                | Kubernetes service Cluster IP                                                     | `""`        |
 | `service.port`                     | etcd client port                                                                  | `2379`      |
 | `service.clientPortNameOverride`   | etcd client port name override                                                    | `""`        |
 | `service.peerPort`                 | etcd peer port                                                                    | `2380`      |

--- a/bitnami/etcd/templates/svc.yaml
+++ b/bitnami/etcd/templates/svc.yaml
@@ -16,7 +16,9 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if and .Values.service.clusterIP (eq .Values.service.type "ClusterIP") }}
   clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
   {{- if and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP)) }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}

--- a/bitnami/etcd/templates/svc.yaml
+++ b/bitnami/etcd/templates/svc.yaml
@@ -16,6 +16,7 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  clusterIP: {{ .Values.service.clusterIP }}
   {{- if and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP)) }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}

--- a/bitnami/etcd/values.yaml
+++ b/bitnami/etcd/values.yaml
@@ -426,6 +426,11 @@ service:
   ## @param service.type Kubernetes Service type
   ##
   type: ClusterIP
+  ## @param service.clusterIP Kubernetes service Cluster IP
+  ## e.g.:
+  ## clusterIP: None
+  ##
+  clusterIP: ""
   ## @param service.port etcd client port
   ##
   port: 2379


### PR DESCRIPTION
**Description of the change**
Add service.clusterIP parameter (taking example from aspnet-core chart)


**Benefits**
ETCD Service does not have the clusterIP parameter, it can be useful to set static IP or None.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
