### PR TITLE
[bitnami/mariadb] Added topology spread constraints to Mariadb chart.

### DIFF
--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Database
 apiVersion: v2
-appVersion: 10.6.0
+appVersion: 10.5.12
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -26,4 +26,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-mariadb
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 9.4.4
+version: 9.5.0

--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Database
 apiVersion: v2
-appVersion: 10.5.12
+appVersion: 10.6.0
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami

--- a/bitnami/mariadb/README.md
+++ b/bitnami/mariadb/README.md
@@ -116,7 +116,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `primary.nodeAffinityPreset.values`          | MariaDB primary node label values to match. Ignored if `primary.affinity` is set.                                 | `[]`            |
 | `primary.affinity`                           | Affinity for MariaDB primary pods assignment                                                                      | `{}`            |
 | `primary.nodeSelector`                       | Node labels for MariaDB primary pods assignment                                                                   | `{}`            |
-| `primary.tolerations`                        | Tolerations for MariaDB primary pods assignment                                                                   | `[]`            |
+| `primary.tolerations`                        | Tolerations for MariaDB primary pods assignment  
+| `primary.topologySpreadConstraints`          | Topology Spread Constraints for for MariaDB primary pods assignment
 | `primary.priorityClassName`                  | Priority class for MariaDB primary pods assignment                                                                | `""`            |
 | `primary.podSecurityContext.enabled`         | Enable security context for MariaDB primary pods                                                                  | `true`          |
 | `primary.podSecurityContext.fsGroup`         | Group ID for the mounted volumes' filesystem                                                                      | `1001`          |
@@ -188,7 +189,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `secondary.nodeAffinityPreset.values`          | MariaDB secondary node label values to match. Ignored if `secondary.affinity` is set.                                 | `[]`            |
 | `secondary.affinity`                           | Affinity for MariaDB secondary pods assignment                                                                        | `{}`            |
 | `secondary.nodeSelector`                       | Node labels for MariaDB secondary pods assignment                                                                     | `{}`            |
-| `secondary.tolerations`                        | Tolerations for MariaDB secondary pods assignment                                                                     | `[]`            |
+| `secondary.tolerations`                        | Tolerations for MariaDB secondary pods assignment   
+| `secondary.topologySpreadConstraints`          | Topology Spread Constraints for for MariaDB secondary pods assignment
 | `secondary.priorityClassName`                  | Priority class for MariaDB secondary pods assignment                                                                  | `""`            |
 | `secondary.podSecurityContext.enabled`         | Enable security context for MariaDB secondary pods                                                                    | `true`          |
 | `secondary.podSecurityContext.fsGroup`         | Group ID for the mounted volumes' filesystem                                                                          | `1001`          |

--- a/bitnami/mariadb/README.md
+++ b/bitnami/mariadb/README.md
@@ -116,8 +116,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `primary.nodeAffinityPreset.values`          | MariaDB primary node label values to match. Ignored if `primary.affinity` is set.                                 | `[]`            |
 | `primary.affinity`                           | Affinity for MariaDB primary pods assignment                                                                      | `{}`            |
 | `primary.nodeSelector`                       | Node labels for MariaDB primary pods assignment                                                                   | `{}`            |
-| `primary.tolerations`                        | Tolerations for MariaDB primary pods assignment  
-| `primary.topologySpreadConstraints`          | Topology Spread Constraints for for MariaDB primary pods assignment
+| `primary.tolerations`                        | Tolerations for MariaDB primary pods assignment                                                                   | `[]`            |
+| `primary.topologySpreadConstraints`          | Topology Spread Constraints for MariaDB primary pods assignment                                                   | `[]`            |
 | `primary.priorityClassName`                  | Priority class for MariaDB primary pods assignment                                                                | `""`            |
 | `primary.podSecurityContext.enabled`         | Enable security context for MariaDB primary pods                                                                  | `true`          |
 | `primary.podSecurityContext.fsGroup`         | Group ID for the mounted volumes' filesystem                                                                      | `1001`          |
