### PR TITLE
[bitnami/elasticsearch] fix sysctl set options

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/bitnami-docker-elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 17.0.2
+version: 17.0.3

--- a/bitnami/elasticsearch/templates/_helpers.tpl
+++ b/bitnami/elasticsearch/templates/_helpers.tpl
@@ -486,3 +486,14 @@ Compile all warnings into a single message, and call fail.
 {{-   printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Sysctl set if less then
+*/}}
+{{- define "elasticsearch.sysctlIfLess" -}}
+CURRENT=`sysctl -n {{ .key }}`;
+DESIRED="{{ .value }}";
+if [ "$DESIRED" -gt "$CURRENT" ]; then
+    sysctl -w {{ .key }}={{ .value }};
+fi;
+{{- end -}}

--- a/bitnami/elasticsearch/templates/coordinating-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/coordinating-statefulset.yaml
@@ -72,7 +72,8 @@ spec:
             - /bin/bash
             - -ec
             - |
-              sysctl -w vm.max_map_count=262144 && sysctl -w fs.file-max=65536
+              {{- include "elasticsearch.sysctlIfLess" (dict "key" "vm.max_map_count" "value" "262144") | nindent 14 }}
+              {{- include "elasticsearch.sysctlIfLess" (dict "key" "fs.file-max" "value" "65536") | nindent 14 }}
           securityContext:
             privileged: true
           {{- if .Values.sysctlImage.resources }}

--- a/bitnami/elasticsearch/templates/data-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/data-statefulset.yaml
@@ -75,7 +75,8 @@ spec:
             - /bin/bash
             - -ec
             - |
-              sysctl -w vm.max_map_count=262144 && sysctl -w fs.file-max=65536
+              {{- include "elasticsearch.sysctlIfLess" (dict "key" "vm.max_map_count" "value" "262144") | nindent 14 }}
+              {{- include "elasticsearch.sysctlIfLess" (dict "key" "fs.file-max" "value" "65536") | nindent 14 }}
           securityContext:
             privileged: true
           {{- if .Values.sysctlImage.resources }}

--- a/bitnami/elasticsearch/templates/ingest-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/ingest-statefulset.yaml
@@ -73,7 +73,8 @@ spec:
             - /bin/bash
             - -ec
             - |
-              sysctl -w vm.max_map_count=262144 && sysctl -w fs.file-max=65536
+              {{- include "elasticsearch.sysctlIfLess" (dict "key" "vm.max_map_count" "value" "262144") | nindent 14 }}
+              {{- include "elasticsearch.sysctlIfLess" (dict "key" "fs.file-max" "value" "65536") | nindent 14 }}
           securityContext:
             privileged: true
           {{- if .Values.sysctlImage.resources }}

--- a/bitnami/elasticsearch/templates/master-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/master-statefulset.yaml
@@ -72,7 +72,8 @@ spec:
             - /bin/bash
             - -ec
             - |
-              sysctl -w vm.max_map_count=262144 && sysctl -w fs.file-max=65536
+              {{- include "elasticsearch.sysctlIfLess" (dict "key" "vm.max_map_count" "value" "262144") | nindent 14 }}
+              {{- include "elasticsearch.sysctlIfLess" (dict "key" "fs.file-max" "value" "65536") | nindent 14 }}
           securityContext:
             privileged: true
           {{- if .Values.sysctlImage.resources }}


### PR DESCRIPTION
Hi guys,

I found bug with sysctl init container.
If node have greater value of some options, than this chart set, it will be overwritten, so I made this PR for fix this behavior.

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
