### PR TITLE
[bitnami/*] Bump Elasticsearch subchart dependency

### DIFF
--- a/bitnami/dataplatform-bp2/Chart.lock
+++ b/bitnami/dataplatform-bp2/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: kafka
   repository: https://charts.bitnami.com/bitnami
-  version: 14.0.5
+  version: 14.1.0
 - name: spark
   repository: https://charts.bitnami.com/bitnami
   version: 5.7.2
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
-  version: 15.10.5
+  version: 17.0.2
 - name: logstash
   repository: https://charts.bitnami.com/bitnami
-  version: 3.6.4
+  version: 3.6.5
 - name: wavefront
   repository: https://charts.bitnami.com/bitnami
-  version: 3.1.10
+  version: 3.1.11
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.8.0
-digest: sha256:af7f38bc8f2ed2882f2f7af17422c4260a88d330456974e6ecba87332c625612
-generated: "2021-08-30T19:32:44.350483+05:30"
+digest: sha256:235a3673c3146ab894e9e3f8f4ddf6140a2155cf82ca305d97f5ebd5ba179e2c
+generated: "2021-09-13T10:00:31.9197+02:00"

--- a/bitnami/dataplatform-bp2/Chart.yaml
+++ b/bitnami/dataplatform-bp2/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
   - condition: elasticsearch.enabled
     name: elasticsearch
     repository: https://charts.bitnami.com/bitnami
-    version: 15.x.x
+    version: 17.x.x
   - condition: logstash.enabled
     name: logstash
     repository: https://charts.bitnami.com/bitnami
@@ -58,4 +58,4 @@ sources:
   - https://www.elastic.co/products/logstash
   - https://zookeeper.apache.org/
   - https://github.com/bitnami/bitnami-docker-zookeeper
-version: 6.0.0
+version: 7.0.0

--- a/bitnami/dataplatform-bp2/README.md
+++ b/bitnami/dataplatform-bp2/README.md
@@ -361,6 +361,10 @@ Regular upgrade is compatible from previous versions.
 
 ## Upgrading
 
+### To 7.0.0
+
+This major updates the MinIO&reg; subchart to its newest major, 17.0.0, which adds support for X-pack security features such as SSL/TLS encryption and password protection. Check [Elasticsearch Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/elasticsearch#to-1700) for more information.
+
 ### To 6.0.0
 
 This major version updates resources for elasticsearch and logstash values. Also updates the README file with instructions on how to enable existing Wavefront deployment for the data platform blueprint.

--- a/bitnami/dataplatform-bp2/README.md
+++ b/bitnami/dataplatform-bp2/README.md
@@ -363,7 +363,7 @@ Regular upgrade is compatible from previous versions.
 
 ### To 7.0.0
 
-This major updates the MinIO&reg; subchart to its newest major, 17.0.0, which adds support for X-pack security features such as SSL/TLS encryption and password protection. Check [Elasticsearch Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/elasticsearch#to-1700) for more information.
+This major updates the Elasticsearch subchart to its newest major, 17.0.0, which adds support for X-pack security features such as SSL/TLS encryption and password protection. Check [Elasticsearch Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/elasticsearch#to-1700) for more information.
 
 ### To 6.0.0
 

--- a/bitnami/magento/Chart.lock
+++ b/bitnami/magento/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.8.0
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 9.4.4
+  version: 9.5.1
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
-  version: 15.10.5
-digest: sha256:8bc9d7154e168febb8619dabbcd3325e9a12660ba8620d1fce78ad225a2e7469
-generated: "2021-08-27T12:49:57.743853592Z"
+  version: 17.0.2
+digest: sha256:b0ab8eea5288a72394a840a32eb0d2ff773f727a26a81d1b9fc5ddbb74527246
+generated: "2021-09-13T09:58:35.702963+02:00"

--- a/bitnami/magento/Chart.yaml
+++ b/bitnami/magento/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   - condition: elasticsearch.enabled
     name: elasticsearch
     repository: https://charts.bitnami.com/bitnami
-    version: 15.x.x
+    version: 17.x.x
 description: A feature-rich flexible e-commerce solution. It includes transaction options, multi-store functionality, loyalty programs, product categorization and shopper filtering, promotion rules, and more.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/magento
@@ -35,4 +35,4 @@ name: magento
 sources:
   - https://github.com/bitnami/bitnami-docker-magento
   - https://magento.com/
-version: 18.2.0
+version: 19.0.0

--- a/bitnami/magento/README.md
+++ b/bitnami/magento/README.md
@@ -545,6 +545,10 @@ Find more information about how to deal with common errors related to Bitnami’
 
 ## Notable changes
 
+### 19.0.0
+
+This major updates the MinIO&reg; subchart to its newest major, 17.0.0, which adds support for X-pack security features such as SSL/TLS encryption and password protection. Check [Elasticsearch Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/elasticsearch#to-1700) for more information.
+
 ### 18.0.0
 
 Elasticsearch dependency version was bumped to a new major version changing the license of some of its components to the [Elastic License](https://www.elastic.co/licensing/elastic-license) that is not currently accepted as an Open Source license by the Open Source Initiative (OSI). Check [Elasticsearch Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/elasticsearch#to-1500) for more information.

--- a/bitnami/magento/README.md
+++ b/bitnami/magento/README.md
@@ -547,7 +547,7 @@ Find more information about how to deal with common errors related to Bitnami’
 
 ### 19.0.0
 
-This major updates the MinIO&reg; subchart to its newest major, 17.0.0, which adds support for X-pack security features such as SSL/TLS encryption and password protection. Check [Elasticsearch Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/elasticsearch#to-1700) for more information.
+This major updates the Elasticsearch subchart to its newest major, 17.0.0, which adds support for X-pack security features such as SSL/TLS encryption and password protection. Check [Elasticsearch Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/elasticsearch#to-1700) for more information.
 
 ### 18.0.0
 


### PR DESCRIPTION
**Description of the change**

This PR updates Elasticsearch subchart for `bitnami/magento` and `bitnami/dataplatform-bp2`.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