@@ -189,8 +189,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `secondary.nodeAffinityPreset.values`          | MariaDB secondary node label values to match. Ignored if `secondary.affinity` is set.                                 | `[]`            |
 | `secondary.affinity`                           | Affinity for MariaDB secondary pods assignment                                                                        | `{}`            |
 | `secondary.nodeSelector`                       | Node labels for MariaDB secondary pods assignment                                                                     | `{}`            |
-| `secondary.tolerations`                        | Tolerations for MariaDB secondary pods assignment   
-| `secondary.topologySpreadConstraints`          | Topology Spread Constraints for for MariaDB secondary pods assignment
+| `secondary.tolerations`                        | Tolerations for MariaDB secondary pods assignment                                                                     | `[]`            |
+| `secondary.topologySpreadConstraints`          | Topology Spread Constraints for MariaDB secondary pods assignment                                                     | `[]`            |
 | `secondary.priorityClassName`                  | Priority class for MariaDB secondary pods assignment                                                                  | `""`            |
 | `secondary.podSecurityContext.enabled`         | Enable security context for MariaDB secondary pods                                                                    | `true`          |
 | `secondary.podSecurityContext.fsGroup`         | Group ID for the mounted volumes' filesystem                                                                          | `1001`          |

--- a/bitnami/mariadb/README.md
+++ b/bitnami/mariadb/README.md
@@ -117,7 +117,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `primary.affinity`                           | Affinity for MariaDB primary pods assignment                                                                      | `{}`            |
 | `primary.nodeSelector`                       | Node labels for MariaDB primary pods assignment                                                                   | `{}`            |
 | `primary.tolerations`                        | Tolerations for MariaDB primary pods assignment                                                                   | `[]`            |
-| `primary.topologySpreadConstraints`          | Topology Spread Constraints for MariaDB primary pods assignment                                                   | `[]`            |
+| `primary.topologySpreadConstraints`          | Topology Spread Constraints for MariaDB primary pods assignment                                                   | `{}`            |
 | `primary.priorityClassName`                  | Priority class for MariaDB primary pods assignment                                                                | `""`            |
 | `primary.podSecurityContext.enabled`         | Enable security context for MariaDB primary pods                                                                  | `true`          |
 | `primary.podSecurityContext.fsGroup`         | Group ID for the mounted volumes' filesystem                                                                      | `1001`          |
@@ -190,7 +190,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `secondary.affinity`                           | Affinity for MariaDB secondary pods assignment                                                                        | `{}`            |
 | `secondary.nodeSelector`                       | Node labels for MariaDB secondary pods assignment                                                                     | `{}`            |
 | `secondary.tolerations`                        | Tolerations for MariaDB secondary pods assignment                                                                     | `[]`            |
-| `secondary.topologySpreadConstraints`          | Topology Spread Constraints for MariaDB secondary pods assignment                                                     | `[]`            |
+| `secondary.topologySpreadConstraints`          | Topology Spread Constraints for MariaDB secondary pods assignment                                                     | `{}`            |
 | `secondary.priorityClassName`                  | Priority class for MariaDB secondary pods assignment                                                                  | `""`            |
 | `secondary.podSecurityContext.enabled`         | Enable security context for MariaDB secondary pods                                                                    | `true`          |
 | `secondary.podSecurityContext.fsGroup`         | Group ID for the mounted volumes' filesystem                                                                          | `1001`          |

--- a/bitnami/mariadb/templates/primary/statefulset.yaml
+++ b/bitnami/mariadb/templates/primary/statefulset.yaml
@@ -63,6 +63,9 @@ spec:
       {{- if .Values.primary.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.primary.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.primary.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.primary.topologySpreadConstraints "context" $) | nindent 8 }}
