### PR TITLE
[bitnami/haproxy] Update apiVersion of PDB to policy/v1 on 1.21+ cluster (via common.capabilities.policy.apiVersion)

### DIFF
--- a/bitnami/haproxy/Chart.yaml
+++ b/bitnami/haproxy/Chart.yaml
@@ -23,4 +23,4 @@ name: haproxy
 sources:
   - https://github.com/bitnami/bitnami-docker-haproxy
   - https://github.com/haproxytech/haproxy
-version: 0.2.7
+version: 0.2.8

--- a/bitnami/haproxy/templates/pdb.yaml
+++ b/bitnami/haproxy/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.pdb.create }}
-apiVersion: policy/v1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "common.names.fullname" . }}

--- a/bitnami/haproxy/templates/pdb.yaml
+++ b/bitnami/haproxy/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.pdb.create }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "common.names.fullname" . }}


### PR DESCRIPTION
According to https://kubernetes.io/docs/reference/using-api/deprecation-guide/ we can start using `policy/v1` in Kubernetes `1.21`.

Without this change you can observe such things in logs:

```
W0901 11:28:35.264440      91 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
W0901 11:28:35.269403      91 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
W0901 11:28:35.297605      91 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
```

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])