### PR TITLE
[bitnami/zookeeper] Fix NetworkPolicy

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -21,4 +21,4 @@ name: zookeeper
 sources:
   - https://github.com/bitnami/bitnami-docker-zookeeper
   - https://zookeeper.apache.org/
-version: 7.4.2
+version: 7.4.3

--- a/bitnami/zookeeper/templates/networkpolicy.yaml
+++ b/bitnami/zookeeper/templates/networkpolicy.yaml
@@ -14,30 +14,28 @@ metadata:
 spec:
   podSelector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
   ingress:
     # Allow inbound connections to zookeeper
     - ports:
-        - port: {{ .Values.service.port }}
-      from:
+        - port: {{ .Values.containerPort }}
+        {{- if .Values.metrics.enabled }}
+        - port: {{ .Values.metrics.containerPort }}
+        {{- end }}
       {{- if not .Values.networkPolicy.allowExternal }}
+      from:
         - podSelector:
             matchLabels:
               {{ include "common.names.fullname" . }}-client: "true"
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" . | nindent 14 }}
-      {{- else }}
-        - podSelector:
-            matchLabels: {}
       {{- end }}
-    # Internal ports
-    - ports: &intranodes_ports
+    # Allow internal communications between nodes
+    - ports:
         - port: {{ .Values.service.followerPort }}
         - port: {{ .Values.service.electionPort }}
       from:
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" . | nindent 14 }}
-  egress:
-    - ports: *intranodes_ports
-    # Allow outbound connections from zookeeper nodes
-
 {{- end }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Our current NetworkPolicy doesn't allow internal communications between nodes. You can test it by simply installing the chart in a namespace (e.g. "dev") and testing the policies with [illuminatio](https://github.com/inovex/illuminatio):

```console
$ helm install zookeeper bitnami/zookeeper --set networkPolicy.enabled=true --set replicaCount=3 --namespace=dev
$ illuminatio run
...
FROM                                                                       TO                                                                         PORT    RESULT
dev:app.kubernetes.io/instance=zookeeper,app.kubernetes.io/name=zookeeper  dev:app.kubernetes.io/instance=zookeeper,app.kubernetes.io/name=zookeeper  3888    failure
dev:app.kubernetes.io/instance=zookeeper,app.kubernetes.io/name=zookeeper  dev:app.kubernetes.io/instance=zookeeper,app.kubernetes.io/name=zookeeper  2181    failure
dev:app.kubernetes.io/instance=zookeeper,app.kubernetes.io/name=zookeeper  dev:app.kubernetes.io/instance=zookeeper,app.kubernetes.io/name=zookeeper  2888    failure
*:*                                                                        dev:app.kubernetes.io/instance=zookeeper,app.kubernetes.io/name=zookeeper  2181    failure

```

**Benefits**

Users can use networkpolicies

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/7218

**Additional information**

N/A

**Checklist** 

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