+      {{- end }}
       {{- if .Values.primary.priorityClassName }}
       priorityClassName: {{ .Values.primary.priorityClassName | quote }}
       {{- else if .Values.priorityClassName }}

--- a/bitnami/mariadb/templates/secondary/statefulset.yaml
+++ b/bitnami/mariadb/templates/secondary/statefulset.yaml
@@ -64,6 +64,9 @@ spec:
       {{- if .Values.secondary.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.secondary.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.secondary.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.secondary.topologySpreadConstraints "context" $) | nindent 8 }}
+      {{- end }}
       {{- if .Values.secondary.priorityClassName }}
       priorityClassName: {{ .Values.secondary.priorityClassName | quote }}
       {{- else if .Values.priorityClassName }}

--- a/bitnami/mariadb/values.yaml
+++ b/bitnami/mariadb/values.yaml
@@ -70,7 +70,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/mariadb
-  tag: 10.5.12-debian-10-r19
+  tag: 10.5.12-debian-10-r32
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -815,7 +815,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r172
+    tag: 10-debian-10-r185
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -848,7 +848,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mysqld-exporter
-    tag: 0.13.0-debian-10-r75
+    tag: 0.13.0-debian-10-r88
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/bitnami/mariadb/values.yaml
+++ b/bitnami/mariadb/values.yaml
@@ -254,7 +254,7 @@ primary:
   ##     topologyKey: topology.kubernetes.io/zone
   ##     whenUnsatisfiable: DoNotSchedule
   ##
-  topologySpreadConstraints: []
+  topologySpreadConstraints: {}
   ## @param primary.priorityClassName Priority class for MariaDB primary pods assignment
   ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   ##
@@ -569,7 +569,7 @@ secondary:
   ##     topologyKey: topology.kubernetes.io/zone
   ##     whenUnsatisfiable: DoNotSchedule
   ##
-  topologySpreadConstraints: []
+  topologySpreadConstraints: {}
   ## @param secondary.priorityClassName Priority class for MariaDB secondary pods assignment
   ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   ##

--- a/bitnami/mariadb/values.yaml
+++ b/bitnami/mariadb/values.yaml
@@ -246,6 +246,15 @@ primary:
   ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
   tolerations: []
+  ## @param primary.topologySpreadConstraints Topology Spread Constraints for for MariaDB primary pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  ## E.g.
+  ## topologySpreadConstraints:
+  ##   - maxSkew: 1
+  ##     topologyKey: topology.kubernetes.io/zone
+  ##     whenUnsatisfiable: DoNotSchedule
+  ##
+  topologySpreadConstraints: []
   ## @param primary.priorityClassName Priority class for MariaDB primary pods assignment
   ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   ##
@@ -552,6 +561,15 @@ secondary:
   ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
   tolerations: []
+  ## @param secondary.topologySpreadConstraints Topology Spread Constraints for for MariaDB secondary pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  ## E.g.
+  ## topologySpreadConstraints:
+  ##   - maxSkew: 1
+  ##     topologyKey: topology.kubernetes.io/zone
+  ##     whenUnsatisfiable: DoNotSchedule
+  ##
+  topologySpreadConstraints: []
   ## @param secondary.priorityClassName Priority class for MariaDB secondary pods assignment
   ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   ##


### PR DESCRIPTION
**Description of the change**
This adds support for specifying [topology spread constraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) to be sure Mariadb pods are spread reasonably in cluster by the topology key specified.

**Benefits**

user can spread pod evenly across cluster.

**Possible drawbacks**
None.

**Applicable issues**
None.

**Additional information**
Before use, please read [topology spread constraints documentation](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) carefully. It is so important to label nodes with proper topologyKey, Otherwise pods will not be scheduled.
Examples
```
topologySpreadConstraints:
  - maxSkew: 1
    topologyKey: topology.kubernetes.io/zone
    whenUnsatisfiable: DoNotSchedule
```

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
