### PR TITLE
[bitnami/metrics-server] Add commonLabels and commonAnnotations 

### DIFF
--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -23,4 +23,4 @@ name: metrics-server
 sources:
   - https://github.com/bitnami/bitnami-docker-metrics-server
   - https://github.com/kubernetes-incubator/metrics-server
-version: 5.9.3
+version: 5.9.4

--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -23,4 +23,4 @@ name: metrics-server
 sources:
   - https://github.com/bitnami/bitnami-docker-metrics-server
   - https://github.com/kubernetes-incubator/metrics-server
-version: 5.9.4
+version: 5.10.0

--- a/bitnami/metrics-server/README.md
+++ b/bitnami/metrics-server/README.md
@@ -59,7 +59,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------ | -------------------------------------------------------------------------------------------- | ----- |
 | `nameOverride`     | String to partially override common.names.fullname template (will maintain the release name) | `""`  |
 | `fullnameOverride` | String to fully override common.names.fullname template                                      | `""`  |
-
+| `commonLabels` | Labels to add to all deployed objects template                                      | `""`  |
+| `commonAnnotations` | Annotations to add to all deployed objects  template                                      | `""`  |
 
 ### Metrics Server parameters
 

--- a/bitnami/metrics-server/templates/auth-delegator-crb.yaml
+++ b/bitnami/metrics-server/templates/auth-delegator-crb.yaml
@@ -5,6 +5,12 @@ metadata:
   name: {{ include "common.names.fullname" . }}-auth-delegator
   namespace: kube-system
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+  {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/bitnami/metrics-server/templates/cluster-role.yaml
+++ b/bitnami/metrics-server/templates/cluster-role.yaml
@@ -4,6 +4,12 @@ kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+  {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups:
       - ""

--- a/bitnami/metrics-server/templates/deployment.yaml
+++ b/bitnami/metrics-server/templates/deployment.yaml
@@ -3,6 +3,12 @@ kind: Deployment
 metadata:
   name: {{ template "common.names.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+  {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:

--- a/bitnami/metrics-server/templates/metrics-api-service.yaml
+++ b/bitnami/metrics-server/templates/metrics-api-service.yaml
@@ -8,6 +8,12 @@ kind: APIService
 metadata:
   name: v1beta1.metrics.k8s.io
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+  {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   service:
     name: {{ template "common.names.fullname" . }}

--- a/bitnami/metrics-server/templates/metrics-server-crb.yaml
+++ b/bitnami/metrics-server/templates/metrics-server-crb.yaml
@@ -4,6 +4,12 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "common.names.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+  {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/bitnami/metrics-server/templates/pdb.yaml
+++ b/bitnami/metrics-server/templates/pdb.yaml
@@ -4,6 +4,12 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ include "common.names.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+  {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.podDisruptionBudget.minAvailable }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}

--- a/bitnami/metrics-server/templates/role-binding.yaml
+++ b/bitnami/metrics-server/templates/role-binding.yaml
@@ -5,6 +5,12 @@ metadata:
   name: {{ printf "%s-auth-reader" (include "common.names.fullname" .) }}
   namespace: kube-system
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+  {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/bitnami/metrics-server/templates/serviceaccount.yaml
+++ b/bitnami/metrics-server/templates/serviceaccount.yaml
@@ -4,5 +4,11 @@ kind: ServiceAccount
 metadata:
   name: {{ template "common.names.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+  {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end -}}

--- a/bitnami/metrics-server/templates/svc.yaml
+++ b/bitnami/metrics-server/templates/svc.yaml
@@ -2,12 +2,22 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "common.names.fullname" . }}
+
   labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.service.labels }}
-  {{- include "common.tplvalues.render" (dict "value" .Values.service.labels "context" $) | nindent 4 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.labels "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if or .Values.service.annotations .Values.commonAnnotations }}
+  annotations:
+  {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
   {{- if .Values.service.annotations }}
-  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+  {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/bitnami/metrics-server/values.yaml
+++ b/bitnami/metrics-server/values.yaml
@@ -23,6 +23,14 @@ nameOverride: ""
 ##
 fullnameOverride: ""
 
+## @param commonLabels Add labels to all the deployed resources
+##
+commonLabels: {}
+
+## @param commonAnnotations Add annotations to all the deployed resources
+##
+commonAnnotations: {}
+
 ## @section Metrics Server parameters
 
 ## Bitnami Metrics Server image version


### PR DESCRIPTION
**Description of the change**

Adds `commonLabels` and `commonAnnotations` to all components of the `metrics-server`

**Benefits**

In multi-tenant environments, provides filtering, ownership and auditing capabilities to distinguish `metrics-server` from other apps.

**Possible drawbacks**


**Applicable issues**


**Additional information**

Leveraged the work done in https://github.com/bitnami/charts/pull/6864 to be consistent across charts.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
