### PR TITLE
bitnami/thanos: Switch deployment strategy to 'Recreate'

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 6.0.10
+version: 6.0.11

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -1357,7 +1357,7 @@ compactor:
   extraFlags: []
   ## @param compactor.strategyType Deployment Strategy Type, can be set to RollingUpdate or Recreate by default
   ##
-  strategyType: RollingUpdate
+  strategyType: Recreate
   ## @param compactor.podAffinityPreset Thanos Compactor pod affinity preset
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
   ##


### PR DESCRIPTION
**Description of the change**

This PR changes the default deployment strategy of Thanos compactor Deployment from `RollingUpdate` to `Recreate`.

**Benefits**

The Thanos compactor Deployment contains two volume mounts by default (https://github.com/bitnami/charts/blob/master/bitnami/thanos/templates/compactor/deployment.yaml#L134). This makes the `RollingUpdate` strategy unsuitable as a new pod cannot be created as long as the old pod is running. The `RollingUpdate` strategy results in


```
Multi-Attach error for volume "pvc-0a8b96f5-249f-4708-8c7d-51c2538d647d" Volume is already used by pod(s) thanos-compactor-7d4dbdf4f9-kgt9j
```

errors. A `Recreate` deployment strategy, waits for the old pod to terminate before starting a new one, avoiding the attempt to mount the PVCs twice.

**Possible drawbacks**

None that I am aware of. Replicas are hardcoded to 1 (https://github.com/bitnami/charts/blob/master/bitnami/thanos/templates/compactor/deployment.yaml#L12), so two thanos-compactor pods are not supposed to run at the same time anyway.

**Applicable issues**

None that I am aware of.

**Additional information**

None.

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
