### PR TITLE
[bitnami/oauth2-proxy] add quotes around host to allow wildcard host

### DIFF
--- a/bitnami/oauth2-proxy/Chart.yaml
+++ b/bitnami/oauth2-proxy/Chart.yaml
@@ -30,4 +30,4 @@ name: oauth2-proxy
 sources:
   - https://github.com/bitnami/bitnami-docker-oauth2-proxy
   - https://github.com/oauth2-proxy/oauth2-proxy
-version: 0.1.8
+version: 0.1.9

--- a/bitnami/oauth2-proxy/templates/ingress.yaml
+++ b/bitnami/oauth2-proxy/templates/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   rules:
     {{- if .Values.ingress.hostname }}
-    - host: {{ .Values.ingress.hostname }}
+    - host: {{ .Values.ingress.hostname | quote }}
       http:
         paths:
           {{- if .Values.ingress.extraPaths }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This adds quotes around the host to allow wildcard hosts. Currently trying to set a wildcard host results in an error:
`Error: YAML parse error on oauth2-proxy/templates/ingress.yaml: error converting YAML to JSON: yaml: line 15: did not find expected alphabetic or numeric character`
Currently this is possible for the extrahosts field.


<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

It adds quotes around the hostname.
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

Personally I don't see any

**Applicable issues**


**Additional information**


**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x ] Variables are documented in the README.md
- [x ] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
