### PR TITLE
[bitnami/etcd] add Prometheus podmonitor relabelings parameter

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -25,4 +25,4 @@ name: etcd
 sources:
   - https://github.com/bitnami/bitnami-docker-etcd
   - https://coreos.com/etcd/
-version: 6.7.0
+version: 6.8.0

--- a/bitnami/etcd/README.md
+++ b/bitnami/etcd/README.md
@@ -240,7 +240,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.podMonitor.additionalLabels` | Additional labels that can be used so PodMonitors will be discovered by Prometheus | `{}`         |
 | `metrics.podMonitor.scheme`           | Scheme to use for scraping                                                         | `http`       |
 | `metrics.podMonitor.tlsConfig`        | TLS configuration used for scrape endpoints used by Prometheus                     | `{}`         |
-| `metrics.podMonitor.relabelings`      | Prometheus relabling rules                                                         | `[]`         |
+| `metrics.podMonitor.relabelings`      | Prometheus relabeling rules                                                         | `[]`         |
 
 
 ### Snapshotting parameters

--- a/bitnami/etcd/README.md
+++ b/bitnami/etcd/README.md
@@ -240,7 +240,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.podMonitor.additionalLabels` | Additional labels that can be used so PodMonitors will be discovered by Prometheus | `{}`         |
 | `metrics.podMonitor.scheme`           | Scheme to use for scraping                                                         | `http`       |
 | `metrics.podMonitor.tlsConfig`        | TLS configuration used for scrape endpoints used by Prometheus                     | `{}`         |
-| `metrics.podMonitor.relabelings`      | Prometheus relabling rules | `[]`         |
+| `metrics.podMonitor.relabelings`      | Prometheus relabling rules                                                         | `[]`         |
 
 
 ### Snapshotting parameters

--- a/bitnami/etcd/README.md
+++ b/bitnami/etcd/README.md
@@ -240,6 +240,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.podMonitor.additionalLabels` | Additional labels that can be used so PodMonitors will be discovered by Prometheus | `{}`         |
 | `metrics.podMonitor.scheme`           | Scheme to use for scraping                                                         | `http`       |
 | `metrics.podMonitor.tlsConfig`        | TLS configuration used for scrape endpoints used by Prometheus                     | `{}`         |
+| `metrics.podMonitor.relabelings`      | Prometheus relabling rules | `[]`         |
 
 
 ### Snapshotting parameters

--- a/bitnami/etcd/templates/podmonitor.yaml
+++ b/bitnami/etcd/templates/podmonitor.yaml
@@ -30,6 +30,10 @@ spec:
       {{- if .Values.metrics.podMonitor.tlsConfig }}
       tlsConfig: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.podMonitor.tlsConfig "context" $ ) | nindent 8 }}
       {{- end }}
+      {{- if .Values.metrics.podMonitor.relabelings }}
+      relabelings: 
+      {{- include "common.tplvalues.render" (dict "value" .Values.metrics.podMonitor.relabelings "context" $) | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/bitnami/etcd/values.yaml
+++ b/bitnami/etcd/values.yaml
@@ -646,7 +646,7 @@ metrics:
     ##
     tlsConfig: {}
     ##
-    ## @param metrics.podMonitor.relabelings [array] add relabling rules to be applied by prometheus
+    ## @param metrics.podMonitor.relabelings [array] Prometheus relabeling rules
     relabelings: []
 
 ## @section Snapshotting parameters

--- a/bitnami/etcd/values.yaml
+++ b/bitnami/etcd/values.yaml
@@ -645,8 +645,8 @@ metrics:
     ##       name: existingSecretName
     ##
     tlsConfig: {}
-    ##
     ## @param metrics.podMonitor.relabelings [array] Prometheus relabeling rules
+    ##
     relabelings: []
 
 ## @section Snapshotting parameters

--- a/bitnami/etcd/values.yaml
+++ b/bitnami/etcd/values.yaml
@@ -645,6 +645,9 @@ metrics:
     ##       name: existingSecretName
     ##
     tlsConfig: {}
+    ##
+    ## @param metrics.podMonitor.relabelings [array] add relabling rules to be applied by prometheus
+    relabelings: []
 
 ## @section Snapshotting parameters
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 -->

**Description of the change**

PodMonitor are used by prometheus to discover endpoints to scrape and to pass scraping configuration (timeout, port ....).
Relabeling is a useful feature that allows promethues to manipulate labels on the generated metrics, these labels will be used later for filtering and alerting.

This PR add the relabelings field to the podmonitor created by the chart.

**Benefits**

- Custom labeling makes the metric more human friendly and easier to manipulate.
- Custom labeling can be used for backward compatibility with existing monitoring system.

**Possible drawbacks**

N/A

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
