### PR TITLE
[bitnami/elasticsearch] Bump Kibana major version

### DIFF
--- a/bitnami/elasticsearch/Chart.lock
+++ b/bitnami/elasticsearch/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.8.0
 - name: kibana
   repository: https://charts.bitnami.com/bitnami
-  version: 8.2.3
-digest: sha256:9e9ca2e06d6d4268467ce3aa4c2469945045e5622ea46dce8f00ea4c52e7e7a0
-generated: "2021-09-01T16:02:41.787162084Z"
+  version: 9.0.1
+digest: sha256:fb6bbc3a5bb8d87cd9ff27dcd37ec0c43b8505ca3e6c59e9b31d7c7488a43879
+generated: "2021-09-02T21:43:48.165906555Z"

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
   - condition: global.kibanaEnabled
     name: kibana
     repository: https://charts.bitnami.com/bitnami
-    version: 8.x.x
+    version: 9.x.x
 description: A highly scalable open-source full-text search and analytics engine
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/elasticsearch
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/bitnami-docker-elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 16.0.2
+version: 17.0.0

--- a/bitnami/elasticsearch/README.md
+++ b/bitnami/elasticsearch/README.md
@@ -642,6 +642,10 @@ Find more information about how to deal with common errors related to Bitnami’
 
 ## Upgrading
 
+### To 17.0.0
+
+This version bumps in a major the version of the Kibana Helm Chart bundled as dependecy, [here](https://github.com/bitnami/charts/tree/master/bitnami/kibana#to-900) you can see the changes implemented in this Kibana major version.
+
 ### To 16.0.0
 
 This version replaces the Ingest and Coordinating Deployments with Statefulsets. This change is required so Coordinating and Ingest nodes have their services associated, required for TLS hostname verification.

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -62,7 +62,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/elasticsearch
-  tag: 7.14.1-debian-10-r0
+  tag: 7.14.1-debian-10-r1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1138,7 +1138,7 @@ curator:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch-curator
-    tag: 5.8.4-debian-10-r110
+    tag: 5.8.4-debian-10-r111
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -1392,7 +1392,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch-exporter
-    tag: 1.2.1-debian-10-r61
+    tag: 1.2.1-debian-10-r62
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -1575,7 +1575,7 @@ sysctlImage:
   ##
   registry: docker.io
   repository: bitnami/bitnami-shell
-  tag: 10-debian-10-r179
+  tag: 10-debian-10-r180
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1628,7 +1628,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r179
+    tag: 10-debian-10-r180
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**

A new major version of Kibana (8.X.X -> 9.X.X) was released a day ago (see https://github.com/bitnami/charts/pull/6487). This Elasticsearch chart bundled Kibana as a subchart, in order to bump the major version of the Kibana subchart we also need to bump the major version of Elasticsearch.

The Elasticsearch major version was also released yesterday (see https://github.com/bitnami/charts/pull/6486) but the subchart was not updated.

Both PRs (https://github.com/bitnami/charts/pull/6486 and https://github.com/bitnami/charts/pull/6487) are related, but since the Elasticsearch PR didn't incorporate the Kibana version bump, a new major version is required.