### PR TITLE
[bitnami/redmine] Missing env var in cronjob.yaml

### DIFF
--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -36,4 +36,4 @@ name: redmine
 sources:
   - https://github.com/bitnami/bitnami-docker-redmine
   - http://www.redmine.org/
-version: 17.0.6
+version: 17.0.7

--- a/bitnami/redmine/templates/cronjob.yaml
+++ b/bitnami/redmine/templates/cronjob.yaml
@@ -84,6 +84,8 @@ spec:
                 {{- end }}
               resources: {{- toYaml .Values.mailReceiver.resources | nindent 16 }}
               env:
+                - name: REDMINE_DATABASE_TYPE
+                  value: {{ .Values.databaseType | quote }}
                 {{- if eq .Values.databaseType "mariadb" }}
                 - name: REDMINE_MAIL_RECEIVER_DB_MYSQL
                 {{- else }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

mail-receiver-configmap.yaml reference $REDMINE_DATABASE_TYPE variable but this variable is never defined in cronjob.yaml

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
