### PR TITLE
bitnami/grafana add folders support

### DIFF
--- a/bitnami/grafana/templates/dashboard-provider.yaml
+++ b/bitnami/grafana/templates/dashboard-provider.yaml
@@ -30,4 +30,6 @@ data:
       options:
         # <string, required> path to dashboard files on disk. Required
         path: /opt/bitnami/grafana/dashboards
+        # <bool> enable folders creation for dashboards
+        #foldersFromFilesStructure: true
 {{- end }}

--- a/bitnami/grafana/templates/deployment.yaml
+++ b/bitnami/grafana/templates/deployment.yaml
@@ -113,9 +113,15 @@ spec:
               mountPath: /opt/bitnami/grafana/conf/provisioning/dashboards
             {{- end }}
             {{- range .Values.dashboardsConfigMaps }}
+            {{- if .folderName }}
+            - name: {{ .configMapName }}
+              mountPath: /opt/bitnami/grafana/dashboards/{{ .folderName }}/{{ .fileName }}
+              subPath: {{ .fileName }}
+            {{- else }}
             - name: {{ .configMapName }}
               mountPath: /opt/bitnami/grafana/dashboards/{{ .fileName }}
               subPath: {{ .fileName }}
+            {{- end }}
             {{- end }}
             {{- if .Values.datasources.secretName }}
             - name: datasources

--- a/bitnami/grafana/values.yaml
+++ b/bitnami/grafana/values.yaml
@@ -160,11 +160,14 @@ dashboardsProvider:
 ## @param dashboardsConfigMaps Array with the names of a series of ConfigMaps containing dashboards files
 ## They will be mounted by the default dashboard provider if it is enabled
 ## Use an array with the configMap names.
+## uncomment "foldersFromFilesStructure: true" line in default provider config. or create yours dashboard provider.
 ## Example:
 ## dashboardsConfigMaps:
 ##   - configMapName: mydashboard
+##       folderName: AWS
 ##     fileName: mydashboard.json
 ##   - configMapName: myotherdashboard
+##      folderName: AWS
 ##     fileName: myotherdashboard.json
 ##
 dashboardsConfigMaps: []


### PR DESCRIPTION

**Description of the change**

Simple PR which adds the ability to set up folders for dashboards provider.

**Benefits**


full support of Grafana provisioning (dashboard-provider) features


**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Variables are documented in the README.md
- [X ] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
