### PR TITLE
Add "extraContainerPorts" parameter

### DIFF
--- a/bitnami/magento/Chart.yaml
+++ b/bitnami/magento/Chart.yaml
@@ -35,4 +35,4 @@ name: magento
 sources:
   - https://github.com/bitnami/bitnami-docker-magento
   - https://magento.com/
-version: 18.1.12
+version: 18.2.0

--- a/bitnami/magento/README.md
+++ b/bitnami/magento/README.md
@@ -109,6 +109,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `tolerations`                        | Tolerations for pod assignment                                                                                       | `[]`                 |
 | `existingSecret`                     | Name of a secret with the application password                                                                       | `""`                 |
 | `containerPorts`                     | Container ports                                                                                                      | `{}`                 |
+| `extraContainerPorts`                | Array of additional container ports for the Magento container                                                        | `[]`                 |
 | `sessionAffinity`                    | Control where client requests go, to the same pod or round-robin                                                     | `None`               |
 | `podAffinityPreset`                  | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                  | `""`                 |
 | `podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                             | `soft`               |

--- a/bitnami/magento/templates/deployment.yaml
+++ b/bitnami/magento/templates/deployment.yaml
@@ -197,6 +197,9 @@ spec:
               containerPort: {{ .Values.containerPorts.http }}
             - name: https
               containerPort: {{ .Values.containerPorts.https }}
+            {{- if .Values.extraContainerPorts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraContainerPorts "context" $) | nindent 12 }}
+            {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:

--- a/bitnami/magento/values.yaml
+++ b/bitnami/magento/values.yaml
@@ -170,6 +170,13 @@ extraVolumes: []
 ## @param extraVolumeMounts Array of extra volume mounts to be added to the container (evaluated as template). Normally used with `extraVolumes`
 ##
 extraVolumeMounts: []
+## @param extraContainerPorts Array of additional container ports for the Magento container
+## e.g:
+## extraContainerPorts:
+##   - name: myservice
+##     containerPort: 9090
+##
+extraContainerPorts: []
 ## @param initContainers Add additional init containers to the pod (evaluated as a template)
 ##
 initContainers: []


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Add a separate parameter `extraContainerPorts` to expose custom ports of the Magento container.
This is especially useful if a custom image is used.

Furthermore there's already an `extraContainerPorts` parameter for the Magento service, so this change completes the current configuration options.

**Benefits**

The chart doesn't has to be forked and customized but can be easily configured with the `extraContainerPorts` variable.

**Possible drawbacks**

Unknown (probably none).

**Additional Information:**

This PR is based on the [`extraContainerPorts` PR](https://github.com/bitnami/charts/pull/7193) for [bitnami/wordpress]. 

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
