### PR TITLE
[bitnami/etcd] Adding the possibility to disable service

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -25,4 +25,4 @@ name: etcd
 sources:
   - https://github.com/bitnami/bitnami-docker-etcd
   - https://coreos.com/etcd/
-version: 6.6.3
+version: 6.7.0

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -25,4 +25,4 @@ name: etcd
 sources:
   - https://github.com/bitnami/bitnami-docker-etcd
   - https://coreos.com/etcd/
-version: 6.6.2
+version: 6.6.3

--- a/bitnami/etcd/README.md
+++ b/bitnami/etcd/README.md
@@ -176,7 +176,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                               | Description                                                                       | Value       |
 | ---------------------------------- | --------------------------------------------------------------------------------- | ----------- |
 | `service.type`                     | Kubernetes Service type                                                           | `ClusterIP` |
-| `service.enable`                   | Enable/Disable second service who allow ressources to reach etcd cluster          | `true`      |
+| `service.enabled`                  | Enable/Disable second service who allow ressources to reach etcd cluster          | `true`      |
 | `service.clusterIP`                | Kubernetes service Cluster IP                                                     | `""`        |
 | `service.port`                     | etcd client port                                                                  | `2379`      |
 | `service.clientPortNameOverride`   | etcd client port name override                                                    | `""`        |

--- a/bitnami/etcd/README.md
+++ b/bitnami/etcd/README.md
@@ -176,7 +176,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                               | Description                                                                       | Value       |
 | ---------------------------------- | --------------------------------------------------------------------------------- | ----------- |
 | `service.type`                     | Kubernetes Service type                                                           | `ClusterIP` |
-| `service.enable`                   | Enable second to allow ressources to reach etcd cluster                           | `true`      |
+| `service.enable`                   | Enable/Disable second service who allow ressources to reach etcd cluster          | `true`      |
 | `service.clusterIP`                | Kubernetes service Cluster IP                                                     | `""`        |
 | `service.port`                     | etcd client port                                                                  | `2379`      |
 | `service.clientPortNameOverride`   | etcd client port name override                                                    | `""`        |

--- a/bitnami/etcd/README.md
+++ b/bitnami/etcd/README.md
@@ -176,6 +176,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                               | Description                                                                       | Value       |
 | ---------------------------------- | --------------------------------------------------------------------------------- | ----------- |
 | `service.type`                     | Kubernetes Service type                                                           | `ClusterIP` |
+| `service.enable`                   | Enable second to allow ressources to reach etcd cluster                           | `true`      |
 | `service.clusterIP`                | Kubernetes service Cluster IP                                                     | `""`        |
 | `service.port`                     | etcd client port                                                                  | `2379`      |
 | `service.clientPortNameOverride`   | etcd client port name override                                                    | `""`        |

--- a/bitnami/etcd/templates/svc.yaml
+++ b/bitnami/etcd/templates/svc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.service.enable }}
+{{- if .Values.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/bitnami/etcd/templates/svc.yaml
+++ b/bitnami/etcd/templates/svc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.service.enable }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -46,3 +47,4 @@ spec:
       nodePort: null
       {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
+{{- end }}

--- a/bitnami/etcd/values.yaml
+++ b/bitnami/etcd/values.yaml
@@ -426,6 +426,9 @@ service:
   ## @param service.type Kubernetes Service type
   ##
   type: ClusterIP
+  ## @param service.enable create second service if equal true
+  ##
+  enable: true
   ## @param service.clusterIP Kubernetes service Cluster IP
   ## e.g.:
   ## clusterIP: None

--- a/bitnami/etcd/values.yaml
+++ b/bitnami/etcd/values.yaml
@@ -428,7 +428,7 @@ service:
   type: ClusterIP
   ## @param service.enable create second service if equal true
   ##
-  enable: true
+  enabled: true
   ## @param service.clusterIP Kubernetes service Cluster IP
   ## e.g.:
   ## clusterIP: None

--- a/bitnami/etcd/values.yaml
+++ b/bitnami/etcd/values.yaml
@@ -426,7 +426,7 @@ service:
   ## @param service.type Kubernetes Service type
   ##
   type: ClusterIP
-  ## @param service.enable create second service if equal true
+  ## @param service.enabled create second service if equal true
   ##
   enabled: true
   ## @param service.clusterIP Kubernetes service Cluster IP


### PR DESCRIPTION
* Adding .Values.service.enable bool set by default to true (service by default activated) on the ETCD Helm Chart

**Description of the change**

I added a conditional to the service creation, thanks to that, user is free to create or not the unnecessary service to the ETCD cluster
 
**Benefits**

Helpful if k8s cluster have mechanism who automatically create service with labeled resources or if administrator encounter errors with Gitops tools like flux (for example, I had an 'clusterIP immutable' when I tried to change values who concerned the STS object. HelmOperator was on error, impossible to modify the HelmRelease to fix that).

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

If user specify a un-boolean value (other than `true` & `false`)

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
