### PR TITLE
[bitnami/solr] : Workaround/Fix for GCE Ingress

### DIFF
--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -27,4 +27,4 @@ name: solr
 sources:
   - https://github.com/bitnami/bitnami-docker-solr
   - https://lucene.apache.org/solr/
-version: 2.0.4
+version: 2.0.5

--- a/bitnami/solr/templates/exporter-deployment.yaml
+++ b/bitnami/solr/templates/exporter-deployment.yaml
@@ -102,7 +102,7 @@ spec:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.exporter.extraEnvVarsSecret "context" $) }}
             {{- end }}
           ports:
-            - name: exporter-port
+            - name: http
               containerPort: {{ .Values.exporter.port }}
           {{- if .Values.exporter.resources }}
           resources: {{- toYaml .Values.exporter.resources | nindent 12 }}

--- a/bitnami/solr/templates/exporter-svc.yaml
+++ b/bitnami/solr/templates/exporter-svc.yaml
@@ -33,7 +33,7 @@ spec:
     - name: tcp-client
       port: {{ .Values.exporter.service.port }}
       protocol: TCP
-      targetPort: exporter-port
+      targetPort: http
       {{- if and (or (eq .Values.exporter.service.type "NodePort") (eq .Values.exporter.service.type "LoadBalancer")) (not (empty .Values.exporter.service.nodePorts.http)) }}
       nodePort: {{ .Values.exporter.service.nodePorts.http }}
       {{- else if eq .Values.exporter.service.type "ClusterIP" }}

--- a/bitnami/solr/templates/statefulset.yaml
+++ b/bitnami/solr/templates/statefulset.yaml
@@ -253,7 +253,7 @@ spec:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
             {{- end }}
           ports:
-            - name: solr-client
+            - name: http
               containerPort: {{ .Values.containerPort }}
           {{- if .Values.resources }}
           resources: {{- include "common.tplvalues.render" (dict "value" .Values.resources "context" $) | nindent 12 }}

--- a/bitnami/solr/templates/svc-headless.yaml
+++ b/bitnami/solr/templates/svc-headless.yaml
@@ -19,6 +19,6 @@ spec:
     - name: tcp-client
       port: {{ .Values.service.port }}
       protocol: TCP
-      targetPort: solr-client
+      targetPort: http
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: solr

--- a/bitnami/solr/templates/svc.yaml
+++ b/bitnami/solr/templates/svc.yaml
@@ -29,7 +29,7 @@ spec:
     - name: tcp-client
       port: {{ .Values.service.port }}
       protocol: TCP
-      targetPort: solr-client
+      targetPort: http
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.http)) }}
       nodePort: {{ .Values.service.nodePorts.http }}
       {{- else if eq .Values.service.type "ClusterIP" }}


### PR DESCRIPTION
**Description of the change**
Renaming `targetPort`  value.

**Benefits**
Provide a "painless" solution for Container Native Loadbalancing on GKE before [kubernetes/ingress-gce/pull/1462](https://github.com/kubernetes/ingress-gce/pull/1462) lands.

**Possible drawbacks**
External references to old values. If this is a concern, one could still introduce a helm value defaulting to old values while allowing those affected to override using `http`.

**Applicable issues**

n/a

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/) - hopefully. ;)
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
