### PR TITLE
[bitnami/grafana-operator] Update CRD grafanas.integreatly.org

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -25,4 +25,4 @@ name: grafana-operator
 sources:
   - https://github.com/integr8ly/grafana-operator
   - https://github.com/bitnami/bitnami-docker-grafana-operator
-version: 1.1.2
+version: 1.1.3

--- a/bitnami/grafana-operator/crds/grafanadashboards.yaml
+++ b/bitnami/grafana-operator/crds/grafanadashboards.yaml
@@ -1,4 +1,4 @@
-#https://raw.githubusercontent.com/integr8ly/grafana-operator/v3.9.0/deploy/crds/GrafanaDashboard.yaml
+# https://raw.githubusercontent.com/grafana-operator/grafana-operator/v3.10.3/deploy/crds/GrafanaDashboard.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/bitnami/grafana-operator/crds/grafanadatasources.yaml
+++ b/bitnami/grafana-operator/crds/grafanadatasources.yaml
@@ -1,4 +1,4 @@
-#https://raw.githubusercontent.com/integr8ly/grafana-operator/v3.9.0/deploy/crds/GrafanaDataSource.yaml
+# https://raw.githubusercontent.com/grafana-operator/grafana-operator/v3.10.3/deploy/crds/GrafanaDataSource.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/bitnami/grafana-operator/crds/grafanas.yaml
+++ b/bitnami/grafana-operator/crds/grafanas.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/integr8ly/grafana-operator/v3.9.0/deploy/crds/Grafana.yaml
+# https://raw.githubusercontent.com/grafana-operator/grafana-operator/v3.10.3/deploy/crds/Grafana.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -14,7 +14,7 @@ spec:
     singular: grafana
   scope: Namespaced
   subresources:
-    status: {}
+    status: { }
   version: v1alpha1
   validation:
     openAPIV3Schema:
@@ -67,9 +67,15 @@ spec:
                 enabled:
                   type: boolean
                   description: Create an ingress / route
+                ingressClassName:
+                  type: string
+                  description: Ingress class name
                 path:
                   type: string
                   description: Ingress path
+                pathType:
+                  type: string
+                  description: pathType specifies how ingress paths should be matched
                 hostname:
                   type: string
                   description: The hostname of the ingress / route
@@ -130,6 +136,18 @@ spec:
                 priorityClassName:
                   type: string
                   description: Pod priority class name
+                extraVolumeMounts:
+                  type: array
+                  description: Extra volumes mounts to be mounted to the grafana deployment
+                  items:
+                    type: object
+                    description: additional volumeMount 
+                extraVolumes:
+                  type: array
+                  description: Extra volumes to be attached to the grafana deployment
+                  items:
+                    type: object
+                    description: additional volume
             serviceAccount:
               type: object
               properties:


### PR DESCRIPTION
The current version doesn't match the corresponding CRD in grafana-operator/grafana-operator v3.10.3

https://github.com/grafana-operator/grafana-operator/blob/v3.10.3/deploy/crds/Grafana.yaml

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Update CRD grafanas.integreatly.org to match the corresponding upstream CRD

See https://github.com/grafana-operator/grafana-operator/blob/v3.10.3/deploy/crds/Grafana.yaml

**Benefits**

The current CRD is out of sync and needs the update. 

**Possible drawbacks**

Not that I am aware of.

**Applicable issues**

  - it isn't possible to see `ingressClassName` in the outdated CRD.

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
