### PR TITLE
[bitnami/kafka] Fix hardcoded metrics port

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 14.1.0
+version: 14.1.1

--- a/bitnami/kafka/templates/kafka-metrics-deployment.yaml
+++ b/bitnami/kafka/templates/kafka-metrics-deployment.yaml
@@ -71,7 +71,7 @@ spec:
               {{- range $key, $value := .Values.metrics.kafka.extraFlags }}
               --{{ $key }}{{ if $value }}={{ $value }}{{ end }} \
               {{- end }}
-              --web.listen-address=:9308
+              --web.listen-address=:{{ .Values.metrics.kafka.service.port }}
           {{- if (include "kafka.client.saslAuthentication" .) }}
           {{- $clientUsers := coalesce .Values.auth.sasl.jaas.clientUsers .Values.auth.jaas.clientUsers }}
           env:
@@ -86,7 +86,7 @@ spec:
           {{- end }}
           ports:
             - name: metrics
-              containerPort: 9308
+              containerPort: {{ .Values.metrics.kafka.service.port }}
           {{- if .Values.metrics.kafka.resources }}
           resources: {{ toYaml .Values.metrics.kafka.resources | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Port `9308` was hardcoded in the `kafka-metrics-deployment.yaml` causing the parameter `metrics.kafka.service.port` to have no effect.

**Benefits**

<!-- What benefits will be realized by the code change? -->
Metrics service port is now customizable.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
Should be none. The default value still is `9308` and the now templatized values where the only instances of them hardcoded:
```bash
~/Bitnami/charts/bitnami/kafka on master
❯ rg 9308
values.yaml
1012:      port: 9308

templates/kafka-metrics-deployment.yaml
74:              --web.listen-address=:9308
89:              containerPort: 9308
```

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #7408

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
