### PR TITLE
[bitnami/memcached] Make liveness and readiness probe configurable

### DIFF
--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -22,4 +22,4 @@ name: memcached
 sources:
   - https://github.com/bitnami/bitnami-docker-memcached
   - http://memcached.org/
-version: 5.14.2
+version: 5.15.0

--- a/bitnami/memcached/README.md
+++ b/bitnami/memcached/README.md
@@ -136,6 +136,18 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.portName`                            | Memcached exporter port name                                                                    | `metrics`                    |
 | `metrics.resources.limits`                    | The resources limits for the container                                                          | `{}`                         |
 | `metrics.resources.requests`                  | The requested resources for the container                                                       | `{}`                         |
+| `metrics.livenessProbe.enabled`               | Enable livenessProbe                                                                            | `true`                       |
+| `metrics.livenessProbe.initialDelaySeconds`   | Initial delay seconds for livenessProbe                                                         | `15`                         |
+| `metrics.livenessProbe.periodSeconds`         | Period seconds for livenessProbe                                                                | `10`                         |
+| `metrics.livenessProbe.timeoutSeconds`        | Timeout seconds for livenessProbe                                                               | `5`                          |
+| `metrics.livenessProbe.failureThreshold`      | Failure threshold for livenessProbe                                                             | `3`                          |
+| `metrics.livenessProbe.successThreshold`      | Success threshold for livenessProbe                                                             | `1`                          |
+| `metrics.readinessProbe.enabled`              | Enable readinessProbe                                                                           | `true`                       |
+| `metrics.readinessProbe.initialDelaySeconds`  | Initial delay seconds for readinessProbe                                                        | `5`                          |
+| `metrics.readinessProbe.periodSeconds`        | Period seconds for readinessProbe                                                               | `10`                         |
+| `metrics.readinessProbe.timeoutSeconds`       | Timeout seconds for readinessProbe                                                              | `1`                          |
+| `metrics.readinessProbe.failureThreshold`     | Failure threshold for readinessProbe                                                            | `3`                          |
+| `metrics.readinessProbe.successThreshold`     | Success threshold for readinessProbe                                                            | `1`                          |
 | `metrics.service.type`                        | Kubernetes service type for Prometheus metrics                                                  | `ClusterIP`                  |
 | `metrics.service.port`                        | Prometheus metrics service port                                                                 | `9150`                       |
 | `metrics.service.annotations`                 | Annotations for the Prometheus metrics service                                                  | `{}`                         |

--- a/bitnami/memcached/templates/statefulset.yaml
+++ b/bitnami/memcached/templates/statefulset.yaml
@@ -164,18 +164,28 @@ spec:
           ports:
             - name: {{ .Values.metrics.portName }}
               containerPort: 9150
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /metrics
               port: metrics
-            initialDelaySeconds: 15
-            timeoutSeconds: 5
+            initialDelaySeconds: {{ .Values.metrics.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.metrics.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.metrics.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.metrics.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.metrics.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /metrics
               port: metrics
-            initialDelaySeconds: 5
-            timeoutSeconds: 1
+            initialDelaySeconds: {{ .Values.metrics.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.metrics.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.metrics.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.metrics.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.metrics.readinessProbe.failureThreshold }}
+          {{- end }}
           {{- if .Values.metrics.resources }}
           resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
           {{- end }}

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -361,6 +361,38 @@ metrics:
     ##    cpu: 100m
     ##    memory: 128Mi
     requests: {}
+  ## Configure extra options for liveness probe
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+  ## @param metrics.livenessProbe.enabled Enable livenessProbe
+  ## @param metrics.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+  ## @param metrics.livenessProbe.periodSeconds Period seconds for livenessProbe
+  ## @param metrics.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+  ## @param metrics.livenessProbe.failureThreshold Failure threshold for livenessProbe
+  ## @param metrics.livenessProbe.successThreshold Success threshold for livenessProbe
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 15
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+    successThreshold: 1
+  ## Configure extra options for readiness probe
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+  ## @param metrics.readinessProbe.enabled Enable readinessProbe
+  ## @param metrics.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+  ## @param metrics.readinessProbe.periodSeconds Period seconds for readinessProbe
+  ## @param metrics.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+  ## @param metrics.readinessProbe.failureThreshold Failure threshold for readinessProbe
+  ## @param metrics.readinessProbe.successThreshold Success threshold for readinessProbe
+  ##
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
   service:
     ## @param metrics.service.type Kubernetes service type for Prometheus metrics
     ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Chart doesn't allow configuration of liveness and readiness probe sections of the metrics container. This PR adds support to allow it.

**Benefits**

We've noticed quite often in our deployments where the readiness probe of the metrics container failed to report in time causing kubernetes to stop traffic to both memcached and metrics container.  Configuring timeoutSeconds & failureThreshold directly on the resource mitigated this problem for us.

Making these fields configurable allows the end user to tweak the probe behaviour

**Possible drawbacks**
-

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
