### PR TITLE
[bitnami/rabbitmq] Set publishNotReadyAddresses to true in headless service

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -23,4 +23,4 @@ name: rabbitmq
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq
   - https://www.rabbitmq.com
-version: 8.22.0
+version: 8.23.0

--- a/bitnami/rabbitmq/templates/svc-headless.yaml
+++ b/bitnami/rabbitmq/templates/svc-headless.yaml
@@ -37,4 +37,6 @@ spec:
       port: {{ .Values.service.managerPort }}
       targetPort: stats
     {{- end }}
-  selector: {{ include "common.labels.matchLabels" . | nindent 4 }}
+  {{- if (eq "Parallel" .Values.podManagementPolicy) }}
+  publishNotReadyAddresses: true
+  {{- end }}


### PR DESCRIPTION
**Description of the change**

Set `publishNotReadyAddresses` to `true` in headless service when `podManagementPolicy` is `Parallel`.

**Benefits**

Pods in the StatefulSet should have their addresses published even before they're ready, since they have to be able to talk to each other to join the cluster in order to become ready.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

StatefulSet with 3 pods was scale down to 0 and than scale up to 3 again.

```
$ kubectl get pods -n rabbitmq 
NAME         READY   STATUS    RESTARTS   AGE
rabbitmq-0   1/1     Running   0          3m22s
rabbitmq-1   0/1     Running   0          3m22s
rabbitmq-2   0/1     Running   0          3m22s

$ kubectl get pods -n rabbitmq           
NAME         READY   STATUS    RESTARTS   AGE
rabbitmq-0   1/1     Running   0          3m50s
rabbitmq-1   0/1     Running   1          3m50s
rabbitmq-2   0/1     Running   1          3m50s
```
Pod `rabbitmq-1` and `rabbitmq-2` were reporting following failure

```
2021-09-08 20:38:55.478300+00:00 [warn] <0.223.0> Error while waiting for Mnesia tables: {timeout_waiting_for_tables,
2021-09-08 20:38:55.478300+00:00 [warn] <0.223.0>                                         ['rabbit@rabbitmq-2.rabbitmq-headless.rabbitmq.svc.cluster.local',
2021-09-08 20:38:55.478300+00:00 [warn] <0.223.0>                                          'rabbit@rabbitmq-1.rabbitmq-headless.rabbitmq.svc.cluster.local',
2021-09-08 20:38:55.478300+00:00 [warn] <0.223.0>                                          'rabbit@rabbitmq-0.rabbit
``` 

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x ] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
