### PR TITLE
[bitnami/elasticsearch] Fixed indent problem on ingest statefulset

### DIFF
--- a/bitnami/elasticsearch/Chart.lock
+++ b/bitnami/elasticsearch/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.8.0
 - name: kibana
   repository: https://charts.bitnami.com/bitnami
-  version: 9.0.1
-digest: sha256:fb6bbc3a5bb8d87cd9ff27dcd37ec0c43b8505ca3e6c59e9b31d7c7488a43879
-generated: "2021-09-02T21:43:48.165906555Z"
+  version: 9.0.2
+digest: sha256:13211a141d276837ad7ad7df71787160fa3ff02068b321fffd494708780dafe9
+generated: "2021-09-09T18:05:38.830012588Z"

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/bitnami-docker-elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 17.0.1
+version: 17.0.2

--- a/bitnami/elasticsearch/templates/ingest-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/ingest-statefulset.yaml
@@ -260,6 +260,6 @@ spec:
             secretName: {{ template "elasticsearch.initScriptsSecret" . }}
             defaultMode: 0755
         {{- end }}
-      - name: "data"
-        emptyDir: {}
+        - name: "data"
+          emptyDir: {}
 {{- end }}

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -62,7 +62,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/elasticsearch
-  tag: 7.14.1-debian-10-r7
+  tag: 7.14.1-debian-10-r8
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1138,7 +1138,7 @@ curator:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch-curator
-    tag: 5.8.4-debian-10-r116
+    tag: 5.8.4-debian-10-r117
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -1392,7 +1392,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/elasticsearch-exporter
-    tag: 1.2.1-debian-10-r68
+    tag: 1.2.1-debian-10-r69
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -1575,7 +1575,7 @@ sysctlImage:
   ##
   registry: docker.io
   repository: bitnami/bitnami-shell
-  tag: 10-debian-10-r186
+  tag: 10-debian-10-r187
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1628,7 +1628,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r186
+    tag: 10-debian-10-r187
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**

When the security and ingest node is enabled, an indent problem occurs in the volumes area for ingest-statefulset.yaml. This problem has been fixed.

<pre>
helm install elastic bitnami/elasticsearch --dry-run --debug --set security.enabled=true --set ingest.enabled=true --set security.tls.autoGenerated=true

Error: YAML parse error on elasticsearch/templates/ingest-statefulset.yaml: error converting YAML to JSON: yaml: line 147: did not find expected key
</pre>

**Possible drawbacks**

There is no drawbacks

**Applicable issues**

**Additional information**

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
