### PR TITLE
[bitnami/airflow] Worker resources to be customizable using 'k8s-executor'

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -32,4 +32,4 @@ name: airflow
 sources:
   - https://github.com/bitnami/bitnami-docker-airflow
   - https://airflow.apache.org/
-version: 10.3.2
+version: 10.3.3

--- a/bitnami/airflow/templates/config/configmap.yaml
+++ b/bitnami/airflow/templates/config/configmap.yaml
@@ -87,6 +87,9 @@ data:
             - secretRef:
                 name: {{ .Values.worker.extraEnvVarsSecret }}
             {{- end }}
+          {{- if .Values.worker.resources }}
+          resources: {{- toYaml .Values.worker.resources | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: k8s-executor-config
               mountPath: /opt/bitnami/airflow/k8s-executor-config


### PR DESCRIPTION
**Description of the change**

This PR allows setting custom resource limits and requests based on the `worker.resources.limits` and `worker.resources.requests` parameters for workers when using  the 'k8s-executor'.

**Benefits**

Flexibility

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/7446

**Additional information**

N/A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
