### PR TITLE
[bitnami/contour] Fix ingressClass

### DIFF
--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/bitnami-docker-contour
   - https://projectcontour.io
-version: 5.5.0
+version: 5.5.1

--- a/bitnami/contour/templates/contour/deployment.yaml
+++ b/bitnami/contour/templates/contour/deployment.yaml
@@ -68,8 +68,8 @@ spec:
             - --contour-cert-file=/certs/tls.crt
             - --contour-key-file=/certs/tls.key
             - --config-path=/config/contour.yaml
-            {{- if .Values.ingressClass }}
-            - --ingress-class-name={{ .Values.ingressClass }}
+            {{- if .Values.contour.ingressClass }}
+            - --ingress-class-name={{ .Values.contour.ingressClass }}
             {{- end }}
             {{- if .Values.contour.extraArgs }}
             {{- include "common.tplvalues.render" (dict "value" .Values.contour.extraArgs "context" $) | nindent 12 }}


### PR DESCRIPTION
**Description of the change**

Issue reported by an user. The ingressClass key now is generated checking the ingressClass in the top of the keys defined in values.yaml instead of contour.ingressClass (properly key definition path).

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Fix ingressClass definition in our templates.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #7372

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
