### PR TITLE
[bitnami/etcd] fix kubectl exec example in chart notes

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -25,4 +25,4 @@ name: etcd
 sources:
   - https://github.com/bitnami/bitnami-docker-etcd
   - https://coreos.com/etcd/
-version: 6.8.0
+version: 6.8.1

--- a/bitnami/etcd/templates/NOTES.txt
+++ b/bitnami/etcd/templates/NOTES.txt
@@ -45,7 +45,7 @@ To create a pod that you can use as a etcd client run the following command:
 
 Then, you can set/get a key using the commands below:
 
-    kubectl exec -it {{ template "common.names.fullname" . }}-client -- bash
+    kubectl exec --namespace {{ .Release.Namespace }} -it {{ template "common.names.fullname" . }}-client -- bash
     {{- $etcdAuthOptions := include "etcd.authOptions" . }}
     etcdctl {{ $etcdAuthOptions }} put /message Hello
     etcdctl {{ $etcdAuthOptions }} get /message


### PR DESCRIPTION
**Description of the change**

In the etcd chart, the `kubectl exec -it ...` example shown in chart notes was missing the `--namespace` argument

**Benefits**

The chart notes will now work for users who do not deploy the etcd chart in their default namespace

**Checklist** 
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
