### PR TITLE
[bitnami/mongodb] Add runtimeClassName support

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 10.24.1
+version: 10.25.0

--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -153,6 +153,7 @@ Refer to the [chart documentation for more information on each of these architec
 | `podLabels`                             | MongoDB&reg; pod labels                                                                                | `{}`            |
 | `podAnnotations`                        | MongoDB&reg; Pod annotations                                                                           | `{}`            |
 | `priorityClassName`                     | Name of the existing priority class to be used by MongoDB&reg; pod(s)                                  | `""`            |
+| `runtimeClassName`                     | Name of the runtime class to be used by MongoDB&reg; pod(s)                                  | `""`            |
 | `podSecurityContext.enabled`            | Enable MongoDB&reg; pod(s)' Security Context                                                           | `true`          |
 | `podSecurityContext.fsGroup`            | Group ID for the volumes of the MongoDB&reg; pod(s)                                                    | `1001`          |
 | `podSecurityContext.sysctls`            | sysctl settings of the MongoDB&reg; pod(s)'                                                            | `[]`            |
@@ -305,6 +306,7 @@ Refer to the [chart documentation for more information on each of these architec
 | `arbiter.podLabels`                          | Arbiter pod labels                                                                                | `{}`    |
 | `arbiter.podAnnotations`                     | Arbiter Pod annotations                                                                           | `{}`    |
 | `arbiter.priorityClassName`                  | Name of the existing priority class to be used by Arbiter pod(s)                                  | `""`    |
+| `arbiter.runtimeClassName`                  | Name of the runtime class to be used by Arbiter pod(s)                                  | `""`    |
 | `arbiter.podSecurityContext.enabled`         | Enable Arbiter pod(s)' Security Context                                                           | `true`  |
 | `arbiter.podSecurityContext.fsGroup`         | Group ID for the volumes of the Arbiter pod(s)                                                    | `1001`  |
 | `arbiter.podSecurityContext.sysctls`         | sysctl settings of the Arbiter pod(s)'                                                            | `[]`    |
@@ -365,6 +367,7 @@ Refer to the [chart documentation for more information on each of these architec
 | `hidden.podLabels`                                   | Hidden node pod labels                                                                               | `{}`               |
 | `hidden.podAnnotations`                              | Hidden node Pod annotations                                                                          | `{}`               |
 | `hidden.priorityClassName`                           | Name of the existing priority class to be used by hidden node pod(s)                                 | `""`               |
+| `hidden.runtimeClassName`                           | Name of the runtime class to be used by hidden node pod(s)                                 | `""`               |
 | `hidden.resources.limits`                            | The resources limits for hidden node containers                                                      | `{}`               |
 | `hidden.resources.requests`                          | The requested resources for hidden node containers                                                   | `{}`               |
 | `hidden.livenessProbe.enabled`                       | Enable livenessProbe                                                                                 | `true`             |

--- a/bitnami/mongodb/templates/arbiter/statefulset.yaml
+++ b/bitnami/mongodb/templates/arbiter/statefulset.yaml
@@ -62,6 +62,9 @@ spec:
       {{- if .Values.arbiter.priorityClassName }}
       priorityClassName: {{ .Values.arbiter.priorityClassName }}
       {{- end }}
+      {{- if .Values.arbiter.runtimeClassName }}
+      runtimeClassName: {{ .Values.arbiter.runtimeClassName }}
+      {{- end }}
       {{- if .Values.arbiter.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.arbiter.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}

--- a/bitnami/mongodb/templates/hidden/statefulset.yaml
+++ b/bitnami/mongodb/templates/hidden/statefulset.yaml
@@ -69,6 +69,9 @@ spec:
       {{- if .Values.hidden.priorityClassName }}
       priorityClassName: {{ .Values.hidden.priorityClassName }}
       {{- end }}
+      {{- if .Values.hidden.runtimeClassName }}
+      runtimeClassName: {{ .Values.hidden.runtimeClassName }}
+      {{- end }}
       {{- if .Values.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -78,6 +78,9 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
+      {{- if .Values.runtimeClassName }}
+      runtimeClassName: {{ .Values.runtimeClassName }}
+      {{- end}}
       {{- if .Values.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}

--- a/bitnami/mongodb/templates/standalone/dep-sts.yaml
+++ b/bitnami/mongodb/templates/standalone/dep-sts.yaml
@@ -81,6 +81,9 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
+      {{- if .Values.runtimeClassName }}
+      runtimeClassName: {{ .Values.runtimeClassName }}
+      {{- end }}
       {{- if .Values.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -375,6 +375,10 @@ podAnnotations: {}
 ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
 ##
 priorityClassName: ""
+## @param runtimeClassName Name of the runtime class to be used by MongoDB&reg; pod(s)
+## ref: https://kubernetes.io/docs/concepts/containers/runtime-class/
+##
+runtimeClassName: ""
 ## MongoDB&reg; pods' Security Context.
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param podSecurityContext.enabled Enable MongoDB&reg; pod(s)' Security Context
@@ -1063,6 +1067,10 @@ arbiter:
   ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   ##
   priorityClassName: ""
+  ## @param arbiter.runtimeClassName Name of the runtime class to be used by Arbiter pod(s)
+  ## ref: https://kubernetes.io/docs/concepts/containers/runtime-class/
+  ##
+  runtimeClassName: ""
   ## MongoDB&reg; Arbiter pods' Security Context.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param arbiter.podSecurityContext.enabled Enable Arbiter pod(s)' Security Context
@@ -1316,6 +1324,10 @@ hidden:
   ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   ##
   priorityClassName: ""
+  ## @param hidden.runtimeClassName Name of the runtime class to be used by hidden node pod(s)
+  ## ref: https://kubernetes.io/docs/concepts/containers/runtime-class/
+  ##
+  runtimeClassName: ""
   ## MongoDB&reg; Hidden containers' resource requests and limits.
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ## We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Added support of runtime classes in mongodb chart

**Benefits**

Will be possible to specify runtime class on clusters that support multiple runtime classes (f.e. gVisor with FireCracker and runc)

**Possible drawbacks**


**Applicable issues**

  - fixes #7361

**Additional information**

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
