### PR TITLE
[bitnami/kibana] Fix KIBANA_SERVER_TLS_USE_PEM

### DIFF
--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -25,4 +25,4 @@ name: kibana
 sources:
   - https://github.com/bitnami/bitnami-docker-kibana
   - https://www.elastic.co/products/kibana
-version: 9.0.1
+version: 9.0.2

--- a/bitnami/kibana/templates/deployment.yaml
+++ b/bitnami/kibana/templates/deployment.yaml
@@ -153,11 +153,12 @@ spec:
           livenessProbe:
             httpGet:
             {{- if .Values.configuration.server.rewriteBasePath }}
-              path: {{ .Values.configuration.server.basePath }}/api/status
+              path: {{ .Values.configuration.server.basePath }}/login
             {{- else }}
-              path: /api/status
+              path: /login
             {{- end }}
               port: http
+              scheme: {{ ternary "HTTPS" "HTTP" .Values.tls.enabled }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -168,11 +169,12 @@ spec:
           readinessProbe:
             httpGet:
             {{- if .Values.configuration.server.rewriteBasePath }}
-              path: {{ .Values.configuration.server.basePath }}/api/status
+              path: {{ .Values.configuration.server.basePath }}/login
             {{- else }}
-              path: /api/status
+              path: /login
             {{- end }}
               port: http
+              scheme: {{ ternary "HTTPS" "HTTP" .Values.tls.enabled }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/bitnami/kibana/templates/deployment.yaml
+++ b/bitnami/kibana/templates/deployment.yaml
@@ -91,8 +91,10 @@ spec:
               value: {{ .Values.forceInitScripts | quote }}
             - name: KIBANA_SERVER_ENABLE_TLS
               value: {{ ternary "true" "false" .Values.tls.enabled | quote }}
+            {{- if or .Values.tls.usePemCerts (include "kibana.createTlsSecret" . ) }}
             - name: KIBANA_SERVER_TLS_USE_PEM
-              value: {{ ternary "true" "false" (or .Values.tls.usePemCerts (include "kibana.createTlsSecret" .)) | quote }}
+              value: "true"
+            {{- end }}
             {{- if and .Values.tls.enabled .Values.tls.usePemCerts (or .Values.tls.keyPassword .Values.tls.passwordsSecret) }}
             - name: KIBANA_SERVER_KEY_PASSWORD
               valueFrom:

--- a/bitnami/kibana/values.yaml
+++ b/bitnami/kibana/values.yaml
@@ -41,7 +41,7 @@ fullnameOverride: ""
 image:
   registry: docker.io
   repository: bitnami/kibana
-  tag: 7.14.1-debian-10-r0
+  tag: 7.14.1-debian-10-r1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -137,7 +137,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r180
+    tag: 10-debian-10-r187
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**

Fixes issue caused by

```
            - name: KIBANA_SERVER_TLS_USE_PEM
              value: {{ ternary "true" "false" (or .Values.tls.usePemCerts (include "kibana.createTlsSecret" .)) | quote }}
```

Error message:
```console
$ helm install --dry-run test bitnami/kibana/ --set elasticsearch.hosts[0]=YOUR_ES_HOST,elasticsearch.port=YOUR_ES_PORT,tls.usePemCerts=true

Error: template: kibana/templates/deployment.yaml:95:109: executing "kibana/templates/deployment.yaml" at <.>: wrong type for value; expected bool; got string
```

**Applicable issues**

  - fixes #7410 

**Possible drawbacks**

None known.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
